### PR TITLE
Replace File.sizeEx call with File.size

### DIFF
--- a/lib/metadata/VmConfig/VmConfig.rb
+++ b/lib/metadata/VmConfig/VmConfig.rb
@@ -446,7 +446,7 @@ class VmConfig
     @files = []
     if @direct_file_access
       Dir.glob(File.join(@configPath, "/*.*")) do |f|
-        s = File.sizeEx(f) rescue 0
+        s = File.size(f) rescue 0
         @files << {:path => f, :name => File.basename(f), :size => s, :mtime => File.mtime(f)}
       end
     else


### PR DESCRIPTION
File.sizeEx is an extension provided by manageiq-gems-pending that is no longer needed.  Its purpose is to handle files larger than 4GB, but File.size handles those now.

@roliveri Please review.