### PR TITLE
Removed questionable check in NTFS code.

### DIFF
--- a/lib/fs/ntfs/directory_index_node.rb
+++ b/lib/fs/ntfs/directory_index_node.rb
@@ -52,10 +52,6 @@ module NTFS
         # Child node VCN is located 8 bytes before 'length' bytes.
         # NOTE: If the node has 0 contents, it's offset 16.
         @child = buf[@contentLen == 0 ? 16 : @length - 8, 8].unpack('Q')[0]
-        if @child.class == Bignum
-          # buf.hex_dump(:obj => STDOUT, :meth => :puts, :newline => false)
-          raise "MIQ(NTFS::DirectoryIndexNode.initialize) Bad child node: #{@child}"
-        end
       end
     end
 


### PR DESCRIPTION
It appears the code is attempting to test for valid data, and raising an error
when the class of the returned data item is Bignum. This should only happen
when the data in question is corrupt, so there shouldn't be an explicit test for it.

Given the test is breaking Ruby 2.4 tests, I'm removing the test.