### PR TITLE
Add dependency on azure-armrest gem

### DIFF
--- a/manageiq-smartstate.gemspec
+++ b/manageiq-smartstate.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "azure-armrest"
   spec.add_dependency "iniparse"
   spec.add_dependency "linux_block_device", "~>0.2.1"
   spec.add_dependency "memory_buffer",      ">=0.1.0"


### PR DESCRIPTION
Moving dependency from https://github.com/ManageIQ/manageiq-gems-pending to this repo.