### PR TITLE
Handle Managed Disk Snapshots

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -24,7 +24,8 @@ engines:
     enabled: true
     config:
       languages:
-      - ruby
+        ruby:
+          mass_threshold: 25
       - javascript
   eslint:
     enabled: false

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -26,7 +26,7 @@ engines:
       languages:
         ruby:
           mass_threshold: 25
-      - javascript
+        javascript:
   eslint:
     enabled: false
     channel: "eslint-3"

--- a/lib/MiqVm/miq_azure_vm.rb
+++ b/lib/MiqVm/miq_azure_vm.rb
@@ -60,13 +60,13 @@ class MiqAzureVm < MiqVm
     #
     diskFiles.each do |dtag, df|
       $log.debug "openDisks: processing disk file (#{dtag}): #{df}"
-      dInfo = open_disks_info(dtag, df)
+      d_info = open_disks_info(dtag, df)
 
       begin
         if @uri
-          d = MiqDiskCache.new(AzureBlobDisk.new(sa_svc, @uri, dInfo), 100, 128)
+          d = MiqDiskCache.new(AzureBlobDisk.new(sa_svc, @uri, d_info), 100, 128)
         else
-          d = MiqDiskCache.new(AzureManagedDisk.new(snap_svc, @snap_name, dInfo), 100, 128)
+          d = MiqDiskCache.new(AzureManagedDisk.new(snap_svc, @snap_name, d_info), 100, 128)
         end
       rescue => err
         $log.error "#{err}: Couldn't open disk file: #{df}"
@@ -94,7 +94,7 @@ class MiqAzureVm < MiqVm
     p_volumes
   end # def openDisks
 
-  def  open_disks_info(disk_tag, disk_file)
+  def open_disks_info(disk_tag, disk_file)
     disk_info                = OpenStruct.new
     disk_info.fileName       = disk_file
     disk_info.hardwareId     = disk_tag

--- a/lib/MiqVm/miq_azure_vm.rb
+++ b/lib/MiqVm/miq_azure_vm.rb
@@ -40,7 +40,7 @@ class MiqAzureVm < MiqVm
     cfg_hash['displayname'] = @name
     file_name               = @uri ? @uri : @snap_name
 
-    $log.debug "MiqAzureVm#getCfg: disk = #{file_name}"
+    $log.debug("MiqAzureVm#getCfg: disk = #{file_name}")
 
     tag = "scsi0:0"
     cfg_hash["#{tag}.present"]    = "true"
@@ -53,7 +53,7 @@ class MiqAzureVm < MiqVm
   def openDisks(diskFiles)
     p_volumes = []
 
-    $log.debug "openDisks: #{diskFiles.size} disk files supplied."
+    $log.debug("openDisks: #{diskFiles.size} disk files supplied.")
 
     #
     # Build a list of the VM's physical volumes.
@@ -69,7 +69,7 @@ class MiqAzureVm < MiqVm
           d = MiqDiskCache.new(AzureManagedDisk.new(snap_svc, @snap_name, d_info), 100, 128)
         end
       rescue => err
-        $log.error "#{err}: Couldn't open disk file: #{df}"
+        $log.error("#{err}: Couldn't open disk file: #{df}")
         $log.debug err.backtrace.join("\n")
         @diskInitErrors[df] = err.to_s
         next

--- a/lib/disk/modules/AzureBlobDisk.rb
+++ b/lib/disk/modules/AzureBlobDisk.rb
@@ -3,6 +3,7 @@ require_relative "../MiqDisk"
 require 'ostruct'
 
 module AzureBlobDisk
+  include AzureDiskCommon
   # The maximum read length that supports MD5 return.
   MAX_READ_LEN = 1024 * 1024 * 4
 
@@ -20,20 +21,20 @@ module AzureBlobDisk
     @blockSize        = AzureDiskCommon::SECTOR_LENGTH
     @blob_uri         = @dInfo.blob_uri
     @storage_acct_svc = @dInfo.storage_acct_svc
-    AzureDiskCommon.d_init_common(@dInfo)
+    d_init_common(@dInfo)
   end
 
   def d_close
-    AzureDiskCommon.d_close_common
+    d_close_common
   end
 
   def d_read(pos, len)
     $log.debug "AzureBlobDisk#d_read(#{pos}, #{len})"
-    AzureDiskCommon.d_read_common(pos, len)
+    d_read_common(pos, len)
   end
 
   def d_size
-    @d_size ||= AzureDiskCommon.blob_properties[:content_length].to_i
+    @d_size ||= blob_properties[:content_length].to_i
   end
 
   def d_write(_pos, _buf, _len)

--- a/lib/disk/modules/AzureBlobDisk.rb
+++ b/lib/disk/modules/AzureBlobDisk.rb
@@ -1,3 +1,4 @@
+require "disk/modules/AzureDiskCommon"
 require_relative "../MiqDisk"
 require 'ostruct'
 
@@ -16,23 +17,23 @@ module AzureBlobDisk
 
   def d_init
     @diskType         = "azure-blob"
-    @blockSize        = AzureCommon::SECTOR_LENGTH
+    @blockSize        = AzureDiskCommon::SECTOR_LENGTH
     @blob_uri         = @dInfo.blob_uri
     @storage_acct_svc = @dInfo.storage_acct_svc
-    AzureCommon.d_init_common(@dInfo)
+    AzureDiskCommon.d_init_common(@dInfo)
   end
 
   def d_close
-    AzureCommon.d_close_common
+    AzureDiskCommon.d_close_common
   end
 
   def d_read(pos, len)
     $log.debug "AzureBlobDisk#d_read(#{pos}, #{len})"
-    AzureCommon.d_read_common(pos, len)
+    AzureDiskCommon.d_read_common(pos, len)
   end
 
   def d_size
-    @d_size ||= AzureCommon.blob_properties[:content_length].to_i
+    @d_size ||= AzureDiskCommon.blob_properties[:content_length].to_i
   end
 
   def d_write(_pos, _buf, _len)

--- a/lib/disk/modules/AzureBlobDisk.rb
+++ b/lib/disk/modules/AzureBlobDisk.rb
@@ -16,86 +16,26 @@ module AzureBlobDisk
 
   def d_init
     @diskType         = "azure-blob"
-    @blockSize        = 512
+    @blockSize        = AzureCommon::SECTOR_LENGTH
     @blob_uri         = @dInfo.blob_uri
     @storage_acct_svc = @dInfo.storage_acct_svc
-
-    uri_info   = @storage_acct_svc.parse_uri(@blob_uri)
-    @container = uri_info[:container]
-    @blob      = uri_info[:blob]
-    @acct_name = uri_info[:account_name]
-    @snapshot  = uri_info[:snapshot]
-
-    @storage_acct = @storage_acct_svc.accounts_by_name[@acct_name]
-    raise "AzureBlob: Storage account #{@acct_name} not found." unless @storage_acct
-
-    $log.debug "AzureBlobDisk: open(#{@blob_uri})"
-    @t0 = Time.now.to_i
-    @reads = 0
-    @bytes = 0
-    @split_reads = 0
+    AzureCommon.d_init_common(@dInfo)
   end
 
   def d_close
-    return nil unless $log.debug?
-    t1 = Time.now.to_i
-    $log.debug "AzureBlobDisk: close(#{@blob_uri})"
-    $log.debug "AzureBlobDisk: (#{@blob_uri}) time:  #{t1 - @t0}"
-    $log.debug "AzureBlobDisk: (#{@blob_uri}) reads: #{@reads}, split_reads: #{@split_reads}"
-    $log.debug "AzureBlobDisk: (#{@blob_uri}) bytes: #{@bytes}"
-    nil
+    AzureCommon.d_close_common
   end
 
   def d_read(pos, len)
     $log.debug "AzureBlobDisk#d_read(#{pos}, #{len})"
-    return blob_read(pos, len) unless len > MAX_READ_LEN
-
-    @split_reads += 1
-    ret = ""
-    blocks, rem = len.divmod(MAX_READ_LEN)
-
-    blocks.times do
-      ret << blob_read(pos, MAX_READ_LEN)
-    end
-    ret << blob_read(pos, rem) if rem > 0
-
-    ret
+    AzureCommon.d_read_common(pos, len)
   end
 
   def d_size
-    @d_size ||= blob_properties[:content_length].to_i
+    @d_size ||= AzureCommon.blob_properties[:content_length].to_i
   end
 
   def d_write(_pos, _buf, _len)
     raise "Write operation not supported."
-  end
-
-  private
-
-  def blob_read(start_byte, length)
-    $log.debug "AzureBlobDisk#blob_read(#{start_byte}, #{length})"
-    options = {
-      :start_byte => start_byte,
-      :length     => length
-    }
-    options[:date] = @snapshot if @snapshot
-
-    ret = @storage_acct.get_blob_raw(@container, @blob, key, options)
-
-    @reads += 1
-    @bytes += ret.body.length
-
-    ret.body
-  end
-
-  def blob_properties
-    @blob_properties ||= begin
-      options = @snapshot ? {:date => @snapshot} : {}
-      @storage_acct.blob_properties(@container, @blob, key, options)
-    end
-  end
-
-  def key
-    @key ||= @storage_acct_svc.list_account_keys(@storage_acct.name, @storage_acct.resource_group).fetch('key1')
   end
 end

--- a/lib/disk/modules/AzureCommon.rb
+++ b/lib/disk/modules/AzureCommon.rb
@@ -1,0 +1,95 @@
+require_relative '../MiqDisk'
+require 'ostruct'
+
+module AzureCommon
+  # The maximum read length that supports MD5 return.
+  MAX_READ_LEN  = 1024 * 1024 * 4
+  SECTOR_LENGTH = 512
+
+  def self.d_init_common(dInfo)
+    @blockSize        = SECTOR_LENGTH
+    @blob_uri         = dInfo.blob_uri if dInfo.blob_uri
+    @disk_name        = dInfo.disk_name if dInfo.disk_name
+    @storage_acct_svc = dInfo.storage_acct_svc if dInfo.storage_acct_svc
+    @storage_disk_svc = dInfo.storage_disk_svc if dInfo.storage_disk_svc
+    @resource_group   = dInfo.resource_group if dInfo.resource_group
+
+    if @storage_acct_svc
+      @my_class     = "AzureBlobDisk"
+      uri_info      = @storage_acct_svc.parse_uri(@blob_uri)
+      @container    = uri_info[:container]
+      @blob         = uri_info[:blob]
+      @acct_name    = uri_info[:account_name]
+      @snapshot     = uri_info[:snapshot]
+      @storage_acct = @storage_acct_svc.accounts_by_name[@acct_name]
+      @disk_path    = @blob_uri
+      raise "AzureBlob: Storage account #{@acct_name} not found." unless @storage_acct
+    else
+      @disk_path = @disk_name
+      @my_class     = "AzureManagedDisk"
+    end
+    $log.debug "#{@class}: open(#{@disk_path})"
+
+    @t0 = Time.now.to_i
+    @reads = 0
+    @bytes = 0
+    @split_reads = 0
+  end
+
+  def self.d_close_common
+    return nil unless $log.debug?
+    t1 = Time.now.to_i
+    $log.debug "#{@my_class}: close(#{@disk_path})"
+    $log.debug "#{@my_class}: (#{@disk_path}) time:  #{t1 - @t0}"
+    $log.debug "#{@my_class}: (#{@disk_path}) reads: #{@reads}, split_reads: #{@split_reads}"
+    $log.debug "#{@my_class}: (#{@disk_path}) bytes: #{@bytes}"
+    nil
+  end
+
+  def self.d_read_common(pos, len)
+    return blob_read(pos, len) unless len > MAX_READ_LEN
+
+    @split_reads += 1
+    ret = ""
+    blocks, rem = len.divmod(MAX_READ_LEN)
+
+    blocks.times do
+      ret << blob_read(pos, MAX_READ_LEN)
+    end
+    ret << blob_read(pos, rem) if rem > 0
+
+    ret
+  end
+
+  def self.blob_properties
+    @blob_properties ||= begin
+      options = @snapshot ? {:date => @snapshot} : {}
+      @storage_acct.blob_properties(@container, @blob, key, options)
+    end
+  end
+
+  private
+
+  def self.blob_read(start_byte, length)
+    $log.debug "#{@my_class}#blob_read(#{start_byte}, #{length})"
+    options = {
+      :start_byte => start_byte,
+      :length     => length
+    }
+    if @storage_acct
+      options[:date] = @snapshot if @snapshot
+      ret = @storage_acct.get_blob_raw(@container, @blob, key, options)
+    else
+      ret = @storage_disk_svc.get_blob_raw(@disk_name, @resource_group, options)
+    end
+
+    @reads += 1
+    @bytes += ret.body.length
+
+    ret.body
+  end
+
+  def self.key
+    @key ||= @storage_acct_svc.list_account_keys(@storage_acct.name, @storage_acct.resource_group).fetch('key1')
+  end
+end

--- a/lib/disk/modules/AzureDiskCommon.rb
+++ b/lib/disk/modules/AzureDiskCommon.rb
@@ -13,7 +13,7 @@ module AzureDiskCommon
     else
       d_init_managed_disk(d_info)
     end
-    $log.debug "#{@class}: open(#{@disk_path})"
+    $log.debug("#{@class}: open(#{@disk_path})")
     @t0 = Time.now.to_i
     @reads = 0
     @bytes = 0
@@ -45,10 +45,10 @@ module AzureDiskCommon
   def d_close_common
     return nil unless $log.debug?
     t1 = Time.now.to_i
-    $log.debug "#{@my_class}: close(#{@disk_path})"
-    $log.debug "#{@my_class}: (#{@disk_path}) time:  #{t1 - @t0}"
-    $log.debug "#{@my_class}: (#{@disk_path}) reads: #{@reads}, split_reads: #{@split_reads}"
-    $log.debug "#{@my_class}: (#{@disk_path}) bytes: #{@bytes}"
+    $log.debug("#{@my_class}: close(#{@disk_path})")
+    $log.debug("#{@my_class}: (#{@disk_path}) time:  #{t1 - @t0}")
+    $log.debug("#{@my_class}: (#{@disk_path}) reads: #{@reads}, split_reads: #{@split_reads}")
+    $log.debug("#{@my_class}: (#{@disk_path}) bytes: #{@bytes}")
     nil
   end
 
@@ -75,7 +75,7 @@ module AzureDiskCommon
   end
 
   def blob_read(start_byte, length)
-    $log.debug "#{@my_class}#blob_read(#{start_byte}, #{length})"
+    $log.debug("#{@my_class}#blob_read(#{start_byte}, #{length})")
     options = {
       :start_byte => start_byte,
       :length     => length

--- a/lib/disk/modules/AzureDiskCommon.rb
+++ b/lib/disk/modules/AzureDiskCommon.rb
@@ -6,7 +6,7 @@ module AzureDiskCommon
   MAX_READ_LEN  = 1024 * 1024 * 4
   SECTOR_LENGTH = 512
 
-  def self.d_init_common(d_info)
+  def d_init_common(d_info)
     @blockSize = SECTOR_LENGTH
     if d_info.blob_uri
       d_init_blob_disk(d_info)
@@ -20,7 +20,7 @@ module AzureDiskCommon
     @split_reads = 0
   end
 
-  def self.d_init_blob_disk(d_info)
+  def d_init_blob_disk(d_info)
     @blob_uri         = d_info.blob_uri
     @storage_acct_svc = d_info.storage_acct_svc
     @my_class         = "AzureBlobDisk"
@@ -34,7 +34,7 @@ module AzureDiskCommon
     raise "AzureBlob: Storage account #{@acct_name} not found." unless @storage_acct
   end
 
-  def self.d_init_managed_disk(d_info)
+  def d_init_managed_disk(d_info)
     @disk_name        = d_info.disk_name
     @storage_disk_svc = d_info.storage_disk_svc
     @resource_group   = d_info.resource_group
@@ -42,7 +42,7 @@ module AzureDiskCommon
     @disk_path        = @disk_name
   end
 
-  def self.d_close_common
+  def d_close_common
     return nil unless $log.debug?
     t1 = Time.now.to_i
     $log.debug "#{@my_class}: close(#{@disk_path})"
@@ -52,7 +52,7 @@ module AzureDiskCommon
     nil
   end
 
-  def self.d_read_common(pos, len)
+  def d_read_common(pos, len)
     return blob_read(pos, len) unless len > MAX_READ_LEN
 
     @split_reads += 1
@@ -67,14 +67,14 @@ module AzureDiskCommon
     ret
   end
 
-  def self.blob_properties
+  def blob_properties
     @blob_properties ||= begin
       options = @snapshot ? {:date => @snapshot} : {}
       @storage_acct.blob_properties(@container, @blob, key, options)
     end
   end
 
-  def self.blob_read(start_byte, length)
+  def blob_read(start_byte, length)
     $log.debug "#{@my_class}#blob_read(#{start_byte}, #{length})"
     options = {
       :start_byte => start_byte,
@@ -93,7 +93,7 @@ module AzureDiskCommon
     ret.body
   end
 
-  def self.key
+  def key
     @key ||= @storage_acct_svc.list_account_keys(@storage_acct.name, @storage_acct.resource_group).fetch('key1')
   end
 end

--- a/lib/disk/modules/AzureDiskCommon.rb
+++ b/lib/disk/modules/AzureDiskCommon.rb
@@ -6,12 +6,12 @@ module AzureDiskCommon
   MAX_READ_LEN  = 1024 * 1024 * 4
   SECTOR_LENGTH = 512
 
-  def self.d_init_common(dInfo)
-    @blockSize        = SECTOR_LENGTH
-    if dInfo.blob_uri
-      d_init_blob_disk(dInfo)
+  def self.d_init_common(d_info)
+    @blockSize = SECTOR_LENGTH
+    if d_info.blob_uri
+      d_init_blob_disk(d_info)
     else
-      d_init_managed_disk(dInfo)
+      d_init_managed_disk(d_info)
     end
     $log.debug "#{@class}: open(#{@disk_path})"
     @t0 = Time.now.to_i
@@ -20,9 +20,9 @@ module AzureDiskCommon
     @split_reads = 0
   end
 
-  def self.d_init_blob_disk(dInfo)
-    @blob_uri         = dInfo.blob_uri
-    @storage_acct_svc = dInfo.storage_acct_svc
+  def self.d_init_blob_disk(d_info)
+    @blob_uri         = d_info.blob_uri
+    @storage_acct_svc = d_info.storage_acct_svc
     @my_class         = "AzureBlobDisk"
     uri_info          = @storage_acct_svc.parse_uri(@blob_uri)
     @container        = uri_info[:container]
@@ -34,10 +34,10 @@ module AzureDiskCommon
     raise "AzureBlob: Storage account #{@acct_name} not found." unless @storage_acct
   end
 
-  def self.d_init_managed_disk(dInfo)
-    @disk_name        = dInfo.disk_name
-    @storage_disk_svc = dInfo.storage_disk_svc
-    @resource_group   = dInfo.resource_group
+  def self.d_init_managed_disk(d_info)
+    @disk_name        = d_info.disk_name
+    @storage_disk_svc = d_info.storage_disk_svc
+    @resource_group   = d_info.resource_group
     @my_class         = "AzureManagedDisk"
     @disk_path        = @disk_name
   end

--- a/lib/disk/modules/AzureManagedDisk.rb
+++ b/lib/disk/modules/AzureManagedDisk.rb
@@ -1,4 +1,6 @@
-require "disk/modules/AzureCommon"
+require "disk/modules/AzureDiskCommon"
+require_relative "../MiqDisk"
+require 'ostruct'
 
 module AzureManagedDisk
 
@@ -13,20 +15,20 @@ module AzureManagedDisk
 
   def d_init
     @diskType         = "azure-managed"
-    @blockSize        = AzureCommon::SECTOR_LENGTH
+    @blockSize        = AzureDiskCommon::SECTOR_LENGTH
     @disk_name        = @dInfo.disk_name
     @storage_disk_svc = @dInfo.storage_disk_svc
     @resource_group   = @dInfo.resource_group
-    AzureCommon.d_init_common(@dInfo)
+    AzureDiskCommon.d_init_common(@dInfo)
   end
 
   def d_close
-    AzureCommon.d_close_common
+    AzureDiskCommon.d_close_common
   end
 
   def d_read(pos, len)
     $log.debug "AzureManagedDisk#d_read(#{pos}, #{len})"
-    AzureCommon.d_read_common(pos, len)
+    AzureDiskCommon.d_read_common(pos, len)
   end
 
   def d_size

--- a/lib/disk/modules/AzureManagedDisk.rb
+++ b/lib/disk/modules/AzureManagedDisk.rb
@@ -3,6 +3,7 @@ require_relative "../MiqDisk"
 require 'ostruct'
 
 module AzureManagedDisk
+  include AzureDiskCommon
   def self.new(svc, disk_name, dInfo = nil)
     d_info = dInfo || OpenStruct.new
     d_info.storage_disk_svc = svc
@@ -14,20 +15,20 @@ module AzureManagedDisk
 
   def d_init
     @diskType         = "azure-managed"
-    @blockSize        = AzureDiskCommon::SECTOR_LENGTH
+    @blockSize        = SECTOR_LENGTH
     @disk_name        = @dInfo.disk_name
     @storage_disk_svc = @dInfo.storage_disk_svc
     @resource_group   = @dInfo.resource_group
-    AzureDiskCommon.d_init_common(@dInfo)
+    d_init_common(@dInfo)
   end
 
   def d_close
-    AzureDiskCommon.d_close_common
+    d_close_common
   end
 
   def d_read(pos, len)
     $log.debug "AzureManagedDisk#d_read(#{pos}, #{len})"
-    AzureDiskCommon.d_read_common(pos, len)
+    d_read_common(pos, len)
   end
 
   def d_size

--- a/lib/disk/modules/AzureManagedDisk.rb
+++ b/lib/disk/modules/AzureManagedDisk.rb
@@ -1,0 +1,95 @@
+require_relative "../MiqDisk"
+require 'ostruct'
+
+module AzureManagedDisk
+  # The maximum read length that supports MD5 return.
+  MAX_READ_LEN = 1024 * 1024 * 4
+
+  def self.new(svc, disk_name, dInfo = nil)
+    d_info = dInfo || OpenStruct.new
+    d_info.storage_disk_svc = svc
+    d_info.disk_name        = disk_name
+    d_info.fileName         = disk_name
+
+    MiqDisk.new(self, d_info, 0)
+  end
+
+  def d_init
+    @diskType         = "azure-managed"
+    @blockSize        = 512
+    @disk_name        = @dInfo.disk_name
+    @storage_disk_svc = @dInfo.storage_disk_svc
+    @resource_group   = @dInfo.resource_group
+
+    $log.debug "AzureManagedDisk: open(#{@disk_name})"
+    @t0 = Time.now.to_i
+    @reads = 0
+    @bytes = 0
+    @split_reads = 0
+  end
+
+  def d_close
+    return nil unless $log.debug?
+    t1 = Time.now.to_i
+    $log.debug "AzureManagedDisk: close(#{@disk_name})"
+    $log.debug "AzureManagedDisk: (#{@disk_name}) time:  #{t1 - @t0}"
+    $log.debug "AzureManagedDisk: (#{@disk_name}) reads: #{@reads}, split_reads: #{@split_reads}"
+    $log.debug "AzureManagedDisk: (#{@disk_name}) bytes: #{@bytes}"
+    nil
+  end
+
+  def d_read(pos, len)
+    $log.debug "AzureManagedDisk#d_read(#{pos}, #{len})"
+    return blob_read(pos, len) unless len > MAX_READ_LEN
+
+    @split_reads += 1
+    ret = ""
+    blocks, rem = len.divmod(MAX_READ_LEN)
+
+    blocks.times do
+      ret << blob_read(pos, MAX_READ_LEN)
+    end
+    ret << blob_read(pos, rem) if rem > 0
+
+    ret
+  end
+
+  def d_size
+    @d_size ||= blob_headers[:content_range].split("/")[1].to_i
+  end
+
+  def d_write(_pos, _buf, _len)
+    raise "Write operation not supported."
+  end
+
+  private
+
+  def blob_read(start_byte, length)
+    $log.debug "AzureManagedDisk#blob_read(#{start_byte}, #{length})"
+    options = {
+      :start_byte => start_byte,
+      :length     => length
+    }
+    # options[:date] = @snapshot if @snapshot
+
+    ret = @storage_disk_svc.get_blob_raw(@disk_name, @resource_group, options)
+    $log.debug "AzureManagedDisk#blob_read read #{disk_name} and returned #{ret.body.length} bytes)"
+
+    @reads += 1
+    @bytes += ret.body.length
+
+    ret.body
+  end
+
+  def blob_headers
+    $log.debug "AzureManagedDisk#blob_headers"
+    @blob_headers ||= begin
+      options = {
+        :start_byte => 0,
+        :length     => 1
+      }
+      data = @storage_disk_svc.get_blob_raw(@disk_name, @resource_group, options)
+      data.headers
+    end
+  end
+end

--- a/lib/disk/modules/AzureManagedDisk.rb
+++ b/lib/disk/modules/AzureManagedDisk.rb
@@ -27,7 +27,7 @@ module AzureManagedDisk
   end
 
   def d_read(pos, len)
-    $log.debug "AzureManagedDisk#d_read(#{pos}, #{len})"
+    $log.debug("AzureManagedDisk#d_read(#{pos}, #{len})")
     d_read_common(pos, len)
   end
 
@@ -42,7 +42,7 @@ module AzureManagedDisk
   private
 
   def blob_headers
-    $log.debug "AzureManagedDisk#blob_headers"
+    $log.debug("AzureManagedDisk#blob_headers")
     @blob_headers ||= begin
       options = {
         :start_byte => 0,

--- a/lib/disk/modules/AzureManagedDisk.rb
+++ b/lib/disk/modules/AzureManagedDisk.rb
@@ -1,9 +1,6 @@
-require_relative "../MiqDisk"
-require 'ostruct'
+require "disk/modules/AzureCommon"
 
 module AzureManagedDisk
-  # The maximum read length that supports MD5 return.
-  MAX_READ_LEN = 1024 * 1024 * 4
 
   def self.new(svc, disk_name, dInfo = nil)
     d_info = dInfo || OpenStruct.new
@@ -16,42 +13,20 @@ module AzureManagedDisk
 
   def d_init
     @diskType         = "azure-managed"
-    @blockSize        = 512
+    @blockSize        = AzureCommon::SECTOR_LENGTH
     @disk_name        = @dInfo.disk_name
     @storage_disk_svc = @dInfo.storage_disk_svc
     @resource_group   = @dInfo.resource_group
-
-    $log.debug "AzureManagedDisk: open(#{@disk_name})"
-    @t0 = Time.now.to_i
-    @reads = 0
-    @bytes = 0
-    @split_reads = 0
+    AzureCommon.d_init_common(@dInfo)
   end
 
   def d_close
-    return nil unless $log.debug?
-    t1 = Time.now.to_i
-    $log.debug "AzureManagedDisk: close(#{@disk_name})"
-    $log.debug "AzureManagedDisk: (#{@disk_name}) time:  #{t1 - @t0}"
-    $log.debug "AzureManagedDisk: (#{@disk_name}) reads: #{@reads}, split_reads: #{@split_reads}"
-    $log.debug "AzureManagedDisk: (#{@disk_name}) bytes: #{@bytes}"
-    nil
+    AzureCommon.d_close_common
   end
 
   def d_read(pos, len)
     $log.debug "AzureManagedDisk#d_read(#{pos}, #{len})"
-    return blob_read(pos, len) unless len > MAX_READ_LEN
-
-    @split_reads += 1
-    ret = ""
-    blocks, rem = len.divmod(MAX_READ_LEN)
-
-    blocks.times do
-      ret << blob_read(pos, MAX_READ_LEN)
-    end
-    ret << blob_read(pos, rem) if rem > 0
-
-    ret
+    AzureCommon.d_read_common(pos, len)
   end
 
   def d_size
@@ -63,23 +38,6 @@ module AzureManagedDisk
   end
 
   private
-
-  def blob_read(start_byte, length)
-    $log.debug "AzureManagedDisk#blob_read(#{start_byte}, #{length})"
-    options = {
-      :start_byte => start_byte,
-      :length     => length
-    }
-    # options[:date] = @snapshot if @snapshot
-
-    ret = @storage_disk_svc.get_blob_raw(@disk_name, @resource_group, options)
-    $log.debug "AzureManagedDisk#blob_read read #{disk_name} and returned #{ret.body.length} bytes)"
-
-    @reads += 1
-    @bytes += ret.body.length
-
-    ret.body
-  end
 
   def blob_headers
     $log.debug "AzureManagedDisk#blob_headers"

--- a/lib/disk/modules/AzureManagedDisk.rb
+++ b/lib/disk/modules/AzureManagedDisk.rb
@@ -3,7 +3,6 @@ require_relative "../MiqDisk"
 require 'ostruct'
 
 module AzureManagedDisk
-
   def self.new(svc, disk_name, dInfo = nil)
     d_info = dInfo || OpenStruct.new
     d_info.storage_disk_svc = svc

--- a/spec/disk/modules/azure_managed_disk_spec.rb
+++ b/spec/disk/modules/azure_managed_disk_spec.rb
@@ -1,0 +1,165 @@
+require 'ostruct'
+require 'azure-armrest'
+require 'disk/modules/AzureManagedDisk'
+require 'vcr'
+
+describe AzureManagedDisk do
+  before(:all) do
+    @test_env = TestEnvHelper.new(__FILE__)
+    @test_env.vcr_filter
+
+    @client_id            = @test_env[:azure_client_id]
+    @client_key           = @test_env[:azure_client_key]
+    @tenant_id            = @test_env[:azure_tenant_id]
+    @subscription_id      = @test_env[:azure_subscription_id]
+    @disk_name            = @test_env[:azure_disk_name]
+    @resource_group       = @test_env[:resource_group]
+
+    @test_env.ensure_recording_dir_exists
+  end
+
+  before(:each) do |example|
+    Azure::Armrest::Configuration.clear_caches
+    #
+    # Each example has its own cassette file.
+    # These cassette files are named based on the spec file name, the example group
+    # containing the example, and the example's tag (example.metadata[:ex_tag]):
+    #     <spec_name><example_group_description>-<example_ex_tag>
+    # For example:
+    #     azure_managed_disk_spec_new-1.yml
+    #
+    example_id = "#{example.example_group.description}-#{example.metadata[:ex_tag]}"
+    cassette_name = @test_env.cassette_for(example_id)
+    VCR.insert_cassette(cassette_name, :decode_compressed_response => true)
+
+    @azure_config = Azure::Armrest::ArmrestService.configure(
+      :client_id       => @client_id,
+      :client_key      => @client_key,
+      :tenant_id       => @tenant_id,
+      :subscription_id => @subscription_id,
+    )
+
+    @disk_service          = Azure::Armrest::Storage::DiskService.new(@azure_config)
+    @d_info                = OpenStruct.new
+    @d_info.resource_group = @resource_group
+  end
+
+  after(:each) do
+    VCR.eject_cassette
+  end
+
+  describe ".new" do
+    it "should raise an error, given a bad disk name", :ex_tag => 1 do
+      expect do
+        AzureManagedDisk.new(@disk_service, "this_is_not_a_disk_name", @d_info)
+      end.to raise_error(Azure::Armrest::NotFoundException)
+    end
+
+    it "should return an MiqDisk object", :ex_tag => 2 do
+      miq_disk = AzureManagedDisk.new(@disk_service, @disk_name, @d_info)
+      expect(miq_disk).to be_kind_of(MiqDisk)
+    end
+  end
+
+  describe "Instance methods" do
+    before(:each) do
+      @miq_disk = AzureManagedDisk.new(@disk_service, @disk_name, @d_info)
+    end
+
+    describe "#diskType" do
+      it "should return the expected disk type", :ex_tag => 1 do
+        expect(@miq_disk.diskType).to eq("azure-managed")
+      end
+    end
+
+    describe "#partType" do
+      it "should return the expected partition type", :ex_tag => 1 do
+        expect(@miq_disk.partType).to eq(0)
+      end
+    end
+
+    describe "#partNum" do
+      it "should return 0 for the whole disk", :ex_tag => 1 do
+        expect(@miq_disk.partNum).to eq(0)
+      end
+    end
+
+    describe "#blockSize" do
+      it "should return the expected block size", :ex_tag => 1 do
+        expect(@miq_disk.blockSize).to eq(512)
+      end
+    end
+
+    # describe "#size" do
+      # it "should return the size of the disk in bytes", :ex_tag => 1 do
+        # expect(@miq_disk.size).to eq(16_492_674_678_784)
+      # end
+    # end
+
+    describe "#lbaStart" do
+      it "should return the expected start logical block address", :ex_tag => 1 do
+        expect(@miq_disk.lbaStart).to eq(0)
+      end
+    end
+
+    describe "#lbaEnd" do
+      it "should return the expected end logical block address", :ex_tag => 1 do
+        expect(@miq_disk.lbaEnd).to eq(34_359_738_880)
+      end
+    end
+
+    describe "#startByteAddr" do
+      it "should return the expected start byte address", :ex_tag => 1 do
+        expect(@miq_disk.startByteAddr).to eq(0)
+      end
+    end
+
+    describe "#endByteAddr" do
+      it "should return the expected end byte address", :ex_tag => 1 do
+        expect(@miq_disk.endByteAddr).to eq(17_592_186_306_560)
+      end
+
+      it "should return a value consistent with the other values", :ex_tag => 2 do
+        expect(@miq_disk.endByteAddr).to eq(@miq_disk.startByteAddr + @miq_disk.lbaEnd * @miq_disk.blockSize)
+      end
+    end
+
+    describe "#getPartitions" do
+      it "should return an array", :ex_tag => 1 do
+        expect(@miq_disk.getPartitions).to be_kind_of(Array)
+      end
+
+      it "should return the expected number of partitions", :ex_tag => 1 do
+        parts = @miq_disk.getPartitions
+        expect(parts.length).to eq(2)
+      end
+
+      it "should return instances of MiqPartition", :ex_tag => 1 do
+        parts = @miq_disk.getPartitions
+        parts.each do |p|
+          expect(p).to be_kind_of(MiqPartition)
+        end
+      end
+
+      it "partition info should be consistent with the parent disk", :ex_tag => 1 do
+        parts = @miq_disk.getPartitions
+        parts.each do |p|
+          expect(p.partNum).to_not eq(0)
+          expect(p.size).to be < @miq_disk.size
+
+          expect(p.lbaStart).to be > @miq_disk.lbaStart
+          expect(p.lbaStart).to be < @miq_disk.lbaEnd
+
+          expect(p.lbaEnd).to be > @miq_disk.lbaStart
+          expect(p.lbaEnd).to be < @miq_disk.lbaEnd
+
+          expect(p.startByteAddr).to be > @miq_disk.startByteAddr
+          expect(p.startByteAddr).to be < @miq_disk.endByteAddr
+
+          expect(p.endByteAddr).to be > @miq_disk.startByteAddr
+          expect(p.endByteAddr).to be < @miq_disk.endByteAddr
+        end
+      end
+    end
+  end
+end

--- a/spec/disk/modules/azure_managed_disk_spec.rb
+++ b/spec/disk/modules/azure_managed_disk_spec.rb
@@ -90,11 +90,11 @@ describe AzureManagedDisk do
       end
     end
 
-    # describe "#size" do
-      # it "should return the size of the disk in bytes", :ex_tag => 1 do
-        # expect(@miq_disk.size).to eq(16_492_674_678_784)
-      # end
-    # end
+    describe "#size" do
+      it "should return the size of the disk in bytes", :ex_tag => 1 do
+        expect(@miq_disk.size).to eq(17_592_186_306_560)
+      end
+    end
 
     describe "#lbaStart" do
       it "should return the expected start logical block address", :ex_tag => 1 do

--- a/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_blockSize-1.yml
+++ b/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_blockSize-1.yml
@@ -1,0 +1,2277 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://login.microsoftonline.com/azure_tenant_id/oauth2/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_key&resource=https%3A%2F%2Fmanagement.azure.com%2F
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - login.microsoftonline.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Server:
+      - Microsoft-IIS/8.5
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Request-Id:
+      - c5f2c503-8aaf-4f66-9e74-54d029b61200
+      P3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Set-Cookie:
+      - esctx=AQABAAAAAAA9kTklhVy7SJTGAzR-p1Bc23l5NNrJW4NWJObtN0mtsBSdfkC6uLc8qDZ7GP9rg1u2i6TTVtim4BZqbK6UYdbactaup5w1wU-eCiSPOajCnOrvAbVoR7uqxs0g0BtuR2by1vlAV5XMpOQvjtCwrFQS-daIeVhAd7Sp1dedQuu91T6eclju_vlUBe9gMkGZOP0gAA;
+        domain=.login.microsoftonline.com; path=/; secure; HttpOnly
+      - stsservicecookie=ests; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=003; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Wed, 30 Aug 2017 15:33:13 GMT
+      Content-Length:
+      - '1505'
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1504110793","not_before":"1504106893","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4OTMsIm5iZiI6MTUwNDEwNjg5MywiZXhwIjoxNTA0MTEwNzkzLCJhaW8iOiJZMkZnWUxqMzhzM2FiajRtanF6SlFaa3o2bDdmQlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQThYeXhhLUtaay1lZEZUUUtiWVNBQSIsInZlciI6IjEuMCJ9.ELUphz8vjoMqBXevzTRi0mBKIgmQED3FfZB8GRQEu70iaS2LLCWUX0yXjwnJsIxcY6Ep5EQrVoAub_lPjMR-ZJ8ANF-N9yo-9S0h4e-e3OAU5G2Aw_pkLLKYNac3xIyTS-rMO1YtNWGrMpgeHSb8fIRE1sn67x-EYIBAKtQgcUY-kwsl5rfgSrD1hHOZ3b6mtaMcHPcZU5L2Rq9Wnmg1aG5-mlNLEirawEQx6MNoQ_uBsUlWRXRbm0-xuJWTwc1PJCwHbrSLJeOXixLVcVNLfBH8-EimNa-aUAdk3E85xEHi46w1NUOR-zc3O-QYBNG67slcdV3w0gOlTurDyji9OA"}'
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:12 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions?api-version=2016-06-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4OTMsIm5iZiI6MTUwNDEwNjg5MywiZXhwIjoxNTA0MTEwNzkzLCJhaW8iOiJZMkZnWUxqMzhzM2FiajRtanF6SlFaa3o2bDdmQlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQThYeXhhLUtaay1lZEZUUUtiWVNBQSIsInZlciI6IjEuMCJ9.ELUphz8vjoMqBXevzTRi0mBKIgmQED3FfZB8GRQEu70iaS2LLCWUX0yXjwnJsIxcY6Ep5EQrVoAub_lPjMR-ZJ8ANF-N9yo-9S0h4e-e3OAU5G2Aw_pkLLKYNac3xIyTS-rMO1YtNWGrMpgeHSb8fIRE1sn67x-EYIBAKtQgcUY-kwsl5rfgSrD1hHOZ3b6mtaMcHPcZU5L2Rq9Wnmg1aG5-mlNLEirawEQx6MNoQ_uBsUlWRXRbm0-xuJWTwc1PJCwHbrSLJeOXixLVcVNLfBH8-EimNa-aUAdk3E85xEHi46w1NUOR-zc3O-QYBNG67slcdV3w0gOlTurDyji9OA
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Tenant-Reads:
+      - '14996'
+      X-Ms-Request-Id:
+      - 7b3c267a-553a-4830-890b-7cf0605b141e
+      X-Ms-Correlation-Request-Id:
+      - 7b3c267a-553a-4830-890b-7cf0605b141e
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153312Z:7b3c267a-553a-4830-890b-7cf0605b141e
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 30 Aug 2017 15:33:12 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
+        Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:12 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers?api-version=2015-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4OTMsIm5iZiI6MTUwNDEwNjg5MywiZXhwIjoxNTA0MTEwNzkzLCJhaW8iOiJZMkZnWUxqMzhzM2FiajRtanF6SlFaa3o2bDdmQlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQThYeXhhLUtaay1lZEZUUUtiWVNBQSIsInZlciI6IjEuMCJ9.ELUphz8vjoMqBXevzTRi0mBKIgmQED3FfZB8GRQEu70iaS2LLCWUX0yXjwnJsIxcY6Ep5EQrVoAub_lPjMR-ZJ8ANF-N9yo-9S0h4e-e3OAU5G2Aw_pkLLKYNac3xIyTS-rMO1YtNWGrMpgeHSb8fIRE1sn67x-EYIBAKtQgcUY-kwsl5rfgSrD1hHOZ3b6mtaMcHPcZU5L2Rq9Wnmg1aG5-mlNLEirawEQx6MNoQ_uBsUlWRXRbm0-xuJWTwc1PJCwHbrSLJeOXixLVcVNLfBH8-EimNa-aUAdk3E85xEHi46w1NUOR-zc3O-QYBNG67slcdV3w0gOlTurDyji9OA
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14950'
+      X-Ms-Request-Id:
+      - b06f0664-12c6-41b2-8747-664f4a48857b
+      X-Ms-Correlation-Request-Id:
+      - b06f0664-12c6-41b2-8747-664f4a48857b
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153313Z:b06f0664-12c6-41b2-8747-664f4a48857b
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 30 Aug 2017 15:33:13 GMT
+      Content-Length:
+      - '241615'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","North Central
+        US","South Central US","West Central US","West US","West US 2","Canada Central","Canada
+        East","North Europe","West Europe","UK South","UK West","East Asia","Southeast
+        Asia","Japan East","Japan West","Korea Central","Korea South","Brazil South","Central
+        India","South India","West India"],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"validateServiceName","locations":[],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"checkServiceNameAvailability","locations":[],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"reportFeedback","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"checkFeedbackRequired","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Automation","namespace":"Microsoft.Automation","authorizations":[{"applicationId":"fc75330b-179d-49af-87dd-3b1acf6827fa","roleDefinitionId":"95fd5de3-d071-4362-92bf-cf341c1de832"}],"resourceTypes":[{"resourceType":"automationAccounts","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
+        South","UK South","West Central US","North Europe","Canada Central","Australia
+        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/runbooks","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
+        South","UK South","West Central US","North Europe","Canada Central","Australia
+        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/configurations","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","North
+        Central US","Brazil South","UK South","West Central US","Central India","Australia
+        Southeast","Canada Central","North Europe"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/webhooks","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
+        South","UK South","West Central US","North Europe","Canada Central","Australia
+        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"operations","locations":["South
+        Central US"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/softwareUpdateConfigurations","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
+        South","UK South","West Central US","North Europe","Canada Central","Australia
+        Southeast","Central India"],"apiVersions":["2017-05-15-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Backup","namespace":"Microsoft.Backup","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"BackupVault","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India"],"apiVersions":["2015-03-15","2014-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Batch","namespace":"Microsoft.Batch","authorization":{"applicationId":"ddbf3205-c6bd-46ae-8127-60eb93363864","roleDefinitionId":"b7f84953-1d03-4eab-9ea4-45f065258ff8"},"resourceTypes":[{"resourceType":"batchAccounts","locations":["West
+        Europe","East US","East US 2","West US","North Central US","Brazil South","North
+        Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
+        West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
+        East","South India","Central India","Canada Central","Canada East","UK South","UK
+        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01","2015-07-01","2014-05-01-privatepreview"]},{"resourceType":"operations","locations":["West
+        Europe","East US","East US 2","West US","North Central US","Brazil South","North
+        Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
+        West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
+        East","South India","Central India","Canada Central","Canada East","UK South","UK
+        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations/quotas","locations":["West
+        Europe","East US","East US 2","West US","North Central US","Brazil South","North
+        Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
+        West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
+        East","South India","Central India","Canada Central","Canada East","UK South","UK
+        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]}],"registrationState":"Unregistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicCompute","namespace":"Microsoft.ClassicCompute","resourceTypes":[{"resourceType":"domainNames","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
+        Central","Canada East","UK South","UK West","West US","Central US","South
+        Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
+        East","Australia Southeast","West US 2","West Central US","South India","Central
+        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
+        Central","Canada East","UK South","UK West","West US","Central US","South
+        Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
+        East","Australia Southeast","West US 2","West Central US","South India","Central
+        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
+        Central US","South Central US","East US","East US 2","Canada Central","Canada
+        East","West US","West US 2","West Central US","Central US","East Asia","Southeast
+        Asia","North Europe","West Europe","UK South","UK West","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operatingSystems","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"operatingSystemFamilies","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicNetwork","namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"virtualNetworks/remoteVirtualNetworkPeeringProxies","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"reservedIps","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicStorage","namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
+        US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
+        Asia","Australia East","Australia Southeast","South India","Central India","West
+        India","West US 2","West Central US","East US","East US 2","North Central
+        US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
+        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
+        US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
+        Asia","Australia East","Australia Southeast","South India","Central India","West
+        India","West US 2","West Central US","East US","East US 2","North Central
+        US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
+        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"vmImages","locations":[],"apiVersions":["2016-11-01"]},{"resourceType":"publicImages","locations":[],"apiVersions":["2016-11-01","2016-04-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"osPlatformImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Compute","namespace":"Microsoft.Compute","authorization":{"applicationId":"60e6cd67-9c8c-4951-9b3c-23c25a2169af","roleDefinitionId":"e4770acb-272e-4dc8-87f3-12f44a612224"},"resourceTypes":[{"resourceType":"availabilitySets","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30"]},{"resourceType":"locations/usages","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"disks","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"snapshots","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"locations/diskoperations","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"images","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
+        US","East US","South Central US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","East Asia","Japan
+        East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/webhooks","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/ping","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/getCallbackConfig","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/listEvents","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"locations","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"locations/operationResults","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/GetCredentials","locations":["West
+        US","East US","South Central US","West Europe"],"apiVersions":["2016-06-27-preview"]},{"resourceType":"registries/listCredentials","locations":["South
+        Central US","East US","West US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","East Asia","Japan
+        East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/regenerateCredential","locations":["South
+        Central US","West US","East US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","East Asia","Japan
+        East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/listUsages","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/regenerateCredentials","locations":["West
+        US","East US","South Central US","West Europe"],"apiVersions":["2016-06-27-preview"]},{"resourceType":"checkNameAvailability","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview","2017-03-01","2016-06-27-preview"]},{"resourceType":"operations","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview","2017-03-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerService","namespace":"Microsoft.ContainerService","authorization":{"applicationId":"7319c514-987d-4e9b-ac3d-d38c4f427f4c","roleDefinitionId":"1b4a0c7f-2217-416f-acfa-cf73452fdc1c"},"resourceTypes":[{"resourceType":"containerServices","locations":["Japan
+        East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
+        East","Australia Southeast","Brazil South","Southeast Asia","West US","North
+        Central US","West Europe","North Europe","East US","UK West","UK South","West
+        Central US","West US 2","South India","Central India","West India","Canada
+        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
+        East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
+        East","Australia Southeast","Brazil South","Southeast Asia","West US","North
+        Central US","West Europe","North Europe","East US","UK West","UK South","West
+        Central US","West US 2","South India","Central India","West India","Canada
+        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DevTestLab","namespace":"Microsoft.DevTestLab","authorization":{"applicationId":"1a14be2a-e903-4cec-99cf-b2e209259a0f","roleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525"},"resourceTypes":[{"resourceType":"labs","locations":["West
+        Central US","Japan East","West US","Australia Southeast","Canada Central","Central
+        India","Central US","East Asia","Korea Central","North Europe","South Central
+        US","UK West","Australia East","Brazil South","Canada East","East US","East
+        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"schedules","locations":["West
+        Central US","Japan East","West US","Australia Southeast","Canada Central","Central
+        India","Central US","East Asia","Korea Central","North Europe","South Central
+        US","UK West","Australia East","Brazil South","Canada East","East US","East
+        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"labs/virtualMachines","locations":["West
+        Central US","Japan East","West US","Australia Southeast","Canada Central","Central
+        India","Central US","East Asia","Korea Central","North Europe","South Central
+        US","UK West","Australia East","Brazil South","Canada East","East US","East
+        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"labs/serviceRunners","locations":["Central
+        US","East US 2","South Central US"],"apiVersions":["2017-04-26-preview","2016-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"locations/operations","locations":["West
+        Central US","Japan East","West US","Australia Southeast","Canada Central","Central
+        India","Central US","East Asia","Korea Central","North Europe","South Central
+        US","UK West","Australia East","Brazil South","Canada East","East US","East
+        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"}],"resourceTypes":[{"resourceType":"components","locations":["East
+        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
+        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01","2014-04-01"]},{"resourceType":"queries","locations":["East
+        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"alertrules","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2016-03-01","2015-04-01","2014-04-01"]},{"resourceType":"autoscalesettings","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2015-04-01","2014-04-01"]},{"resourceType":"eventtypes","locations":[],"apiVersions":["2017-03-01-preview","2016-09-01-preview","2015-04-01","2014-11-01","2014-04-01"]},{"resourceType":"locations","locations":["East
+        US"],"apiVersions":["2015-04-01","2014-04-01"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2015-04-01","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-04-01","2014-06-01","2014-04-01"]},{"resourceType":"automatedExportSettings","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2015-04-01","2014-04-01"]},{"resourceType":"diagnosticSettings","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2017-05-01-preview","2016-09-01","2015-07-01"]},{"resourceType":"diagnosticSettingsCategories","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"extendedDiagnosticSettings","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2017-02-01"]},{"resourceType":"metricDefinitions","locations":["East
+        US","West US","West Europe","East Asia","Southeast Asia","Japan East","Japan
+        West","North Central US","South Central US","East US 2","Canada East","Canada
+        Central","Central US","Australia East","Australia Southeast","Brazil South","South
+        India","Central India","West India","North Europe","West US 2","West Central
+        US","Korea South","Korea Central","UK South","UK West","Global"],"apiVersions":["2017-05-01-preview","2016-03-01","2015-07-01"]},{"resourceType":"logDefinitions","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2015-07-01"]},{"resourceType":"eventCategories","locations":[],"apiVersions":["2015-04-01"]},{"resourceType":"metrics","locations":["East
+        US","West US","West Europe","East Asia","Southeast Asia","Japan East","Japan
+        West","North Central US","South Central US","East US 2","Canada East","Canada
+        Central","Central US","Australia East","Australia Southeast","Brazil South","South
+        India","Central India","West India","North Europe","West US 2","West Central
+        US","Korea South","Korea Central","UK South","UK West"],"apiVersions":["2017-05-01-preview","2016-09-01","2016-06-01"]},{"resourceType":"actiongroups","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]},{"resourceType":"activityLogAlerts","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.KeyVault","namespace":"Microsoft.KeyVault","resourceTypes":[{"resourceType":"vaults","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/accessPolicies","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-10-01","2015-06-01","2014-12-19-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"deletedVaults","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-10-01"]},{"resourceType":"locations/deletedVaults","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorization":{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"routeTables","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2017-04-26-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"]},{"resourceType":"workspaces/dataSources","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"storageInsightConfigs","locations":[],"apiVersions":["2014-10-10"]},{"resourceType":"workspaces/linkedServices","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"linkTargets","locations":["East
+        US"],"apiVersions":["2015-03-20"]},{"resourceType":"operations","locations":[],"apiVersions":["2014-11-10"]},{"resourceType":"devices","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationsManagement","namespace":"Microsoft.OperationsManagement","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"aa249101-6816-4966-aafa-08175d795f14"},"resourceTypes":[{"resourceType":"solutions","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Portal","namespace":"Microsoft.Portal","resourceTypes":[{"resourceType":"dashboards","locations":["Central
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
+        East","West India","South India","Central India","Canada Central","Canada
+        East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"operations","locations":["Central
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
+        East","West India","South India","Central India","Canada Central","Canada
+        East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"consoles","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/consoles","locations":["West
+        US","East US","Central India","North Europe","West Europe","South Central
+        US","Southeast Asia"],"apiVersions":["2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
+        US","East US","Central India","North Europe","West Europe","South Central
+        US","Southeast Asia"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","Canada Central","Canada East","West Central US","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-07-01","2016-12-01","2016-08-10","2016-06-01","2016-05-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"operations","locations":["Southeast
+        Asia"],"apiVersions":["2016-08-10","2016-06-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01"]},{"resourceType":"locations/backupStatus","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]},{"resourceType":"locations/allocatedStamp","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]},{"resourceType":"locations/allocateStamp","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ResourceHealth","namespace":"Microsoft.ResourceHealth","authorization":{"applicationId":"8bdebf23-c0fe-4187-a378-717ad86f6a53","roleDefinitionId":"cc026344-c8b1-4561-83ba-59eba84b27cc"},"resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2017-07-01","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"notifications","locations":["Australia
+        Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Security","namespace":"Microsoft.Security","authorization":{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatuses","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/virtualMachines","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/endpoints","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/subnets","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"tasks","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"alerts","locations":["Central
+        US","East US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"monitoring","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"monitoring/patch","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"monitoring/baseline","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"monitoring/antimalware","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"dataCollectionAgents","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"dataCollectionResults","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"pricings","locations":["Central
+        US","East US"],"apiVersions":["2017-08-01-preview"]},{"resourceType":"complianceResults","locations":["Central
+        US","East US"],"apiVersions":["2017-08-01"]},{"resourceType":"policies","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"appliances","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"webApplicationFirewalls","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/webApplicationFirewalls","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securitySolutions","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/securitySolutions","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securitySolutionsReferenceData","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/securitySolutionsReferenceData","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"jitNetworkAccessPolicies","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/jitNetworkAccessPolicies","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatusesSummaries","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/alerts","locations":["Central
+        US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/tasks","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.SiteRecovery","namespace":"Microsoft.SiteRecovery","authorization":{"applicationId":"b8340c3b-9267-498f-b21a-15d5547fd85e","roleDefinitionId":"8A00C8EA-8F1B-45A7-8F64-F4CC61EEE9B6"},"resourceTypes":[{"resourceType":"SiteRecoveryVault","locations":["East
+        US","West US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","Australia East","Australia Southeast","Brazil South","North
+        Central US","South Central US","Central US","East US 2","Central India","South
+        India"],"apiVersions":["2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Sql","namespace":"Microsoft.Sql","authorizations":[{"applicationId":"e4ab13ed-33cb-41b4-9140-6e264582cf85","roleDefinitionId":"ec3ddc95-44dc-47a2-9926-5e9f5ffd44ec"},{"applicationId":"0130cc9f-7ac5-4026-bd5f-80a08a54e6d9","roleDefinitionId":"45e8abf8-0ec4-44f3-9c37-cff4f7779302"},{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},{"applicationId":"76c7f279-7959-468f-8943-3954880e0d8c","roleDefinitionId":"7f7513a8-73f9-4c5f-97a2-c41f0ea783ef"}],"resourceTypes":[{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/capabilities","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverKeyOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/keys","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/encryptionProtector","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/communicationLinks","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recoverableDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/importExportOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/operationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/firewallrules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/elasticpools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-09-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/dnsAliases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/failoverGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/virtualNetworkRules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/virtualNetworkRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/virtualNetworkRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/databaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/extensions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditRecords","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/VulnerabilityAssessmentScans","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentScans","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups/syncMembers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/syncAgents","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncMemberOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncAgentOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncDatabaseIds","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorization":{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
+        US","West US","West Europe","North Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":["East
+        US","West US","West Europe","North Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Web","namespace":"Microsoft.Web","authorization":{"applicationId":"abfa0a7c-a6b6-4736-8310-5855508787cd","roleDefinitionId":"f47ed98b-b063-4a5b-9e10-4b9b44fa7735"},"resourceTypes":[{"resourceType":"sites/extensions","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots/extensions","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/instances","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots/instances","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/instances/extensions","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots/instances/extensions","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/publicCertificates","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots/publicCertificates","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"publishingUsers","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"ishostnameavailable","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"validate","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"isusernameavailable","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sourceControls","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"availableStacks","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"listSitesAssignedToHostName","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"sites/hostNameBindings","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"sites/domainOwnershipIdentifiers","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"sites/slots/hostNameBindings","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"operations","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"certificates","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms/workers","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"runtimes","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"sites/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"sites/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"sites/slots/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"sites/slots/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"serverFarms/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"serverFarms/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"sites/recommendations","locations":[],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"georegions","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/premieraddons","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01"]},{"resourceType":"hostingEnvironments","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/instances","locations":[],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/instances/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/instances/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/instances","locations":[],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/instances/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/instances/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"deploymentLocations","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"functions","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"deletedSites","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"ishostingenvironmentnameavailable","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"classicMobileServices","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"connections","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/managedApis","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/apiOperations","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"connectionGateways","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/connectionGatewayInstallations","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"checkNameAvailability","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"billingMeters","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/84codes.CloudAMQP","namespace":"84codes.CloudAMQP","resourceTypes":[{"resourceType":"servers","locations":["East
+        US 2","Central US","East US","North Central US","South Central US","West US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast"],"apiVersions":["2016-08-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/AppDynamics.APM","namespace":"AppDynamics.APM","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2016-05-26"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-05-26"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-05-26"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-05-26"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-05-26"]},{"resourceType":"locations/operationResults","locations":["West
+        US"],"apiVersions":["2016-05-26"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Aspera.Transfers","namespace":"Aspera.Transfers","resourceTypes":[{"resourceType":"services","locations":["West
+        US","North Europe","Central US","East US","West Europe","East Asia","Southeast
+        Asia","Japan East","East US 2","Japan West"],"apiVersions":["2016-03-25"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-03-25"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-03-25"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-03-25"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Auth0.Cloud","namespace":"Auth0.Cloud","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-11-23"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Citrix.Cloud","namespace":"Citrix.Cloud","resourceTypes":[{"resourceType":"accounts","locations":["West
+        US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Cloudyn.Analytics","namespace":"Cloudyn.Analytics","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US"],"apiVersions":["2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Conexlink.MyCloudIT","namespace":"Conexlink.MyCloudIT","resourceTypes":[{"resourceType":"accounts","locations":["Central
+        US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Crypteron.DataSecurity","namespace":"Crypteron.DataSecurity","resourceTypes":[{"resourceType":"apps","locations":["West
+        US"],"apiVersions":["2016-08-12"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-12"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-12"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-12"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Dynatrace.DynatraceSaaS","namespace":"Dynatrace.DynatraceSaaS","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-09-27"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Dynatrace.Ruxit","namespace":"Dynatrace.Ruxit","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US"],"apiVersions":["2016-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-09-07","2016-04-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-04-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/LiveArena.Broadcast","namespace":"LiveArena.Broadcast","resourceTypes":[{"resourceType":"services","locations":["West
+        US","North Europe","Japan West","Japan East","East Asia","West Europe","East
+        US","Southeast Asia","Central US"],"apiVersions":["2016-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Lombiq.DotNest","namespace":"Lombiq.DotNest","resourceTypes":[{"resourceType":"sites","locations":["East
+        US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Mailjet.Email","namespace":"Mailjet.Email","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]},{"resourceType":"diagnosticSettings","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"addsservices","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"configuration","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"agents","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"aadsupportcases","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"reports","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"servicehealthmetrics","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"logs","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"anonymousapiusers","locations":["West
+        US"],"apiVersions":["2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AnalysisServices","namespace":"Microsoft.AnalysisServices","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"servers","locations":["West
+        US","North Europe","South Central US","West Europe","West Central US","Southeast
+        Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
+        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/checkNameAvailability","locations":["West
+        US","North Europe","South Central US","West Europe","West Central US","Southeast
+        Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
+        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationresults","locations":["West
+        US","North Europe","South Central US","West Europe","West Central US","Southeast
+        Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
+        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationstatuses","locations":["West
+        US","North Europe","South Central US","West Europe","West Central US","Southeast
+        Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
+        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"operations","locations":["East
+        US 2","West Central US"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AppService","namespace":"Microsoft.AppService","authorization":{"applicationId":"dee7ba80-6a55-4f3b-a86c-746a9231ae49","roleDefinitionId":"6715d172-49c4-46f6-bb21-60512a8689dc"},"resourceTypes":[{"resourceType":"apiapps","locations":["East
+        US","West US","South Central US","North Europe","East Asia","Japan East","West
+        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
+        South","East US 2","Australia Southeast","Australia East","West India","South
+        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"appIdentities","locations":["East
+        US","West US","South Central US","North Europe","East Asia","Japan East","West
+        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
+        South","East US 2","Australia Southeast","Australia East","West India","South
+        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"gateways","locations":["East
+        US","West US","South Central US","North Europe","East Asia","Japan East","West
+        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
+        South","East US 2","Australia Southeast","Australia East","West India","South
+        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"deploymenttemplates","locations":[],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Authorization","namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"roleDefinitions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"classicAdministrators","locations":[],"apiVersions":["2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"permissions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"locks","locations":[],"apiVersions":["2017-04-01","2016-09-01","2015-06-01","2015-05-01-preview","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-01-01","2014-10-01-preview","2014-06-01"]},{"resourceType":"policyDefinitions","locations":[],"apiVersions":["2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"policySetDefinitions","locations":[],"apiVersions":["2017-06-01-preview"]},{"resourceType":"policyAssignments","locations":[],"apiVersions":["2017-06-01-preview","2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"providerOperations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01-preview","2015-07-01"]},{"resourceType":"elevateAccess","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureActiveDirectory","namespace":"Microsoft.AzureActiveDirectory","resourceTypes":[{"resourceType":"b2cDirectories","locations":["Global","United
+        States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureStack","namespace":"Microsoft.AzureStack","resourceTypes":[{"resourceType":"operations","locations":["Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations","locations":["West
+        Central US","Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations/products","locations":["West
+        Central US","Global"],"apiVersions":["2017-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Billing","namespace":"Microsoft.Billing","resourceTypes":[{"resourceType":"BillingPeriods","locations":["Central
+        US"],"apiVersions":["2017-04-24-preview"]},{"resourceType":"Invoices","locations":["Central
+        US"],"apiVersions":["2017-04-24-preview","2017-02-27-preview"]},{"resourceType":"operations","locations":["Central
+        US"],"apiVersions":["2017-04-24-preview","2017-02-27-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BingMaps","namespace":"Microsoft.BingMaps","resourceTypes":[{"resourceType":"mapApis","locations":["West
+        US"],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-18","2015-07-02"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BizTalkServices","namespace":"Microsoft.BizTalkServices","resourceTypes":[{"resourceType":"BizTalk","locations":["East
+        US","West US","North Europe","West Europe","Southeast Asia","East Asia","North
+        Central US","Japan West","Japan East","South Central US"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Cache","namespace":"Microsoft.Cache","authorization":{"applicationId":"96231a05-34ce-4eb4-aa6a-70759cbb5e83","roleDefinitionId":"4f731528-ba85-45c7-acfb-cd0a9b3cf31b"},"resourceTypes":[{"resourceType":"Redis","locations":["North
+        Central US","South Central US","Central US","West Europe","North Europe","West
+        US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
+        Asia","East Asia","Australia East","Australia Southeast","Central India","West
+        India","Canada Central","Canada East","UK South","UK West","West US 2","West
+        Central US","South India","Korea Central","Korea South"],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","South Central US","Central US","West Europe","North Europe","West
+        US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
+        Asia","East Asia","Australia East","Australia Southeast","Central India","West
+        India","South India","Canada Central","Canada East","UK South","UK West","West
+        US 2","West Central US","Korea Central","Korea South"],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01"]},{"resourceType":"Redis/metricDefinitions","locations":["North
+        Central US","South Central US","East US","East US 2","West US","Central US","East
+        Asia","Southeast Asia","North Europe","West Europe","Japan East","Japan West","Brazil
+        South","Australia Southeast","Australia East","Central India","West India","South
+        India","Canada Central","Canada East","UK West","UK South","West US 2","West
+        Central US","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"Redis/diagnosticSettings","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","West
+        US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
+        Asia","Australia East","Australia Southeast","Central India","West India","South
+        India","Canada Central","Canada East","UK West","UK South","West US 2","West
+        Central US","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Cdn","namespace":"Microsoft.Cdn","resourceTypes":[{"resourceType":"profiles","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/origins","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/customdomains","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/originresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/customdomainresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkResourceUsage","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02"]},{"resourceType":"validateProbe","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"edgenodes","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CertificateRegistration","namespace":"Microsoft.CertificateRegistration","authorization":{"applicationId":"f3c21649-0979-4721-ac85-b0216b2cf413","roleDefinitionId":"933fba7e-2ed3-4da8-973d-8bd8298a9b40"},"resourceTypes":[{"resourceType":"certificateOrders","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"certificateOrders/certificates","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"validateCertificateRegistrationInformation","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicSubscription","namespace":"Microsoft.ClassicSubscription","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicInfrastructureMigrate","namespace":"Microsoft.ClassicInfrastructureMigrate","authorization":{"applicationId":"5e5abe2b-83cd-4786-826a-a05653ebb103","roleDefinitionId":"766c4d9b-ef83-4f73-8352-1450a506a69b"},"resourceTypes":[{"resourceType":"classicInfrastructureResources","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","West
+        India","South India"],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CognitiveServices","namespace":"Microsoft.CognitiveServices","authorizations":[{"applicationId":"7d312290-28c8-473c-a0ed-8e53749b6d6d","roleDefinitionId":"5cb87f79-a7c3-4a95-9414-45b65974b51b"}],"resourceTypes":[{"resourceType":"accounts","locations":["Global","West
+        US","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"operations","locations":["Global","West
+        US","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations","locations":["Global","West
+        US","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/checkSkuAvailability","locations":["West
+        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/updateAccountsCreationSettings","locations":["West
+        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/accountsCreationSettings","locations":["West
+        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2016-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Commerce","namespace":"Microsoft.Commerce","resourceTypes":[{"resourceType":"UsageAggregates","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]},{"resourceType":"RateCard","locations":[],"apiVersions":["2016-08-31-preview","2015-06-01-preview","2015-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Consumption","namespace":"Microsoft.Consumption","resourceTypes":[{"resourceType":"reservationsummaries","locations":[],"apiVersions":["2017-01-30"]},{"resourceType":"reservationdetails","locations":[],"apiVersions":["2017-01-30"]},{"resourceType":"UsageDetails","locations":[],"apiVersions":["2017-06-30-preview","2017-04-24-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-30-preview","2017-04-24-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","resourceTypes":[{"resourceType":"containerGroups","locations":["West
+        US","East US","West Europe"],"apiVersions":["2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
+        US"],"apiVersions":["2016-04-08"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CustomerInsights","namespace":"Microsoft.CustomerInsights","authorization":{"applicationId":"38c77d00-5fcb-4cce-9d93-af4738258e3c","roleDefinitionId":"E006F9C7-F333-477C-8AD6-1F3A9FE87F55"},"resourceTypes":[{"resourceType":"hubs","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/profiles","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/interactions","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/authorizationPolicies","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/connectors","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/connectors/mappings","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/kpi","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/views","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/links","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/roleAssignments","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/roles","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/widgetTypes","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/suggestTypeSchema","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"operations","locations":["East
+        US 2"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataCatalog","namespace":"Microsoft.DataCatalog","resourceTypes":[{"resourceType":"catalogs","locations":["East
+        US","West US","Australia East","West Europe","North Europe","Southeast Asia","West
+        Central US"],"apiVersions":["2016-03-30","2015-07-01-preview"]},{"resourceType":"checkNameAvailability","locations":["West
+        Europe"],"apiVersions":["2016-03-30","2015-07-01-preview"]},{"resourceType":"operations","locations":["West
+        Europe"],"apiVersions":["2016-03-30","2015-07-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-03-30","2015-07-01-preview"]},{"resourceType":"locations/jobs","locations":["East
+        US","West US","Australia East","West Europe","North Europe","Southeast Asia","West
+        Central US"],"apiVersions":["2016-03-30","2015-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataFactory","namespace":"Microsoft.DataFactory","resourceTypes":[{"resourceType":"dataFactories","locations":["West
+        US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview","2014-04-01"]},{"resourceType":"factories","locations":["East
+        US"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
+        US"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
+        Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"dataFactories/metricDefinitions","locations":["North
+        Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"checkDataFactoryNameAvailability","locations":[],"apiVersions":["2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"checkAzureDataFactoryNameAvailability","locations":["West
+        US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"dataFactorySchema","locations":["West
+        US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"operations","locations":["West
+        US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeAnalytics","namespace":"Microsoft.DataLakeAnalytics","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/dataLakeStoreAccounts","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers/listSasTokens","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeStore","namespace":"Microsoft.DataLakeStore","authorization":{"applicationId":"e9f49c6b-5ce5-44c8-925d-015017e9f7ad","roleDefinitionId":"17eb9cca-f08a-4499-b2d3-852d175f614f"},"resourceTypes":[{"resourceType":"accounts","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/firewallRules","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","resourceTypes":[{"resourceType":"operations","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforPostgreSQL","namespace":"Microsoft.DBforPostgreSQL","resourceTypes":[{"resourceType":"operations","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
+        US","North Europe","East Asia","East US","West Europe","Southeast Asia","Japan
+        East","Japan West","Australia East","Australia Southeast","West US 2","West
+        Central US","East US 2","Central US","UK South","UK West","South India","Central
+        India"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"databaseAccountNames","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DomainRegistration","namespace":"Microsoft.DomainRegistration","authorization":{"applicationId":"ea2f600a-4980-45b7-89bf-d34da487bda1","roleDefinitionId":"54d7f2e3-5040-48a7-ae90-eebf629cfa0b"},"resourceTypes":[{"resourceType":"domains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"domains/domainOwnershipIdentifiers","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"topLevelDomains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"checkDomainAvailability","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"listDomainRecommendations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"validateDomainRegistrationInformation","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"generateSsoRequest","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DynamicsLcs","namespace":"Microsoft.DynamicsLcs","resourceTypes":[{"resourceType":"lcsprojects","locations":["Brazil
+        South","East Asia","East US","Japan East","Japan West","North Central US","North
+        Europe","South Central US","West Europe","West US","Southeast Asia","Central
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"lcsprojects/connectors","locations":["Brazil
+        South","East Asia","East US","Japan East","Japan West","North Central US","North
+        Europe","South Central US","West Europe","West US","Southeast Asia","Central
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"lcsprojects/clouddeployments","locations":["Brazil
+        South","East Asia","East US","Japan East","Japan West","North Central US","North
+        Europe","South Central US","West Europe","West US","Southeast Asia","Central
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"operations","locations":["Brazil
+        South","East Asia","East US","Japan East","Japan West","North Central US","North
+        Europe","South Central US","West Europe","West US","Southeast Asia","Central
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"topics","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operations","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"clusters/applications","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"clusters/operationresults","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations/capabilities","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations/operationresults","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations/azureasyncoperations","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations/validateCreateRequest","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"operations","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India"],"apiVersions":["2015-03-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ImportExport","namespace":"Microsoft.ImportExport","authorization":{"applicationId":"7de4d5c5-5b32-4235-b8a9-33b34d6bcd2a","roleDefinitionId":"9f7aa6bb-9454-46b6-8c01-a4b0f33ca151"},"resourceTypes":[{"resourceType":"jobs","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","North Central US","North Europe","South Central US","Southeast
+        Asia","South India","UK South","West Central US","West Europe","West India","West
+        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","North Central US","North Europe","South Central US","Southeast
+        Asia","South India","UK South","West Central US","West Europe","West India","West
+        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations/operationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","North Central US","North Europe","South Central US","Southeast
+        Asia","South India","UK South","West Central US","West Europe","West India","West
+        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","North Central US","North Europe","South Central US","Southeast
+        Asia","South India","UK South","West Central US","West Europe","West India","West
+        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Logic","namespace":"Microsoft.Logic","authorization":{"applicationId":"7cd684f4-8a78-49b0-91ec-6a35d38739ba","roleDefinitionId":"cb3ef1fb-6e31-49e2-9d87-ed821053fe58"},"resourceTypes":[{"resourceType":"workflows","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West"],"apiVersions":["2017-07-01","2016-10-01","2016-06-01","2015-08-01-preview","2015-02-01-preview"]},{"resourceType":"locations/workflows","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West"],"apiVersions":["2017-07-01","2016-10-01","2016-06-01","2015-08-01-preview","2015-02-01-preview"]},{"resourceType":"locations","locations":["North
+        Central US"],"apiVersions":["2017-07-01","2016-10-01","2016-06-01","2015-08-01-preview","2015-02-01-preview"]},{"resourceType":"operations","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West"],"apiVersions":["2017-07-01","2016-10-01","2016-06-01","2015-08-01-preview","2015-02-01-preview"]},{"resourceType":"integrationAccounts","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","West Central US"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"operations","locations":["South
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations","locations":["South
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operations","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"commitmentPlans","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
+        Central US","West US"],"apiVersions":["2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Media","namespace":"Microsoft.Media","authorization":{"applicationId":"374b2a64-3b6b-436b-934c-b820eacca870","roleDefinitionId":"aab70789-0cec-44b5-95d7-84b64c9487af"},"resourceTypes":[{"resourceType":"mediaservices","locations":["Japan
+        West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
+        US","West US","Australia East","Australia Southeast","Central US","Brazil
+        South","Central India","West India","South India","South Central US","Canada
+        Central","Canada East","West Central US"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
+        Central US","North Central US","East US 2","West US","West Europe","North
+        Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
+        East","UK South","West India"],"apiVersions":["2016-01-29"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-01-29"]},{"resourceType":"locations/checkNameAvailability","locations":["South
+        Central US","North Central US","East US 2","West US","West Europe","North
+        Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
+        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"operations","locations":["East
+        US 2"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Relay","namespace":"Microsoft.Relay","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US 2","West
+        US","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
+        East","West India","South India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
+        East","West India","South India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
+        Central US","South Central US","North Europe","West Europe","East Asia","Southeast
+        Asia","West US","East US","Japan West","Japan East","Brazil South","Central
+        US","East US 2","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-03-01","2016-01-01","2014-08-01-preview"]},{"resourceType":"operations","locations":["North
+        Central US","South Central US","North Europe","West Europe","East Asia","Southeast
+        Asia","West US","East US","Japan West","Japan East","Brazil South","Central
+        US","East US 2","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-03-01","2016-01-01","2014-08-01-preview"]},{"resourceType":"operationResults","locations":["North
+        Central US","South Central US","North Europe","West Europe","East Asia","Southeast
+        Asia","West US","East US","Japan West","Japan East","Brazil South","Central
+        US","East US 2","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-03-01","2016-01-01","2014-08-01-preview"]},{"resourceType":"flows","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast"],"apiVersions":["2015-08-01-preview","2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Search","namespace":"Microsoft.Search","resourceTypes":[{"resourceType":"searchServices","locations":["West
+        US","East US","North Europe","West Europe","Southeast Asia","East Asia","North
+        Central US","South Central US","Japan West","Australia East","Brazil South","Central
+        India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19","2015-02-28"]},{"resourceType":"checkServiceNameAvailability","locations":[],"apiVersions":["2015-02-28","2014-07-31-Preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2015-08-19"]},{"resourceType":"resourceHealthMetadata","locations":["West
+        US","East US","North Europe","West Europe","Southeast Asia","East Asia","North
+        Central US","South Central US","Japan West","Australia East","Brazil South","Central
+        India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US 2","West
+        US","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"premiumMessagingRegions","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceFabric","namespace":"Microsoft.ServiceFabric","authorization":{"applicationId":"74cb6831-0dbb-4be1-8206-fd4df301cdc2","roleDefinitionId":"e55cc65f-6903-4917-b4ef-f8d4640b57f5"},"resourceTypes":[{"resourceType":"clusters","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/clusterVersions","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operations","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Canada
+        Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","West Central US","Japan East","Japan West","Australia East","Australia
+        Southeast"],"apiVersions":["2017-06-01","2017-05-15","2017-01-01","2016-10-01","2016-06-01","2015-03-15","2014-09-01"]},{"resourceType":"operations","locations":["West
+        Central US","Southeast Asia"],"apiVersions":["2016-10-01","2016-06-01","2015-03-15","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StreamAnalytics","namespace":"Microsoft.StreamAnalytics","resourceTypes":[{"resourceType":"streamingjobs","locations":["Central
+        US","West Europe","East US 2","North Europe","Japan East","West US","Southeast
+        Asia","South Central US","East Asia","Japan West","North Central US","East
+        US","Australia East","Australia Southeast","Brazil South","Central India","West
+        Central US","UK South","UK West","Canada Central","Canada East","West US 2"],"apiVersions":["2017-04-01-preview","2016-03-01","2015-11-01","2015-10-01","2015-09-01","2015-08-01-preview","2015-06-01","2015-05-01","2015-04-01","2015-03-01-preview"]},{"resourceType":"locations","locations":["West
+        Europe","Central US","East US 2","North Europe","Japan East","West US","Southeast
+        Asia","South Central US","East Asia","Japan West","North Central US","East
+        US","Australia East","Australia Southeast","Brazil South","Central India","West
+        Central US","UK South","West US 2","UK West","Canada Central","Canada East"],"apiVersions":["2017-04-01-preview","2016-03-01","2015-11-01","2015-10-01","2015-09-01","2015-08-01-preview","2015-06-01","2015-05-01","2015-04-01","2015-03-01-preview"]},{"resourceType":"locations/quotas","locations":[],"apiVersions":["2017-04-01-preview","2016-03-01","2015-11-01","2015-10-01","2015-09-01","2015-08-01-preview","2015-06-01","2015-05-01","2015-04-01","2015-03-01-preview"]},{"resourceType":"streamingjobs/diagnosticSettings","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","Central
+        India","West Central US","UK South","UK West","Canada Central","Canada East","West
+        US 2","West US","Central US","South Central US","Japan East","Japan West","East
+        Asia","Southeast Asia","Australia East","Australia Southeast"],"apiVersions":["2014-04-01"]},{"resourceType":"streamingjobs/metricDefinitions","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","Central
+        India","West Central US","UK South","UK West","Canada Central","Canada East","West
+        US 2","West US","Central US","South Central US","Japan East","Japan West","East
+        Asia","Southeast Asia","Australia East","Australia Southeast"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":["West
+        Europe","West US","Central US","East US 2","North Europe","Japan East","Southeast
+        Asia","South Central US","East Asia","Japan West","North Central US","East
+        US","Australia East","Australia Southeast","Brazil South","Central India","West
+        Central US","UK South","UK West","Canada Central","Canada East","West US 2"],"apiVersions":["2017-04-01-preview","2016-03-01","2015-11-01","2015-10-01","2015-09-01","2015-08-01-preview","2015-06-01","2015-05-01","2015-04-01","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.support","namespace":"microsoft.support","resourceTypes":[{"resourceType":"operations","locations":["North
+        Central US","South Central US","Central US","West Europe","North Europe","West
+        US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
+        Asia","East Asia","Australia East","Australia Southeast"],"apiVersions":["2015-07-01-Preview","2015-03-01"]},{"resourceType":"supporttickets","locations":["North
+        Central US","South Central US","Central US","West Europe","North Europe","West
+        US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
+        Asia","East Asia","Australia East","Australia Southeast"],"apiVersions":["2015-07-01-Preview","2015-03-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.TimeSeriesInsights","namespace":"Microsoft.TimeSeriesInsights","authorizations":[{"applicationId":"120d688d-1518-4cf7-bd38-182f158850b6","roleDefinitionId":"5a43abdf-bb87-42c4-9e56-1c24bf364150"}],"resourceTypes":[{"resourceType":"environments","locations":["East
+        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/eventsources","locations":["East
+        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/referenceDataSets","locations":["East
+        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/accessPolicies","locations":["East
+        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"operations","locations":["East
+        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/project","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/extension","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"checkNameAvailability","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Myget.PackageManagement","namespace":"Myget.PackageManagement","resourceTypes":[{"resourceType":"services","locations":["West
+        Europe"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/NewRelic.APM","namespace":"NewRelic.APM","authorization":{"allowedThirdPartyExtensions":[{"name":"NewRelic_AzurePortal_APM"}]},"resourceTypes":[{"resourceType":"accounts","locations":["North
+        Central US","South Central US","West US","East US","North Europe","West Europe","Southeast
+        Asia","East Asia","Japan East","Japan West"],"apiVersions":["2014-10-01","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/nuubit.nextgencdn","namespace":"nuubit.nextgencdn","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US","East US 2","North Central US","South Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","West US","Central US"],"apiVersions":["2017-05-05"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-05"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-05-05"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-05-05"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Paraleap.CloudMonix","namespace":"Paraleap.CloudMonix","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2016-08-10"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-10"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-10"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Pokitdok.Platform","namespace":"Pokitdok.Platform","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2016-05-17"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-05-17"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-05-17"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-05-17"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RavenHq.Db","namespace":"RavenHq.Db","resourceTypes":[{"resourceType":"databases","locations":["East
+        US"],"apiVersions":["2016-07-18","2016-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-07-18","2016-06-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-07-18","2016-06-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-07-18","2016-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Raygun.CrashReporting","namespace":"Raygun.CrashReporting","resourceTypes":[{"resourceType":"apps","locations":["East
+        US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RedisLabs.Memcached","namespace":"RedisLabs.Memcached","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-07-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RedisLabs.Redis","namespace":"RedisLabs.Redis","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-07-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RevAPM.MobileCDN","namespace":"RevAPM.MobileCDN","resourceTypes":[{"resourceType":"accounts","locations":["Central
+        US","East US","East US 2","North Central US","South Central US","West US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast"],"apiVersions":["2016-08-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-24","2016-08-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sendgrid.Email","namespace":"Sendgrid.Email","resourceTypes":[{"resourceType":"accounts","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Canada Central","Canada
+        East","West Central US","West US 2","UK South","UK West"],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Signiant.Flight","namespace":"Signiant.Flight","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US","Central US","North Central US","South Central US","West US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast"],"apiVersions":["2015-06-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sparkpost.Basic","namespace":"Sparkpost.Basic","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2016-08-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/stackify.retrace","namespace":"stackify.retrace","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2016-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/SuccessBricks.ClearDB","namespace":"SuccessBricks.ClearDB","resourceTypes":[{"resourceType":"databases","locations":["Brazil
+        South","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","Southeast Asia","West Europe","West
+        US","South Central US","Australia East","Australia Southeast","Canada Central","Canada
+        East","Central India","South India","West India"],"apiVersions":["2014-04-01"]},{"resourceType":"clusters","locations":["Brazil
+        South","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","Southeast Asia","West Europe","West
+        US","Australia Southeast","Australia East","South Central US","Canada Central","Canada
+        East","Central India","South India","West India"],"apiVersions":["2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/TrendMicro.DeepSecurity","namespace":"TrendMicro.DeepSecurity","resourceTypes":[{"resourceType":"accounts","locations":["Central
+        US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
+        Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:13 GMT
+- request:
+    method: post
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
+    body:
+      encoding: UTF-8
+      string: '{"access":"read","durationInSeconds":3600}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4OTMsIm5iZiI6MTUwNDEwNjg5MywiZXhwIjoxNTA0MTEwNzkzLCJhaW8iOiJZMkZnWUxqMzhzM2FiajRtanF6SlFaa3o2bDdmQlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQThYeXhhLUtaay1lZEZUUUtiWVNBQSIsInZlciI6IjEuMCJ9.ELUphz8vjoMqBXevzTRi0mBKIgmQED3FfZB8GRQEu70iaS2LLCWUX0yXjwnJsIxcY6Ep5EQrVoAub_lPjMR-ZJ8ANF-N9yo-9S0h4e-e3OAU5G2Aw_pkLLKYNac3xIyTS-rMO1YtNWGrMpgeHSb8fIRE1sn67x-EYIBAKtQgcUY-kwsl5rfgSrD1hHOZ3b6mtaMcHPcZU5L2Rq9Wnmg1aG5-mlNLEirawEQx6MNoQ_uBsUlWRXRbm0-xuJWTwc1PJCwHbrSLJeOXixLVcVNLfBH8-EimNa-aUAdk3E85xEHi46w1NUOR-zc3O-QYBNG67slcdV3w0gOlTurDyji9OA
+      Content-Length:
+      - '42'
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '0'
+      Expires:
+      - "-1"
+      Location:
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/106bde4d-441e-452a-b6a6-db14a67663d9?monitor=true&api-version=2017-03-30
+      Azure-Asyncoperation:
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/106bde4d-441e-452a-b6a6-db14a67663d9?api-version=2017-03-30
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      X-Ms-Request-Id:
+      - 106bde4d-441e-452a-b6a6-db14a67663d9
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Writes:
+      - '1198'
+      X-Ms-Correlation-Request-Id:
+      - 7472aec7-50fc-41ff-9062-9fd8db61f88d
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153314Z:7472aec7-50fc-41ff-9062-9fd8db61f88d
+      Date:
+      - Wed, 30 Aug 2017 15:33:13 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:14 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/106bde4d-441e-452a-b6a6-db14a67663d9?api-version=2017-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4OTMsIm5iZiI6MTUwNDEwNjg5MywiZXhwIjoxNTA0MTEwNzkzLCJhaW8iOiJZMkZnWUxqMzhzM2FiajRtanF6SlFaa3o2bDdmQlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQThYeXhhLUtaay1lZEZUUUtiWVNBQSIsInZlciI6IjEuMCJ9.ELUphz8vjoMqBXevzTRi0mBKIgmQED3FfZB8GRQEu70iaS2LLCWUX0yXjwnJsIxcY6Ep5EQrVoAub_lPjMR-ZJ8ANF-N9yo-9S0h4e-e3OAU5G2Aw_pkLLKYNac3xIyTS-rMO1YtNWGrMpgeHSb8fIRE1sn67x-EYIBAKtQgcUY-kwsl5rfgSrD1hHOZ3b6mtaMcHPcZU5L2Rq9Wnmg1aG5-mlNLEirawEQx6MNoQ_uBsUlWRXRbm0-xuJWTwc1PJCwHbrSLJeOXixLVcVNLfBH8-EimNa-aUAdk3E85xEHi46w1NUOR-zc3O-QYBNG67slcdV3w0gOlTurDyji9OA
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      X-Ms-Request-Id:
+      - 2df577c4-38a7-4ef3-a551-0836b26ff64d
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14949'
+      X-Ms-Correlation-Request-Id:
+      - 5cb7d7cc-c9ba-45dd-ac0a-568f2f70273a
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153314Z:5cb7d7cc-c9ba-45dd-ac0a-568f2f70273a
+      Date:
+      - Wed, 30 Aug 2017 15:33:13 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"startTime\": \"2017-08-30T15:33:13.7275066+00:00\",\r\n  \"endTime\":
+        \"2017-08-30T15:33:13.9469777+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=2db7faf1-bd36-43f1-a7b6-8792967844e4&sig=36XK1wgJAFrH84xYZWyvfUCDeHyf6x3alszxH0vyeJE%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"106bde4d-441e-452a-b6a6-db14a67663d9\"\r\n}"
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:14 GMT
+- request:
+    method: get
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=2db7faf1-bd36-43f1-a7b6-8792967844e4&sig=36XK1wgJAFrH84xYZWyvfUCDeHyf6x3alszxH0vyeJE=&sr=b&sv=2016-05-31
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      X-Ms-Range:
+      - bytes=0-0
+      Host:
+      - md-t4jdgqqlgszp.blob.core.windows.net
+  response:
+    status:
+      code: 206
+      message: Partial Content
+    headers:
+      Content-Length:
+      - '1'
+      Content-Type:
+      - application/octet-stream
+      Content-Range:
+      - bytes 0-0/34359738880
+      Last-Modified:
+      - Sat, 15 Jul 2017 14:23:07 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D4CB8D039FC699"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 2a1e2eea-0001-000c-5ca5-214fdc000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Meta-Pirtag:
+      - '1'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '20'
+      X-Ms-Copy-Id:
+      - 30cedd78-548a-4fd8-967e-f8344f587e3c
+      X-Ms-Copy-Source:
+      - http://md-t4jdgqqlgszp.blob.core.windows.net:8080/fg25xxtqx0gc/abcd?sv=2016-02-19&sr=b&st=2017-05-04T21%3a06%3a57Z&se=9999-12-31T23%3a59%3a59Z&sp=r&api-version=2016-02-19
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 34359738880/34359738880
+      X-Ms-Copy-Completion-Time:
+      - Thu, 04 May 2017 21:21:56 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Wed, 30 Aug 2017 15:33:14 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        6w==
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:14 GMT
+- request:
+    method: post
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
+    body:
+      encoding: UTF-8
+      string: '{"access":"read","durationInSeconds":3600}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4OTMsIm5iZiI6MTUwNDEwNjg5MywiZXhwIjoxNTA0MTEwNzkzLCJhaW8iOiJZMkZnWUxqMzhzM2FiajRtanF6SlFaa3o2bDdmQlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQThYeXhhLUtaay1lZEZUUUtiWVNBQSIsInZlciI6IjEuMCJ9.ELUphz8vjoMqBXevzTRi0mBKIgmQED3FfZB8GRQEu70iaS2LLCWUX0yXjwnJsIxcY6Ep5EQrVoAub_lPjMR-ZJ8ANF-N9yo-9S0h4e-e3OAU5G2Aw_pkLLKYNac3xIyTS-rMO1YtNWGrMpgeHSb8fIRE1sn67x-EYIBAKtQgcUY-kwsl5rfgSrD1hHOZ3b6mtaMcHPcZU5L2Rq9Wnmg1aG5-mlNLEirawEQx6MNoQ_uBsUlWRXRbm0-xuJWTwc1PJCwHbrSLJeOXixLVcVNLfBH8-EimNa-aUAdk3E85xEHi46w1NUOR-zc3O-QYBNG67slcdV3w0gOlTurDyji9OA
+      Content-Length:
+      - '42'
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '0'
+      Expires:
+      - "-1"
+      Location:
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/026f0874-df8b-437c-96ec-87873625b0fd?monitor=true&api-version=2017-03-30
+      Azure-Asyncoperation:
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/026f0874-df8b-437c-96ec-87873625b0fd?api-version=2017-03-30
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      X-Ms-Request-Id:
+      - 026f0874-df8b-437c-96ec-87873625b0fd
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Writes:
+      - '1192'
+      X-Ms-Correlation-Request-Id:
+      - a5736f23-59cf-4dbb-be38-a58d831726a6
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153315Z:a5736f23-59cf-4dbb-be38-a58d831726a6
+      Date:
+      - Wed, 30 Aug 2017 15:33:14 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:15 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/026f0874-df8b-437c-96ec-87873625b0fd?api-version=2017-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4OTMsIm5iZiI6MTUwNDEwNjg5MywiZXhwIjoxNTA0MTEwNzkzLCJhaW8iOiJZMkZnWUxqMzhzM2FiajRtanF6SlFaa3o2bDdmQlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQThYeXhhLUtaay1lZEZUUUtiWVNBQSIsInZlciI6IjEuMCJ9.ELUphz8vjoMqBXevzTRi0mBKIgmQED3FfZB8GRQEu70iaS2LLCWUX0yXjwnJsIxcY6Ep5EQrVoAub_lPjMR-ZJ8ANF-N9yo-9S0h4e-e3OAU5G2Aw_pkLLKYNac3xIyTS-rMO1YtNWGrMpgeHSb8fIRE1sn67x-EYIBAKtQgcUY-kwsl5rfgSrD1hHOZ3b6mtaMcHPcZU5L2Rq9Wnmg1aG5-mlNLEirawEQx6MNoQ_uBsUlWRXRbm0-xuJWTwc1PJCwHbrSLJeOXixLVcVNLfBH8-EimNa-aUAdk3E85xEHi46w1NUOR-zc3O-QYBNG67slcdV3w0gOlTurDyji9OA
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      X-Ms-Request-Id:
+      - b6d18038-1202-4cde-9a76-22dd4608fb5f
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14697'
+      X-Ms-Correlation-Request-Id:
+      - 83f6d7bd-3f46-4985-81bd-584edad4e38d
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153315Z:83f6d7bd-3f46-4985-81bd-584edad4e38d
+      Date:
+      - Wed, 30 Aug 2017 15:33:15 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"startTime\": \"2017-08-30T15:33:14.4469557+00:00\",\r\n  \"endTime\":
+        \"2017-08-30T15:33:14.6656883+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=61b9186d-484b-41c3-851e-ff3a6b9239ac&sig=Fm%2BUOJ5Iu%2BdKrVAa2PP2xD4WVxrW29pGjI6CTAZufKE%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"026f0874-df8b-437c-96ec-87873625b0fd\"\r\n}"
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:15 GMT
+- request:
+    method: get
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=61b9186d-484b-41c3-851e-ff3a6b9239ac&sig=Fm%2BUOJ5Iu%2BdKrVAa2PP2xD4WVxrW29pGjI6CTAZufKE=&sr=b&sv=2016-05-31
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      X-Ms-Range:
+      - bytes=440-443
+      Host:
+      - md-t4jdgqqlgszp.blob.core.windows.net
+  response:
+    status:
+      code: 206
+      message: Partial Content
+    headers:
+      Content-Length:
+      - '4'
+      Content-Type:
+      - application/octet-stream
+      Content-Range:
+      - bytes 440-443/34359738880
+      Last-Modified:
+      - Sat, 15 Jul 2017 14:23:07 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D4CB8D039FC699"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 3b041a91-0001-012c-1da5-216545000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Meta-Pirtag:
+      - '1'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '20'
+      X-Ms-Copy-Id:
+      - 30cedd78-548a-4fd8-967e-f8344f587e3c
+      X-Ms-Copy-Source:
+      - http://md-t4jdgqqlgszp.blob.core.windows.net:8080/fg25xxtqx0gc/abcd?sv=2016-02-19&sr=b&st=2017-05-04T21%3a06%3a57Z&se=9999-12-31T23%3a59%3a59Z&sp=r&api-version=2016-02-19
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 34359738880/34359738880
+      X-Ms-Copy-Completion-Time:
+      - Thu, 04 May 2017 21:21:56 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Wed, 30 Aug 2017 15:33:14 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        U5MJAA==
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:15 GMT
+recorded_with: VCR 3.0.3

--- a/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_blockSize-1.yml
+++ b/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_blockSize-1.yml
@@ -39,25 +39,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - c5f2c503-8aaf-4f66-9e74-54d029b61200
+      - 6cfafbc3-6270-4e91-8768-06d26da01100
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAAA9kTklhVy7SJTGAzR-p1Bc23l5NNrJW4NWJObtN0mtsBSdfkC6uLc8qDZ7GP9rg1u2i6TTVtim4BZqbK6UYdbactaup5w1wU-eCiSPOajCnOrvAbVoR7uqxs0g0BtuR2by1vlAV5XMpOQvjtCwrFQS-daIeVhAd7Sp1dedQuu91T6eclju_vlUBe9gMkGZOP0gAA;
+      - esctx=AQABAAAAAAA9kTklhVy7SJTGAzR-p1Bcw3CEKzviVts3K_WxtLLOg8HCKjasHI_fQs5ctkTgr-zoS_GZSCco36wIUSctv7HlcMVuSXTF607b4M-bZA89mSzuiLkaTV8RS40aTDmdAlf7LHuvVZPPC0f-BPWQJTQ2ScaR2_jMZAQtgMoedv0TIlRgefh5B3lQMGjkKA5JeyYgAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=003; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=002; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Wed, 30 Aug 2017 15:33:13 GMT
+      - Wed, 30 Aug 2017 17:05:23 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1504110793","not_before":"1504106893","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4OTMsIm5iZiI6MTUwNDEwNjg5MywiZXhwIjoxNTA0MTEwNzkzLCJhaW8iOiJZMkZnWUxqMzhzM2FiajRtanF6SlFaa3o2bDdmQlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQThYeXhhLUtaay1lZEZUUUtiWVNBQSIsInZlciI6IjEuMCJ9.ELUphz8vjoMqBXevzTRi0mBKIgmQED3FfZB8GRQEu70iaS2LLCWUX0yXjwnJsIxcY6Ep5EQrVoAub_lPjMR-ZJ8ANF-N9yo-9S0h4e-e3OAU5G2Aw_pkLLKYNac3xIyTS-rMO1YtNWGrMpgeHSb8fIRE1sn67x-EYIBAKtQgcUY-kwsl5rfgSrD1hHOZ3b6mtaMcHPcZU5L2Rq9Wnmg1aG5-mlNLEirawEQx6MNoQ_uBsUlWRXRbm0-xuJWTwc1PJCwHbrSLJeOXixLVcVNLfBH8-EimNa-aUAdk3E85xEHi46w1NUOR-zc3O-QYBNG67slcdV3w0gOlTurDyji9OA"}'
+      string: '{"token_type":"Bearer","expires_in":"3600","ext_expires_in":"0","expires_on":"1504116324","not_before":"1504112424","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MjQsIm5iZiI6MTUwNDExMjQyNCwiZXhwIjoxNTA0MTE2MzI0LCJhaW8iOiJZMkZnWUloZ1dIOHVWdkV5MDZRbnIvUWk2bllWQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoid192NmJIQmlrVTZIYUFiU2JhQVJBQSIsInZlciI6IjEuMCJ9.oVKRyzdF132kkMP9AkuRBVcmcdyIT3KBlEj6s8oelDE7S3Gzc7-Lk5JnnYcYVO_PPqWNx8lZlTt315YBtOdjLCR6-RhJV2PZ5xCQgVMf7I6o6lQvMt9IcM4qxQo8GPLXM2aO-VKiL-yCuVUeIfdYCXzfgp1ZXNtZ-tXHlKsnGO-q_DDjGxq9KmzYyhT3sAgFitfrpZeppajoRUHgvxzPUCjUe9Zhllt_v_kBUBNR18gCGQoubI-kYo3FL-2B6OwuVHz7wxTiOFfqx27oa0c7zlBYKBUn2ZLhhV6FedT0mN9_iiC-Z6z4Q79FHlxhrnW3RtsbYf-fUlq4fOhdS6VoUA"}'
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:33:12 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:23 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -74,7 +74,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4OTMsIm5iZiI6MTUwNDEwNjg5MywiZXhwIjoxNTA0MTEwNzkzLCJhaW8iOiJZMkZnWUxqMzhzM2FiajRtanF6SlFaa3o2bDdmQlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQThYeXhhLUtaay1lZEZUUUtiWVNBQSIsInZlciI6IjEuMCJ9.ELUphz8vjoMqBXevzTRi0mBKIgmQED3FfZB8GRQEu70iaS2LLCWUX0yXjwnJsIxcY6Ep5EQrVoAub_lPjMR-ZJ8ANF-N9yo-9S0h4e-e3OAU5G2Aw_pkLLKYNac3xIyTS-rMO1YtNWGrMpgeHSb8fIRE1sn67x-EYIBAKtQgcUY-kwsl5rfgSrD1hHOZ3b6mtaMcHPcZU5L2Rq9Wnmg1aG5-mlNLEirawEQx6MNoQ_uBsUlWRXRbm0-xuJWTwc1PJCwHbrSLJeOXixLVcVNLfBH8-EimNa-aUAdk3E85xEHi46w1NUOR-zc3O-QYBNG67slcdV3w0gOlTurDyji9OA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MjQsIm5iZiI6MTUwNDExMjQyNCwiZXhwIjoxNTA0MTE2MzI0LCJhaW8iOiJZMkZnWUloZ1dIOHVWdkV5MDZRbnIvUWk2bllWQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoid192NmJIQmlrVTZIYUFiU2JhQVJBQSIsInZlciI6IjEuMCJ9.oVKRyzdF132kkMP9AkuRBVcmcdyIT3KBlEj6s8oelDE7S3Gzc7-Lk5JnnYcYVO_PPqWNx8lZlTt315YBtOdjLCR6-RhJV2PZ5xCQgVMf7I6o6lQvMt9IcM4qxQo8GPLXM2aO-VKiL-yCuVUeIfdYCXzfgp1ZXNtZ-tXHlKsnGO-q_DDjGxq9KmzYyhT3sAgFitfrpZeppajoRUHgvxzPUCjUe9Zhllt_v_kBUBNR18gCGQoubI-kYo3FL-2B6OwuVHz7wxTiOFfqx27oa0c7zlBYKBUn2ZLhhV6FedT0mN9_iiC-Z6z4Q79FHlxhrnW3RtsbYf-fUlq4fOhdS6VoUA
       Host:
       - management.azure.com
   response:
@@ -95,23 +95,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14996'
+      - '14997'
       X-Ms-Request-Id:
-      - 7b3c267a-553a-4830-890b-7cf0605b141e
+      - f93458a3-f659-405e-9e5f-21392a44379c
       X-Ms-Correlation-Request-Id:
-      - 7b3c267a-553a-4830-890b-7cf0605b141e
+      - f93458a3-f659-405e-9e5f-21392a44379c
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153312Z:7b3c267a-553a-4830-890b-7cf0605b141e
+      - EASTUS:20170830T170524Z:f93458a3-f659-405e-9e5f-21392a44379c
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 30 Aug 2017 15:33:12 GMT
+      - Wed, 30 Aug 2017 17:05:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:33:12 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:23 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/azure_subscription_id/providers?api-version=2015-01-01
@@ -128,7 +128,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4OTMsIm5iZiI6MTUwNDEwNjg5MywiZXhwIjoxNTA0MTEwNzkzLCJhaW8iOiJZMkZnWUxqMzhzM2FiajRtanF6SlFaa3o2bDdmQlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQThYeXhhLUtaay1lZEZUUUtiWVNBQSIsInZlciI6IjEuMCJ9.ELUphz8vjoMqBXevzTRi0mBKIgmQED3FfZB8GRQEu70iaS2LLCWUX0yXjwnJsIxcY6Ep5EQrVoAub_lPjMR-ZJ8ANF-N9yo-9S0h4e-e3OAU5G2Aw_pkLLKYNac3xIyTS-rMO1YtNWGrMpgeHSb8fIRE1sn67x-EYIBAKtQgcUY-kwsl5rfgSrD1hHOZ3b6mtaMcHPcZU5L2Rq9Wnmg1aG5-mlNLEirawEQx6MNoQ_uBsUlWRXRbm0-xuJWTwc1PJCwHbrSLJeOXixLVcVNLfBH8-EimNa-aUAdk3E85xEHi46w1NUOR-zc3O-QYBNG67slcdV3w0gOlTurDyji9OA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MjQsIm5iZiI6MTUwNDExMjQyNCwiZXhwIjoxNTA0MTE2MzI0LCJhaW8iOiJZMkZnWUloZ1dIOHVWdkV5MDZRbnIvUWk2bllWQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoid192NmJIQmlrVTZIYUFiU2JhQVJBQSIsInZlciI6IjEuMCJ9.oVKRyzdF132kkMP9AkuRBVcmcdyIT3KBlEj6s8oelDE7S3Gzc7-Lk5JnnYcYVO_PPqWNx8lZlTt315YBtOdjLCR6-RhJV2PZ5xCQgVMf7I6o6lQvMt9IcM4qxQo8GPLXM2aO-VKiL-yCuVUeIfdYCXzfgp1ZXNtZ-tXHlKsnGO-q_DDjGxq9KmzYyhT3sAgFitfrpZeppajoRUHgvxzPUCjUe9Zhllt_v_kBUBNR18gCGQoubI-kYo3FL-2B6OwuVHz7wxTiOFfqx27oa0c7zlBYKBUn2ZLhhV6FedT0mN9_iiC-Z6z4Q79FHlxhrnW3RtsbYf-fUlq4fOhdS6VoUA
       Host:
       - management.azure.com
   response:
@@ -147,17 +147,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14950'
+      - '14927'
       X-Ms-Request-Id:
-      - b06f0664-12c6-41b2-8747-664f4a48857b
+      - f54d5c4b-27af-4796-a351-f46edfa248c7
       X-Ms-Correlation-Request-Id:
-      - b06f0664-12c6-41b2-8747-664f4a48857b
+      - f54d5c4b-27af-4796-a351-f46edfa248c7
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153313Z:b06f0664-12c6-41b2-8747-664f4a48857b
+      - EASTUS:20170830T170524Z:f54d5c4b-27af-4796-a351-f46edfa248c7
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 30 Aug 2017 15:33:13 GMT
+      - Wed, 30 Aug 2017 17:05:24 GMT
       Content-Length:
       - '241615'
     body:
@@ -1891,7 +1891,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:33:13 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:24 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
@@ -1908,7 +1908,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4OTMsIm5iZiI6MTUwNDEwNjg5MywiZXhwIjoxNTA0MTEwNzkzLCJhaW8iOiJZMkZnWUxqMzhzM2FiajRtanF6SlFaa3o2bDdmQlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQThYeXhhLUtaay1lZEZUUUtiWVNBQSIsInZlciI6IjEuMCJ9.ELUphz8vjoMqBXevzTRi0mBKIgmQED3FfZB8GRQEu70iaS2LLCWUX0yXjwnJsIxcY6Ep5EQrVoAub_lPjMR-ZJ8ANF-N9yo-9S0h4e-e3OAU5G2Aw_pkLLKYNac3xIyTS-rMO1YtNWGrMpgeHSb8fIRE1sn67x-EYIBAKtQgcUY-kwsl5rfgSrD1hHOZ3b6mtaMcHPcZU5L2Rq9Wnmg1aG5-mlNLEirawEQx6MNoQ_uBsUlWRXRbm0-xuJWTwc1PJCwHbrSLJeOXixLVcVNLfBH8-EimNa-aUAdk3E85xEHi46w1NUOR-zc3O-QYBNG67slcdV3w0gOlTurDyji9OA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MjQsIm5iZiI6MTUwNDExMjQyNCwiZXhwIjoxNTA0MTE2MzI0LCJhaW8iOiJZMkZnWUloZ1dIOHVWdkV5MDZRbnIvUWk2bllWQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoid192NmJIQmlrVTZIYUFiU2JhQVJBQSIsInZlciI6IjEuMCJ9.oVKRyzdF132kkMP9AkuRBVcmcdyIT3KBlEj6s8oelDE7S3Gzc7-Lk5JnnYcYVO_PPqWNx8lZlTt315YBtOdjLCR6-RhJV2PZ5xCQgVMf7I6o6lQvMt9IcM4qxQo8GPLXM2aO-VKiL-yCuVUeIfdYCXzfgp1ZXNtZ-tXHlKsnGO-q_DDjGxq9KmzYyhT3sAgFitfrpZeppajoRUHgvxzPUCjUe9Zhllt_v_kBUBNR18gCGQoubI-kYo3FL-2B6OwuVHz7wxTiOFfqx27oa0c7zlBYKBUn2ZLhhV6FedT0mN9_iiC-Z6z4Q79FHlxhrnW3RtsbYf-fUlq4fOhdS6VoUA
       Content-Length:
       - '42'
       Host:
@@ -1927,34 +1927,34 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/106bde4d-441e-452a-b6a6-db14a67663d9?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/fa8ecc0a-03f9-4108-b537-587fc7dfff92?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/106bde4d-441e-452a-b6a6-db14a67663d9?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/fa8ecc0a-03f9-4108-b537-587fc7dfff92?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
       - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
       X-Ms-Request-Id:
-      - 106bde4d-441e-452a-b6a6-db14a67663d9
+      - fa8ecc0a-03f9-4108-b537-587fc7dfff92
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1198'
+      - '1195'
       X-Ms-Correlation-Request-Id:
-      - 7472aec7-50fc-41ff-9062-9fd8db61f88d
+      - f00e4ac7-cea7-4264-a63c-f36f4bca95ea
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153314Z:7472aec7-50fc-41ff-9062-9fd8db61f88d
+      - EASTUS:20170830T170525Z:f00e4ac7-cea7-4264-a63c-f36f4bca95ea
       Date:
-      - Wed, 30 Aug 2017 15:33:13 GMT
+      - Wed, 30 Aug 2017 17:05:25 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:33:14 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:24 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/106bde4d-441e-452a-b6a6-db14a67663d9?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/fa8ecc0a-03f9-4108-b537-587fc7dfff92?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -1968,7 +1968,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4OTMsIm5iZiI6MTUwNDEwNjg5MywiZXhwIjoxNTA0MTEwNzkzLCJhaW8iOiJZMkZnWUxqMzhzM2FiajRtanF6SlFaa3o2bDdmQlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQThYeXhhLUtaay1lZEZUUUtiWVNBQSIsInZlciI6IjEuMCJ9.ELUphz8vjoMqBXevzTRi0mBKIgmQED3FfZB8GRQEu70iaS2LLCWUX0yXjwnJsIxcY6Ep5EQrVoAub_lPjMR-ZJ8ANF-N9yo-9S0h4e-e3OAU5G2Aw_pkLLKYNac3xIyTS-rMO1YtNWGrMpgeHSb8fIRE1sn67x-EYIBAKtQgcUY-kwsl5rfgSrD1hHOZ3b6mtaMcHPcZU5L2Rq9Wnmg1aG5-mlNLEirawEQx6MNoQ_uBsUlWRXRbm0-xuJWTwc1PJCwHbrSLJeOXixLVcVNLfBH8-EimNa-aUAdk3E85xEHi46w1NUOR-zc3O-QYBNG67slcdV3w0gOlTurDyji9OA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MjQsIm5iZiI6MTUwNDExMjQyNCwiZXhwIjoxNTA0MTE2MzI0LCJhaW8iOiJZMkZnWUloZ1dIOHVWdkV5MDZRbnIvUWk2bllWQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoid192NmJIQmlrVTZIYUFiU2JhQVJBQSIsInZlciI6IjEuMCJ9.oVKRyzdF132kkMP9AkuRBVcmcdyIT3KBlEj6s8oelDE7S3Gzc7-Lk5JnnYcYVO_PPqWNx8lZlTt315YBtOdjLCR6-RhJV2PZ5xCQgVMf7I6o6lQvMt9IcM4qxQo8GPLXM2aO-VKiL-yCuVUeIfdYCXzfgp1ZXNtZ-tXHlKsnGO-q_DDjGxq9KmzYyhT3sAgFitfrpZeppajoRUHgvxzPUCjUe9Zhllt_v_kBUBNR18gCGQoubI-kYo3FL-2B6OwuVHz7wxTiOFfqx27oa0c7zlBYKBUn2ZLhhV6FedT0mN9_iiC-Z6z4Q79FHlxhrnW3RtsbYf-fUlq4fOhdS6VoUA
       Host:
       - management.azure.com
   response:
@@ -1993,29 +1993,29 @@ http_interactions:
       X-Ms-Served-By:
       - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
       X-Ms-Request-Id:
-      - 2df577c4-38a7-4ef3-a551-0836b26ff64d
+      - 205dbf14-ed56-4069-926e-c83193003d4a
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14949'
+      - '14947'
       X-Ms-Correlation-Request-Id:
-      - 5cb7d7cc-c9ba-45dd-ac0a-568f2f70273a
+      - 1d0fb9b0-b10e-412a-a5f5-5b45ca31efd7
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153314Z:5cb7d7cc-c9ba-45dd-ac0a-568f2f70273a
+      - EASTUS:20170830T170525Z:1d0fb9b0-b10e-412a-a5f5-5b45ca31efd7
       Date:
-      - Wed, 30 Aug 2017 15:33:13 GMT
+      - Wed, 30 Aug 2017 17:05:25 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-08-30T15:33:13.7275066+00:00\",\r\n  \"endTime\":
-        \"2017-08-30T15:33:13.9469777+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=2db7faf1-bd36-43f1-a7b6-8792967844e4&sig=36XK1wgJAFrH84xYZWyvfUCDeHyf6x3alszxH0vyeJE%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"106bde4d-441e-452a-b6a6-db14a67663d9\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2017-08-30T17:05:25.0310489+00:00\",\r\n  \"endTime\":
+        \"2017-08-30T17:05:25.1716474+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=0603b9d8-6e4f-41ee-bc51-0aeb4f1b0989&sig=Lrfl%2FzoC5ll0JGt2N%2FNs92%2Fb8TLc4Y4hxQ%2F3GCtPKxc%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"fa8ecc0a-03f9-4108-b537-587fc7dfff92\"\r\n}"
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:33:14 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:24 GMT
 - request:
     method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=2db7faf1-bd36-43f1-a7b6-8792967844e4&sig=36XK1wgJAFrH84xYZWyvfUCDeHyf6x3alszxH0vyeJE=&sr=b&sv=2016-05-31
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=0603b9d8-6e4f-41ee-bc51-0aeb4f1b0989&sig=Lrfl/zoC5ll0JGt2N/Ns92/b8TLc4Y4hxQ/3GCtPKxc=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2050,7 +2050,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 2a1e2eea-0001-000c-5ca5-214fdc000000
+      - 7ea75229-0001-012e-07b2-2167bf000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2076,13 +2076,13 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 30 Aug 2017 15:33:14 GMT
+      - Wed, 30 Aug 2017 17:05:25 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         6w==
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:33:14 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:25 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
@@ -2099,7 +2099,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4OTMsIm5iZiI6MTUwNDEwNjg5MywiZXhwIjoxNTA0MTEwNzkzLCJhaW8iOiJZMkZnWUxqMzhzM2FiajRtanF6SlFaa3o2bDdmQlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQThYeXhhLUtaay1lZEZUUUtiWVNBQSIsInZlciI6IjEuMCJ9.ELUphz8vjoMqBXevzTRi0mBKIgmQED3FfZB8GRQEu70iaS2LLCWUX0yXjwnJsIxcY6Ep5EQrVoAub_lPjMR-ZJ8ANF-N9yo-9S0h4e-e3OAU5G2Aw_pkLLKYNac3xIyTS-rMO1YtNWGrMpgeHSb8fIRE1sn67x-EYIBAKtQgcUY-kwsl5rfgSrD1hHOZ3b6mtaMcHPcZU5L2Rq9Wnmg1aG5-mlNLEirawEQx6MNoQ_uBsUlWRXRbm0-xuJWTwc1PJCwHbrSLJeOXixLVcVNLfBH8-EimNa-aUAdk3E85xEHi46w1NUOR-zc3O-QYBNG67slcdV3w0gOlTurDyji9OA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MjQsIm5iZiI6MTUwNDExMjQyNCwiZXhwIjoxNTA0MTE2MzI0LCJhaW8iOiJZMkZnWUloZ1dIOHVWdkV5MDZRbnIvUWk2bllWQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoid192NmJIQmlrVTZIYUFiU2JhQVJBQSIsInZlciI6IjEuMCJ9.oVKRyzdF132kkMP9AkuRBVcmcdyIT3KBlEj6s8oelDE7S3Gzc7-Lk5JnnYcYVO_PPqWNx8lZlTt315YBtOdjLCR6-RhJV2PZ5xCQgVMf7I6o6lQvMt9IcM4qxQo8GPLXM2aO-VKiL-yCuVUeIfdYCXzfgp1ZXNtZ-tXHlKsnGO-q_DDjGxq9KmzYyhT3sAgFitfrpZeppajoRUHgvxzPUCjUe9Zhllt_v_kBUBNR18gCGQoubI-kYo3FL-2B6OwuVHz7wxTiOFfqx27oa0c7zlBYKBUn2ZLhhV6FedT0mN9_iiC-Z6z4Q79FHlxhrnW3RtsbYf-fUlq4fOhdS6VoUA
       Content-Length:
       - '42'
       Host:
@@ -2118,34 +2118,34 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/026f0874-df8b-437c-96ec-87873625b0fd?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/529e8588-0dbc-47c4-b392-c19a7b2e7dda?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/026f0874-df8b-437c-96ec-87873625b0fd?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/529e8588-0dbc-47c4-b392-c19a7b2e7dda?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
       - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
       X-Ms-Request-Id:
-      - 026f0874-df8b-437c-96ec-87873625b0fd
+      - 529e8588-0dbc-47c4-b392-c19a7b2e7dda
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1192'
+      - '1191'
       X-Ms-Correlation-Request-Id:
-      - a5736f23-59cf-4dbb-be38-a58d831726a6
+      - a58a8094-5fc6-4e3c-9fa5-cfb43be08c52
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153315Z:a5736f23-59cf-4dbb-be38-a58d831726a6
+      - EASTUS:20170830T170526Z:a58a8094-5fc6-4e3c-9fa5-cfb43be08c52
       Date:
-      - Wed, 30 Aug 2017 15:33:14 GMT
+      - Wed, 30 Aug 2017 17:05:26 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:33:15 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:25 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/026f0874-df8b-437c-96ec-87873625b0fd?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/529e8588-0dbc-47c4-b392-c19a7b2e7dda?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -2159,7 +2159,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4OTMsIm5iZiI6MTUwNDEwNjg5MywiZXhwIjoxNTA0MTEwNzkzLCJhaW8iOiJZMkZnWUxqMzhzM2FiajRtanF6SlFaa3o2bDdmQlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQThYeXhhLUtaay1lZEZUUUtiWVNBQSIsInZlciI6IjEuMCJ9.ELUphz8vjoMqBXevzTRi0mBKIgmQED3FfZB8GRQEu70iaS2LLCWUX0yXjwnJsIxcY6Ep5EQrVoAub_lPjMR-ZJ8ANF-N9yo-9S0h4e-e3OAU5G2Aw_pkLLKYNac3xIyTS-rMO1YtNWGrMpgeHSb8fIRE1sn67x-EYIBAKtQgcUY-kwsl5rfgSrD1hHOZ3b6mtaMcHPcZU5L2Rq9Wnmg1aG5-mlNLEirawEQx6MNoQ_uBsUlWRXRbm0-xuJWTwc1PJCwHbrSLJeOXixLVcVNLfBH8-EimNa-aUAdk3E85xEHi46w1NUOR-zc3O-QYBNG67slcdV3w0gOlTurDyji9OA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MjQsIm5iZiI6MTUwNDExMjQyNCwiZXhwIjoxNTA0MTE2MzI0LCJhaW8iOiJZMkZnWUloZ1dIOHVWdkV5MDZRbnIvUWk2bllWQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoid192NmJIQmlrVTZIYUFiU2JhQVJBQSIsInZlciI6IjEuMCJ9.oVKRyzdF132kkMP9AkuRBVcmcdyIT3KBlEj6s8oelDE7S3Gzc7-Lk5JnnYcYVO_PPqWNx8lZlTt315YBtOdjLCR6-RhJV2PZ5xCQgVMf7I6o6lQvMt9IcM4qxQo8GPLXM2aO-VKiL-yCuVUeIfdYCXzfgp1ZXNtZ-tXHlKsnGO-q_DDjGxq9KmzYyhT3sAgFitfrpZeppajoRUHgvxzPUCjUe9Zhllt_v_kBUBNR18gCGQoubI-kYo3FL-2B6OwuVHz7wxTiOFfqx27oa0c7zlBYKBUn2ZLhhV6FedT0mN9_iiC-Z6z4Q79FHlxhrnW3RtsbYf-fUlq4fOhdS6VoUA
       Host:
       - management.azure.com
   response:
@@ -2184,29 +2184,29 @@ http_interactions:
       X-Ms-Served-By:
       - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
       X-Ms-Request-Id:
-      - b6d18038-1202-4cde-9a76-22dd4608fb5f
+      - 2519071b-a40c-46d6-924f-e9c031f1302b
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14697'
+      - '14946'
       X-Ms-Correlation-Request-Id:
-      - 83f6d7bd-3f46-4985-81bd-584edad4e38d
+      - e6adc014-4cd3-4016-8736-88b7d18afe4f
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153315Z:83f6d7bd-3f46-4985-81bd-584edad4e38d
+      - EASTUS:20170830T170526Z:e6adc014-4cd3-4016-8736-88b7d18afe4f
       Date:
-      - Wed, 30 Aug 2017 15:33:15 GMT
+      - Wed, 30 Aug 2017 17:05:26 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-08-30T15:33:14.4469557+00:00\",\r\n  \"endTime\":
-        \"2017-08-30T15:33:14.6656883+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=61b9186d-484b-41c3-851e-ff3a6b9239ac&sig=Fm%2BUOJ5Iu%2BdKrVAa2PP2xD4WVxrW29pGjI6CTAZufKE%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"026f0874-df8b-437c-96ec-87873625b0fd\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2017-08-30T17:05:25.7029059+00:00\",\r\n  \"endTime\":
+        \"2017-08-30T17:05:25.8435094+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=a58da682-9835-4067-91d3-14004493cb83&sig=YAoWuVjsGqKYB2ZRwwEzUUOZrZPDWO18HsaAuo3IdTA%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"529e8588-0dbc-47c4-b392-c19a7b2e7dda\"\r\n}"
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:33:15 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:25 GMT
 - request:
     method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=61b9186d-484b-41c3-851e-ff3a6b9239ac&sig=Fm%2BUOJ5Iu%2BdKrVAa2PP2xD4WVxrW29pGjI6CTAZufKE=&sr=b&sv=2016-05-31
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=a58da682-9835-4067-91d3-14004493cb83&sig=YAoWuVjsGqKYB2ZRwwEzUUOZrZPDWO18HsaAuo3IdTA=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2241,7 +2241,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 3b041a91-0001-012c-1da5-216545000000
+      - 067dcafc-0001-0040-1bb2-2188c3000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2267,11 +2267,11 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 30 Aug 2017 15:33:14 GMT
+      - Wed, 30 Aug 2017 17:05:24 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         U5MJAA==
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:33:15 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:25 GMT
 recorded_with: VCR 3.0.3

--- a/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_diskType-1.yml
+++ b/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_diskType-1.yml
@@ -1,0 +1,2277 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://login.microsoftonline.com/azure_tenant_id/oauth2/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_key&resource=https%3A%2F%2Fmanagement.azure.com%2F
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - login.microsoftonline.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Server:
+      - Microsoft-IIS/8.5
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Request-Id:
+      - f62d4169-d404-4e9c-8937-9e8c30e81200
+      P3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Set-Cookie:
+      - esctx=AQABAAAAAAA9kTklhVy7SJTGAzR-p1BcOMxxx0QMjjc3eCQN9wwdAKhLf8SARlmHQoZzzVm6Yg4tw1QSGVQA7eQfnTv-a9OVvIm9ndmIOD4kc5zRIGD3uKimnyg47zKpJ5nP_iIcNQLUKxuwOKpdcrPzfPNjUqjRL16_FfymkiXqZ8Ldq8AIgTHHBac1NDZ2ZMCmYG1QVHIgAA;
+        domain=.login.microsoftonline.com; path=/; secure; HttpOnly
+      - stsservicecookie=ests; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=008; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Wed, 30 Aug 2017 15:33:29 GMT
+      Content-Length:
+      - '1505'
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"Bearer","expires_in":"3600","ext_expires_in":"0","expires_on":"1504110809","not_before":"1504106909","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY5MDksIm5iZiI6MTUwNDEwNjkwOSwiZXhwIjoxNTA0MTEwODA5LCJhaW8iOiJZMkZnWUJBUFdSVjhqM0c5ellaWTVpMXpaV3pxQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYVVFdDlnVFVuRTZKTjU2TU1PZ1NBQSIsInZlciI6IjEuMCJ9.EaWjRAtseWvOmBvRQejbTyAt82TxhJgifxEO52Nb-kI0cENXp8f96qMWTYq40BJyZ8VDQmb40U85rRUbtyRtfMWo4RJbSEjlUEmDrBiICfrpnv_7HxNRCE_tRyu8edPFragAHPP9xYpI9jMKbmuikI-Gs_1ZRyvl2urx8bQgxgWGMg5E_4YTx_VsatjfPp77zVRAa4GU1p4fFbikJpMMmPRR2n3CHw7ENINsQD3NrwKXfZQrrzGjMDIvlyEVCcuhZlzlLdlDOHcrUl0_-ou2xlAO1e4-FFthgHBxy78Oq_iIsM11cGzss53ySNhaMJm2YugjTi_3GzzxkVsxQHI_og"}'
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:29 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions?api-version=2016-06-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY5MDksIm5iZiI6MTUwNDEwNjkwOSwiZXhwIjoxNTA0MTEwODA5LCJhaW8iOiJZMkZnWUJBUFdSVjhqM0c5ellaWTVpMXpaV3pxQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYVVFdDlnVFVuRTZKTjU2TU1PZ1NBQSIsInZlciI6IjEuMCJ9.EaWjRAtseWvOmBvRQejbTyAt82TxhJgifxEO52Nb-kI0cENXp8f96qMWTYq40BJyZ8VDQmb40U85rRUbtyRtfMWo4RJbSEjlUEmDrBiICfrpnv_7HxNRCE_tRyu8edPFragAHPP9xYpI9jMKbmuikI-Gs_1ZRyvl2urx8bQgxgWGMg5E_4YTx_VsatjfPp77zVRAa4GU1p4fFbikJpMMmPRR2n3CHw7ENINsQD3NrwKXfZQrrzGjMDIvlyEVCcuhZlzlLdlDOHcrUl0_-ou2xlAO1e4-FFthgHBxy78Oq_iIsM11cGzss53ySNhaMJm2YugjTi_3GzzxkVsxQHI_og
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Tenant-Reads:
+      - '14999'
+      X-Ms-Request-Id:
+      - dda4c8e4-4865-4443-821b-99594cbfd861
+      X-Ms-Correlation-Request-Id:
+      - dda4c8e4-4865-4443-821b-99594cbfd861
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153329Z:dda4c8e4-4865-4443-821b-99594cbfd861
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 30 Aug 2017 15:33:29 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
+        Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:29 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers?api-version=2015-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY5MDksIm5iZiI6MTUwNDEwNjkwOSwiZXhwIjoxNTA0MTEwODA5LCJhaW8iOiJZMkZnWUJBUFdSVjhqM0c5ellaWTVpMXpaV3pxQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYVVFdDlnVFVuRTZKTjU2TU1PZ1NBQSIsInZlciI6IjEuMCJ9.EaWjRAtseWvOmBvRQejbTyAt82TxhJgifxEO52Nb-kI0cENXp8f96qMWTYq40BJyZ8VDQmb40U85rRUbtyRtfMWo4RJbSEjlUEmDrBiICfrpnv_7HxNRCE_tRyu8edPFragAHPP9xYpI9jMKbmuikI-Gs_1ZRyvl2urx8bQgxgWGMg5E_4YTx_VsatjfPp77zVRAa4GU1p4fFbikJpMMmPRR2n3CHw7ENINsQD3NrwKXfZQrrzGjMDIvlyEVCcuhZlzlLdlDOHcrUl0_-ou2xlAO1e4-FFthgHBxy78Oq_iIsM11cGzss53ySNhaMJm2YugjTi_3GzzxkVsxQHI_og
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14937'
+      X-Ms-Request-Id:
+      - 0dd0b103-0d2b-4bcf-930a-840d9a2dbffd
+      X-Ms-Correlation-Request-Id:
+      - 0dd0b103-0d2b-4bcf-930a-840d9a2dbffd
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153330Z:0dd0b103-0d2b-4bcf-930a-840d9a2dbffd
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 30 Aug 2017 15:33:30 GMT
+      Content-Length:
+      - '241615'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","North Central
+        US","South Central US","West Central US","West US","West US 2","Canada Central","Canada
+        East","North Europe","West Europe","UK South","UK West","East Asia","Southeast
+        Asia","Japan East","Japan West","Korea Central","Korea South","Brazil South","Central
+        India","South India","West India"],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"validateServiceName","locations":[],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"checkServiceNameAvailability","locations":[],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"reportFeedback","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"checkFeedbackRequired","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Automation","namespace":"Microsoft.Automation","authorizations":[{"applicationId":"fc75330b-179d-49af-87dd-3b1acf6827fa","roleDefinitionId":"95fd5de3-d071-4362-92bf-cf341c1de832"}],"resourceTypes":[{"resourceType":"automationAccounts","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
+        South","UK South","West Central US","North Europe","Canada Central","Australia
+        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/runbooks","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
+        South","UK South","West Central US","North Europe","Canada Central","Australia
+        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/configurations","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","North
+        Central US","Brazil South","UK South","West Central US","Central India","Australia
+        Southeast","Canada Central","North Europe"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/webhooks","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
+        South","UK South","West Central US","North Europe","Canada Central","Australia
+        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"operations","locations":["South
+        Central US"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/softwareUpdateConfigurations","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
+        South","UK South","West Central US","North Europe","Canada Central","Australia
+        Southeast","Central India"],"apiVersions":["2017-05-15-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Backup","namespace":"Microsoft.Backup","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"BackupVault","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India"],"apiVersions":["2015-03-15","2014-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Batch","namespace":"Microsoft.Batch","authorization":{"applicationId":"ddbf3205-c6bd-46ae-8127-60eb93363864","roleDefinitionId":"b7f84953-1d03-4eab-9ea4-45f065258ff8"},"resourceTypes":[{"resourceType":"batchAccounts","locations":["West
+        Europe","East US","East US 2","West US","North Central US","Brazil South","North
+        Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
+        West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
+        East","South India","Central India","Canada Central","Canada East","UK South","UK
+        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01","2015-07-01","2014-05-01-privatepreview"]},{"resourceType":"operations","locations":["West
+        Europe","East US","East US 2","West US","North Central US","Brazil South","North
+        Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
+        West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
+        East","South India","Central India","Canada Central","Canada East","UK South","UK
+        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations/quotas","locations":["West
+        Europe","East US","East US 2","West US","North Central US","Brazil South","North
+        Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
+        West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
+        East","South India","Central India","Canada Central","Canada East","UK South","UK
+        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]}],"registrationState":"Unregistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicCompute","namespace":"Microsoft.ClassicCompute","resourceTypes":[{"resourceType":"domainNames","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
+        Central","Canada East","UK South","UK West","West US","Central US","South
+        Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
+        East","Australia Southeast","West US 2","West Central US","South India","Central
+        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
+        Central","Canada East","UK South","UK West","West US","Central US","South
+        Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
+        East","Australia Southeast","West US 2","West Central US","South India","Central
+        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
+        Central US","South Central US","East US","East US 2","Canada Central","Canada
+        East","West US","West US 2","West Central US","Central US","East Asia","Southeast
+        Asia","North Europe","West Europe","UK South","UK West","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operatingSystems","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"operatingSystemFamilies","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicNetwork","namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"virtualNetworks/remoteVirtualNetworkPeeringProxies","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"reservedIps","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicStorage","namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
+        US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
+        Asia","Australia East","Australia Southeast","South India","Central India","West
+        India","West US 2","West Central US","East US","East US 2","North Central
+        US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
+        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
+        US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
+        Asia","Australia East","Australia Southeast","South India","Central India","West
+        India","West US 2","West Central US","East US","East US 2","North Central
+        US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
+        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"vmImages","locations":[],"apiVersions":["2016-11-01"]},{"resourceType":"publicImages","locations":[],"apiVersions":["2016-11-01","2016-04-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"osPlatformImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Compute","namespace":"Microsoft.Compute","authorization":{"applicationId":"60e6cd67-9c8c-4951-9b3c-23c25a2169af","roleDefinitionId":"e4770acb-272e-4dc8-87f3-12f44a612224"},"resourceTypes":[{"resourceType":"availabilitySets","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30"]},{"resourceType":"locations/usages","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"disks","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"snapshots","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"locations/diskoperations","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"images","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
+        US","East US","South Central US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","East Asia","Japan
+        East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/webhooks","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/ping","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/getCallbackConfig","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/listEvents","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"locations","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"locations/operationResults","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/GetCredentials","locations":["West
+        US","East US","South Central US","West Europe"],"apiVersions":["2016-06-27-preview"]},{"resourceType":"registries/listCredentials","locations":["South
+        Central US","East US","West US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","East Asia","Japan
+        East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/regenerateCredential","locations":["South
+        Central US","West US","East US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","East Asia","Japan
+        East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/listUsages","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/regenerateCredentials","locations":["West
+        US","East US","South Central US","West Europe"],"apiVersions":["2016-06-27-preview"]},{"resourceType":"checkNameAvailability","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview","2017-03-01","2016-06-27-preview"]},{"resourceType":"operations","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview","2017-03-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerService","namespace":"Microsoft.ContainerService","authorization":{"applicationId":"7319c514-987d-4e9b-ac3d-d38c4f427f4c","roleDefinitionId":"1b4a0c7f-2217-416f-acfa-cf73452fdc1c"},"resourceTypes":[{"resourceType":"containerServices","locations":["Japan
+        East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
+        East","Australia Southeast","Brazil South","Southeast Asia","West US","North
+        Central US","West Europe","North Europe","East US","UK West","UK South","West
+        Central US","West US 2","South India","Central India","West India","Canada
+        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
+        East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
+        East","Australia Southeast","Brazil South","Southeast Asia","West US","North
+        Central US","West Europe","North Europe","East US","UK West","UK South","West
+        Central US","West US 2","South India","Central India","West India","Canada
+        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DevTestLab","namespace":"Microsoft.DevTestLab","authorization":{"applicationId":"1a14be2a-e903-4cec-99cf-b2e209259a0f","roleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525"},"resourceTypes":[{"resourceType":"labs","locations":["West
+        Central US","Japan East","West US","Australia Southeast","Canada Central","Central
+        India","Central US","East Asia","Korea Central","North Europe","South Central
+        US","UK West","Australia East","Brazil South","Canada East","East US","East
+        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"schedules","locations":["West
+        Central US","Japan East","West US","Australia Southeast","Canada Central","Central
+        India","Central US","East Asia","Korea Central","North Europe","South Central
+        US","UK West","Australia East","Brazil South","Canada East","East US","East
+        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"labs/virtualMachines","locations":["West
+        Central US","Japan East","West US","Australia Southeast","Canada Central","Central
+        India","Central US","East Asia","Korea Central","North Europe","South Central
+        US","UK West","Australia East","Brazil South","Canada East","East US","East
+        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"labs/serviceRunners","locations":["Central
+        US","East US 2","South Central US"],"apiVersions":["2017-04-26-preview","2016-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"locations/operations","locations":["West
+        Central US","Japan East","West US","Australia Southeast","Canada Central","Central
+        India","Central US","East Asia","Korea Central","North Europe","South Central
+        US","UK West","Australia East","Brazil South","Canada East","East US","East
+        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"}],"resourceTypes":[{"resourceType":"components","locations":["East
+        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
+        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01","2014-04-01"]},{"resourceType":"queries","locations":["East
+        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"alertrules","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2016-03-01","2015-04-01","2014-04-01"]},{"resourceType":"autoscalesettings","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2015-04-01","2014-04-01"]},{"resourceType":"eventtypes","locations":[],"apiVersions":["2017-03-01-preview","2016-09-01-preview","2015-04-01","2014-11-01","2014-04-01"]},{"resourceType":"locations","locations":["East
+        US"],"apiVersions":["2015-04-01","2014-04-01"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2015-04-01","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-04-01","2014-06-01","2014-04-01"]},{"resourceType":"automatedExportSettings","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2015-04-01","2014-04-01"]},{"resourceType":"diagnosticSettings","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2017-05-01-preview","2016-09-01","2015-07-01"]},{"resourceType":"diagnosticSettingsCategories","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"extendedDiagnosticSettings","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2017-02-01"]},{"resourceType":"metricDefinitions","locations":["East
+        US","West US","West Europe","East Asia","Southeast Asia","Japan East","Japan
+        West","North Central US","South Central US","East US 2","Canada East","Canada
+        Central","Central US","Australia East","Australia Southeast","Brazil South","South
+        India","Central India","West India","North Europe","West US 2","West Central
+        US","Korea South","Korea Central","UK South","UK West","Global"],"apiVersions":["2017-05-01-preview","2016-03-01","2015-07-01"]},{"resourceType":"logDefinitions","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2015-07-01"]},{"resourceType":"eventCategories","locations":[],"apiVersions":["2015-04-01"]},{"resourceType":"metrics","locations":["East
+        US","West US","West Europe","East Asia","Southeast Asia","Japan East","Japan
+        West","North Central US","South Central US","East US 2","Canada East","Canada
+        Central","Central US","Australia East","Australia Southeast","Brazil South","South
+        India","Central India","West India","North Europe","West US 2","West Central
+        US","Korea South","Korea Central","UK South","UK West"],"apiVersions":["2017-05-01-preview","2016-09-01","2016-06-01"]},{"resourceType":"actiongroups","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]},{"resourceType":"activityLogAlerts","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.KeyVault","namespace":"Microsoft.KeyVault","resourceTypes":[{"resourceType":"vaults","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/accessPolicies","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-10-01","2015-06-01","2014-12-19-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"deletedVaults","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-10-01"]},{"resourceType":"locations/deletedVaults","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorization":{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"routeTables","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2017-04-26-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"]},{"resourceType":"workspaces/dataSources","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"storageInsightConfigs","locations":[],"apiVersions":["2014-10-10"]},{"resourceType":"workspaces/linkedServices","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"linkTargets","locations":["East
+        US"],"apiVersions":["2015-03-20"]},{"resourceType":"operations","locations":[],"apiVersions":["2014-11-10"]},{"resourceType":"devices","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationsManagement","namespace":"Microsoft.OperationsManagement","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"aa249101-6816-4966-aafa-08175d795f14"},"resourceTypes":[{"resourceType":"solutions","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Portal","namespace":"Microsoft.Portal","resourceTypes":[{"resourceType":"dashboards","locations":["Central
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
+        East","West India","South India","Central India","Canada Central","Canada
+        East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"operations","locations":["Central
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
+        East","West India","South India","Central India","Canada Central","Canada
+        East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"consoles","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/consoles","locations":["West
+        US","East US","Central India","North Europe","West Europe","South Central
+        US","Southeast Asia"],"apiVersions":["2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
+        US","East US","Central India","North Europe","West Europe","South Central
+        US","Southeast Asia"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","Canada Central","Canada East","West Central US","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-07-01","2016-12-01","2016-08-10","2016-06-01","2016-05-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"operations","locations":["Southeast
+        Asia"],"apiVersions":["2016-08-10","2016-06-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01"]},{"resourceType":"locations/backupStatus","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]},{"resourceType":"locations/allocatedStamp","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]},{"resourceType":"locations/allocateStamp","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ResourceHealth","namespace":"Microsoft.ResourceHealth","authorization":{"applicationId":"8bdebf23-c0fe-4187-a378-717ad86f6a53","roleDefinitionId":"cc026344-c8b1-4561-83ba-59eba84b27cc"},"resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2017-07-01","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"notifications","locations":["Australia
+        Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Security","namespace":"Microsoft.Security","authorization":{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatuses","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/virtualMachines","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/endpoints","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/subnets","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"tasks","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"alerts","locations":["Central
+        US","East US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"monitoring","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"monitoring/patch","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"monitoring/baseline","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"monitoring/antimalware","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"dataCollectionAgents","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"dataCollectionResults","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"pricings","locations":["Central
+        US","East US"],"apiVersions":["2017-08-01-preview"]},{"resourceType":"complianceResults","locations":["Central
+        US","East US"],"apiVersions":["2017-08-01"]},{"resourceType":"policies","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"appliances","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"webApplicationFirewalls","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/webApplicationFirewalls","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securitySolutions","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/securitySolutions","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securitySolutionsReferenceData","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/securitySolutionsReferenceData","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"jitNetworkAccessPolicies","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/jitNetworkAccessPolicies","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatusesSummaries","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/alerts","locations":["Central
+        US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/tasks","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.SiteRecovery","namespace":"Microsoft.SiteRecovery","authorization":{"applicationId":"b8340c3b-9267-498f-b21a-15d5547fd85e","roleDefinitionId":"8A00C8EA-8F1B-45A7-8F64-F4CC61EEE9B6"},"resourceTypes":[{"resourceType":"SiteRecoveryVault","locations":["East
+        US","West US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","Australia East","Australia Southeast","Brazil South","North
+        Central US","South Central US","Central US","East US 2","Central India","South
+        India"],"apiVersions":["2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Sql","namespace":"Microsoft.Sql","authorizations":[{"applicationId":"e4ab13ed-33cb-41b4-9140-6e264582cf85","roleDefinitionId":"ec3ddc95-44dc-47a2-9926-5e9f5ffd44ec"},{"applicationId":"0130cc9f-7ac5-4026-bd5f-80a08a54e6d9","roleDefinitionId":"45e8abf8-0ec4-44f3-9c37-cff4f7779302"},{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},{"applicationId":"76c7f279-7959-468f-8943-3954880e0d8c","roleDefinitionId":"7f7513a8-73f9-4c5f-97a2-c41f0ea783ef"}],"resourceTypes":[{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/capabilities","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverKeyOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/keys","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/encryptionProtector","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/communicationLinks","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recoverableDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/importExportOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/operationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/firewallrules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/elasticpools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-09-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/dnsAliases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/failoverGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/virtualNetworkRules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/virtualNetworkRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/virtualNetworkRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/databaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/extensions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditRecords","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/VulnerabilityAssessmentScans","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentScans","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups/syncMembers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/syncAgents","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncMemberOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncAgentOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncDatabaseIds","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorization":{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
+        US","West US","West Europe","North Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":["East
+        US","West US","West Europe","North Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Web","namespace":"Microsoft.Web","authorization":{"applicationId":"abfa0a7c-a6b6-4736-8310-5855508787cd","roleDefinitionId":"f47ed98b-b063-4a5b-9e10-4b9b44fa7735"},"resourceTypes":[{"resourceType":"sites/extensions","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots/extensions","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/instances","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots/instances","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/instances/extensions","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots/instances/extensions","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/publicCertificates","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots/publicCertificates","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"publishingUsers","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"ishostnameavailable","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"validate","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"isusernameavailable","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sourceControls","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"availableStacks","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"listSitesAssignedToHostName","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"sites/hostNameBindings","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"sites/domainOwnershipIdentifiers","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"sites/slots/hostNameBindings","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"operations","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"certificates","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms/workers","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"runtimes","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"sites/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"sites/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"sites/slots/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"sites/slots/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"serverFarms/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"serverFarms/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"sites/recommendations","locations":[],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"georegions","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/premieraddons","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01"]},{"resourceType":"hostingEnvironments","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/instances","locations":[],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/instances/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/instances/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/instances","locations":[],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/instances/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/instances/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"deploymentLocations","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"functions","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"deletedSites","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"ishostingenvironmentnameavailable","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"classicMobileServices","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"connections","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/managedApis","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/apiOperations","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"connectionGateways","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/connectionGatewayInstallations","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"checkNameAvailability","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"billingMeters","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/84codes.CloudAMQP","namespace":"84codes.CloudAMQP","resourceTypes":[{"resourceType":"servers","locations":["East
+        US 2","Central US","East US","North Central US","South Central US","West US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast"],"apiVersions":["2016-08-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/AppDynamics.APM","namespace":"AppDynamics.APM","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2016-05-26"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-05-26"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-05-26"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-05-26"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-05-26"]},{"resourceType":"locations/operationResults","locations":["West
+        US"],"apiVersions":["2016-05-26"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Aspera.Transfers","namespace":"Aspera.Transfers","resourceTypes":[{"resourceType":"services","locations":["West
+        US","North Europe","Central US","East US","West Europe","East Asia","Southeast
+        Asia","Japan East","East US 2","Japan West"],"apiVersions":["2016-03-25"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-03-25"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-03-25"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-03-25"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Auth0.Cloud","namespace":"Auth0.Cloud","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-11-23"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Citrix.Cloud","namespace":"Citrix.Cloud","resourceTypes":[{"resourceType":"accounts","locations":["West
+        US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Cloudyn.Analytics","namespace":"Cloudyn.Analytics","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US"],"apiVersions":["2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Conexlink.MyCloudIT","namespace":"Conexlink.MyCloudIT","resourceTypes":[{"resourceType":"accounts","locations":["Central
+        US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Crypteron.DataSecurity","namespace":"Crypteron.DataSecurity","resourceTypes":[{"resourceType":"apps","locations":["West
+        US"],"apiVersions":["2016-08-12"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-12"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-12"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-12"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Dynatrace.DynatraceSaaS","namespace":"Dynatrace.DynatraceSaaS","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-09-27"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Dynatrace.Ruxit","namespace":"Dynatrace.Ruxit","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US"],"apiVersions":["2016-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-09-07","2016-04-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-04-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/LiveArena.Broadcast","namespace":"LiveArena.Broadcast","resourceTypes":[{"resourceType":"services","locations":["West
+        US","North Europe","Japan West","Japan East","East Asia","West Europe","East
+        US","Southeast Asia","Central US"],"apiVersions":["2016-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Lombiq.DotNest","namespace":"Lombiq.DotNest","resourceTypes":[{"resourceType":"sites","locations":["East
+        US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Mailjet.Email","namespace":"Mailjet.Email","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]},{"resourceType":"diagnosticSettings","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"addsservices","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"configuration","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"agents","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"aadsupportcases","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"reports","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"servicehealthmetrics","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"logs","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"anonymousapiusers","locations":["West
+        US"],"apiVersions":["2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AnalysisServices","namespace":"Microsoft.AnalysisServices","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"servers","locations":["West
+        US","North Europe","South Central US","West Europe","West Central US","Southeast
+        Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
+        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/checkNameAvailability","locations":["West
+        US","North Europe","South Central US","West Europe","West Central US","Southeast
+        Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
+        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationresults","locations":["West
+        US","North Europe","South Central US","West Europe","West Central US","Southeast
+        Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
+        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationstatuses","locations":["West
+        US","North Europe","South Central US","West Europe","West Central US","Southeast
+        Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
+        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"operations","locations":["East
+        US 2","West Central US"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AppService","namespace":"Microsoft.AppService","authorization":{"applicationId":"dee7ba80-6a55-4f3b-a86c-746a9231ae49","roleDefinitionId":"6715d172-49c4-46f6-bb21-60512a8689dc"},"resourceTypes":[{"resourceType":"apiapps","locations":["East
+        US","West US","South Central US","North Europe","East Asia","Japan East","West
+        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
+        South","East US 2","Australia Southeast","Australia East","West India","South
+        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"appIdentities","locations":["East
+        US","West US","South Central US","North Europe","East Asia","Japan East","West
+        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
+        South","East US 2","Australia Southeast","Australia East","West India","South
+        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"gateways","locations":["East
+        US","West US","South Central US","North Europe","East Asia","Japan East","West
+        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
+        South","East US 2","Australia Southeast","Australia East","West India","South
+        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"deploymenttemplates","locations":[],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Authorization","namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"roleDefinitions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"classicAdministrators","locations":[],"apiVersions":["2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"permissions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"locks","locations":[],"apiVersions":["2017-04-01","2016-09-01","2015-06-01","2015-05-01-preview","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-01-01","2014-10-01-preview","2014-06-01"]},{"resourceType":"policyDefinitions","locations":[],"apiVersions":["2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"policySetDefinitions","locations":[],"apiVersions":["2017-06-01-preview"]},{"resourceType":"policyAssignments","locations":[],"apiVersions":["2017-06-01-preview","2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"providerOperations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01-preview","2015-07-01"]},{"resourceType":"elevateAccess","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureActiveDirectory","namespace":"Microsoft.AzureActiveDirectory","resourceTypes":[{"resourceType":"b2cDirectories","locations":["Global","United
+        States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureStack","namespace":"Microsoft.AzureStack","resourceTypes":[{"resourceType":"operations","locations":["Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations","locations":["West
+        Central US","Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations/products","locations":["West
+        Central US","Global"],"apiVersions":["2017-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Billing","namespace":"Microsoft.Billing","resourceTypes":[{"resourceType":"BillingPeriods","locations":["Central
+        US"],"apiVersions":["2017-04-24-preview"]},{"resourceType":"Invoices","locations":["Central
+        US"],"apiVersions":["2017-04-24-preview","2017-02-27-preview"]},{"resourceType":"operations","locations":["Central
+        US"],"apiVersions":["2017-04-24-preview","2017-02-27-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BingMaps","namespace":"Microsoft.BingMaps","resourceTypes":[{"resourceType":"mapApis","locations":["West
+        US"],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-18","2015-07-02"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BizTalkServices","namespace":"Microsoft.BizTalkServices","resourceTypes":[{"resourceType":"BizTalk","locations":["East
+        US","West US","North Europe","West Europe","Southeast Asia","East Asia","North
+        Central US","Japan West","Japan East","South Central US"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Cache","namespace":"Microsoft.Cache","authorization":{"applicationId":"96231a05-34ce-4eb4-aa6a-70759cbb5e83","roleDefinitionId":"4f731528-ba85-45c7-acfb-cd0a9b3cf31b"},"resourceTypes":[{"resourceType":"Redis","locations":["North
+        Central US","South Central US","Central US","West Europe","North Europe","West
+        US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
+        Asia","East Asia","Australia East","Australia Southeast","Central India","West
+        India","Canada Central","Canada East","UK South","UK West","West US 2","West
+        Central US","South India","Korea Central","Korea South"],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","South Central US","Central US","West Europe","North Europe","West
+        US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
+        Asia","East Asia","Australia East","Australia Southeast","Central India","West
+        India","South India","Canada Central","Canada East","UK South","UK West","West
+        US 2","West Central US","Korea Central","Korea South"],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01"]},{"resourceType":"Redis/metricDefinitions","locations":["North
+        Central US","South Central US","East US","East US 2","West US","Central US","East
+        Asia","Southeast Asia","North Europe","West Europe","Japan East","Japan West","Brazil
+        South","Australia Southeast","Australia East","Central India","West India","South
+        India","Canada Central","Canada East","UK West","UK South","West US 2","West
+        Central US","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"Redis/diagnosticSettings","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","West
+        US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
+        Asia","Australia East","Australia Southeast","Central India","West India","South
+        India","Canada Central","Canada East","UK West","UK South","West US 2","West
+        Central US","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Cdn","namespace":"Microsoft.Cdn","resourceTypes":[{"resourceType":"profiles","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/origins","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/customdomains","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/originresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/customdomainresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkResourceUsage","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02"]},{"resourceType":"validateProbe","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"edgenodes","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CertificateRegistration","namespace":"Microsoft.CertificateRegistration","authorization":{"applicationId":"f3c21649-0979-4721-ac85-b0216b2cf413","roleDefinitionId":"933fba7e-2ed3-4da8-973d-8bd8298a9b40"},"resourceTypes":[{"resourceType":"certificateOrders","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"certificateOrders/certificates","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"validateCertificateRegistrationInformation","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicSubscription","namespace":"Microsoft.ClassicSubscription","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicInfrastructureMigrate","namespace":"Microsoft.ClassicInfrastructureMigrate","authorization":{"applicationId":"5e5abe2b-83cd-4786-826a-a05653ebb103","roleDefinitionId":"766c4d9b-ef83-4f73-8352-1450a506a69b"},"resourceTypes":[{"resourceType":"classicInfrastructureResources","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","West
+        India","South India"],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CognitiveServices","namespace":"Microsoft.CognitiveServices","authorizations":[{"applicationId":"7d312290-28c8-473c-a0ed-8e53749b6d6d","roleDefinitionId":"5cb87f79-a7c3-4a95-9414-45b65974b51b"}],"resourceTypes":[{"resourceType":"accounts","locations":["Global","West
+        US","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"operations","locations":["Global","West
+        US","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations","locations":["Global","West
+        US","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/checkSkuAvailability","locations":["West
+        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/updateAccountsCreationSettings","locations":["West
+        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/accountsCreationSettings","locations":["West
+        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2016-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Commerce","namespace":"Microsoft.Commerce","resourceTypes":[{"resourceType":"UsageAggregates","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]},{"resourceType":"RateCard","locations":[],"apiVersions":["2016-08-31-preview","2015-06-01-preview","2015-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Consumption","namespace":"Microsoft.Consumption","resourceTypes":[{"resourceType":"reservationsummaries","locations":[],"apiVersions":["2017-01-30"]},{"resourceType":"reservationdetails","locations":[],"apiVersions":["2017-01-30"]},{"resourceType":"UsageDetails","locations":[],"apiVersions":["2017-06-30-preview","2017-04-24-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-30-preview","2017-04-24-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","resourceTypes":[{"resourceType":"containerGroups","locations":["West
+        US","East US","West Europe"],"apiVersions":["2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
+        US"],"apiVersions":["2016-04-08"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CustomerInsights","namespace":"Microsoft.CustomerInsights","authorization":{"applicationId":"38c77d00-5fcb-4cce-9d93-af4738258e3c","roleDefinitionId":"E006F9C7-F333-477C-8AD6-1F3A9FE87F55"},"resourceTypes":[{"resourceType":"hubs","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/profiles","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/interactions","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/authorizationPolicies","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/connectors","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/connectors/mappings","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/kpi","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/views","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/links","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/roleAssignments","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/roles","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/widgetTypes","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/suggestTypeSchema","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"operations","locations":["East
+        US 2"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataCatalog","namespace":"Microsoft.DataCatalog","resourceTypes":[{"resourceType":"catalogs","locations":["East
+        US","West US","Australia East","West Europe","North Europe","Southeast Asia","West
+        Central US"],"apiVersions":["2016-03-30","2015-07-01-preview"]},{"resourceType":"checkNameAvailability","locations":["West
+        Europe"],"apiVersions":["2016-03-30","2015-07-01-preview"]},{"resourceType":"operations","locations":["West
+        Europe"],"apiVersions":["2016-03-30","2015-07-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-03-30","2015-07-01-preview"]},{"resourceType":"locations/jobs","locations":["East
+        US","West US","Australia East","West Europe","North Europe","Southeast Asia","West
+        Central US"],"apiVersions":["2016-03-30","2015-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataFactory","namespace":"Microsoft.DataFactory","resourceTypes":[{"resourceType":"dataFactories","locations":["West
+        US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview","2014-04-01"]},{"resourceType":"factories","locations":["East
+        US"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
+        US"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
+        Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"dataFactories/metricDefinitions","locations":["North
+        Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"checkDataFactoryNameAvailability","locations":[],"apiVersions":["2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"checkAzureDataFactoryNameAvailability","locations":["West
+        US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"dataFactorySchema","locations":["West
+        US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"operations","locations":["West
+        US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeAnalytics","namespace":"Microsoft.DataLakeAnalytics","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/dataLakeStoreAccounts","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers/listSasTokens","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeStore","namespace":"Microsoft.DataLakeStore","authorization":{"applicationId":"e9f49c6b-5ce5-44c8-925d-015017e9f7ad","roleDefinitionId":"17eb9cca-f08a-4499-b2d3-852d175f614f"},"resourceTypes":[{"resourceType":"accounts","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/firewallRules","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","resourceTypes":[{"resourceType":"operations","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforPostgreSQL","namespace":"Microsoft.DBforPostgreSQL","resourceTypes":[{"resourceType":"operations","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
+        US","North Europe","East Asia","East US","West Europe","Southeast Asia","Japan
+        East","Japan West","Australia East","Australia Southeast","West US 2","West
+        Central US","East US 2","Central US","UK South","UK West","South India","Central
+        India"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"databaseAccountNames","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DomainRegistration","namespace":"Microsoft.DomainRegistration","authorization":{"applicationId":"ea2f600a-4980-45b7-89bf-d34da487bda1","roleDefinitionId":"54d7f2e3-5040-48a7-ae90-eebf629cfa0b"},"resourceTypes":[{"resourceType":"domains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"domains/domainOwnershipIdentifiers","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"topLevelDomains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"checkDomainAvailability","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"listDomainRecommendations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"validateDomainRegistrationInformation","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"generateSsoRequest","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DynamicsLcs","namespace":"Microsoft.DynamicsLcs","resourceTypes":[{"resourceType":"lcsprojects","locations":["Brazil
+        South","East Asia","East US","Japan East","Japan West","North Central US","North
+        Europe","South Central US","West Europe","West US","Southeast Asia","Central
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"lcsprojects/connectors","locations":["Brazil
+        South","East Asia","East US","Japan East","Japan West","North Central US","North
+        Europe","South Central US","West Europe","West US","Southeast Asia","Central
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"lcsprojects/clouddeployments","locations":["Brazil
+        South","East Asia","East US","Japan East","Japan West","North Central US","North
+        Europe","South Central US","West Europe","West US","Southeast Asia","Central
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"operations","locations":["Brazil
+        South","East Asia","East US","Japan East","Japan West","North Central US","North
+        Europe","South Central US","West Europe","West US","Southeast Asia","Central
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"topics","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operations","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"clusters/applications","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"clusters/operationresults","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations/capabilities","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations/operationresults","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations/azureasyncoperations","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations/validateCreateRequest","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"operations","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India"],"apiVersions":["2015-03-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ImportExport","namespace":"Microsoft.ImportExport","authorization":{"applicationId":"7de4d5c5-5b32-4235-b8a9-33b34d6bcd2a","roleDefinitionId":"9f7aa6bb-9454-46b6-8c01-a4b0f33ca151"},"resourceTypes":[{"resourceType":"jobs","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","North Central US","North Europe","South Central US","Southeast
+        Asia","South India","UK South","West Central US","West Europe","West India","West
+        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","North Central US","North Europe","South Central US","Southeast
+        Asia","South India","UK South","West Central US","West Europe","West India","West
+        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations/operationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","North Central US","North Europe","South Central US","Southeast
+        Asia","South India","UK South","West Central US","West Europe","West India","West
+        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","North Central US","North Europe","South Central US","Southeast
+        Asia","South India","UK South","West Central US","West Europe","West India","West
+        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Logic","namespace":"Microsoft.Logic","authorization":{"applicationId":"7cd684f4-8a78-49b0-91ec-6a35d38739ba","roleDefinitionId":"cb3ef1fb-6e31-49e2-9d87-ed821053fe58"},"resourceTypes":[{"resourceType":"workflows","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West"],"apiVersions":["2017-07-01","2016-10-01","2016-06-01","2015-08-01-preview","2015-02-01-preview"]},{"resourceType":"locations/workflows","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West"],"apiVersions":["2017-07-01","2016-10-01","2016-06-01","2015-08-01-preview","2015-02-01-preview"]},{"resourceType":"locations","locations":["North
+        Central US"],"apiVersions":["2017-07-01","2016-10-01","2016-06-01","2015-08-01-preview","2015-02-01-preview"]},{"resourceType":"operations","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West"],"apiVersions":["2017-07-01","2016-10-01","2016-06-01","2015-08-01-preview","2015-02-01-preview"]},{"resourceType":"integrationAccounts","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","West Central US"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"operations","locations":["South
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations","locations":["South
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operations","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"commitmentPlans","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
+        Central US","West US"],"apiVersions":["2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Media","namespace":"Microsoft.Media","authorization":{"applicationId":"374b2a64-3b6b-436b-934c-b820eacca870","roleDefinitionId":"aab70789-0cec-44b5-95d7-84b64c9487af"},"resourceTypes":[{"resourceType":"mediaservices","locations":["Japan
+        West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
+        US","West US","Australia East","Australia Southeast","Central US","Brazil
+        South","Central India","West India","South India","South Central US","Canada
+        Central","Canada East","West Central US"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
+        Central US","North Central US","East US 2","West US","West Europe","North
+        Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
+        East","UK South","West India"],"apiVersions":["2016-01-29"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-01-29"]},{"resourceType":"locations/checkNameAvailability","locations":["South
+        Central US","North Central US","East US 2","West US","West Europe","North
+        Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
+        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"operations","locations":["East
+        US 2"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Relay","namespace":"Microsoft.Relay","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US 2","West
+        US","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
+        East","West India","South India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
+        East","West India","South India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
+        Central US","South Central US","North Europe","West Europe","East Asia","Southeast
+        Asia","West US","East US","Japan West","Japan East","Brazil South","Central
+        US","East US 2","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-03-01","2016-01-01","2014-08-01-preview"]},{"resourceType":"operations","locations":["North
+        Central US","South Central US","North Europe","West Europe","East Asia","Southeast
+        Asia","West US","East US","Japan West","Japan East","Brazil South","Central
+        US","East US 2","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-03-01","2016-01-01","2014-08-01-preview"]},{"resourceType":"operationResults","locations":["North
+        Central US","South Central US","North Europe","West Europe","East Asia","Southeast
+        Asia","West US","East US","Japan West","Japan East","Brazil South","Central
+        US","East US 2","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-03-01","2016-01-01","2014-08-01-preview"]},{"resourceType":"flows","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast"],"apiVersions":["2015-08-01-preview","2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Search","namespace":"Microsoft.Search","resourceTypes":[{"resourceType":"searchServices","locations":["West
+        US","East US","North Europe","West Europe","Southeast Asia","East Asia","North
+        Central US","South Central US","Japan West","Australia East","Brazil South","Central
+        India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19","2015-02-28"]},{"resourceType":"checkServiceNameAvailability","locations":[],"apiVersions":["2015-02-28","2014-07-31-Preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2015-08-19"]},{"resourceType":"resourceHealthMetadata","locations":["West
+        US","East US","North Europe","West Europe","Southeast Asia","East Asia","North
+        Central US","South Central US","Japan West","Australia East","Brazil South","Central
+        India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US 2","West
+        US","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"premiumMessagingRegions","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceFabric","namespace":"Microsoft.ServiceFabric","authorization":{"applicationId":"74cb6831-0dbb-4be1-8206-fd4df301cdc2","roleDefinitionId":"e55cc65f-6903-4917-b4ef-f8d4640b57f5"},"resourceTypes":[{"resourceType":"clusters","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/clusterVersions","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operations","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Canada
+        Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","West Central US","Japan East","Japan West","Australia East","Australia
+        Southeast"],"apiVersions":["2017-06-01","2017-05-15","2017-01-01","2016-10-01","2016-06-01","2015-03-15","2014-09-01"]},{"resourceType":"operations","locations":["West
+        Central US","Southeast Asia"],"apiVersions":["2016-10-01","2016-06-01","2015-03-15","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StreamAnalytics","namespace":"Microsoft.StreamAnalytics","resourceTypes":[{"resourceType":"streamingjobs","locations":["Central
+        US","West Europe","East US 2","North Europe","Japan East","West US","Southeast
+        Asia","South Central US","East Asia","Japan West","North Central US","East
+        US","Australia East","Australia Southeast","Brazil South","Central India","West
+        Central US","UK South","UK West","Canada Central","Canada East","West US 2"],"apiVersions":["2017-04-01-preview","2016-03-01","2015-11-01","2015-10-01","2015-09-01","2015-08-01-preview","2015-06-01","2015-05-01","2015-04-01","2015-03-01-preview"]},{"resourceType":"locations","locations":["West
+        Europe","Central US","East US 2","North Europe","Japan East","West US","Southeast
+        Asia","South Central US","East Asia","Japan West","North Central US","East
+        US","Australia East","Australia Southeast","Brazil South","Central India","West
+        Central US","UK South","West US 2","UK West","Canada Central","Canada East"],"apiVersions":["2017-04-01-preview","2016-03-01","2015-11-01","2015-10-01","2015-09-01","2015-08-01-preview","2015-06-01","2015-05-01","2015-04-01","2015-03-01-preview"]},{"resourceType":"locations/quotas","locations":[],"apiVersions":["2017-04-01-preview","2016-03-01","2015-11-01","2015-10-01","2015-09-01","2015-08-01-preview","2015-06-01","2015-05-01","2015-04-01","2015-03-01-preview"]},{"resourceType":"streamingjobs/diagnosticSettings","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","Central
+        India","West Central US","UK South","UK West","Canada Central","Canada East","West
+        US 2","West US","Central US","South Central US","Japan East","Japan West","East
+        Asia","Southeast Asia","Australia East","Australia Southeast"],"apiVersions":["2014-04-01"]},{"resourceType":"streamingjobs/metricDefinitions","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","Central
+        India","West Central US","UK South","UK West","Canada Central","Canada East","West
+        US 2","West US","Central US","South Central US","Japan East","Japan West","East
+        Asia","Southeast Asia","Australia East","Australia Southeast"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":["West
+        Europe","West US","Central US","East US 2","North Europe","Japan East","Southeast
+        Asia","South Central US","East Asia","Japan West","North Central US","East
+        US","Australia East","Australia Southeast","Brazil South","Central India","West
+        Central US","UK South","UK West","Canada Central","Canada East","West US 2"],"apiVersions":["2017-04-01-preview","2016-03-01","2015-11-01","2015-10-01","2015-09-01","2015-08-01-preview","2015-06-01","2015-05-01","2015-04-01","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.support","namespace":"microsoft.support","resourceTypes":[{"resourceType":"operations","locations":["North
+        Central US","South Central US","Central US","West Europe","North Europe","West
+        US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
+        Asia","East Asia","Australia East","Australia Southeast"],"apiVersions":["2015-07-01-Preview","2015-03-01"]},{"resourceType":"supporttickets","locations":["North
+        Central US","South Central US","Central US","West Europe","North Europe","West
+        US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
+        Asia","East Asia","Australia East","Australia Southeast"],"apiVersions":["2015-07-01-Preview","2015-03-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.TimeSeriesInsights","namespace":"Microsoft.TimeSeriesInsights","authorizations":[{"applicationId":"120d688d-1518-4cf7-bd38-182f158850b6","roleDefinitionId":"5a43abdf-bb87-42c4-9e56-1c24bf364150"}],"resourceTypes":[{"resourceType":"environments","locations":["East
+        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/eventsources","locations":["East
+        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/referenceDataSets","locations":["East
+        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/accessPolicies","locations":["East
+        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"operations","locations":["East
+        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/project","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/extension","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"checkNameAvailability","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Myget.PackageManagement","namespace":"Myget.PackageManagement","resourceTypes":[{"resourceType":"services","locations":["West
+        Europe"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/NewRelic.APM","namespace":"NewRelic.APM","authorization":{"allowedThirdPartyExtensions":[{"name":"NewRelic_AzurePortal_APM"}]},"resourceTypes":[{"resourceType":"accounts","locations":["North
+        Central US","South Central US","West US","East US","North Europe","West Europe","Southeast
+        Asia","East Asia","Japan East","Japan West"],"apiVersions":["2014-10-01","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/nuubit.nextgencdn","namespace":"nuubit.nextgencdn","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US","East US 2","North Central US","South Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","West US","Central US"],"apiVersions":["2017-05-05"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-05"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-05-05"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-05-05"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Paraleap.CloudMonix","namespace":"Paraleap.CloudMonix","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2016-08-10"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-10"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-10"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Pokitdok.Platform","namespace":"Pokitdok.Platform","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2016-05-17"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-05-17"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-05-17"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-05-17"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RavenHq.Db","namespace":"RavenHq.Db","resourceTypes":[{"resourceType":"databases","locations":["East
+        US"],"apiVersions":["2016-07-18","2016-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-07-18","2016-06-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-07-18","2016-06-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-07-18","2016-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Raygun.CrashReporting","namespace":"Raygun.CrashReporting","resourceTypes":[{"resourceType":"apps","locations":["East
+        US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RedisLabs.Memcached","namespace":"RedisLabs.Memcached","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-07-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RedisLabs.Redis","namespace":"RedisLabs.Redis","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-07-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RevAPM.MobileCDN","namespace":"RevAPM.MobileCDN","resourceTypes":[{"resourceType":"accounts","locations":["Central
+        US","East US","East US 2","North Central US","South Central US","West US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast"],"apiVersions":["2016-08-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-24","2016-08-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sendgrid.Email","namespace":"Sendgrid.Email","resourceTypes":[{"resourceType":"accounts","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Canada Central","Canada
+        East","West Central US","West US 2","UK South","UK West"],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Signiant.Flight","namespace":"Signiant.Flight","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US","Central US","North Central US","South Central US","West US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast"],"apiVersions":["2015-06-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sparkpost.Basic","namespace":"Sparkpost.Basic","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2016-08-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/stackify.retrace","namespace":"stackify.retrace","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2016-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/SuccessBricks.ClearDB","namespace":"SuccessBricks.ClearDB","resourceTypes":[{"resourceType":"databases","locations":["Brazil
+        South","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","Southeast Asia","West Europe","West
+        US","South Central US","Australia East","Australia Southeast","Canada Central","Canada
+        East","Central India","South India","West India"],"apiVersions":["2014-04-01"]},{"resourceType":"clusters","locations":["Brazil
+        South","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","Southeast Asia","West Europe","West
+        US","Australia Southeast","Australia East","South Central US","Canada Central","Canada
+        East","Central India","South India","West India"],"apiVersions":["2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/TrendMicro.DeepSecurity","namespace":"TrendMicro.DeepSecurity","resourceTypes":[{"resourceType":"accounts","locations":["Central
+        US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
+        Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:30 GMT
+- request:
+    method: post
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
+    body:
+      encoding: UTF-8
+      string: '{"access":"read","durationInSeconds":3600}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY5MDksIm5iZiI6MTUwNDEwNjkwOSwiZXhwIjoxNTA0MTEwODA5LCJhaW8iOiJZMkZnWUJBUFdSVjhqM0c5ellaWTVpMXpaV3pxQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYVVFdDlnVFVuRTZKTjU2TU1PZ1NBQSIsInZlciI6IjEuMCJ9.EaWjRAtseWvOmBvRQejbTyAt82TxhJgifxEO52Nb-kI0cENXp8f96qMWTYq40BJyZ8VDQmb40U85rRUbtyRtfMWo4RJbSEjlUEmDrBiICfrpnv_7HxNRCE_tRyu8edPFragAHPP9xYpI9jMKbmuikI-Gs_1ZRyvl2urx8bQgxgWGMg5E_4YTx_VsatjfPp77zVRAa4GU1p4fFbikJpMMmPRR2n3CHw7ENINsQD3NrwKXfZQrrzGjMDIvlyEVCcuhZlzlLdlDOHcrUl0_-ou2xlAO1e4-FFthgHBxy78Oq_iIsM11cGzss53ySNhaMJm2YugjTi_3GzzxkVsxQHI_og
+      Content-Length:
+      - '42'
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '0'
+      Expires:
+      - "-1"
+      Location:
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/02dfba12-4f3a-4fbb-8806-6a16005fd46b?monitor=true&api-version=2017-03-30
+      Azure-Asyncoperation:
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/02dfba12-4f3a-4fbb-8806-6a16005fd46b?api-version=2017-03-30
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      X-Ms-Request-Id:
+      - 02dfba12-4f3a-4fbb-8806-6a16005fd46b
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Writes:
+      - '1198'
+      X-Ms-Correlation-Request-Id:
+      - 1991ca77-6548-4a7a-8106-7f90e8b9fc05
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153331Z:1991ca77-6548-4a7a-8106-7f90e8b9fc05
+      Date:
+      - Wed, 30 Aug 2017 15:33:30 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:30 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/02dfba12-4f3a-4fbb-8806-6a16005fd46b?api-version=2017-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY5MDksIm5iZiI6MTUwNDEwNjkwOSwiZXhwIjoxNTA0MTEwODA5LCJhaW8iOiJZMkZnWUJBUFdSVjhqM0c5ellaWTVpMXpaV3pxQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYVVFdDlnVFVuRTZKTjU2TU1PZ1NBQSIsInZlciI6IjEuMCJ9.EaWjRAtseWvOmBvRQejbTyAt82TxhJgifxEO52Nb-kI0cENXp8f96qMWTYq40BJyZ8VDQmb40U85rRUbtyRtfMWo4RJbSEjlUEmDrBiICfrpnv_7HxNRCE_tRyu8edPFragAHPP9xYpI9jMKbmuikI-Gs_1ZRyvl2urx8bQgxgWGMg5E_4YTx_VsatjfPp77zVRAa4GU1p4fFbikJpMMmPRR2n3CHw7ENINsQD3NrwKXfZQrrzGjMDIvlyEVCcuhZlzlLdlDOHcrUl0_-ou2xlAO1e4-FFthgHBxy78Oq_iIsM11cGzss53ySNhaMJm2YugjTi_3GzzxkVsxQHI_og
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      X-Ms-Request-Id:
+      - 12960511-a41c-4bd0-ab1f-ad784cc6f043
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14924'
+      X-Ms-Correlation-Request-Id:
+      - 7cfe68a1-051e-4b55-9faa-cf0a1804a809
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153331Z:7cfe68a1-051e-4b55-9faa-cf0a1804a809
+      Date:
+      - Wed, 30 Aug 2017 15:33:30 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"startTime\": \"2017-08-30T15:33:30.7879609+00:00\",\r\n  \"endTime\":
+        \"2017-08-30T15:33:30.9760046+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=dd82785b-657d-4cc2-b3ad-9c5ef8eb0802&sig=690SnzAE5dC9UzJGD03L%2FSzkuOgCODgdwVsqjSo4kfg%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"02dfba12-4f3a-4fbb-8806-6a16005fd46b\"\r\n}"
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:30 GMT
+- request:
+    method: get
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=dd82785b-657d-4cc2-b3ad-9c5ef8eb0802&sig=690SnzAE5dC9UzJGD03L/SzkuOgCODgdwVsqjSo4kfg=&sr=b&sv=2016-05-31
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      X-Ms-Range:
+      - bytes=0-0
+      Host:
+      - md-t4jdgqqlgszp.blob.core.windows.net
+  response:
+    status:
+      code: 206
+      message: Partial Content
+    headers:
+      Content-Length:
+      - '1'
+      Content-Type:
+      - application/octet-stream
+      Content-Range:
+      - bytes 0-0/34359738880
+      Last-Modified:
+      - Sat, 15 Jul 2017 14:23:07 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D4CB8D039FC699"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 064df520-0001-0040-1da5-2188c3000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Meta-Pirtag:
+      - '1'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '20'
+      X-Ms-Copy-Id:
+      - 30cedd78-548a-4fd8-967e-f8344f587e3c
+      X-Ms-Copy-Source:
+      - http://md-t4jdgqqlgszp.blob.core.windows.net:8080/fg25xxtqx0gc/abcd?sv=2016-02-19&sr=b&st=2017-05-04T21%3a06%3a57Z&se=9999-12-31T23%3a59%3a59Z&sp=r&api-version=2016-02-19
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 34359738880/34359738880
+      X-Ms-Copy-Completion-Time:
+      - Thu, 04 May 2017 21:21:56 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Wed, 30 Aug 2017 15:33:30 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        6w==
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:31 GMT
+- request:
+    method: post
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
+    body:
+      encoding: UTF-8
+      string: '{"access":"read","durationInSeconds":3600}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY5MDksIm5iZiI6MTUwNDEwNjkwOSwiZXhwIjoxNTA0MTEwODA5LCJhaW8iOiJZMkZnWUJBUFdSVjhqM0c5ellaWTVpMXpaV3pxQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYVVFdDlnVFVuRTZKTjU2TU1PZ1NBQSIsInZlciI6IjEuMCJ9.EaWjRAtseWvOmBvRQejbTyAt82TxhJgifxEO52Nb-kI0cENXp8f96qMWTYq40BJyZ8VDQmb40U85rRUbtyRtfMWo4RJbSEjlUEmDrBiICfrpnv_7HxNRCE_tRyu8edPFragAHPP9xYpI9jMKbmuikI-Gs_1ZRyvl2urx8bQgxgWGMg5E_4YTx_VsatjfPp77zVRAa4GU1p4fFbikJpMMmPRR2n3CHw7ENINsQD3NrwKXfZQrrzGjMDIvlyEVCcuhZlzlLdlDOHcrUl0_-ou2xlAO1e4-FFthgHBxy78Oq_iIsM11cGzss53ySNhaMJm2YugjTi_3GzzxkVsxQHI_og
+      Content-Length:
+      - '42'
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '0'
+      Expires:
+      - "-1"
+      Location:
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/04677803-5b14-4e35-9697-4c010dd294f6?monitor=true&api-version=2017-03-30
+      Azure-Asyncoperation:
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/04677803-5b14-4e35-9697-4c010dd294f6?api-version=2017-03-30
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      X-Ms-Request-Id:
+      - '04677803-5b14-4e35-9697-4c010dd294f6'
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Writes:
+      - '1195'
+      X-Ms-Correlation-Request-Id:
+      - 6baa13aa-2933-453f-a3bb-4e8e35370b6c
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153331Z:6baa13aa-2933-453f-a3bb-4e8e35370b6c
+      Date:
+      - Wed, 30 Aug 2017 15:33:31 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:31 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/04677803-5b14-4e35-9697-4c010dd294f6?api-version=2017-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY5MDksIm5iZiI6MTUwNDEwNjkwOSwiZXhwIjoxNTA0MTEwODA5LCJhaW8iOiJZMkZnWUJBUFdSVjhqM0c5ellaWTVpMXpaV3pxQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYVVFdDlnVFVuRTZKTjU2TU1PZ1NBQSIsInZlciI6IjEuMCJ9.EaWjRAtseWvOmBvRQejbTyAt82TxhJgifxEO52Nb-kI0cENXp8f96qMWTYq40BJyZ8VDQmb40U85rRUbtyRtfMWo4RJbSEjlUEmDrBiICfrpnv_7HxNRCE_tRyu8edPFragAHPP9xYpI9jMKbmuikI-Gs_1ZRyvl2urx8bQgxgWGMg5E_4YTx_VsatjfPp77zVRAa4GU1p4fFbikJpMMmPRR2n3CHw7ENINsQD3NrwKXfZQrrzGjMDIvlyEVCcuhZlzlLdlDOHcrUl0_-ou2xlAO1e4-FFthgHBxy78Oq_iIsM11cGzss53ySNhaMJm2YugjTi_3GzzxkVsxQHI_og
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      X-Ms-Request-Id:
+      - 369efffe-c212-4f6c-81d2-26eaafb68898
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14930'
+      X-Ms-Correlation-Request-Id:
+      - 5be46b85-2753-4727-823d-9d118d64d20b
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153332Z:5be46b85-2753-4727-823d-9d118d64d20b
+      Date:
+      - Wed, 30 Aug 2017 15:33:31 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"startTime\": \"2017-08-30T15:33:31.5228836+00:00\",\r\n  \"endTime\":
+        \"2017-08-30T15:33:31.6634751+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=c65895ff-2752-4c76-bb44-e19586e7a543&sig=j6VTkx1xh67Wv8WRiuq2qbypfbVpRu1yJ9bHfS5TwqA%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"04677803-5b14-4e35-9697-4c010dd294f6\"\r\n}"
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:31 GMT
+- request:
+    method: get
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=c65895ff-2752-4c76-bb44-e19586e7a543&sig=j6VTkx1xh67Wv8WRiuq2qbypfbVpRu1yJ9bHfS5TwqA=&sr=b&sv=2016-05-31
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      X-Ms-Range:
+      - bytes=440-443
+      Host:
+      - md-t4jdgqqlgszp.blob.core.windows.net
+  response:
+    status:
+      code: 206
+      message: Partial Content
+    headers:
+      Content-Length:
+      - '4'
+      Content-Type:
+      - application/octet-stream
+      Content-Range:
+      - bytes 440-443/34359738880
+      Last-Modified:
+      - Sat, 15 Jul 2017 14:23:07 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D4CB8D039FC699"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - f313a090-0001-0018-5aa5-218cb8000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Meta-Pirtag:
+      - '1'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '20'
+      X-Ms-Copy-Id:
+      - 30cedd78-548a-4fd8-967e-f8344f587e3c
+      X-Ms-Copy-Source:
+      - http://md-t4jdgqqlgszp.blob.core.windows.net:8080/fg25xxtqx0gc/abcd?sv=2016-02-19&sr=b&st=2017-05-04T21%3a06%3a57Z&se=9999-12-31T23%3a59%3a59Z&sp=r&api-version=2016-02-19
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 34359738880/34359738880
+      X-Ms-Copy-Completion-Time:
+      - Thu, 04 May 2017 21:21:56 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Wed, 30 Aug 2017 15:33:32 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        U5MJAA==
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:31 GMT
+recorded_with: VCR 3.0.3

--- a/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_endByteAddr-1.yml
+++ b/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_endByteAddr-1.yml
@@ -1,0 +1,2277 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://login.microsoftonline.com/azure_tenant_id/oauth2/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_key&resource=https%3A%2F%2Fmanagement.azure.com%2F
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - login.microsoftonline.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Server:
+      - Microsoft-IIS/8.5
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Request-Id:
+      - 82b7d5ec-80e3-4807-871f-a2fcf0c01200
+      P3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Set-Cookie:
+      - esctx=AQABAAAAAAA9kTklhVy7SJTGAzR-p1BcIpr9LnNz_RQq8GA1q38agMY7K2oQ1zQGxI4qkkP7UgqTydl9p4zXkx4UCCpwrTbM0DkBxKvP4E7EuAnID0d8HBNNeThay82FFSCofIF2DilMyavp1PicQX2Jnw65jH3X3g9OFyVSlznIsiM0hPDXkh6QWhkA2hHbKeaAJXpTVpIgAA;
+        domain=.login.microsoftonline.com; path=/; secure; HttpOnly
+      - stsservicecookie=ests; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=007; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Wed, 30 Aug 2017 15:32:57 GMT
+      Content-Length:
+      - '1505'
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"Bearer","expires_in":"3600","ext_expires_in":"0","expires_on":"1504110778","not_before":"1504106878","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NzgsIm5iZiI6MTUwNDEwNjg3OCwiZXhwIjoxNTA0MTEwNzc4LCJhaW8iOiJZMkZnWUZCY25ycm1tbGFFeTZPRk9yd0dmWjg4QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiN05XM2d1T0FCMGlISDZMODhNQVNBQSIsInZlciI6IjEuMCJ9.Yfke5b0kH6_7eOGt4vQ_aaxM4X_Z_GIpNAgkjb-jVDCtiJ-xvuT3hrXsAbLHYyPVBZfYDKYwPKFqnml-dC2bNxxOxNv6cY2omPcdYlzzcmx7xy9z18QNu1pTdeDCL6BfFAKGa-Lb1dCgaJK9fmq__uQ30YaEIO1EY6dac4b1rJpa9zfvYpHytyI_6J_DIJyaxdpiYnu9fg0QHilzVwbKFxX5YuJY2Qjo9nOVFjVaAA_68v5Yh1Y1RlpuShJ7VafBGcXW2lOkNHxB9I0X2E-Nh7QWWV7KWj_1oCDsiTksw3TsDRECVb1hGHAMu7zUbCbIDSP45pYptAPLLf3Odr7T9w"}'
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:32:56 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions?api-version=2016-06-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NzgsIm5iZiI6MTUwNDEwNjg3OCwiZXhwIjoxNTA0MTEwNzc4LCJhaW8iOiJZMkZnWUZCY25ycm1tbGFFeTZPRk9yd0dmWjg4QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiN05XM2d1T0FCMGlISDZMODhNQVNBQSIsInZlciI6IjEuMCJ9.Yfke5b0kH6_7eOGt4vQ_aaxM4X_Z_GIpNAgkjb-jVDCtiJ-xvuT3hrXsAbLHYyPVBZfYDKYwPKFqnml-dC2bNxxOxNv6cY2omPcdYlzzcmx7xy9z18QNu1pTdeDCL6BfFAKGa-Lb1dCgaJK9fmq__uQ30YaEIO1EY6dac4b1rJpa9zfvYpHytyI_6J_DIJyaxdpiYnu9fg0QHilzVwbKFxX5YuJY2Qjo9nOVFjVaAA_68v5Yh1Y1RlpuShJ7VafBGcXW2lOkNHxB9I0X2E-Nh7QWWV7KWj_1oCDsiTksw3TsDRECVb1hGHAMu7zUbCbIDSP45pYptAPLLf3Odr7T9w
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Tenant-Reads:
+      - '14997'
+      X-Ms-Request-Id:
+      - f53dc0a0-5ccd-47bc-bbab-f7ea5fc43a9b
+      X-Ms-Correlation-Request-Id:
+      - f53dc0a0-5ccd-47bc-bbab-f7ea5fc43a9b
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153258Z:f53dc0a0-5ccd-47bc-bbab-f7ea5fc43a9b
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 30 Aug 2017 15:32:58 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
+        Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:32:56 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers?api-version=2015-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NzgsIm5iZiI6MTUwNDEwNjg3OCwiZXhwIjoxNTA0MTEwNzc4LCJhaW8iOiJZMkZnWUZCY25ycm1tbGFFeTZPRk9yd0dmWjg4QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiN05XM2d1T0FCMGlISDZMODhNQVNBQSIsInZlciI6IjEuMCJ9.Yfke5b0kH6_7eOGt4vQ_aaxM4X_Z_GIpNAgkjb-jVDCtiJ-xvuT3hrXsAbLHYyPVBZfYDKYwPKFqnml-dC2bNxxOxNv6cY2omPcdYlzzcmx7xy9z18QNu1pTdeDCL6BfFAKGa-Lb1dCgaJK9fmq__uQ30YaEIO1EY6dac4b1rJpa9zfvYpHytyI_6J_DIJyaxdpiYnu9fg0QHilzVwbKFxX5YuJY2Qjo9nOVFjVaAA_68v5Yh1Y1RlpuShJ7VafBGcXW2lOkNHxB9I0X2E-Nh7QWWV7KWj_1oCDsiTksw3TsDRECVb1hGHAMu7zUbCbIDSP45pYptAPLLf3Odr7T9w
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14934'
+      X-Ms-Request-Id:
+      - 47effc27-aeea-4126-a2ec-161ba547fdfe
+      X-Ms-Correlation-Request-Id:
+      - 47effc27-aeea-4126-a2ec-161ba547fdfe
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153259Z:47effc27-aeea-4126-a2ec-161ba547fdfe
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 30 Aug 2017 15:32:58 GMT
+      Content-Length:
+      - '241615'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","North Central
+        US","South Central US","West Central US","West US","West US 2","Canada Central","Canada
+        East","North Europe","West Europe","UK South","UK West","East Asia","Southeast
+        Asia","Japan East","Japan West","Korea Central","Korea South","Brazil South","Central
+        India","South India","West India"],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"validateServiceName","locations":[],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"checkServiceNameAvailability","locations":[],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"reportFeedback","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"checkFeedbackRequired","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Automation","namespace":"Microsoft.Automation","authorizations":[{"applicationId":"fc75330b-179d-49af-87dd-3b1acf6827fa","roleDefinitionId":"95fd5de3-d071-4362-92bf-cf341c1de832"}],"resourceTypes":[{"resourceType":"automationAccounts","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
+        South","UK South","West Central US","North Europe","Canada Central","Australia
+        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/runbooks","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
+        South","UK South","West Central US","North Europe","Canada Central","Australia
+        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/configurations","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","North
+        Central US","Brazil South","UK South","West Central US","Central India","Australia
+        Southeast","Canada Central","North Europe"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/webhooks","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
+        South","UK South","West Central US","North Europe","Canada Central","Australia
+        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"operations","locations":["South
+        Central US"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/softwareUpdateConfigurations","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
+        South","UK South","West Central US","North Europe","Canada Central","Australia
+        Southeast","Central India"],"apiVersions":["2017-05-15-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Backup","namespace":"Microsoft.Backup","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"BackupVault","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India"],"apiVersions":["2015-03-15","2014-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Batch","namespace":"Microsoft.Batch","authorization":{"applicationId":"ddbf3205-c6bd-46ae-8127-60eb93363864","roleDefinitionId":"b7f84953-1d03-4eab-9ea4-45f065258ff8"},"resourceTypes":[{"resourceType":"batchAccounts","locations":["West
+        Europe","East US","East US 2","West US","North Central US","Brazil South","North
+        Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
+        West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
+        East","South India","Central India","Canada Central","Canada East","UK South","UK
+        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01","2015-07-01","2014-05-01-privatepreview"]},{"resourceType":"operations","locations":["West
+        Europe","East US","East US 2","West US","North Central US","Brazil South","North
+        Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
+        West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
+        East","South India","Central India","Canada Central","Canada East","UK South","UK
+        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations/quotas","locations":["West
+        Europe","East US","East US 2","West US","North Central US","Brazil South","North
+        Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
+        West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
+        East","South India","Central India","Canada Central","Canada East","UK South","UK
+        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]}],"registrationState":"Unregistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicCompute","namespace":"Microsoft.ClassicCompute","resourceTypes":[{"resourceType":"domainNames","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
+        Central","Canada East","UK South","UK West","West US","Central US","South
+        Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
+        East","Australia Southeast","West US 2","West Central US","South India","Central
+        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
+        Central","Canada East","UK South","UK West","West US","Central US","South
+        Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
+        East","Australia Southeast","West US 2","West Central US","South India","Central
+        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
+        Central US","South Central US","East US","East US 2","Canada Central","Canada
+        East","West US","West US 2","West Central US","Central US","East Asia","Southeast
+        Asia","North Europe","West Europe","UK South","UK West","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operatingSystems","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"operatingSystemFamilies","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicNetwork","namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"virtualNetworks/remoteVirtualNetworkPeeringProxies","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"reservedIps","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicStorage","namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
+        US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
+        Asia","Australia East","Australia Southeast","South India","Central India","West
+        India","West US 2","West Central US","East US","East US 2","North Central
+        US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
+        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
+        US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
+        Asia","Australia East","Australia Southeast","South India","Central India","West
+        India","West US 2","West Central US","East US","East US 2","North Central
+        US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
+        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"vmImages","locations":[],"apiVersions":["2016-11-01"]},{"resourceType":"publicImages","locations":[],"apiVersions":["2016-11-01","2016-04-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"osPlatformImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Compute","namespace":"Microsoft.Compute","authorization":{"applicationId":"60e6cd67-9c8c-4951-9b3c-23c25a2169af","roleDefinitionId":"e4770acb-272e-4dc8-87f3-12f44a612224"},"resourceTypes":[{"resourceType":"availabilitySets","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30"]},{"resourceType":"locations/usages","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"disks","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"snapshots","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"locations/diskoperations","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"images","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
+        US","East US","South Central US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","East Asia","Japan
+        East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/webhooks","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/ping","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/getCallbackConfig","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/listEvents","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"locations","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"locations/operationResults","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/GetCredentials","locations":["West
+        US","East US","South Central US","West Europe"],"apiVersions":["2016-06-27-preview"]},{"resourceType":"registries/listCredentials","locations":["South
+        Central US","East US","West US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","East Asia","Japan
+        East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/regenerateCredential","locations":["South
+        Central US","West US","East US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","East Asia","Japan
+        East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/listUsages","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/regenerateCredentials","locations":["West
+        US","East US","South Central US","West Europe"],"apiVersions":["2016-06-27-preview"]},{"resourceType":"checkNameAvailability","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview","2017-03-01","2016-06-27-preview"]},{"resourceType":"operations","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview","2017-03-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerService","namespace":"Microsoft.ContainerService","authorization":{"applicationId":"7319c514-987d-4e9b-ac3d-d38c4f427f4c","roleDefinitionId":"1b4a0c7f-2217-416f-acfa-cf73452fdc1c"},"resourceTypes":[{"resourceType":"containerServices","locations":["Japan
+        East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
+        East","Australia Southeast","Brazil South","Southeast Asia","West US","North
+        Central US","West Europe","North Europe","East US","UK West","UK South","West
+        Central US","West US 2","South India","Central India","West India","Canada
+        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
+        East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
+        East","Australia Southeast","Brazil South","Southeast Asia","West US","North
+        Central US","West Europe","North Europe","East US","UK West","UK South","West
+        Central US","West US 2","South India","Central India","West India","Canada
+        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DevTestLab","namespace":"Microsoft.DevTestLab","authorization":{"applicationId":"1a14be2a-e903-4cec-99cf-b2e209259a0f","roleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525"},"resourceTypes":[{"resourceType":"labs","locations":["West
+        Central US","Japan East","West US","Australia Southeast","Canada Central","Central
+        India","Central US","East Asia","Korea Central","North Europe","South Central
+        US","UK West","Australia East","Brazil South","Canada East","East US","East
+        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"schedules","locations":["West
+        Central US","Japan East","West US","Australia Southeast","Canada Central","Central
+        India","Central US","East Asia","Korea Central","North Europe","South Central
+        US","UK West","Australia East","Brazil South","Canada East","East US","East
+        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"labs/virtualMachines","locations":["West
+        Central US","Japan East","West US","Australia Southeast","Canada Central","Central
+        India","Central US","East Asia","Korea Central","North Europe","South Central
+        US","UK West","Australia East","Brazil South","Canada East","East US","East
+        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"labs/serviceRunners","locations":["Central
+        US","East US 2","South Central US"],"apiVersions":["2017-04-26-preview","2016-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"locations/operations","locations":["West
+        Central US","Japan East","West US","Australia Southeast","Canada Central","Central
+        India","Central US","East Asia","Korea Central","North Europe","South Central
+        US","UK West","Australia East","Brazil South","Canada East","East US","East
+        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"}],"resourceTypes":[{"resourceType":"components","locations":["East
+        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
+        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01","2014-04-01"]},{"resourceType":"queries","locations":["East
+        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"alertrules","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2016-03-01","2015-04-01","2014-04-01"]},{"resourceType":"autoscalesettings","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2015-04-01","2014-04-01"]},{"resourceType":"eventtypes","locations":[],"apiVersions":["2017-03-01-preview","2016-09-01-preview","2015-04-01","2014-11-01","2014-04-01"]},{"resourceType":"locations","locations":["East
+        US"],"apiVersions":["2015-04-01","2014-04-01"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2015-04-01","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-04-01","2014-06-01","2014-04-01"]},{"resourceType":"automatedExportSettings","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2015-04-01","2014-04-01"]},{"resourceType":"diagnosticSettings","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2017-05-01-preview","2016-09-01","2015-07-01"]},{"resourceType":"diagnosticSettingsCategories","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"extendedDiagnosticSettings","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2017-02-01"]},{"resourceType":"metricDefinitions","locations":["East
+        US","West US","West Europe","East Asia","Southeast Asia","Japan East","Japan
+        West","North Central US","South Central US","East US 2","Canada East","Canada
+        Central","Central US","Australia East","Australia Southeast","Brazil South","South
+        India","Central India","West India","North Europe","West US 2","West Central
+        US","Korea South","Korea Central","UK South","UK West","Global"],"apiVersions":["2017-05-01-preview","2016-03-01","2015-07-01"]},{"resourceType":"logDefinitions","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2015-07-01"]},{"resourceType":"eventCategories","locations":[],"apiVersions":["2015-04-01"]},{"resourceType":"metrics","locations":["East
+        US","West US","West Europe","East Asia","Southeast Asia","Japan East","Japan
+        West","North Central US","South Central US","East US 2","Canada East","Canada
+        Central","Central US","Australia East","Australia Southeast","Brazil South","South
+        India","Central India","West India","North Europe","West US 2","West Central
+        US","Korea South","Korea Central","UK South","UK West"],"apiVersions":["2017-05-01-preview","2016-09-01","2016-06-01"]},{"resourceType":"actiongroups","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]},{"resourceType":"activityLogAlerts","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.KeyVault","namespace":"Microsoft.KeyVault","resourceTypes":[{"resourceType":"vaults","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/accessPolicies","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-10-01","2015-06-01","2014-12-19-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"deletedVaults","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-10-01"]},{"resourceType":"locations/deletedVaults","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorization":{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"routeTables","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2017-04-26-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"]},{"resourceType":"workspaces/dataSources","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"storageInsightConfigs","locations":[],"apiVersions":["2014-10-10"]},{"resourceType":"workspaces/linkedServices","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"linkTargets","locations":["East
+        US"],"apiVersions":["2015-03-20"]},{"resourceType":"operations","locations":[],"apiVersions":["2014-11-10"]},{"resourceType":"devices","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationsManagement","namespace":"Microsoft.OperationsManagement","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"aa249101-6816-4966-aafa-08175d795f14"},"resourceTypes":[{"resourceType":"solutions","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Portal","namespace":"Microsoft.Portal","resourceTypes":[{"resourceType":"dashboards","locations":["Central
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
+        East","West India","South India","Central India","Canada Central","Canada
+        East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"operations","locations":["Central
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
+        East","West India","South India","Central India","Canada Central","Canada
+        East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"consoles","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/consoles","locations":["West
+        US","East US","Central India","North Europe","West Europe","South Central
+        US","Southeast Asia"],"apiVersions":["2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
+        US","East US","Central India","North Europe","West Europe","South Central
+        US","Southeast Asia"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","Canada Central","Canada East","West Central US","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-07-01","2016-12-01","2016-08-10","2016-06-01","2016-05-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"operations","locations":["Southeast
+        Asia"],"apiVersions":["2016-08-10","2016-06-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01"]},{"resourceType":"locations/backupStatus","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]},{"resourceType":"locations/allocatedStamp","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]},{"resourceType":"locations/allocateStamp","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ResourceHealth","namespace":"Microsoft.ResourceHealth","authorization":{"applicationId":"8bdebf23-c0fe-4187-a378-717ad86f6a53","roleDefinitionId":"cc026344-c8b1-4561-83ba-59eba84b27cc"},"resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2017-07-01","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"notifications","locations":["Australia
+        Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Security","namespace":"Microsoft.Security","authorization":{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatuses","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/virtualMachines","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/endpoints","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/subnets","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"tasks","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"alerts","locations":["Central
+        US","East US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"monitoring","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"monitoring/patch","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"monitoring/baseline","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"monitoring/antimalware","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"dataCollectionAgents","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"dataCollectionResults","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"pricings","locations":["Central
+        US","East US"],"apiVersions":["2017-08-01-preview"]},{"resourceType":"complianceResults","locations":["Central
+        US","East US"],"apiVersions":["2017-08-01"]},{"resourceType":"policies","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"appliances","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"webApplicationFirewalls","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/webApplicationFirewalls","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securitySolutions","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/securitySolutions","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securitySolutionsReferenceData","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/securitySolutionsReferenceData","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"jitNetworkAccessPolicies","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/jitNetworkAccessPolicies","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatusesSummaries","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/alerts","locations":["Central
+        US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/tasks","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.SiteRecovery","namespace":"Microsoft.SiteRecovery","authorization":{"applicationId":"b8340c3b-9267-498f-b21a-15d5547fd85e","roleDefinitionId":"8A00C8EA-8F1B-45A7-8F64-F4CC61EEE9B6"},"resourceTypes":[{"resourceType":"SiteRecoveryVault","locations":["East
+        US","West US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","Australia East","Australia Southeast","Brazil South","North
+        Central US","South Central US","Central US","East US 2","Central India","South
+        India"],"apiVersions":["2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Sql","namespace":"Microsoft.Sql","authorizations":[{"applicationId":"e4ab13ed-33cb-41b4-9140-6e264582cf85","roleDefinitionId":"ec3ddc95-44dc-47a2-9926-5e9f5ffd44ec"},{"applicationId":"0130cc9f-7ac5-4026-bd5f-80a08a54e6d9","roleDefinitionId":"45e8abf8-0ec4-44f3-9c37-cff4f7779302"},{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},{"applicationId":"76c7f279-7959-468f-8943-3954880e0d8c","roleDefinitionId":"7f7513a8-73f9-4c5f-97a2-c41f0ea783ef"}],"resourceTypes":[{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/capabilities","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverKeyOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/keys","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/encryptionProtector","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/communicationLinks","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recoverableDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/importExportOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/operationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/firewallrules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/elasticpools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-09-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/dnsAliases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/failoverGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/virtualNetworkRules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/virtualNetworkRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/virtualNetworkRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/databaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/extensions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditRecords","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/VulnerabilityAssessmentScans","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentScans","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups/syncMembers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/syncAgents","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncMemberOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncAgentOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncDatabaseIds","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorization":{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
+        US","West US","West Europe","North Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":["East
+        US","West US","West Europe","North Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Web","namespace":"Microsoft.Web","authorization":{"applicationId":"abfa0a7c-a6b6-4736-8310-5855508787cd","roleDefinitionId":"f47ed98b-b063-4a5b-9e10-4b9b44fa7735"},"resourceTypes":[{"resourceType":"sites/extensions","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots/extensions","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/instances","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots/instances","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/instances/extensions","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots/instances/extensions","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/publicCertificates","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots/publicCertificates","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"publishingUsers","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"ishostnameavailable","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"validate","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"isusernameavailable","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sourceControls","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"availableStacks","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"listSitesAssignedToHostName","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"sites/hostNameBindings","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"sites/domainOwnershipIdentifiers","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"sites/slots/hostNameBindings","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"operations","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"certificates","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms/workers","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"runtimes","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"sites/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"sites/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"sites/slots/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"sites/slots/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"serverFarms/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"serverFarms/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"sites/recommendations","locations":[],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"georegions","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/premieraddons","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01"]},{"resourceType":"hostingEnvironments","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/instances","locations":[],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/instances/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/instances/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/instances","locations":[],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/instances/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/instances/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"deploymentLocations","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"functions","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"deletedSites","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"ishostingenvironmentnameavailable","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"classicMobileServices","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"connections","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/managedApis","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/apiOperations","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"connectionGateways","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/connectionGatewayInstallations","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"checkNameAvailability","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"billingMeters","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/84codes.CloudAMQP","namespace":"84codes.CloudAMQP","resourceTypes":[{"resourceType":"servers","locations":["East
+        US 2","Central US","East US","North Central US","South Central US","West US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast"],"apiVersions":["2016-08-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/AppDynamics.APM","namespace":"AppDynamics.APM","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2016-05-26"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-05-26"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-05-26"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-05-26"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-05-26"]},{"resourceType":"locations/operationResults","locations":["West
+        US"],"apiVersions":["2016-05-26"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Aspera.Transfers","namespace":"Aspera.Transfers","resourceTypes":[{"resourceType":"services","locations":["West
+        US","North Europe","Central US","East US","West Europe","East Asia","Southeast
+        Asia","Japan East","East US 2","Japan West"],"apiVersions":["2016-03-25"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-03-25"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-03-25"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-03-25"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Auth0.Cloud","namespace":"Auth0.Cloud","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-11-23"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Citrix.Cloud","namespace":"Citrix.Cloud","resourceTypes":[{"resourceType":"accounts","locations":["West
+        US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Cloudyn.Analytics","namespace":"Cloudyn.Analytics","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US"],"apiVersions":["2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Conexlink.MyCloudIT","namespace":"Conexlink.MyCloudIT","resourceTypes":[{"resourceType":"accounts","locations":["Central
+        US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Crypteron.DataSecurity","namespace":"Crypteron.DataSecurity","resourceTypes":[{"resourceType":"apps","locations":["West
+        US"],"apiVersions":["2016-08-12"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-12"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-12"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-12"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Dynatrace.DynatraceSaaS","namespace":"Dynatrace.DynatraceSaaS","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-09-27"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Dynatrace.Ruxit","namespace":"Dynatrace.Ruxit","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US"],"apiVersions":["2016-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-09-07","2016-04-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-04-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/LiveArena.Broadcast","namespace":"LiveArena.Broadcast","resourceTypes":[{"resourceType":"services","locations":["West
+        US","North Europe","Japan West","Japan East","East Asia","West Europe","East
+        US","Southeast Asia","Central US"],"apiVersions":["2016-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Lombiq.DotNest","namespace":"Lombiq.DotNest","resourceTypes":[{"resourceType":"sites","locations":["East
+        US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Mailjet.Email","namespace":"Mailjet.Email","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]},{"resourceType":"diagnosticSettings","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"addsservices","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"configuration","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"agents","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"aadsupportcases","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"reports","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"servicehealthmetrics","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"logs","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"anonymousapiusers","locations":["West
+        US"],"apiVersions":["2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AnalysisServices","namespace":"Microsoft.AnalysisServices","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"servers","locations":["West
+        US","North Europe","South Central US","West Europe","West Central US","Southeast
+        Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
+        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/checkNameAvailability","locations":["West
+        US","North Europe","South Central US","West Europe","West Central US","Southeast
+        Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
+        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationresults","locations":["West
+        US","North Europe","South Central US","West Europe","West Central US","Southeast
+        Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
+        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationstatuses","locations":["West
+        US","North Europe","South Central US","West Europe","West Central US","Southeast
+        Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
+        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"operations","locations":["East
+        US 2","West Central US"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AppService","namespace":"Microsoft.AppService","authorization":{"applicationId":"dee7ba80-6a55-4f3b-a86c-746a9231ae49","roleDefinitionId":"6715d172-49c4-46f6-bb21-60512a8689dc"},"resourceTypes":[{"resourceType":"apiapps","locations":["East
+        US","West US","South Central US","North Europe","East Asia","Japan East","West
+        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
+        South","East US 2","Australia Southeast","Australia East","West India","South
+        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"appIdentities","locations":["East
+        US","West US","South Central US","North Europe","East Asia","Japan East","West
+        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
+        South","East US 2","Australia Southeast","Australia East","West India","South
+        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"gateways","locations":["East
+        US","West US","South Central US","North Europe","East Asia","Japan East","West
+        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
+        South","East US 2","Australia Southeast","Australia East","West India","South
+        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"deploymenttemplates","locations":[],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Authorization","namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"roleDefinitions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"classicAdministrators","locations":[],"apiVersions":["2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"permissions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"locks","locations":[],"apiVersions":["2017-04-01","2016-09-01","2015-06-01","2015-05-01-preview","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-01-01","2014-10-01-preview","2014-06-01"]},{"resourceType":"policyDefinitions","locations":[],"apiVersions":["2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"policySetDefinitions","locations":[],"apiVersions":["2017-06-01-preview"]},{"resourceType":"policyAssignments","locations":[],"apiVersions":["2017-06-01-preview","2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"providerOperations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01-preview","2015-07-01"]},{"resourceType":"elevateAccess","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureActiveDirectory","namespace":"Microsoft.AzureActiveDirectory","resourceTypes":[{"resourceType":"b2cDirectories","locations":["Global","United
+        States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureStack","namespace":"Microsoft.AzureStack","resourceTypes":[{"resourceType":"operations","locations":["Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations","locations":["West
+        Central US","Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations/products","locations":["West
+        Central US","Global"],"apiVersions":["2017-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Billing","namespace":"Microsoft.Billing","resourceTypes":[{"resourceType":"BillingPeriods","locations":["Central
+        US"],"apiVersions":["2017-04-24-preview"]},{"resourceType":"Invoices","locations":["Central
+        US"],"apiVersions":["2017-04-24-preview","2017-02-27-preview"]},{"resourceType":"operations","locations":["Central
+        US"],"apiVersions":["2017-04-24-preview","2017-02-27-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BingMaps","namespace":"Microsoft.BingMaps","resourceTypes":[{"resourceType":"mapApis","locations":["West
+        US"],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-18","2015-07-02"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BizTalkServices","namespace":"Microsoft.BizTalkServices","resourceTypes":[{"resourceType":"BizTalk","locations":["East
+        US","West US","North Europe","West Europe","Southeast Asia","East Asia","North
+        Central US","Japan West","Japan East","South Central US"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Cache","namespace":"Microsoft.Cache","authorization":{"applicationId":"96231a05-34ce-4eb4-aa6a-70759cbb5e83","roleDefinitionId":"4f731528-ba85-45c7-acfb-cd0a9b3cf31b"},"resourceTypes":[{"resourceType":"Redis","locations":["North
+        Central US","South Central US","Central US","West Europe","North Europe","West
+        US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
+        Asia","East Asia","Australia East","Australia Southeast","Central India","West
+        India","Canada Central","Canada East","UK South","UK West","West US 2","West
+        Central US","South India","Korea Central","Korea South"],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","South Central US","Central US","West Europe","North Europe","West
+        US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
+        Asia","East Asia","Australia East","Australia Southeast","Central India","West
+        India","South India","Canada Central","Canada East","UK South","UK West","West
+        US 2","West Central US","Korea Central","Korea South"],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01"]},{"resourceType":"Redis/metricDefinitions","locations":["North
+        Central US","South Central US","East US","East US 2","West US","Central US","East
+        Asia","Southeast Asia","North Europe","West Europe","Japan East","Japan West","Brazil
+        South","Australia Southeast","Australia East","Central India","West India","South
+        India","Canada Central","Canada East","UK West","UK South","West US 2","West
+        Central US","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"Redis/diagnosticSettings","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","West
+        US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
+        Asia","Australia East","Australia Southeast","Central India","West India","South
+        India","Canada Central","Canada East","UK West","UK South","West US 2","West
+        Central US","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Cdn","namespace":"Microsoft.Cdn","resourceTypes":[{"resourceType":"profiles","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/origins","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/customdomains","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/originresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/customdomainresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkResourceUsage","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02"]},{"resourceType":"validateProbe","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"edgenodes","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CertificateRegistration","namespace":"Microsoft.CertificateRegistration","authorization":{"applicationId":"f3c21649-0979-4721-ac85-b0216b2cf413","roleDefinitionId":"933fba7e-2ed3-4da8-973d-8bd8298a9b40"},"resourceTypes":[{"resourceType":"certificateOrders","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"certificateOrders/certificates","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"validateCertificateRegistrationInformation","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicSubscription","namespace":"Microsoft.ClassicSubscription","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicInfrastructureMigrate","namespace":"Microsoft.ClassicInfrastructureMigrate","authorization":{"applicationId":"5e5abe2b-83cd-4786-826a-a05653ebb103","roleDefinitionId":"766c4d9b-ef83-4f73-8352-1450a506a69b"},"resourceTypes":[{"resourceType":"classicInfrastructureResources","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","West
+        India","South India"],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CognitiveServices","namespace":"Microsoft.CognitiveServices","authorizations":[{"applicationId":"7d312290-28c8-473c-a0ed-8e53749b6d6d","roleDefinitionId":"5cb87f79-a7c3-4a95-9414-45b65974b51b"}],"resourceTypes":[{"resourceType":"accounts","locations":["Global","West
+        US","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"operations","locations":["Global","West
+        US","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations","locations":["Global","West
+        US","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/checkSkuAvailability","locations":["West
+        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/updateAccountsCreationSettings","locations":["West
+        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/accountsCreationSettings","locations":["West
+        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2016-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Commerce","namespace":"Microsoft.Commerce","resourceTypes":[{"resourceType":"UsageAggregates","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]},{"resourceType":"RateCard","locations":[],"apiVersions":["2016-08-31-preview","2015-06-01-preview","2015-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Consumption","namespace":"Microsoft.Consumption","resourceTypes":[{"resourceType":"reservationsummaries","locations":[],"apiVersions":["2017-01-30"]},{"resourceType":"reservationdetails","locations":[],"apiVersions":["2017-01-30"]},{"resourceType":"UsageDetails","locations":[],"apiVersions":["2017-06-30-preview","2017-04-24-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-30-preview","2017-04-24-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","resourceTypes":[{"resourceType":"containerGroups","locations":["West
+        US","East US","West Europe"],"apiVersions":["2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
+        US"],"apiVersions":["2016-04-08"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CustomerInsights","namespace":"Microsoft.CustomerInsights","authorization":{"applicationId":"38c77d00-5fcb-4cce-9d93-af4738258e3c","roleDefinitionId":"E006F9C7-F333-477C-8AD6-1F3A9FE87F55"},"resourceTypes":[{"resourceType":"hubs","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/profiles","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/interactions","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/authorizationPolicies","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/connectors","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/connectors/mappings","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/kpi","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/views","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/links","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/roleAssignments","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/roles","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/widgetTypes","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/suggestTypeSchema","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"operations","locations":["East
+        US 2"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataCatalog","namespace":"Microsoft.DataCatalog","resourceTypes":[{"resourceType":"catalogs","locations":["East
+        US","West US","Australia East","West Europe","North Europe","Southeast Asia","West
+        Central US"],"apiVersions":["2016-03-30","2015-07-01-preview"]},{"resourceType":"checkNameAvailability","locations":["West
+        Europe"],"apiVersions":["2016-03-30","2015-07-01-preview"]},{"resourceType":"operations","locations":["West
+        Europe"],"apiVersions":["2016-03-30","2015-07-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-03-30","2015-07-01-preview"]},{"resourceType":"locations/jobs","locations":["East
+        US","West US","Australia East","West Europe","North Europe","Southeast Asia","West
+        Central US"],"apiVersions":["2016-03-30","2015-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataFactory","namespace":"Microsoft.DataFactory","resourceTypes":[{"resourceType":"dataFactories","locations":["West
+        US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview","2014-04-01"]},{"resourceType":"factories","locations":["East
+        US"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
+        US"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
+        Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"dataFactories/metricDefinitions","locations":["North
+        Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"checkDataFactoryNameAvailability","locations":[],"apiVersions":["2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"checkAzureDataFactoryNameAvailability","locations":["West
+        US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"dataFactorySchema","locations":["West
+        US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"operations","locations":["West
+        US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeAnalytics","namespace":"Microsoft.DataLakeAnalytics","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/dataLakeStoreAccounts","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers/listSasTokens","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeStore","namespace":"Microsoft.DataLakeStore","authorization":{"applicationId":"e9f49c6b-5ce5-44c8-925d-015017e9f7ad","roleDefinitionId":"17eb9cca-f08a-4499-b2d3-852d175f614f"},"resourceTypes":[{"resourceType":"accounts","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/firewallRules","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","resourceTypes":[{"resourceType":"operations","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforPostgreSQL","namespace":"Microsoft.DBforPostgreSQL","resourceTypes":[{"resourceType":"operations","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
+        US","North Europe","East Asia","East US","West Europe","Southeast Asia","Japan
+        East","Japan West","Australia East","Australia Southeast","West US 2","West
+        Central US","East US 2","Central US","UK South","UK West","South India","Central
+        India"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"databaseAccountNames","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DomainRegistration","namespace":"Microsoft.DomainRegistration","authorization":{"applicationId":"ea2f600a-4980-45b7-89bf-d34da487bda1","roleDefinitionId":"54d7f2e3-5040-48a7-ae90-eebf629cfa0b"},"resourceTypes":[{"resourceType":"domains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"domains/domainOwnershipIdentifiers","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"topLevelDomains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"checkDomainAvailability","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"listDomainRecommendations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"validateDomainRegistrationInformation","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"generateSsoRequest","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DynamicsLcs","namespace":"Microsoft.DynamicsLcs","resourceTypes":[{"resourceType":"lcsprojects","locations":["Brazil
+        South","East Asia","East US","Japan East","Japan West","North Central US","North
+        Europe","South Central US","West Europe","West US","Southeast Asia","Central
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"lcsprojects/connectors","locations":["Brazil
+        South","East Asia","East US","Japan East","Japan West","North Central US","North
+        Europe","South Central US","West Europe","West US","Southeast Asia","Central
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"lcsprojects/clouddeployments","locations":["Brazil
+        South","East Asia","East US","Japan East","Japan West","North Central US","North
+        Europe","South Central US","West Europe","West US","Southeast Asia","Central
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"operations","locations":["Brazil
+        South","East Asia","East US","Japan East","Japan West","North Central US","North
+        Europe","South Central US","West Europe","West US","Southeast Asia","Central
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"topics","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operations","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"clusters/applications","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"clusters/operationresults","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations/capabilities","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations/operationresults","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations/azureasyncoperations","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations/validateCreateRequest","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"operations","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India"],"apiVersions":["2015-03-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ImportExport","namespace":"Microsoft.ImportExport","authorization":{"applicationId":"7de4d5c5-5b32-4235-b8a9-33b34d6bcd2a","roleDefinitionId":"9f7aa6bb-9454-46b6-8c01-a4b0f33ca151"},"resourceTypes":[{"resourceType":"jobs","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","North Central US","North Europe","South Central US","Southeast
+        Asia","South India","UK South","West Central US","West Europe","West India","West
+        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","North Central US","North Europe","South Central US","Southeast
+        Asia","South India","UK South","West Central US","West Europe","West India","West
+        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations/operationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","North Central US","North Europe","South Central US","Southeast
+        Asia","South India","UK South","West Central US","West Europe","West India","West
+        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","North Central US","North Europe","South Central US","Southeast
+        Asia","South India","UK South","West Central US","West Europe","West India","West
+        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Logic","namespace":"Microsoft.Logic","authorization":{"applicationId":"7cd684f4-8a78-49b0-91ec-6a35d38739ba","roleDefinitionId":"cb3ef1fb-6e31-49e2-9d87-ed821053fe58"},"resourceTypes":[{"resourceType":"workflows","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West"],"apiVersions":["2017-07-01","2016-10-01","2016-06-01","2015-08-01-preview","2015-02-01-preview"]},{"resourceType":"locations/workflows","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West"],"apiVersions":["2017-07-01","2016-10-01","2016-06-01","2015-08-01-preview","2015-02-01-preview"]},{"resourceType":"locations","locations":["North
+        Central US"],"apiVersions":["2017-07-01","2016-10-01","2016-06-01","2015-08-01-preview","2015-02-01-preview"]},{"resourceType":"operations","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West"],"apiVersions":["2017-07-01","2016-10-01","2016-06-01","2015-08-01-preview","2015-02-01-preview"]},{"resourceType":"integrationAccounts","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","West Central US"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"operations","locations":["South
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations","locations":["South
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operations","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"commitmentPlans","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
+        Central US","West US"],"apiVersions":["2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Media","namespace":"Microsoft.Media","authorization":{"applicationId":"374b2a64-3b6b-436b-934c-b820eacca870","roleDefinitionId":"aab70789-0cec-44b5-95d7-84b64c9487af"},"resourceTypes":[{"resourceType":"mediaservices","locations":["Japan
+        West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
+        US","West US","Australia East","Australia Southeast","Central US","Brazil
+        South","Central India","West India","South India","South Central US","Canada
+        Central","Canada East","West Central US"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
+        Central US","North Central US","East US 2","West US","West Europe","North
+        Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
+        East","UK South","West India"],"apiVersions":["2016-01-29"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-01-29"]},{"resourceType":"locations/checkNameAvailability","locations":["South
+        Central US","North Central US","East US 2","West US","West Europe","North
+        Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
+        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"operations","locations":["East
+        US 2"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Relay","namespace":"Microsoft.Relay","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US 2","West
+        US","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
+        East","West India","South India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
+        East","West India","South India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
+        Central US","South Central US","North Europe","West Europe","East Asia","Southeast
+        Asia","West US","East US","Japan West","Japan East","Brazil South","Central
+        US","East US 2","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-03-01","2016-01-01","2014-08-01-preview"]},{"resourceType":"operations","locations":["North
+        Central US","South Central US","North Europe","West Europe","East Asia","Southeast
+        Asia","West US","East US","Japan West","Japan East","Brazil South","Central
+        US","East US 2","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-03-01","2016-01-01","2014-08-01-preview"]},{"resourceType":"operationResults","locations":["North
+        Central US","South Central US","North Europe","West Europe","East Asia","Southeast
+        Asia","West US","East US","Japan West","Japan East","Brazil South","Central
+        US","East US 2","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-03-01","2016-01-01","2014-08-01-preview"]},{"resourceType":"flows","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast"],"apiVersions":["2015-08-01-preview","2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Search","namespace":"Microsoft.Search","resourceTypes":[{"resourceType":"searchServices","locations":["West
+        US","East US","North Europe","West Europe","Southeast Asia","East Asia","North
+        Central US","South Central US","Japan West","Australia East","Brazil South","Central
+        India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19","2015-02-28"]},{"resourceType":"checkServiceNameAvailability","locations":[],"apiVersions":["2015-02-28","2014-07-31-Preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2015-08-19"]},{"resourceType":"resourceHealthMetadata","locations":["West
+        US","East US","North Europe","West Europe","Southeast Asia","East Asia","North
+        Central US","South Central US","Japan West","Australia East","Brazil South","Central
+        India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US 2","West
+        US","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"premiumMessagingRegions","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceFabric","namespace":"Microsoft.ServiceFabric","authorization":{"applicationId":"74cb6831-0dbb-4be1-8206-fd4df301cdc2","roleDefinitionId":"e55cc65f-6903-4917-b4ef-f8d4640b57f5"},"resourceTypes":[{"resourceType":"clusters","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/clusterVersions","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operations","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Canada
+        Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","West Central US","Japan East","Japan West","Australia East","Australia
+        Southeast"],"apiVersions":["2017-06-01","2017-05-15","2017-01-01","2016-10-01","2016-06-01","2015-03-15","2014-09-01"]},{"resourceType":"operations","locations":["West
+        Central US","Southeast Asia"],"apiVersions":["2016-10-01","2016-06-01","2015-03-15","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StreamAnalytics","namespace":"Microsoft.StreamAnalytics","resourceTypes":[{"resourceType":"streamingjobs","locations":["Central
+        US","West Europe","East US 2","North Europe","Japan East","West US","Southeast
+        Asia","South Central US","East Asia","Japan West","North Central US","East
+        US","Australia East","Australia Southeast","Brazil South","Central India","West
+        Central US","UK South","UK West","Canada Central","Canada East","West US 2"],"apiVersions":["2017-04-01-preview","2016-03-01","2015-11-01","2015-10-01","2015-09-01","2015-08-01-preview","2015-06-01","2015-05-01","2015-04-01","2015-03-01-preview"]},{"resourceType":"locations","locations":["West
+        Europe","Central US","East US 2","North Europe","Japan East","West US","Southeast
+        Asia","South Central US","East Asia","Japan West","North Central US","East
+        US","Australia East","Australia Southeast","Brazil South","Central India","West
+        Central US","UK South","West US 2","UK West","Canada Central","Canada East"],"apiVersions":["2017-04-01-preview","2016-03-01","2015-11-01","2015-10-01","2015-09-01","2015-08-01-preview","2015-06-01","2015-05-01","2015-04-01","2015-03-01-preview"]},{"resourceType":"locations/quotas","locations":[],"apiVersions":["2017-04-01-preview","2016-03-01","2015-11-01","2015-10-01","2015-09-01","2015-08-01-preview","2015-06-01","2015-05-01","2015-04-01","2015-03-01-preview"]},{"resourceType":"streamingjobs/diagnosticSettings","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","Central
+        India","West Central US","UK South","UK West","Canada Central","Canada East","West
+        US 2","West US","Central US","South Central US","Japan East","Japan West","East
+        Asia","Southeast Asia","Australia East","Australia Southeast"],"apiVersions":["2014-04-01"]},{"resourceType":"streamingjobs/metricDefinitions","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","Central
+        India","West Central US","UK South","UK West","Canada Central","Canada East","West
+        US 2","West US","Central US","South Central US","Japan East","Japan West","East
+        Asia","Southeast Asia","Australia East","Australia Southeast"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":["West
+        Europe","West US","Central US","East US 2","North Europe","Japan East","Southeast
+        Asia","South Central US","East Asia","Japan West","North Central US","East
+        US","Australia East","Australia Southeast","Brazil South","Central India","West
+        Central US","UK South","UK West","Canada Central","Canada East","West US 2"],"apiVersions":["2017-04-01-preview","2016-03-01","2015-11-01","2015-10-01","2015-09-01","2015-08-01-preview","2015-06-01","2015-05-01","2015-04-01","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.support","namespace":"microsoft.support","resourceTypes":[{"resourceType":"operations","locations":["North
+        Central US","South Central US","Central US","West Europe","North Europe","West
+        US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
+        Asia","East Asia","Australia East","Australia Southeast"],"apiVersions":["2015-07-01-Preview","2015-03-01"]},{"resourceType":"supporttickets","locations":["North
+        Central US","South Central US","Central US","West Europe","North Europe","West
+        US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
+        Asia","East Asia","Australia East","Australia Southeast"],"apiVersions":["2015-07-01-Preview","2015-03-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.TimeSeriesInsights","namespace":"Microsoft.TimeSeriesInsights","authorizations":[{"applicationId":"120d688d-1518-4cf7-bd38-182f158850b6","roleDefinitionId":"5a43abdf-bb87-42c4-9e56-1c24bf364150"}],"resourceTypes":[{"resourceType":"environments","locations":["East
+        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/eventsources","locations":["East
+        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/referenceDataSets","locations":["East
+        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/accessPolicies","locations":["East
+        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"operations","locations":["East
+        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/project","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/extension","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"checkNameAvailability","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Myget.PackageManagement","namespace":"Myget.PackageManagement","resourceTypes":[{"resourceType":"services","locations":["West
+        Europe"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/NewRelic.APM","namespace":"NewRelic.APM","authorization":{"allowedThirdPartyExtensions":[{"name":"NewRelic_AzurePortal_APM"}]},"resourceTypes":[{"resourceType":"accounts","locations":["North
+        Central US","South Central US","West US","East US","North Europe","West Europe","Southeast
+        Asia","East Asia","Japan East","Japan West"],"apiVersions":["2014-10-01","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/nuubit.nextgencdn","namespace":"nuubit.nextgencdn","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US","East US 2","North Central US","South Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","West US","Central US"],"apiVersions":["2017-05-05"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-05"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-05-05"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-05-05"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Paraleap.CloudMonix","namespace":"Paraleap.CloudMonix","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2016-08-10"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-10"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-10"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Pokitdok.Platform","namespace":"Pokitdok.Platform","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2016-05-17"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-05-17"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-05-17"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-05-17"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RavenHq.Db","namespace":"RavenHq.Db","resourceTypes":[{"resourceType":"databases","locations":["East
+        US"],"apiVersions":["2016-07-18","2016-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-07-18","2016-06-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-07-18","2016-06-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-07-18","2016-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Raygun.CrashReporting","namespace":"Raygun.CrashReporting","resourceTypes":[{"resourceType":"apps","locations":["East
+        US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RedisLabs.Memcached","namespace":"RedisLabs.Memcached","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-07-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RedisLabs.Redis","namespace":"RedisLabs.Redis","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-07-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RevAPM.MobileCDN","namespace":"RevAPM.MobileCDN","resourceTypes":[{"resourceType":"accounts","locations":["Central
+        US","East US","East US 2","North Central US","South Central US","West US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast"],"apiVersions":["2016-08-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-24","2016-08-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sendgrid.Email","namespace":"Sendgrid.Email","resourceTypes":[{"resourceType":"accounts","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Canada Central","Canada
+        East","West Central US","West US 2","UK South","UK West"],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Signiant.Flight","namespace":"Signiant.Flight","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US","Central US","North Central US","South Central US","West US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast"],"apiVersions":["2015-06-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sparkpost.Basic","namespace":"Sparkpost.Basic","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2016-08-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/stackify.retrace","namespace":"stackify.retrace","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2016-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/SuccessBricks.ClearDB","namespace":"SuccessBricks.ClearDB","resourceTypes":[{"resourceType":"databases","locations":["Brazil
+        South","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","Southeast Asia","West Europe","West
+        US","South Central US","Australia East","Australia Southeast","Canada Central","Canada
+        East","Central India","South India","West India"],"apiVersions":["2014-04-01"]},{"resourceType":"clusters","locations":["Brazil
+        South","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","Southeast Asia","West Europe","West
+        US","Australia Southeast","Australia East","South Central US","Canada Central","Canada
+        East","Central India","South India","West India"],"apiVersions":["2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/TrendMicro.DeepSecurity","namespace":"TrendMicro.DeepSecurity","resourceTypes":[{"resourceType":"accounts","locations":["Central
+        US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
+        Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:32:57 GMT
+- request:
+    method: post
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
+    body:
+      encoding: UTF-8
+      string: '{"access":"read","durationInSeconds":3600}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NzgsIm5iZiI6MTUwNDEwNjg3OCwiZXhwIjoxNTA0MTEwNzc4LCJhaW8iOiJZMkZnWUZCY25ycm1tbGFFeTZPRk9yd0dmWjg4QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiN05XM2d1T0FCMGlISDZMODhNQVNBQSIsInZlciI6IjEuMCJ9.Yfke5b0kH6_7eOGt4vQ_aaxM4X_Z_GIpNAgkjb-jVDCtiJ-xvuT3hrXsAbLHYyPVBZfYDKYwPKFqnml-dC2bNxxOxNv6cY2omPcdYlzzcmx7xy9z18QNu1pTdeDCL6BfFAKGa-Lb1dCgaJK9fmq__uQ30YaEIO1EY6dac4b1rJpa9zfvYpHytyI_6J_DIJyaxdpiYnu9fg0QHilzVwbKFxX5YuJY2Qjo9nOVFjVaAA_68v5Yh1Y1RlpuShJ7VafBGcXW2lOkNHxB9I0X2E-Nh7QWWV7KWj_1oCDsiTksw3TsDRECVb1hGHAMu7zUbCbIDSP45pYptAPLLf3Odr7T9w
+      Content-Length:
+      - '42'
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '0'
+      Expires:
+      - "-1"
+      Location:
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/a66c7488-ac44-475a-9b7f-ed6864d15d77?monitor=true&api-version=2017-03-30
+      Azure-Asyncoperation:
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/a66c7488-ac44-475a-9b7f-ed6864d15d77?api-version=2017-03-30
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      X-Ms-Request-Id:
+      - a66c7488-ac44-475a-9b7f-ed6864d15d77
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Writes:
+      - '1198'
+      X-Ms-Correlation-Request-Id:
+      - b3d25388-edff-42ac-83e5-4181aa017c2e
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153300Z:b3d25388-edff-42ac-83e5-4181aa017c2e
+      Date:
+      - Wed, 30 Aug 2017 15:32:59 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:32:58 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/a66c7488-ac44-475a-9b7f-ed6864d15d77?api-version=2017-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NzgsIm5iZiI6MTUwNDEwNjg3OCwiZXhwIjoxNTA0MTEwNzc4LCJhaW8iOiJZMkZnWUZCY25ycm1tbGFFeTZPRk9yd0dmWjg4QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiN05XM2d1T0FCMGlISDZMODhNQVNBQSIsInZlciI6IjEuMCJ9.Yfke5b0kH6_7eOGt4vQ_aaxM4X_Z_GIpNAgkjb-jVDCtiJ-xvuT3hrXsAbLHYyPVBZfYDKYwPKFqnml-dC2bNxxOxNv6cY2omPcdYlzzcmx7xy9z18QNu1pTdeDCL6BfFAKGa-Lb1dCgaJK9fmq__uQ30YaEIO1EY6dac4b1rJpa9zfvYpHytyI_6J_DIJyaxdpiYnu9fg0QHilzVwbKFxX5YuJY2Qjo9nOVFjVaAA_68v5Yh1Y1RlpuShJ7VafBGcXW2lOkNHxB9I0X2E-Nh7QWWV7KWj_1oCDsiTksw3TsDRECVb1hGHAMu7zUbCbIDSP45pYptAPLLf3Odr7T9w
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      X-Ms-Request-Id:
+      - 4611b216-f570-4d26-a9c8-6fe318713af1
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14701'
+      X-Ms-Correlation-Request-Id:
+      - 412b2b51-8a72-4b1b-9638-28bb08502f0b
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153300Z:412b2b51-8a72-4b1b-9638-28bb08502f0b
+      Date:
+      - Wed, 30 Aug 2017 15:32:59 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"startTime\": \"2017-08-30T15:32:59.6334993+00:00\",\r\n  \"endTime\":
+        \"2017-08-30T15:32:59.8522326+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=5ae4fd77-73d4-429a-980c-dc4af936a837&sig=tI36BZ44UHpmqmekoNbqtqyF6dhqUGTov%2Bh9TyA0Uqk%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"a66c7488-ac44-475a-9b7f-ed6864d15d77\"\r\n}"
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:32:58 GMT
+- request:
+    method: get
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=5ae4fd77-73d4-429a-980c-dc4af936a837&sig=tI36BZ44UHpmqmekoNbqtqyF6dhqUGTov%2Bh9TyA0Uqk=&sr=b&sv=2016-05-31
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      X-Ms-Range:
+      - bytes=0-0
+      Host:
+      - md-t4jdgqqlgszp.blob.core.windows.net
+  response:
+    status:
+      code: 206
+      message: Partial Content
+    headers:
+      Content-Length:
+      - '1'
+      Content-Type:
+      - application/octet-stream
+      Content-Range:
+      - bytes 0-0/34359738880
+      Last-Modified:
+      - Sat, 15 Jul 2017 14:23:07 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D4CB8D039FC699"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 4363e57f-0001-000b-75a5-21b959000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Meta-Pirtag:
+      - '1'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '20'
+      X-Ms-Copy-Id:
+      - 30cedd78-548a-4fd8-967e-f8344f587e3c
+      X-Ms-Copy-Source:
+      - http://md-t4jdgqqlgszp.blob.core.windows.net:8080/fg25xxtqx0gc/abcd?sv=2016-02-19&sr=b&st=2017-05-04T21%3a06%3a57Z&se=9999-12-31T23%3a59%3a59Z&sp=r&api-version=2016-02-19
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 34359738880/34359738880
+      X-Ms-Copy-Completion-Time:
+      - Thu, 04 May 2017 21:21:56 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Wed, 30 Aug 2017 15:33:00 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        6w==
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:32:58 GMT
+- request:
+    method: post
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
+    body:
+      encoding: UTF-8
+      string: '{"access":"read","durationInSeconds":3600}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NzgsIm5iZiI6MTUwNDEwNjg3OCwiZXhwIjoxNTA0MTEwNzc4LCJhaW8iOiJZMkZnWUZCY25ycm1tbGFFeTZPRk9yd0dmWjg4QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiN05XM2d1T0FCMGlISDZMODhNQVNBQSIsInZlciI6IjEuMCJ9.Yfke5b0kH6_7eOGt4vQ_aaxM4X_Z_GIpNAgkjb-jVDCtiJ-xvuT3hrXsAbLHYyPVBZfYDKYwPKFqnml-dC2bNxxOxNv6cY2omPcdYlzzcmx7xy9z18QNu1pTdeDCL6BfFAKGa-Lb1dCgaJK9fmq__uQ30YaEIO1EY6dac4b1rJpa9zfvYpHytyI_6J_DIJyaxdpiYnu9fg0QHilzVwbKFxX5YuJY2Qjo9nOVFjVaAA_68v5Yh1Y1RlpuShJ7VafBGcXW2lOkNHxB9I0X2E-Nh7QWWV7KWj_1oCDsiTksw3TsDRECVb1hGHAMu7zUbCbIDSP45pYptAPLLf3Odr7T9w
+      Content-Length:
+      - '42'
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '0'
+      Expires:
+      - "-1"
+      Location:
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/d0f9b626-5d1b-4c06-bdb5-9491f1c3e6f0?monitor=true&api-version=2017-03-30
+      Azure-Asyncoperation:
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/d0f9b626-5d1b-4c06-bdb5-9491f1c3e6f0?api-version=2017-03-30
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      X-Ms-Request-Id:
+      - d0f9b626-5d1b-4c06-bdb5-9491f1c3e6f0
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Writes:
+      - '1197'
+      X-Ms-Correlation-Request-Id:
+      - 99d6ce58-cbdb-4473-9711-47c282413c4a
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153300Z:99d6ce58-cbdb-4473-9711-47c282413c4a
+      Date:
+      - Wed, 30 Aug 2017 15:33:00 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:00 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/d0f9b626-5d1b-4c06-bdb5-9491f1c3e6f0?api-version=2017-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NzgsIm5iZiI6MTUwNDEwNjg3OCwiZXhwIjoxNTA0MTEwNzc4LCJhaW8iOiJZMkZnWUZCY25ycm1tbGFFeTZPRk9yd0dmWjg4QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiN05XM2d1T0FCMGlISDZMODhNQVNBQSIsInZlciI6IjEuMCJ9.Yfke5b0kH6_7eOGt4vQ_aaxM4X_Z_GIpNAgkjb-jVDCtiJ-xvuT3hrXsAbLHYyPVBZfYDKYwPKFqnml-dC2bNxxOxNv6cY2omPcdYlzzcmx7xy9z18QNu1pTdeDCL6BfFAKGa-Lb1dCgaJK9fmq__uQ30YaEIO1EY6dac4b1rJpa9zfvYpHytyI_6J_DIJyaxdpiYnu9fg0QHilzVwbKFxX5YuJY2Qjo9nOVFjVaAA_68v5Yh1Y1RlpuShJ7VafBGcXW2lOkNHxB9I0X2E-Nh7QWWV7KWj_1oCDsiTksw3TsDRECVb1hGHAMu7zUbCbIDSP45pYptAPLLf3Odr7T9w
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      X-Ms-Request-Id:
+      - a4d38346-6bab-4f17-bb80-5f72c78aafdf
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14940'
+      X-Ms-Correlation-Request-Id:
+      - 16ca39c2-b4f8-4603-a365-6f5daa756b7c
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153301Z:16ca39c2-b4f8-4603-a365-6f5daa756b7c
+      Date:
+      - Wed, 30 Aug 2017 15:33:00 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"startTime\": \"2017-08-30T15:33:00.4243378+00:00\",\r\n  \"endTime\":
+        \"2017-08-30T15:33:00.6743376+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=3aa189f8-a01d-4d35-88d6-caf8d51a589a&sig=fYv58w33EJeNFAjLUxGDE6df0E%2B%2BSCuKkcoUqcfyid0%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"d0f9b626-5d1b-4c06-bdb5-9491f1c3e6f0\"\r\n}"
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:01 GMT
+- request:
+    method: get
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=3aa189f8-a01d-4d35-88d6-caf8d51a589a&sig=fYv58w33EJeNFAjLUxGDE6df0E%2B%2BSCuKkcoUqcfyid0=&sr=b&sv=2016-05-31
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      X-Ms-Range:
+      - bytes=440-443
+      Host:
+      - md-t4jdgqqlgszp.blob.core.windows.net
+  response:
+    status:
+      code: 206
+      message: Partial Content
+    headers:
+      Content-Length:
+      - '4'
+      Content-Type:
+      - application/octet-stream
+      Content-Range:
+      - bytes 440-443/34359738880
+      Last-Modified:
+      - Sat, 15 Jul 2017 14:23:07 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D4CB8D039FC699"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 80f6e214-0001-00e3-24a5-2144a2000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Meta-Pirtag:
+      - '1'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '20'
+      X-Ms-Copy-Id:
+      - 30cedd78-548a-4fd8-967e-f8344f587e3c
+      X-Ms-Copy-Source:
+      - http://md-t4jdgqqlgszp.blob.core.windows.net:8080/fg25xxtqx0gc/abcd?sv=2016-02-19&sr=b&st=2017-05-04T21%3a06%3a57Z&se=9999-12-31T23%3a59%3a59Z&sp=r&api-version=2016-02-19
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 34359738880/34359738880
+      X-Ms-Copy-Completion-Time:
+      - Thu, 04 May 2017 21:21:56 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Wed, 30 Aug 2017 15:33:00 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        U5MJAA==
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:01 GMT
+recorded_with: VCR 3.0.3

--- a/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_endByteAddr-1.yml
+++ b/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_endByteAddr-1.yml
@@ -39,25 +39,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 82b7d5ec-80e3-4807-871f-a2fcf0c01200
+      - 6d5e73e9-e32e-48f1-b3a3-e0bca19a1300
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAAA9kTklhVy7SJTGAzR-p1BcIpr9LnNz_RQq8GA1q38agMY7K2oQ1zQGxI4qkkP7UgqTydl9p4zXkx4UCCpwrTbM0DkBxKvP4E7EuAnID0d8HBNNeThay82FFSCofIF2DilMyavp1PicQX2Jnw65jH3X3g9OFyVSlznIsiM0hPDXkh6QWhkA2hHbKeaAJXpTVpIgAA;
+      - esctx=AQABAAAAAAA9kTklhVy7SJTGAzR-p1BcwYmyQQ_E9scG1H3vRWuwJttS41uCBM8FZw9LzCa0xbGhUFHgl5_1tELFdBXQYGApndsYpjSR1ysrk2Mg2P-rF8Ubw2wo6J_iHOcqQAt-tqKFyITVb5xTu5bLvnNWsfkHdoSimEX4o26-wWJv-8X03Fs9U1AMcwbeVRxVKl6uhu0gAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=007; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=005; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Wed, 30 Aug 2017 15:32:57 GMT
+      - Wed, 30 Aug 2017 17:05:31 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3600","ext_expires_in":"0","expires_on":"1504110778","not_before":"1504106878","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NzgsIm5iZiI6MTUwNDEwNjg3OCwiZXhwIjoxNTA0MTEwNzc4LCJhaW8iOiJZMkZnWUZCY25ycm1tbGFFeTZPRk9yd0dmWjg4QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiN05XM2d1T0FCMGlISDZMODhNQVNBQSIsInZlciI6IjEuMCJ9.Yfke5b0kH6_7eOGt4vQ_aaxM4X_Z_GIpNAgkjb-jVDCtiJ-xvuT3hrXsAbLHYyPVBZfYDKYwPKFqnml-dC2bNxxOxNv6cY2omPcdYlzzcmx7xy9z18QNu1pTdeDCL6BfFAKGa-Lb1dCgaJK9fmq__uQ30YaEIO1EY6dac4b1rJpa9zfvYpHytyI_6J_DIJyaxdpiYnu9fg0QHilzVwbKFxX5YuJY2Qjo9nOVFjVaAA_68v5Yh1Y1RlpuShJ7VafBGcXW2lOkNHxB9I0X2E-Nh7QWWV7KWj_1oCDsiTksw3TsDRECVb1hGHAMu7zUbCbIDSP45pYptAPLLf3Odr7T9w"}'
+      string: '{"token_type":"Bearer","expires_in":"3600","ext_expires_in":"0","expires_on":"1504116331","not_before":"1504112431","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MzEsIm5iZiI6MTUwNDExMjQzMSwiZXhwIjoxNTA0MTE2MzMxLCJhaW8iOiJZMkZnWUZpWEx5cktrbVVvMzlSN3czekdIOWN2QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNlhOZWJTN2o4VWl6by1DOG9ab1RBQSIsInZlciI6IjEuMCJ9.m0_Vihy5lkruM9QqCylndiKsZYd8CxoMyR4Y7xaG8y-bVzaVDplg2ayxf3Vw2yfHJkbYzBLQ5p7MSwj6XZk_QxM9nEAKpyitOFZG2gcg_gA31tbBAlS_u4xbb_lF5HEAwc2CPF-9tIc0h-voQUXhzYtElmRxxxUZ_l1WGijrrM3y7KYSSfyYUsyieIc30XCulfC01Yh_G_1nf7KQ1JOZytOlOWoOf38saks0HMCBaF5DpaC9KUeD3qbHjdmzfyd4qP7dIq_1e9q7ysKlYFZmrHSUSvK4tuphY8YkgHOnreYl-UHneaJdMJLGKrTZMLc0zP5b-8lXNdukb_JXG5Umxg"}'
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:32:56 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:31 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -74,7 +74,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NzgsIm5iZiI6MTUwNDEwNjg3OCwiZXhwIjoxNTA0MTEwNzc4LCJhaW8iOiJZMkZnWUZCY25ycm1tbGFFeTZPRk9yd0dmWjg4QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiN05XM2d1T0FCMGlISDZMODhNQVNBQSIsInZlciI6IjEuMCJ9.Yfke5b0kH6_7eOGt4vQ_aaxM4X_Z_GIpNAgkjb-jVDCtiJ-xvuT3hrXsAbLHYyPVBZfYDKYwPKFqnml-dC2bNxxOxNv6cY2omPcdYlzzcmx7xy9z18QNu1pTdeDCL6BfFAKGa-Lb1dCgaJK9fmq__uQ30YaEIO1EY6dac4b1rJpa9zfvYpHytyI_6J_DIJyaxdpiYnu9fg0QHilzVwbKFxX5YuJY2Qjo9nOVFjVaAA_68v5Yh1Y1RlpuShJ7VafBGcXW2lOkNHxB9I0X2E-Nh7QWWV7KWj_1oCDsiTksw3TsDRECVb1hGHAMu7zUbCbIDSP45pYptAPLLf3Odr7T9w
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MzEsIm5iZiI6MTUwNDExMjQzMSwiZXhwIjoxNTA0MTE2MzMxLCJhaW8iOiJZMkZnWUZpWEx5cktrbVVvMzlSN3czekdIOWN2QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNlhOZWJTN2o4VWl6by1DOG9ab1RBQSIsInZlciI6IjEuMCJ9.m0_Vihy5lkruM9QqCylndiKsZYd8CxoMyR4Y7xaG8y-bVzaVDplg2ayxf3Vw2yfHJkbYzBLQ5p7MSwj6XZk_QxM9nEAKpyitOFZG2gcg_gA31tbBAlS_u4xbb_lF5HEAwc2CPF-9tIc0h-voQUXhzYtElmRxxxUZ_l1WGijrrM3y7KYSSfyYUsyieIc30XCulfC01Yh_G_1nf7KQ1JOZytOlOWoOf38saks0HMCBaF5DpaC9KUeD3qbHjdmzfyd4qP7dIq_1e9q7ysKlYFZmrHSUSvK4tuphY8YkgHOnreYl-UHneaJdMJLGKrTZMLc0zP5b-8lXNdukb_JXG5Umxg
       Host:
       - management.azure.com
   response:
@@ -95,23 +95,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14997'
+      - '14996'
       X-Ms-Request-Id:
-      - f53dc0a0-5ccd-47bc-bbab-f7ea5fc43a9b
+      - e572aabf-e7b4-45aa-96a4-b018bb0f065f
       X-Ms-Correlation-Request-Id:
-      - f53dc0a0-5ccd-47bc-bbab-f7ea5fc43a9b
+      - e572aabf-e7b4-45aa-96a4-b018bb0f065f
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153258Z:f53dc0a0-5ccd-47bc-bbab-f7ea5fc43a9b
+      - EASTUS:20170830T170532Z:e572aabf-e7b4-45aa-96a4-b018bb0f065f
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 30 Aug 2017 15:32:58 GMT
+      - Wed, 30 Aug 2017 17:05:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:32:56 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:31 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/azure_subscription_id/providers?api-version=2015-01-01
@@ -128,7 +128,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NzgsIm5iZiI6MTUwNDEwNjg3OCwiZXhwIjoxNTA0MTEwNzc4LCJhaW8iOiJZMkZnWUZCY25ycm1tbGFFeTZPRk9yd0dmWjg4QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiN05XM2d1T0FCMGlISDZMODhNQVNBQSIsInZlciI6IjEuMCJ9.Yfke5b0kH6_7eOGt4vQ_aaxM4X_Z_GIpNAgkjb-jVDCtiJ-xvuT3hrXsAbLHYyPVBZfYDKYwPKFqnml-dC2bNxxOxNv6cY2omPcdYlzzcmx7xy9z18QNu1pTdeDCL6BfFAKGa-Lb1dCgaJK9fmq__uQ30YaEIO1EY6dac4b1rJpa9zfvYpHytyI_6J_DIJyaxdpiYnu9fg0QHilzVwbKFxX5YuJY2Qjo9nOVFjVaAA_68v5Yh1Y1RlpuShJ7VafBGcXW2lOkNHxB9I0X2E-Nh7QWWV7KWj_1oCDsiTksw3TsDRECVb1hGHAMu7zUbCbIDSP45pYptAPLLf3Odr7T9w
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MzEsIm5iZiI6MTUwNDExMjQzMSwiZXhwIjoxNTA0MTE2MzMxLCJhaW8iOiJZMkZnWUZpWEx5cktrbVVvMzlSN3czekdIOWN2QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNlhOZWJTN2o4VWl6by1DOG9ab1RBQSIsInZlciI6IjEuMCJ9.m0_Vihy5lkruM9QqCylndiKsZYd8CxoMyR4Y7xaG8y-bVzaVDplg2ayxf3Vw2yfHJkbYzBLQ5p7MSwj6XZk_QxM9nEAKpyitOFZG2gcg_gA31tbBAlS_u4xbb_lF5HEAwc2CPF-9tIc0h-voQUXhzYtElmRxxxUZ_l1WGijrrM3y7KYSSfyYUsyieIc30XCulfC01Yh_G_1nf7KQ1JOZytOlOWoOf38saks0HMCBaF5DpaC9KUeD3qbHjdmzfyd4qP7dIq_1e9q7ysKlYFZmrHSUSvK4tuphY8YkgHOnreYl-UHneaJdMJLGKrTZMLc0zP5b-8lXNdukb_JXG5Umxg
       Host:
       - management.azure.com
   response:
@@ -147,17 +147,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14934'
+      - '14940'
       X-Ms-Request-Id:
-      - 47effc27-aeea-4126-a2ec-161ba547fdfe
+      - cafb84d7-9c94-4cd2-ba1f-66cc48f9a489
       X-Ms-Correlation-Request-Id:
-      - 47effc27-aeea-4126-a2ec-161ba547fdfe
+      - cafb84d7-9c94-4cd2-ba1f-66cc48f9a489
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153259Z:47effc27-aeea-4126-a2ec-161ba547fdfe
+      - EASTUS:20170830T170533Z:cafb84d7-9c94-4cd2-ba1f-66cc48f9a489
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 30 Aug 2017 15:32:58 GMT
+      - Wed, 30 Aug 2017 17:05:32 GMT
       Content-Length:
       - '241615'
     body:
@@ -1891,7 +1891,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:32:57 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:32 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
@@ -1908,7 +1908,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NzgsIm5iZiI6MTUwNDEwNjg3OCwiZXhwIjoxNTA0MTEwNzc4LCJhaW8iOiJZMkZnWUZCY25ycm1tbGFFeTZPRk9yd0dmWjg4QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiN05XM2d1T0FCMGlISDZMODhNQVNBQSIsInZlciI6IjEuMCJ9.Yfke5b0kH6_7eOGt4vQ_aaxM4X_Z_GIpNAgkjb-jVDCtiJ-xvuT3hrXsAbLHYyPVBZfYDKYwPKFqnml-dC2bNxxOxNv6cY2omPcdYlzzcmx7xy9z18QNu1pTdeDCL6BfFAKGa-Lb1dCgaJK9fmq__uQ30YaEIO1EY6dac4b1rJpa9zfvYpHytyI_6J_DIJyaxdpiYnu9fg0QHilzVwbKFxX5YuJY2Qjo9nOVFjVaAA_68v5Yh1Y1RlpuShJ7VafBGcXW2lOkNHxB9I0X2E-Nh7QWWV7KWj_1oCDsiTksw3TsDRECVb1hGHAMu7zUbCbIDSP45pYptAPLLf3Odr7T9w
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MzEsIm5iZiI6MTUwNDExMjQzMSwiZXhwIjoxNTA0MTE2MzMxLCJhaW8iOiJZMkZnWUZpWEx5cktrbVVvMzlSN3czekdIOWN2QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNlhOZWJTN2o4VWl6by1DOG9ab1RBQSIsInZlciI6IjEuMCJ9.m0_Vihy5lkruM9QqCylndiKsZYd8CxoMyR4Y7xaG8y-bVzaVDplg2ayxf3Vw2yfHJkbYzBLQ5p7MSwj6XZk_QxM9nEAKpyitOFZG2gcg_gA31tbBAlS_u4xbb_lF5HEAwc2CPF-9tIc0h-voQUXhzYtElmRxxxUZ_l1WGijrrM3y7KYSSfyYUsyieIc30XCulfC01Yh_G_1nf7KQ1JOZytOlOWoOf38saks0HMCBaF5DpaC9KUeD3qbHjdmzfyd4qP7dIq_1e9q7ysKlYFZmrHSUSvK4tuphY8YkgHOnreYl-UHneaJdMJLGKrTZMLc0zP5b-8lXNdukb_JXG5Umxg
       Content-Length:
       - '42'
       Host:
@@ -1927,34 +1927,34 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/a66c7488-ac44-475a-9b7f-ed6864d15d77?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/f14f68f4-248a-4bc4-81e3-626056d4bdd4?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/a66c7488-ac44-475a-9b7f-ed6864d15d77?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/f14f68f4-248a-4bc4-81e3-626056d4bdd4?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
       - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
       X-Ms-Request-Id:
-      - a66c7488-ac44-475a-9b7f-ed6864d15d77
+      - f14f68f4-248a-4bc4-81e3-626056d4bdd4
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1198'
+      - '1195'
       X-Ms-Correlation-Request-Id:
-      - b3d25388-edff-42ac-83e5-4181aa017c2e
+      - 44ee292a-f956-4455-b041-20f8e38477d8
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153300Z:b3d25388-edff-42ac-83e5-4181aa017c2e
+      - EASTUS:20170830T170533Z:44ee292a-f956-4455-b041-20f8e38477d8
       Date:
-      - Wed, 30 Aug 2017 15:32:59 GMT
+      - Wed, 30 Aug 2017 17:05:33 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:32:58 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:32 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/a66c7488-ac44-475a-9b7f-ed6864d15d77?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/f14f68f4-248a-4bc4-81e3-626056d4bdd4?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -1968,7 +1968,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NzgsIm5iZiI6MTUwNDEwNjg3OCwiZXhwIjoxNTA0MTEwNzc4LCJhaW8iOiJZMkZnWUZCY25ycm1tbGFFeTZPRk9yd0dmWjg4QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiN05XM2d1T0FCMGlISDZMODhNQVNBQSIsInZlciI6IjEuMCJ9.Yfke5b0kH6_7eOGt4vQ_aaxM4X_Z_GIpNAgkjb-jVDCtiJ-xvuT3hrXsAbLHYyPVBZfYDKYwPKFqnml-dC2bNxxOxNv6cY2omPcdYlzzcmx7xy9z18QNu1pTdeDCL6BfFAKGa-Lb1dCgaJK9fmq__uQ30YaEIO1EY6dac4b1rJpa9zfvYpHytyI_6J_DIJyaxdpiYnu9fg0QHilzVwbKFxX5YuJY2Qjo9nOVFjVaAA_68v5Yh1Y1RlpuShJ7VafBGcXW2lOkNHxB9I0X2E-Nh7QWWV7KWj_1oCDsiTksw3TsDRECVb1hGHAMu7zUbCbIDSP45pYptAPLLf3Odr7T9w
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MzEsIm5iZiI6MTUwNDExMjQzMSwiZXhwIjoxNTA0MTE2MzMxLCJhaW8iOiJZMkZnWUZpWEx5cktrbVVvMzlSN3czekdIOWN2QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNlhOZWJTN2o4VWl6by1DOG9ab1RBQSIsInZlciI6IjEuMCJ9.m0_Vihy5lkruM9QqCylndiKsZYd8CxoMyR4Y7xaG8y-bVzaVDplg2ayxf3Vw2yfHJkbYzBLQ5p7MSwj6XZk_QxM9nEAKpyitOFZG2gcg_gA31tbBAlS_u4xbb_lF5HEAwc2CPF-9tIc0h-voQUXhzYtElmRxxxUZ_l1WGijrrM3y7KYSSfyYUsyieIc30XCulfC01Yh_G_1nf7KQ1JOZytOlOWoOf38saks0HMCBaF5DpaC9KUeD3qbHjdmzfyd4qP7dIq_1e9q7ysKlYFZmrHSUSvK4tuphY8YkgHOnreYl-UHneaJdMJLGKrTZMLc0zP5b-8lXNdukb_JXG5Umxg
       Host:
       - management.azure.com
   response:
@@ -1993,29 +1993,29 @@ http_interactions:
       X-Ms-Served-By:
       - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
       X-Ms-Request-Id:
-      - 4611b216-f570-4d26-a9c8-6fe318713af1
+      - 7bf64242-a0de-4668-b4c3-dcdf3e6d4983
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14701'
+      - '14924'
       X-Ms-Correlation-Request-Id:
-      - 412b2b51-8a72-4b1b-9638-28bb08502f0b
+      - 29a85c2d-a9ff-451f-80c9-9adaf44853be
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153300Z:412b2b51-8a72-4b1b-9638-28bb08502f0b
+      - EASTUS:20170830T170534Z:29a85c2d-a9ff-451f-80c9-9adaf44853be
       Date:
-      - Wed, 30 Aug 2017 15:32:59 GMT
+      - Wed, 30 Aug 2017 17:05:33 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-08-30T15:32:59.6334993+00:00\",\r\n  \"endTime\":
-        \"2017-08-30T15:32:59.8522326+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=5ae4fd77-73d4-429a-980c-dc4af936a837&sig=tI36BZ44UHpmqmekoNbqtqyF6dhqUGTov%2Bh9TyA0Uqk%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"a66c7488-ac44-475a-9b7f-ed6864d15d77\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2017-08-30T17:05:33.2581669+00:00\",\r\n  \"endTime\":
+        \"2017-08-30T17:05:33.3831546+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=80514038-cdf0-4fed-add7-b54c8a06c9bd&sig=4hV5ItSf73TqIiPHQHhfJI2o%2BzffeF%2BkWsqdj2f99%2F0%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"f14f68f4-248a-4bc4-81e3-626056d4bdd4\"\r\n}"
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:32:58 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:32 GMT
 - request:
     method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=5ae4fd77-73d4-429a-980c-dc4af936a837&sig=tI36BZ44UHpmqmekoNbqtqyF6dhqUGTov%2Bh9TyA0Uqk=&sr=b&sv=2016-05-31
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=80514038-cdf0-4fed-add7-b54c8a06c9bd&sig=4hV5ItSf73TqIiPHQHhfJI2o%2BzffeF%2BkWsqdj2f99/0=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2050,7 +2050,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 4363e57f-0001-000b-75a5-21b959000000
+      - 2c77fd36-0001-007f-25b2-213f1f000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2076,13 +2076,13 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 30 Aug 2017 15:33:00 GMT
+      - Wed, 30 Aug 2017 17:05:33 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         6w==
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:32:58 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:33 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
@@ -2099,7 +2099,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NzgsIm5iZiI6MTUwNDEwNjg3OCwiZXhwIjoxNTA0MTEwNzc4LCJhaW8iOiJZMkZnWUZCY25ycm1tbGFFeTZPRk9yd0dmWjg4QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiN05XM2d1T0FCMGlISDZMODhNQVNBQSIsInZlciI6IjEuMCJ9.Yfke5b0kH6_7eOGt4vQ_aaxM4X_Z_GIpNAgkjb-jVDCtiJ-xvuT3hrXsAbLHYyPVBZfYDKYwPKFqnml-dC2bNxxOxNv6cY2omPcdYlzzcmx7xy9z18QNu1pTdeDCL6BfFAKGa-Lb1dCgaJK9fmq__uQ30YaEIO1EY6dac4b1rJpa9zfvYpHytyI_6J_DIJyaxdpiYnu9fg0QHilzVwbKFxX5YuJY2Qjo9nOVFjVaAA_68v5Yh1Y1RlpuShJ7VafBGcXW2lOkNHxB9I0X2E-Nh7QWWV7KWj_1oCDsiTksw3TsDRECVb1hGHAMu7zUbCbIDSP45pYptAPLLf3Odr7T9w
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MzEsIm5iZiI6MTUwNDExMjQzMSwiZXhwIjoxNTA0MTE2MzMxLCJhaW8iOiJZMkZnWUZpWEx5cktrbVVvMzlSN3czekdIOWN2QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNlhOZWJTN2o4VWl6by1DOG9ab1RBQSIsInZlciI6IjEuMCJ9.m0_Vihy5lkruM9QqCylndiKsZYd8CxoMyR4Y7xaG8y-bVzaVDplg2ayxf3Vw2yfHJkbYzBLQ5p7MSwj6XZk_QxM9nEAKpyitOFZG2gcg_gA31tbBAlS_u4xbb_lF5HEAwc2CPF-9tIc0h-voQUXhzYtElmRxxxUZ_l1WGijrrM3y7KYSSfyYUsyieIc30XCulfC01Yh_G_1nf7KQ1JOZytOlOWoOf38saks0HMCBaF5DpaC9KUeD3qbHjdmzfyd4qP7dIq_1e9q7ysKlYFZmrHSUSvK4tuphY8YkgHOnreYl-UHneaJdMJLGKrTZMLc0zP5b-8lXNdukb_JXG5Umxg
       Content-Length:
       - '42'
       Host:
@@ -2118,34 +2118,34 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/d0f9b626-5d1b-4c06-bdb5-9491f1c3e6f0?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/b761e0b5-30c5-4b10-a132-12a9d43d5135?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/d0f9b626-5d1b-4c06-bdb5-9491f1c3e6f0?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/b761e0b5-30c5-4b10-a132-12a9d43d5135?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
       - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
       X-Ms-Request-Id:
-      - d0f9b626-5d1b-4c06-bdb5-9491f1c3e6f0
+      - b761e0b5-30c5-4b10-a132-12a9d43d5135
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1197'
+      - '1196'
       X-Ms-Correlation-Request-Id:
-      - 99d6ce58-cbdb-4473-9711-47c282413c4a
+      - 9e472060-569a-46f9-81b3-164ee6f53dc4
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153300Z:99d6ce58-cbdb-4473-9711-47c282413c4a
+      - EASTUS:20170830T170534Z:9e472060-569a-46f9-81b3-164ee6f53dc4
       Date:
-      - Wed, 30 Aug 2017 15:33:00 GMT
+      - Wed, 30 Aug 2017 17:05:34 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:33:00 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:33 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/d0f9b626-5d1b-4c06-bdb5-9491f1c3e6f0?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/b761e0b5-30c5-4b10-a132-12a9d43d5135?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -2159,7 +2159,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NzgsIm5iZiI6MTUwNDEwNjg3OCwiZXhwIjoxNTA0MTEwNzc4LCJhaW8iOiJZMkZnWUZCY25ycm1tbGFFeTZPRk9yd0dmWjg4QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiN05XM2d1T0FCMGlISDZMODhNQVNBQSIsInZlciI6IjEuMCJ9.Yfke5b0kH6_7eOGt4vQ_aaxM4X_Z_GIpNAgkjb-jVDCtiJ-xvuT3hrXsAbLHYyPVBZfYDKYwPKFqnml-dC2bNxxOxNv6cY2omPcdYlzzcmx7xy9z18QNu1pTdeDCL6BfFAKGa-Lb1dCgaJK9fmq__uQ30YaEIO1EY6dac4b1rJpa9zfvYpHytyI_6J_DIJyaxdpiYnu9fg0QHilzVwbKFxX5YuJY2Qjo9nOVFjVaAA_68v5Yh1Y1RlpuShJ7VafBGcXW2lOkNHxB9I0X2E-Nh7QWWV7KWj_1oCDsiTksw3TsDRECVb1hGHAMu7zUbCbIDSP45pYptAPLLf3Odr7T9w
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MzEsIm5iZiI6MTUwNDExMjQzMSwiZXhwIjoxNTA0MTE2MzMxLCJhaW8iOiJZMkZnWUZpWEx5cktrbVVvMzlSN3czekdIOWN2QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNlhOZWJTN2o4VWl6by1DOG9ab1RBQSIsInZlciI6IjEuMCJ9.m0_Vihy5lkruM9QqCylndiKsZYd8CxoMyR4Y7xaG8y-bVzaVDplg2ayxf3Vw2yfHJkbYzBLQ5p7MSwj6XZk_QxM9nEAKpyitOFZG2gcg_gA31tbBAlS_u4xbb_lF5HEAwc2CPF-9tIc0h-voQUXhzYtElmRxxxUZ_l1WGijrrM3y7KYSSfyYUsyieIc30XCulfC01Yh_G_1nf7KQ1JOZytOlOWoOf38saks0HMCBaF5DpaC9KUeD3qbHjdmzfyd4qP7dIq_1e9q7ysKlYFZmrHSUSvK4tuphY8YkgHOnreYl-UHneaJdMJLGKrTZMLc0zP5b-8lXNdukb_JXG5Umxg
       Host:
       - management.azure.com
   response:
@@ -2184,29 +2184,29 @@ http_interactions:
       X-Ms-Served-By:
       - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
       X-Ms-Request-Id:
-      - a4d38346-6bab-4f17-bb80-5f72c78aafdf
+      - efefa4e6-e44f-4086-b1d1-fa39c117219f
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14940'
+      - '14949'
       X-Ms-Correlation-Request-Id:
-      - 16ca39c2-b4f8-4603-a365-6f5daa756b7c
+      - 7ae534a2-b1a8-40e0-9e8d-7862afd5d36c
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153301Z:16ca39c2-b4f8-4603-a365-6f5daa756b7c
+      - EASTUS:20170830T170534Z:7ae534a2-b1a8-40e0-9e8d-7862afd5d36c
       Date:
-      - Wed, 30 Aug 2017 15:33:00 GMT
+      - Wed, 30 Aug 2017 17:05:34 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-08-30T15:33:00.4243378+00:00\",\r\n  \"endTime\":
-        \"2017-08-30T15:33:00.6743376+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=3aa189f8-a01d-4d35-88d6-caf8d51a589a&sig=fYv58w33EJeNFAjLUxGDE6df0E%2B%2BSCuKkcoUqcfyid0%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"d0f9b626-5d1b-4c06-bdb5-9491f1c3e6f0\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2017-08-30T17:05:34.101939+00:00\",\r\n  \"endTime\":
+        \"2017-08-30T17:05:34.2425331+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=3307f131-bc55-4e5e-b345-e61139e2194e&sig=pPm6UejMws7tb%2FPxA5K3ad366tpAqNjfrZh7OFYyCTo%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"b761e0b5-30c5-4b10-a132-12a9d43d5135\"\r\n}"
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:33:01 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:33 GMT
 - request:
     method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=3aa189f8-a01d-4d35-88d6-caf8d51a589a&sig=fYv58w33EJeNFAjLUxGDE6df0E%2B%2BSCuKkcoUqcfyid0=&sr=b&sv=2016-05-31
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=3307f131-bc55-4e5e-b345-e61139e2194e&sig=pPm6UejMws7tb/PxA5K3ad366tpAqNjfrZh7OFYyCTo=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2241,7 +2241,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 80f6e214-0001-00e3-24a5-2144a2000000
+      - 02a0d1ff-0001-0083-6bb2-210180000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2267,11 +2267,11 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 30 Aug 2017 15:33:00 GMT
+      - Wed, 30 Aug 2017 17:05:34 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         U5MJAA==
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:33:01 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:33 GMT
 recorded_with: VCR 3.0.3

--- a/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_endByteAddr-2.yml
+++ b/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_endByteAddr-2.yml
@@ -1,0 +1,2277 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://login.microsoftonline.com/azure_tenant_id/oauth2/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_key&resource=https%3A%2F%2Fmanagement.azure.com%2F
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - login.microsoftonline.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Server:
+      - Microsoft-IIS/8.5
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Request-Id:
+      - 735f80a7-77bb-444c-9b7e-c8d53d161200
+      P3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Set-Cookie:
+      - esctx=AQABAAAAAAA9kTklhVy7SJTGAzR-p1BcIgbUur_CkEZpVZDi_mo8i0Vvn1odl9w3aJUdmnW5LbhIf5F9M4agA7APcmOhk3VUDiQL8Dbrad6dD1jtDgsdnyv801kbme0VHKz4hC81N4DcMpe8zBvbBoFmTs8NQVruY8dI0EREsuFdPJi61CvHJwoBSatRGUE3IggvYJZmYnAgAA;
+        domain=.login.microsoftonline.com; path=/; secure; HttpOnly
+      - stsservicecookie=ests; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=003; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Wed, 30 Aug 2017 15:33:03 GMT
+      Content-Length:
+      - '1500'
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1504110782","not_before":"1504106882","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4ODIsIm5iZiI6MTUwNDEwNjg4MiwiZXhwIjoxNTA0MTEwNzgyLCJhaW8iOiJZMkVBZ29tZkdqL3MwV2k0bWp5ejg1NUVZeHNBIiwiYXBwaWQiOiJmYzFjMjIyNS0wNjVmLTRiYTgtODNkOS1kODY2NjJmNTc4YWYiLCJhcHBpZGFjciI6IjEiLCJncm91cHMiOlsiNDA3Mzg5ODYtM2M4Mi00Y2YxLTk5ZmMtMTM0NTdlMzMzMmZjIiwiMGQwMTQzZWEtMzM5ZS00MmUwLWEyNGUtYjVhOGZjNjlmZjE0IiwiZDY1ZjJlNWQtZmJmYi00MTUzLTg2YjItNTk3OWI0ZTZiNTkyIl0sImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ1dGkiOiJwNEJmYzd0M1RFU2Jmc2pWUFJZU0FBIiwidmVyIjoiMS4wIn0.EK4xnQ-CGOt1ADV9wF5PPIwsevthxYM7O-tIrVeg_yxzjTjeF1BYDs9mXYFBld8ZfcrPsaC5vufzM8RyD_768PpWjpqacrSoVEvrZzLXxtwyDUGx3dOBvrLZV_cM5ER7w1ORxlJo3Yq4N0WMcdVz9rYNyeDs_gGOutOC3DFK9fuRtTPm6gyL7E-pv1acyR566RXpS8_r1Kb6e6SvR0MaX2JgeDxjdxwYGuA4HMypQwi1JCy6joswNjE-8aPDcrXR13dz_N0efxHm7pb3RkbuYophUITniUCCH0KHKAsZWEhT6c0qNtI4wT6vtwzsAoqFtOCeIRJoiZYRkVt3iwYJUw"}'
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:02 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions?api-version=2016-06-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4ODIsIm5iZiI6MTUwNDEwNjg4MiwiZXhwIjoxNTA0MTEwNzgyLCJhaW8iOiJZMkVBZ29tZkdqL3MwV2k0bWp5ejg1NUVZeHNBIiwiYXBwaWQiOiJmYzFjMjIyNS0wNjVmLTRiYTgtODNkOS1kODY2NjJmNTc4YWYiLCJhcHBpZGFjciI6IjEiLCJncm91cHMiOlsiNDA3Mzg5ODYtM2M4Mi00Y2YxLTk5ZmMtMTM0NTdlMzMzMmZjIiwiMGQwMTQzZWEtMzM5ZS00MmUwLWEyNGUtYjVhOGZjNjlmZjE0IiwiZDY1ZjJlNWQtZmJmYi00MTUzLTg2YjItNTk3OWI0ZTZiNTkyIl0sImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ1dGkiOiJwNEJmYzd0M1RFU2Jmc2pWUFJZU0FBIiwidmVyIjoiMS4wIn0.EK4xnQ-CGOt1ADV9wF5PPIwsevthxYM7O-tIrVeg_yxzjTjeF1BYDs9mXYFBld8ZfcrPsaC5vufzM8RyD_768PpWjpqacrSoVEvrZzLXxtwyDUGx3dOBvrLZV_cM5ER7w1ORxlJo3Yq4N0WMcdVz9rYNyeDs_gGOutOC3DFK9fuRtTPm6gyL7E-pv1acyR566RXpS8_r1Kb6e6SvR0MaX2JgeDxjdxwYGuA4HMypQwi1JCy6joswNjE-8aPDcrXR13dz_N0efxHm7pb3RkbuYophUITniUCCH0KHKAsZWEhT6c0qNtI4wT6vtwzsAoqFtOCeIRJoiZYRkVt3iwYJUw
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Tenant-Reads:
+      - '14997'
+      X-Ms-Request-Id:
+      - d6cd401a-de41-4e1e-b438-4042750479c6
+      X-Ms-Correlation-Request-Id:
+      - d6cd401a-de41-4e1e-b438-4042750479c6
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153302Z:d6cd401a-de41-4e1e-b438-4042750479c6
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 30 Aug 2017 15:33:01 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
+        Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:02 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers?api-version=2015-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4ODIsIm5iZiI6MTUwNDEwNjg4MiwiZXhwIjoxNTA0MTEwNzgyLCJhaW8iOiJZMkVBZ29tZkdqL3MwV2k0bWp5ejg1NUVZeHNBIiwiYXBwaWQiOiJmYzFjMjIyNS0wNjVmLTRiYTgtODNkOS1kODY2NjJmNTc4YWYiLCJhcHBpZGFjciI6IjEiLCJncm91cHMiOlsiNDA3Mzg5ODYtM2M4Mi00Y2YxLTk5ZmMtMTM0NTdlMzMzMmZjIiwiMGQwMTQzZWEtMzM5ZS00MmUwLWEyNGUtYjVhOGZjNjlmZjE0IiwiZDY1ZjJlNWQtZmJmYi00MTUzLTg2YjItNTk3OWI0ZTZiNTkyIl0sImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ1dGkiOiJwNEJmYzd0M1RFU2Jmc2pWUFJZU0FBIiwidmVyIjoiMS4wIn0.EK4xnQ-CGOt1ADV9wF5PPIwsevthxYM7O-tIrVeg_yxzjTjeF1BYDs9mXYFBld8ZfcrPsaC5vufzM8RyD_768PpWjpqacrSoVEvrZzLXxtwyDUGx3dOBvrLZV_cM5ER7w1ORxlJo3Yq4N0WMcdVz9rYNyeDs_gGOutOC3DFK9fuRtTPm6gyL7E-pv1acyR566RXpS8_r1Kb6e6SvR0MaX2JgeDxjdxwYGuA4HMypQwi1JCy6joswNjE-8aPDcrXR13dz_N0efxHm7pb3RkbuYophUITniUCCH0KHKAsZWEhT6c0qNtI4wT6vtwzsAoqFtOCeIRJoiZYRkVt3iwYJUw
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14943'
+      X-Ms-Request-Id:
+      - 70221b4c-313c-4982-82f3-42762d3e7065
+      X-Ms-Correlation-Request-Id:
+      - 70221b4c-313c-4982-82f3-42762d3e7065
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153303Z:70221b4c-313c-4982-82f3-42762d3e7065
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 30 Aug 2017 15:33:02 GMT
+      Content-Length:
+      - '241615'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","North Central
+        US","South Central US","West Central US","West US","West US 2","Canada Central","Canada
+        East","North Europe","West Europe","UK South","UK West","East Asia","Southeast
+        Asia","Japan East","Japan West","Korea Central","Korea South","Brazil South","Central
+        India","South India","West India"],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"validateServiceName","locations":[],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"checkServiceNameAvailability","locations":[],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"reportFeedback","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"checkFeedbackRequired","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Automation","namespace":"Microsoft.Automation","authorizations":[{"applicationId":"fc75330b-179d-49af-87dd-3b1acf6827fa","roleDefinitionId":"95fd5de3-d071-4362-92bf-cf341c1de832"}],"resourceTypes":[{"resourceType":"automationAccounts","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
+        South","UK South","West Central US","North Europe","Canada Central","Australia
+        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/runbooks","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
+        South","UK South","West Central US","North Europe","Canada Central","Australia
+        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/configurations","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","North
+        Central US","Brazil South","UK South","West Central US","Central India","Australia
+        Southeast","Canada Central","North Europe"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/webhooks","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
+        South","UK South","West Central US","North Europe","Canada Central","Australia
+        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"operations","locations":["South
+        Central US"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/softwareUpdateConfigurations","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
+        South","UK South","West Central US","North Europe","Canada Central","Australia
+        Southeast","Central India"],"apiVersions":["2017-05-15-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Backup","namespace":"Microsoft.Backup","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"BackupVault","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India"],"apiVersions":["2015-03-15","2014-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Batch","namespace":"Microsoft.Batch","authorization":{"applicationId":"ddbf3205-c6bd-46ae-8127-60eb93363864","roleDefinitionId":"b7f84953-1d03-4eab-9ea4-45f065258ff8"},"resourceTypes":[{"resourceType":"batchAccounts","locations":["West
+        Europe","East US","East US 2","West US","North Central US","Brazil South","North
+        Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
+        West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
+        East","South India","Central India","Canada Central","Canada East","UK South","UK
+        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01","2015-07-01","2014-05-01-privatepreview"]},{"resourceType":"operations","locations":["West
+        Europe","East US","East US 2","West US","North Central US","Brazil South","North
+        Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
+        West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
+        East","South India","Central India","Canada Central","Canada East","UK South","UK
+        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations/quotas","locations":["West
+        Europe","East US","East US 2","West US","North Central US","Brazil South","North
+        Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
+        West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
+        East","South India","Central India","Canada Central","Canada East","UK South","UK
+        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]}],"registrationState":"Unregistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicCompute","namespace":"Microsoft.ClassicCompute","resourceTypes":[{"resourceType":"domainNames","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
+        Central","Canada East","UK South","UK West","West US","Central US","South
+        Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
+        East","Australia Southeast","West US 2","West Central US","South India","Central
+        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
+        Central","Canada East","UK South","UK West","West US","Central US","South
+        Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
+        East","Australia Southeast","West US 2","West Central US","South India","Central
+        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
+        Central US","South Central US","East US","East US 2","Canada Central","Canada
+        East","West US","West US 2","West Central US","Central US","East Asia","Southeast
+        Asia","North Europe","West Europe","UK South","UK West","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operatingSystems","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"operatingSystemFamilies","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicNetwork","namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"virtualNetworks/remoteVirtualNetworkPeeringProxies","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"reservedIps","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicStorage","namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
+        US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
+        Asia","Australia East","Australia Southeast","South India","Central India","West
+        India","West US 2","West Central US","East US","East US 2","North Central
+        US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
+        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
+        US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
+        Asia","Australia East","Australia Southeast","South India","Central India","West
+        India","West US 2","West Central US","East US","East US 2","North Central
+        US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
+        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"vmImages","locations":[],"apiVersions":["2016-11-01"]},{"resourceType":"publicImages","locations":[],"apiVersions":["2016-11-01","2016-04-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"osPlatformImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Compute","namespace":"Microsoft.Compute","authorization":{"applicationId":"60e6cd67-9c8c-4951-9b3c-23c25a2169af","roleDefinitionId":"e4770acb-272e-4dc8-87f3-12f44a612224"},"resourceTypes":[{"resourceType":"availabilitySets","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30"]},{"resourceType":"locations/usages","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"disks","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"snapshots","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"locations/diskoperations","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"images","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
+        US","East US","South Central US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","East Asia","Japan
+        East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/webhooks","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/ping","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/getCallbackConfig","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/listEvents","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"locations","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"locations/operationResults","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/GetCredentials","locations":["West
+        US","East US","South Central US","West Europe"],"apiVersions":["2016-06-27-preview"]},{"resourceType":"registries/listCredentials","locations":["South
+        Central US","East US","West US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","East Asia","Japan
+        East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/regenerateCredential","locations":["South
+        Central US","West US","East US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","East Asia","Japan
+        East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/listUsages","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/regenerateCredentials","locations":["West
+        US","East US","South Central US","West Europe"],"apiVersions":["2016-06-27-preview"]},{"resourceType":"checkNameAvailability","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview","2017-03-01","2016-06-27-preview"]},{"resourceType":"operations","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview","2017-03-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerService","namespace":"Microsoft.ContainerService","authorization":{"applicationId":"7319c514-987d-4e9b-ac3d-d38c4f427f4c","roleDefinitionId":"1b4a0c7f-2217-416f-acfa-cf73452fdc1c"},"resourceTypes":[{"resourceType":"containerServices","locations":["Japan
+        East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
+        East","Australia Southeast","Brazil South","Southeast Asia","West US","North
+        Central US","West Europe","North Europe","East US","UK West","UK South","West
+        Central US","West US 2","South India","Central India","West India","Canada
+        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
+        East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
+        East","Australia Southeast","Brazil South","Southeast Asia","West US","North
+        Central US","West Europe","North Europe","East US","UK West","UK South","West
+        Central US","West US 2","South India","Central India","West India","Canada
+        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DevTestLab","namespace":"Microsoft.DevTestLab","authorization":{"applicationId":"1a14be2a-e903-4cec-99cf-b2e209259a0f","roleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525"},"resourceTypes":[{"resourceType":"labs","locations":["West
+        Central US","Japan East","West US","Australia Southeast","Canada Central","Central
+        India","Central US","East Asia","Korea Central","North Europe","South Central
+        US","UK West","Australia East","Brazil South","Canada East","East US","East
+        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"schedules","locations":["West
+        Central US","Japan East","West US","Australia Southeast","Canada Central","Central
+        India","Central US","East Asia","Korea Central","North Europe","South Central
+        US","UK West","Australia East","Brazil South","Canada East","East US","East
+        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"labs/virtualMachines","locations":["West
+        Central US","Japan East","West US","Australia Southeast","Canada Central","Central
+        India","Central US","East Asia","Korea Central","North Europe","South Central
+        US","UK West","Australia East","Brazil South","Canada East","East US","East
+        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"labs/serviceRunners","locations":["Central
+        US","East US 2","South Central US"],"apiVersions":["2017-04-26-preview","2016-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"locations/operations","locations":["West
+        Central US","Japan East","West US","Australia Southeast","Canada Central","Central
+        India","Central US","East Asia","Korea Central","North Europe","South Central
+        US","UK West","Australia East","Brazil South","Canada East","East US","East
+        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"}],"resourceTypes":[{"resourceType":"components","locations":["East
+        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
+        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01","2014-04-01"]},{"resourceType":"queries","locations":["East
+        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"alertrules","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2016-03-01","2015-04-01","2014-04-01"]},{"resourceType":"autoscalesettings","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2015-04-01","2014-04-01"]},{"resourceType":"eventtypes","locations":[],"apiVersions":["2017-03-01-preview","2016-09-01-preview","2015-04-01","2014-11-01","2014-04-01"]},{"resourceType":"locations","locations":["East
+        US"],"apiVersions":["2015-04-01","2014-04-01"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2015-04-01","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-04-01","2014-06-01","2014-04-01"]},{"resourceType":"automatedExportSettings","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2015-04-01","2014-04-01"]},{"resourceType":"diagnosticSettings","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2017-05-01-preview","2016-09-01","2015-07-01"]},{"resourceType":"diagnosticSettingsCategories","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"extendedDiagnosticSettings","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2017-02-01"]},{"resourceType":"metricDefinitions","locations":["East
+        US","West US","West Europe","East Asia","Southeast Asia","Japan East","Japan
+        West","North Central US","South Central US","East US 2","Canada East","Canada
+        Central","Central US","Australia East","Australia Southeast","Brazil South","South
+        India","Central India","West India","North Europe","West US 2","West Central
+        US","Korea South","Korea Central","UK South","UK West","Global"],"apiVersions":["2017-05-01-preview","2016-03-01","2015-07-01"]},{"resourceType":"logDefinitions","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2015-07-01"]},{"resourceType":"eventCategories","locations":[],"apiVersions":["2015-04-01"]},{"resourceType":"metrics","locations":["East
+        US","West US","West Europe","East Asia","Southeast Asia","Japan East","Japan
+        West","North Central US","South Central US","East US 2","Canada East","Canada
+        Central","Central US","Australia East","Australia Southeast","Brazil South","South
+        India","Central India","West India","North Europe","West US 2","West Central
+        US","Korea South","Korea Central","UK South","UK West"],"apiVersions":["2017-05-01-preview","2016-09-01","2016-06-01"]},{"resourceType":"actiongroups","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]},{"resourceType":"activityLogAlerts","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.KeyVault","namespace":"Microsoft.KeyVault","resourceTypes":[{"resourceType":"vaults","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/accessPolicies","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-10-01","2015-06-01","2014-12-19-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"deletedVaults","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-10-01"]},{"resourceType":"locations/deletedVaults","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorization":{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"routeTables","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2017-04-26-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"]},{"resourceType":"workspaces/dataSources","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"storageInsightConfigs","locations":[],"apiVersions":["2014-10-10"]},{"resourceType":"workspaces/linkedServices","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"linkTargets","locations":["East
+        US"],"apiVersions":["2015-03-20"]},{"resourceType":"operations","locations":[],"apiVersions":["2014-11-10"]},{"resourceType":"devices","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationsManagement","namespace":"Microsoft.OperationsManagement","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"aa249101-6816-4966-aafa-08175d795f14"},"resourceTypes":[{"resourceType":"solutions","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Portal","namespace":"Microsoft.Portal","resourceTypes":[{"resourceType":"dashboards","locations":["Central
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
+        East","West India","South India","Central India","Canada Central","Canada
+        East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"operations","locations":["Central
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
+        East","West India","South India","Central India","Canada Central","Canada
+        East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"consoles","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/consoles","locations":["West
+        US","East US","Central India","North Europe","West Europe","South Central
+        US","Southeast Asia"],"apiVersions":["2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
+        US","East US","Central India","North Europe","West Europe","South Central
+        US","Southeast Asia"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","Canada Central","Canada East","West Central US","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-07-01","2016-12-01","2016-08-10","2016-06-01","2016-05-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"operations","locations":["Southeast
+        Asia"],"apiVersions":["2016-08-10","2016-06-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01"]},{"resourceType":"locations/backupStatus","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]},{"resourceType":"locations/allocatedStamp","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]},{"resourceType":"locations/allocateStamp","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ResourceHealth","namespace":"Microsoft.ResourceHealth","authorization":{"applicationId":"8bdebf23-c0fe-4187-a378-717ad86f6a53","roleDefinitionId":"cc026344-c8b1-4561-83ba-59eba84b27cc"},"resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2017-07-01","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"notifications","locations":["Australia
+        Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Security","namespace":"Microsoft.Security","authorization":{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatuses","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/virtualMachines","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/endpoints","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/subnets","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"tasks","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"alerts","locations":["Central
+        US","East US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"monitoring","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"monitoring/patch","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"monitoring/baseline","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"monitoring/antimalware","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"dataCollectionAgents","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"dataCollectionResults","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"pricings","locations":["Central
+        US","East US"],"apiVersions":["2017-08-01-preview"]},{"resourceType":"complianceResults","locations":["Central
+        US","East US"],"apiVersions":["2017-08-01"]},{"resourceType":"policies","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"appliances","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"webApplicationFirewalls","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/webApplicationFirewalls","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securitySolutions","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/securitySolutions","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securitySolutionsReferenceData","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/securitySolutionsReferenceData","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"jitNetworkAccessPolicies","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/jitNetworkAccessPolicies","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatusesSummaries","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/alerts","locations":["Central
+        US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/tasks","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.SiteRecovery","namespace":"Microsoft.SiteRecovery","authorization":{"applicationId":"b8340c3b-9267-498f-b21a-15d5547fd85e","roleDefinitionId":"8A00C8EA-8F1B-45A7-8F64-F4CC61EEE9B6"},"resourceTypes":[{"resourceType":"SiteRecoveryVault","locations":["East
+        US","West US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","Australia East","Australia Southeast","Brazil South","North
+        Central US","South Central US","Central US","East US 2","Central India","South
+        India"],"apiVersions":["2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Sql","namespace":"Microsoft.Sql","authorizations":[{"applicationId":"e4ab13ed-33cb-41b4-9140-6e264582cf85","roleDefinitionId":"ec3ddc95-44dc-47a2-9926-5e9f5ffd44ec"},{"applicationId":"0130cc9f-7ac5-4026-bd5f-80a08a54e6d9","roleDefinitionId":"45e8abf8-0ec4-44f3-9c37-cff4f7779302"},{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},{"applicationId":"76c7f279-7959-468f-8943-3954880e0d8c","roleDefinitionId":"7f7513a8-73f9-4c5f-97a2-c41f0ea783ef"}],"resourceTypes":[{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/capabilities","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverKeyOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/keys","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/encryptionProtector","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/communicationLinks","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recoverableDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/importExportOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/operationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/firewallrules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/elasticpools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-09-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/dnsAliases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/failoverGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/virtualNetworkRules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/virtualNetworkRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/virtualNetworkRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/databaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/extensions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditRecords","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/VulnerabilityAssessmentScans","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentScans","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups/syncMembers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/syncAgents","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncMemberOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncAgentOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncDatabaseIds","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorization":{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
+        US","West US","West Europe","North Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":["East
+        US","West US","West Europe","North Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Web","namespace":"Microsoft.Web","authorization":{"applicationId":"abfa0a7c-a6b6-4736-8310-5855508787cd","roleDefinitionId":"f47ed98b-b063-4a5b-9e10-4b9b44fa7735"},"resourceTypes":[{"resourceType":"sites/extensions","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots/extensions","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/instances","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots/instances","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/instances/extensions","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots/instances/extensions","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/publicCertificates","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots/publicCertificates","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"publishingUsers","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"ishostnameavailable","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"validate","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"isusernameavailable","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sourceControls","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"availableStacks","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"listSitesAssignedToHostName","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"sites/hostNameBindings","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"sites/domainOwnershipIdentifiers","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"sites/slots/hostNameBindings","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"operations","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"certificates","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms/workers","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"runtimes","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"sites/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"sites/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"sites/slots/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"sites/slots/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"serverFarms/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"serverFarms/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"sites/recommendations","locations":[],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"georegions","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/premieraddons","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01"]},{"resourceType":"hostingEnvironments","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/instances","locations":[],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/instances/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/instances/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/instances","locations":[],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/instances/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/instances/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"deploymentLocations","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"functions","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"deletedSites","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"ishostingenvironmentnameavailable","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"classicMobileServices","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"connections","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/managedApis","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/apiOperations","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"connectionGateways","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/connectionGatewayInstallations","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"checkNameAvailability","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"billingMeters","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/84codes.CloudAMQP","namespace":"84codes.CloudAMQP","resourceTypes":[{"resourceType":"servers","locations":["East
+        US 2","Central US","East US","North Central US","South Central US","West US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast"],"apiVersions":["2016-08-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/AppDynamics.APM","namespace":"AppDynamics.APM","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2016-05-26"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-05-26"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-05-26"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-05-26"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-05-26"]},{"resourceType":"locations/operationResults","locations":["West
+        US"],"apiVersions":["2016-05-26"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Aspera.Transfers","namespace":"Aspera.Transfers","resourceTypes":[{"resourceType":"services","locations":["West
+        US","North Europe","Central US","East US","West Europe","East Asia","Southeast
+        Asia","Japan East","East US 2","Japan West"],"apiVersions":["2016-03-25"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-03-25"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-03-25"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-03-25"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Auth0.Cloud","namespace":"Auth0.Cloud","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-11-23"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Citrix.Cloud","namespace":"Citrix.Cloud","resourceTypes":[{"resourceType":"accounts","locations":["West
+        US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Cloudyn.Analytics","namespace":"Cloudyn.Analytics","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US"],"apiVersions":["2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Conexlink.MyCloudIT","namespace":"Conexlink.MyCloudIT","resourceTypes":[{"resourceType":"accounts","locations":["Central
+        US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Crypteron.DataSecurity","namespace":"Crypteron.DataSecurity","resourceTypes":[{"resourceType":"apps","locations":["West
+        US"],"apiVersions":["2016-08-12"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-12"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-12"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-12"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Dynatrace.DynatraceSaaS","namespace":"Dynatrace.DynatraceSaaS","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-09-27"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Dynatrace.Ruxit","namespace":"Dynatrace.Ruxit","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US"],"apiVersions":["2016-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-09-07","2016-04-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-04-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/LiveArena.Broadcast","namespace":"LiveArena.Broadcast","resourceTypes":[{"resourceType":"services","locations":["West
+        US","North Europe","Japan West","Japan East","East Asia","West Europe","East
+        US","Southeast Asia","Central US"],"apiVersions":["2016-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Lombiq.DotNest","namespace":"Lombiq.DotNest","resourceTypes":[{"resourceType":"sites","locations":["East
+        US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Mailjet.Email","namespace":"Mailjet.Email","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]},{"resourceType":"diagnosticSettings","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"addsservices","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"configuration","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"agents","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"aadsupportcases","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"reports","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"servicehealthmetrics","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"logs","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"anonymousapiusers","locations":["West
+        US"],"apiVersions":["2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AnalysisServices","namespace":"Microsoft.AnalysisServices","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"servers","locations":["West
+        US","North Europe","South Central US","West Europe","West Central US","Southeast
+        Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
+        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/checkNameAvailability","locations":["West
+        US","North Europe","South Central US","West Europe","West Central US","Southeast
+        Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
+        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationresults","locations":["West
+        US","North Europe","South Central US","West Europe","West Central US","Southeast
+        Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
+        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationstatuses","locations":["West
+        US","North Europe","South Central US","West Europe","West Central US","Southeast
+        Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
+        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"operations","locations":["East
+        US 2","West Central US"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AppService","namespace":"Microsoft.AppService","authorization":{"applicationId":"dee7ba80-6a55-4f3b-a86c-746a9231ae49","roleDefinitionId":"6715d172-49c4-46f6-bb21-60512a8689dc"},"resourceTypes":[{"resourceType":"apiapps","locations":["East
+        US","West US","South Central US","North Europe","East Asia","Japan East","West
+        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
+        South","East US 2","Australia Southeast","Australia East","West India","South
+        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"appIdentities","locations":["East
+        US","West US","South Central US","North Europe","East Asia","Japan East","West
+        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
+        South","East US 2","Australia Southeast","Australia East","West India","South
+        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"gateways","locations":["East
+        US","West US","South Central US","North Europe","East Asia","Japan East","West
+        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
+        South","East US 2","Australia Southeast","Australia East","West India","South
+        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"deploymenttemplates","locations":[],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Authorization","namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"roleDefinitions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"classicAdministrators","locations":[],"apiVersions":["2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"permissions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"locks","locations":[],"apiVersions":["2017-04-01","2016-09-01","2015-06-01","2015-05-01-preview","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-01-01","2014-10-01-preview","2014-06-01"]},{"resourceType":"policyDefinitions","locations":[],"apiVersions":["2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"policySetDefinitions","locations":[],"apiVersions":["2017-06-01-preview"]},{"resourceType":"policyAssignments","locations":[],"apiVersions":["2017-06-01-preview","2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"providerOperations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01-preview","2015-07-01"]},{"resourceType":"elevateAccess","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureActiveDirectory","namespace":"Microsoft.AzureActiveDirectory","resourceTypes":[{"resourceType":"b2cDirectories","locations":["Global","United
+        States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureStack","namespace":"Microsoft.AzureStack","resourceTypes":[{"resourceType":"operations","locations":["Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations","locations":["West
+        Central US","Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations/products","locations":["West
+        Central US","Global"],"apiVersions":["2017-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Billing","namespace":"Microsoft.Billing","resourceTypes":[{"resourceType":"BillingPeriods","locations":["Central
+        US"],"apiVersions":["2017-04-24-preview"]},{"resourceType":"Invoices","locations":["Central
+        US"],"apiVersions":["2017-04-24-preview","2017-02-27-preview"]},{"resourceType":"operations","locations":["Central
+        US"],"apiVersions":["2017-04-24-preview","2017-02-27-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BingMaps","namespace":"Microsoft.BingMaps","resourceTypes":[{"resourceType":"mapApis","locations":["West
+        US"],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-18","2015-07-02"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BizTalkServices","namespace":"Microsoft.BizTalkServices","resourceTypes":[{"resourceType":"BizTalk","locations":["East
+        US","West US","North Europe","West Europe","Southeast Asia","East Asia","North
+        Central US","Japan West","Japan East","South Central US"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Cache","namespace":"Microsoft.Cache","authorization":{"applicationId":"96231a05-34ce-4eb4-aa6a-70759cbb5e83","roleDefinitionId":"4f731528-ba85-45c7-acfb-cd0a9b3cf31b"},"resourceTypes":[{"resourceType":"Redis","locations":["North
+        Central US","South Central US","Central US","West Europe","North Europe","West
+        US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
+        Asia","East Asia","Australia East","Australia Southeast","Central India","West
+        India","Canada Central","Canada East","UK South","UK West","West US 2","West
+        Central US","South India","Korea Central","Korea South"],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","South Central US","Central US","West Europe","North Europe","West
+        US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
+        Asia","East Asia","Australia East","Australia Southeast","Central India","West
+        India","South India","Canada Central","Canada East","UK South","UK West","West
+        US 2","West Central US","Korea Central","Korea South"],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01"]},{"resourceType":"Redis/metricDefinitions","locations":["North
+        Central US","South Central US","East US","East US 2","West US","Central US","East
+        Asia","Southeast Asia","North Europe","West Europe","Japan East","Japan West","Brazil
+        South","Australia Southeast","Australia East","Central India","West India","South
+        India","Canada Central","Canada East","UK West","UK South","West US 2","West
+        Central US","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"Redis/diagnosticSettings","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","West
+        US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
+        Asia","Australia East","Australia Southeast","Central India","West India","South
+        India","Canada Central","Canada East","UK West","UK South","West US 2","West
+        Central US","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Cdn","namespace":"Microsoft.Cdn","resourceTypes":[{"resourceType":"profiles","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/origins","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/customdomains","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/originresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/customdomainresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkResourceUsage","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02"]},{"resourceType":"validateProbe","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"edgenodes","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CertificateRegistration","namespace":"Microsoft.CertificateRegistration","authorization":{"applicationId":"f3c21649-0979-4721-ac85-b0216b2cf413","roleDefinitionId":"933fba7e-2ed3-4da8-973d-8bd8298a9b40"},"resourceTypes":[{"resourceType":"certificateOrders","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"certificateOrders/certificates","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"validateCertificateRegistrationInformation","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicSubscription","namespace":"Microsoft.ClassicSubscription","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicInfrastructureMigrate","namespace":"Microsoft.ClassicInfrastructureMigrate","authorization":{"applicationId":"5e5abe2b-83cd-4786-826a-a05653ebb103","roleDefinitionId":"766c4d9b-ef83-4f73-8352-1450a506a69b"},"resourceTypes":[{"resourceType":"classicInfrastructureResources","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","West
+        India","South India"],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CognitiveServices","namespace":"Microsoft.CognitiveServices","authorizations":[{"applicationId":"7d312290-28c8-473c-a0ed-8e53749b6d6d","roleDefinitionId":"5cb87f79-a7c3-4a95-9414-45b65974b51b"}],"resourceTypes":[{"resourceType":"accounts","locations":["Global","West
+        US","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"operations","locations":["Global","West
+        US","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations","locations":["Global","West
+        US","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/checkSkuAvailability","locations":["West
+        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/updateAccountsCreationSettings","locations":["West
+        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/accountsCreationSettings","locations":["West
+        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2016-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Commerce","namespace":"Microsoft.Commerce","resourceTypes":[{"resourceType":"UsageAggregates","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]},{"resourceType":"RateCard","locations":[],"apiVersions":["2016-08-31-preview","2015-06-01-preview","2015-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Consumption","namespace":"Microsoft.Consumption","resourceTypes":[{"resourceType":"reservationsummaries","locations":[],"apiVersions":["2017-01-30"]},{"resourceType":"reservationdetails","locations":[],"apiVersions":["2017-01-30"]},{"resourceType":"UsageDetails","locations":[],"apiVersions":["2017-06-30-preview","2017-04-24-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-30-preview","2017-04-24-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","resourceTypes":[{"resourceType":"containerGroups","locations":["West
+        US","East US","West Europe"],"apiVersions":["2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
+        US"],"apiVersions":["2016-04-08"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CustomerInsights","namespace":"Microsoft.CustomerInsights","authorization":{"applicationId":"38c77d00-5fcb-4cce-9d93-af4738258e3c","roleDefinitionId":"E006F9C7-F333-477C-8AD6-1F3A9FE87F55"},"resourceTypes":[{"resourceType":"hubs","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/profiles","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/interactions","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/authorizationPolicies","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/connectors","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/connectors/mappings","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/kpi","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/views","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/links","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/roleAssignments","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/roles","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/widgetTypes","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/suggestTypeSchema","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"operations","locations":["East
+        US 2"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataCatalog","namespace":"Microsoft.DataCatalog","resourceTypes":[{"resourceType":"catalogs","locations":["East
+        US","West US","Australia East","West Europe","North Europe","Southeast Asia","West
+        Central US"],"apiVersions":["2016-03-30","2015-07-01-preview"]},{"resourceType":"checkNameAvailability","locations":["West
+        Europe"],"apiVersions":["2016-03-30","2015-07-01-preview"]},{"resourceType":"operations","locations":["West
+        Europe"],"apiVersions":["2016-03-30","2015-07-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-03-30","2015-07-01-preview"]},{"resourceType":"locations/jobs","locations":["East
+        US","West US","Australia East","West Europe","North Europe","Southeast Asia","West
+        Central US"],"apiVersions":["2016-03-30","2015-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataFactory","namespace":"Microsoft.DataFactory","resourceTypes":[{"resourceType":"dataFactories","locations":["West
+        US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview","2014-04-01"]},{"resourceType":"factories","locations":["East
+        US"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
+        US"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
+        Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"dataFactories/metricDefinitions","locations":["North
+        Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"checkDataFactoryNameAvailability","locations":[],"apiVersions":["2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"checkAzureDataFactoryNameAvailability","locations":["West
+        US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"dataFactorySchema","locations":["West
+        US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"operations","locations":["West
+        US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeAnalytics","namespace":"Microsoft.DataLakeAnalytics","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/dataLakeStoreAccounts","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers/listSasTokens","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeStore","namespace":"Microsoft.DataLakeStore","authorization":{"applicationId":"e9f49c6b-5ce5-44c8-925d-015017e9f7ad","roleDefinitionId":"17eb9cca-f08a-4499-b2d3-852d175f614f"},"resourceTypes":[{"resourceType":"accounts","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/firewallRules","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","resourceTypes":[{"resourceType":"operations","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforPostgreSQL","namespace":"Microsoft.DBforPostgreSQL","resourceTypes":[{"resourceType":"operations","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
+        US","North Europe","East Asia","East US","West Europe","Southeast Asia","Japan
+        East","Japan West","Australia East","Australia Southeast","West US 2","West
+        Central US","East US 2","Central US","UK South","UK West","South India","Central
+        India"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"databaseAccountNames","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DomainRegistration","namespace":"Microsoft.DomainRegistration","authorization":{"applicationId":"ea2f600a-4980-45b7-89bf-d34da487bda1","roleDefinitionId":"54d7f2e3-5040-48a7-ae90-eebf629cfa0b"},"resourceTypes":[{"resourceType":"domains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"domains/domainOwnershipIdentifiers","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"topLevelDomains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"checkDomainAvailability","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"listDomainRecommendations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"validateDomainRegistrationInformation","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"generateSsoRequest","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DynamicsLcs","namespace":"Microsoft.DynamicsLcs","resourceTypes":[{"resourceType":"lcsprojects","locations":["Brazil
+        South","East Asia","East US","Japan East","Japan West","North Central US","North
+        Europe","South Central US","West Europe","West US","Southeast Asia","Central
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"lcsprojects/connectors","locations":["Brazil
+        South","East Asia","East US","Japan East","Japan West","North Central US","North
+        Europe","South Central US","West Europe","West US","Southeast Asia","Central
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"lcsprojects/clouddeployments","locations":["Brazil
+        South","East Asia","East US","Japan East","Japan West","North Central US","North
+        Europe","South Central US","West Europe","West US","Southeast Asia","Central
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"operations","locations":["Brazil
+        South","East Asia","East US","Japan East","Japan West","North Central US","North
+        Europe","South Central US","West Europe","West US","Southeast Asia","Central
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"topics","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operations","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"clusters/applications","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"clusters/operationresults","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations/capabilities","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations/operationresults","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations/azureasyncoperations","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations/validateCreateRequest","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"operations","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India"],"apiVersions":["2015-03-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ImportExport","namespace":"Microsoft.ImportExport","authorization":{"applicationId":"7de4d5c5-5b32-4235-b8a9-33b34d6bcd2a","roleDefinitionId":"9f7aa6bb-9454-46b6-8c01-a4b0f33ca151"},"resourceTypes":[{"resourceType":"jobs","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","North Central US","North Europe","South Central US","Southeast
+        Asia","South India","UK South","West Central US","West Europe","West India","West
+        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","North Central US","North Europe","South Central US","Southeast
+        Asia","South India","UK South","West Central US","West Europe","West India","West
+        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations/operationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","North Central US","North Europe","South Central US","Southeast
+        Asia","South India","UK South","West Central US","West Europe","West India","West
+        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","North Central US","North Europe","South Central US","Southeast
+        Asia","South India","UK South","West Central US","West Europe","West India","West
+        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Logic","namespace":"Microsoft.Logic","authorization":{"applicationId":"7cd684f4-8a78-49b0-91ec-6a35d38739ba","roleDefinitionId":"cb3ef1fb-6e31-49e2-9d87-ed821053fe58"},"resourceTypes":[{"resourceType":"workflows","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West"],"apiVersions":["2017-07-01","2016-10-01","2016-06-01","2015-08-01-preview","2015-02-01-preview"]},{"resourceType":"locations/workflows","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West"],"apiVersions":["2017-07-01","2016-10-01","2016-06-01","2015-08-01-preview","2015-02-01-preview"]},{"resourceType":"locations","locations":["North
+        Central US"],"apiVersions":["2017-07-01","2016-10-01","2016-06-01","2015-08-01-preview","2015-02-01-preview"]},{"resourceType":"operations","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West"],"apiVersions":["2017-07-01","2016-10-01","2016-06-01","2015-08-01-preview","2015-02-01-preview"]},{"resourceType":"integrationAccounts","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","West Central US"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"operations","locations":["South
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations","locations":["South
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operations","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"commitmentPlans","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
+        Central US","West US"],"apiVersions":["2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Media","namespace":"Microsoft.Media","authorization":{"applicationId":"374b2a64-3b6b-436b-934c-b820eacca870","roleDefinitionId":"aab70789-0cec-44b5-95d7-84b64c9487af"},"resourceTypes":[{"resourceType":"mediaservices","locations":["Japan
+        West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
+        US","West US","Australia East","Australia Southeast","Central US","Brazil
+        South","Central India","West India","South India","South Central US","Canada
+        Central","Canada East","West Central US"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
+        Central US","North Central US","East US 2","West US","West Europe","North
+        Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
+        East","UK South","West India"],"apiVersions":["2016-01-29"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-01-29"]},{"resourceType":"locations/checkNameAvailability","locations":["South
+        Central US","North Central US","East US 2","West US","West Europe","North
+        Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
+        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"operations","locations":["East
+        US 2"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Relay","namespace":"Microsoft.Relay","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US 2","West
+        US","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
+        East","West India","South India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
+        East","West India","South India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
+        Central US","South Central US","North Europe","West Europe","East Asia","Southeast
+        Asia","West US","East US","Japan West","Japan East","Brazil South","Central
+        US","East US 2","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-03-01","2016-01-01","2014-08-01-preview"]},{"resourceType":"operations","locations":["North
+        Central US","South Central US","North Europe","West Europe","East Asia","Southeast
+        Asia","West US","East US","Japan West","Japan East","Brazil South","Central
+        US","East US 2","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-03-01","2016-01-01","2014-08-01-preview"]},{"resourceType":"operationResults","locations":["North
+        Central US","South Central US","North Europe","West Europe","East Asia","Southeast
+        Asia","West US","East US","Japan West","Japan East","Brazil South","Central
+        US","East US 2","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-03-01","2016-01-01","2014-08-01-preview"]},{"resourceType":"flows","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast"],"apiVersions":["2015-08-01-preview","2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Search","namespace":"Microsoft.Search","resourceTypes":[{"resourceType":"searchServices","locations":["West
+        US","East US","North Europe","West Europe","Southeast Asia","East Asia","North
+        Central US","South Central US","Japan West","Australia East","Brazil South","Central
+        India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19","2015-02-28"]},{"resourceType":"checkServiceNameAvailability","locations":[],"apiVersions":["2015-02-28","2014-07-31-Preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2015-08-19"]},{"resourceType":"resourceHealthMetadata","locations":["West
+        US","East US","North Europe","West Europe","Southeast Asia","East Asia","North
+        Central US","South Central US","Japan West","Australia East","Brazil South","Central
+        India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US 2","West
+        US","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"premiumMessagingRegions","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceFabric","namespace":"Microsoft.ServiceFabric","authorization":{"applicationId":"74cb6831-0dbb-4be1-8206-fd4df301cdc2","roleDefinitionId":"e55cc65f-6903-4917-b4ef-f8d4640b57f5"},"resourceTypes":[{"resourceType":"clusters","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/clusterVersions","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operations","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Canada
+        Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","West Central US","Japan East","Japan West","Australia East","Australia
+        Southeast"],"apiVersions":["2017-06-01","2017-05-15","2017-01-01","2016-10-01","2016-06-01","2015-03-15","2014-09-01"]},{"resourceType":"operations","locations":["West
+        Central US","Southeast Asia"],"apiVersions":["2016-10-01","2016-06-01","2015-03-15","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StreamAnalytics","namespace":"Microsoft.StreamAnalytics","resourceTypes":[{"resourceType":"streamingjobs","locations":["Central
+        US","West Europe","East US 2","North Europe","Japan East","West US","Southeast
+        Asia","South Central US","East Asia","Japan West","North Central US","East
+        US","Australia East","Australia Southeast","Brazil South","Central India","West
+        Central US","UK South","UK West","Canada Central","Canada East","West US 2"],"apiVersions":["2017-04-01-preview","2016-03-01","2015-11-01","2015-10-01","2015-09-01","2015-08-01-preview","2015-06-01","2015-05-01","2015-04-01","2015-03-01-preview"]},{"resourceType":"locations","locations":["West
+        Europe","Central US","East US 2","North Europe","Japan East","West US","Southeast
+        Asia","South Central US","East Asia","Japan West","North Central US","East
+        US","Australia East","Australia Southeast","Brazil South","Central India","West
+        Central US","UK South","West US 2","UK West","Canada Central","Canada East"],"apiVersions":["2017-04-01-preview","2016-03-01","2015-11-01","2015-10-01","2015-09-01","2015-08-01-preview","2015-06-01","2015-05-01","2015-04-01","2015-03-01-preview"]},{"resourceType":"locations/quotas","locations":[],"apiVersions":["2017-04-01-preview","2016-03-01","2015-11-01","2015-10-01","2015-09-01","2015-08-01-preview","2015-06-01","2015-05-01","2015-04-01","2015-03-01-preview"]},{"resourceType":"streamingjobs/diagnosticSettings","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","Central
+        India","West Central US","UK South","UK West","Canada Central","Canada East","West
+        US 2","West US","Central US","South Central US","Japan East","Japan West","East
+        Asia","Southeast Asia","Australia East","Australia Southeast"],"apiVersions":["2014-04-01"]},{"resourceType":"streamingjobs/metricDefinitions","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","Central
+        India","West Central US","UK South","UK West","Canada Central","Canada East","West
+        US 2","West US","Central US","South Central US","Japan East","Japan West","East
+        Asia","Southeast Asia","Australia East","Australia Southeast"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":["West
+        Europe","West US","Central US","East US 2","North Europe","Japan East","Southeast
+        Asia","South Central US","East Asia","Japan West","North Central US","East
+        US","Australia East","Australia Southeast","Brazil South","Central India","West
+        Central US","UK South","UK West","Canada Central","Canada East","West US 2"],"apiVersions":["2017-04-01-preview","2016-03-01","2015-11-01","2015-10-01","2015-09-01","2015-08-01-preview","2015-06-01","2015-05-01","2015-04-01","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.support","namespace":"microsoft.support","resourceTypes":[{"resourceType":"operations","locations":["North
+        Central US","South Central US","Central US","West Europe","North Europe","West
+        US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
+        Asia","East Asia","Australia East","Australia Southeast"],"apiVersions":["2015-07-01-Preview","2015-03-01"]},{"resourceType":"supporttickets","locations":["North
+        Central US","South Central US","Central US","West Europe","North Europe","West
+        US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
+        Asia","East Asia","Australia East","Australia Southeast"],"apiVersions":["2015-07-01-Preview","2015-03-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.TimeSeriesInsights","namespace":"Microsoft.TimeSeriesInsights","authorizations":[{"applicationId":"120d688d-1518-4cf7-bd38-182f158850b6","roleDefinitionId":"5a43abdf-bb87-42c4-9e56-1c24bf364150"}],"resourceTypes":[{"resourceType":"environments","locations":["East
+        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/eventsources","locations":["East
+        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/referenceDataSets","locations":["East
+        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/accessPolicies","locations":["East
+        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"operations","locations":["East
+        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/project","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/extension","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"checkNameAvailability","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Myget.PackageManagement","namespace":"Myget.PackageManagement","resourceTypes":[{"resourceType":"services","locations":["West
+        Europe"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/NewRelic.APM","namespace":"NewRelic.APM","authorization":{"allowedThirdPartyExtensions":[{"name":"NewRelic_AzurePortal_APM"}]},"resourceTypes":[{"resourceType":"accounts","locations":["North
+        Central US","South Central US","West US","East US","North Europe","West Europe","Southeast
+        Asia","East Asia","Japan East","Japan West"],"apiVersions":["2014-10-01","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/nuubit.nextgencdn","namespace":"nuubit.nextgencdn","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US","East US 2","North Central US","South Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","West US","Central US"],"apiVersions":["2017-05-05"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-05"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-05-05"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-05-05"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Paraleap.CloudMonix","namespace":"Paraleap.CloudMonix","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2016-08-10"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-10"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-10"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Pokitdok.Platform","namespace":"Pokitdok.Platform","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2016-05-17"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-05-17"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-05-17"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-05-17"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RavenHq.Db","namespace":"RavenHq.Db","resourceTypes":[{"resourceType":"databases","locations":["East
+        US"],"apiVersions":["2016-07-18","2016-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-07-18","2016-06-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-07-18","2016-06-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-07-18","2016-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Raygun.CrashReporting","namespace":"Raygun.CrashReporting","resourceTypes":[{"resourceType":"apps","locations":["East
+        US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RedisLabs.Memcached","namespace":"RedisLabs.Memcached","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-07-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RedisLabs.Redis","namespace":"RedisLabs.Redis","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-07-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RevAPM.MobileCDN","namespace":"RevAPM.MobileCDN","resourceTypes":[{"resourceType":"accounts","locations":["Central
+        US","East US","East US 2","North Central US","South Central US","West US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast"],"apiVersions":["2016-08-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-24","2016-08-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sendgrid.Email","namespace":"Sendgrid.Email","resourceTypes":[{"resourceType":"accounts","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Canada Central","Canada
+        East","West Central US","West US 2","UK South","UK West"],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Signiant.Flight","namespace":"Signiant.Flight","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US","Central US","North Central US","South Central US","West US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast"],"apiVersions":["2015-06-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sparkpost.Basic","namespace":"Sparkpost.Basic","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2016-08-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/stackify.retrace","namespace":"stackify.retrace","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2016-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/SuccessBricks.ClearDB","namespace":"SuccessBricks.ClearDB","resourceTypes":[{"resourceType":"databases","locations":["Brazil
+        South","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","Southeast Asia","West Europe","West
+        US","South Central US","Australia East","Australia Southeast","Canada Central","Canada
+        East","Central India","South India","West India"],"apiVersions":["2014-04-01"]},{"resourceType":"clusters","locations":["Brazil
+        South","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","Southeast Asia","West Europe","West
+        US","Australia Southeast","Australia East","South Central US","Canada Central","Canada
+        East","Central India","South India","West India"],"apiVersions":["2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/TrendMicro.DeepSecurity","namespace":"TrendMicro.DeepSecurity","resourceTypes":[{"resourceType":"accounts","locations":["Central
+        US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
+        Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:03 GMT
+- request:
+    method: post
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
+    body:
+      encoding: UTF-8
+      string: '{"access":"read","durationInSeconds":3600}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4ODIsIm5iZiI6MTUwNDEwNjg4MiwiZXhwIjoxNTA0MTEwNzgyLCJhaW8iOiJZMkVBZ29tZkdqL3MwV2k0bWp5ejg1NUVZeHNBIiwiYXBwaWQiOiJmYzFjMjIyNS0wNjVmLTRiYTgtODNkOS1kODY2NjJmNTc4YWYiLCJhcHBpZGFjciI6IjEiLCJncm91cHMiOlsiNDA3Mzg5ODYtM2M4Mi00Y2YxLTk5ZmMtMTM0NTdlMzMzMmZjIiwiMGQwMTQzZWEtMzM5ZS00MmUwLWEyNGUtYjVhOGZjNjlmZjE0IiwiZDY1ZjJlNWQtZmJmYi00MTUzLTg2YjItNTk3OWI0ZTZiNTkyIl0sImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ1dGkiOiJwNEJmYzd0M1RFU2Jmc2pWUFJZU0FBIiwidmVyIjoiMS4wIn0.EK4xnQ-CGOt1ADV9wF5PPIwsevthxYM7O-tIrVeg_yxzjTjeF1BYDs9mXYFBld8ZfcrPsaC5vufzM8RyD_768PpWjpqacrSoVEvrZzLXxtwyDUGx3dOBvrLZV_cM5ER7w1ORxlJo3Yq4N0WMcdVz9rYNyeDs_gGOutOC3DFK9fuRtTPm6gyL7E-pv1acyR566RXpS8_r1Kb6e6SvR0MaX2JgeDxjdxwYGuA4HMypQwi1JCy6joswNjE-8aPDcrXR13dz_N0efxHm7pb3RkbuYophUITniUCCH0KHKAsZWEhT6c0qNtI4wT6vtwzsAoqFtOCeIRJoiZYRkVt3iwYJUw
+      Content-Length:
+      - '42'
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '0'
+      Expires:
+      - "-1"
+      Location:
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/a6250cc9-86a7-4f09-a0f7-c40a7213c7fa?monitor=true&api-version=2017-03-30
+      Azure-Asyncoperation:
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/a6250cc9-86a7-4f09-a0f7-c40a7213c7fa?api-version=2017-03-30
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      X-Ms-Request-Id:
+      - a6250cc9-86a7-4f09-a0f7-c40a7213c7fa
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Writes:
+      - '1194'
+      X-Ms-Correlation-Request-Id:
+      - 5d1c0695-78f5-4a4c-8d10-8634091e625d
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153303Z:5d1c0695-78f5-4a4c-8d10-8634091e625d
+      Date:
+      - Wed, 30 Aug 2017 15:33:03 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:03 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/a6250cc9-86a7-4f09-a0f7-c40a7213c7fa?api-version=2017-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4ODIsIm5iZiI6MTUwNDEwNjg4MiwiZXhwIjoxNTA0MTEwNzgyLCJhaW8iOiJZMkVBZ29tZkdqL3MwV2k0bWp5ejg1NUVZeHNBIiwiYXBwaWQiOiJmYzFjMjIyNS0wNjVmLTRiYTgtODNkOS1kODY2NjJmNTc4YWYiLCJhcHBpZGFjciI6IjEiLCJncm91cHMiOlsiNDA3Mzg5ODYtM2M4Mi00Y2YxLTk5ZmMtMTM0NTdlMzMzMmZjIiwiMGQwMTQzZWEtMzM5ZS00MmUwLWEyNGUtYjVhOGZjNjlmZjE0IiwiZDY1ZjJlNWQtZmJmYi00MTUzLTg2YjItNTk3OWI0ZTZiNTkyIl0sImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ1dGkiOiJwNEJmYzd0M1RFU2Jmc2pWUFJZU0FBIiwidmVyIjoiMS4wIn0.EK4xnQ-CGOt1ADV9wF5PPIwsevthxYM7O-tIrVeg_yxzjTjeF1BYDs9mXYFBld8ZfcrPsaC5vufzM8RyD_768PpWjpqacrSoVEvrZzLXxtwyDUGx3dOBvrLZV_cM5ER7w1ORxlJo3Yq4N0WMcdVz9rYNyeDs_gGOutOC3DFK9fuRtTPm6gyL7E-pv1acyR566RXpS8_r1Kb6e6SvR0MaX2JgeDxjdxwYGuA4HMypQwi1JCy6joswNjE-8aPDcrXR13dz_N0efxHm7pb3RkbuYophUITniUCCH0KHKAsZWEhT6c0qNtI4wT6vtwzsAoqFtOCeIRJoiZYRkVt3iwYJUw
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      X-Ms-Request-Id:
+      - 741cce73-2d24-4c23-aa98-024954c968da
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14247'
+      X-Ms-Correlation-Request-Id:
+      - 1f436bde-0919-4ee1-81b8-f09d83314e90
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153304Z:1f436bde-0919-4ee1-81b8-f09d83314e90
+      Date:
+      - Wed, 30 Aug 2017 15:33:04 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"startTime\": \"2017-08-30T15:33:03.3830837+00:00\",\r\n  \"endTime\":
+        \"2017-08-30T15:33:03.5877005+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=eeb9a981-6e66-4467-8c1f-8632d5115fe8&sig=UbH5gv%2B2R%2BGJBBWMuz77kvi163B%2F3iJrcw93Ln3zmkk%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"a6250cc9-86a7-4f09-a0f7-c40a7213c7fa\"\r\n}"
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:04 GMT
+- request:
+    method: get
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=eeb9a981-6e66-4467-8c1f-8632d5115fe8&sig=UbH5gv%2B2R%2BGJBBWMuz77kvi163B/3iJrcw93Ln3zmkk=&sr=b&sv=2016-05-31
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      X-Ms-Range:
+      - bytes=0-0
+      Host:
+      - md-t4jdgqqlgszp.blob.core.windows.net
+  response:
+    status:
+      code: 206
+      message: Partial Content
+    headers:
+      Content-Length:
+      - '1'
+      Content-Type:
+      - application/octet-stream
+      Content-Range:
+      - bytes 0-0/34359738880
+      Last-Modified:
+      - Sat, 15 Jul 2017 14:23:07 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D4CB8D039FC699"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 14bb1f1f-0001-00b5-79a5-21acd2000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Meta-Pirtag:
+      - '1'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '20'
+      X-Ms-Copy-Id:
+      - 30cedd78-548a-4fd8-967e-f8344f587e3c
+      X-Ms-Copy-Source:
+      - http://md-t4jdgqqlgszp.blob.core.windows.net:8080/fg25xxtqx0gc/abcd?sv=2016-02-19&sr=b&st=2017-05-04T21%3a06%3a57Z&se=9999-12-31T23%3a59%3a59Z&sp=r&api-version=2016-02-19
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 34359738880/34359738880
+      X-Ms-Copy-Completion-Time:
+      - Thu, 04 May 2017 21:21:56 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Wed, 30 Aug 2017 15:33:03 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        6w==
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:04 GMT
+- request:
+    method: post
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
+    body:
+      encoding: UTF-8
+      string: '{"access":"read","durationInSeconds":3600}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4ODIsIm5iZiI6MTUwNDEwNjg4MiwiZXhwIjoxNTA0MTEwNzgyLCJhaW8iOiJZMkVBZ29tZkdqL3MwV2k0bWp5ejg1NUVZeHNBIiwiYXBwaWQiOiJmYzFjMjIyNS0wNjVmLTRiYTgtODNkOS1kODY2NjJmNTc4YWYiLCJhcHBpZGFjciI6IjEiLCJncm91cHMiOlsiNDA3Mzg5ODYtM2M4Mi00Y2YxLTk5ZmMtMTM0NTdlMzMzMmZjIiwiMGQwMTQzZWEtMzM5ZS00MmUwLWEyNGUtYjVhOGZjNjlmZjE0IiwiZDY1ZjJlNWQtZmJmYi00MTUzLTg2YjItNTk3OWI0ZTZiNTkyIl0sImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ1dGkiOiJwNEJmYzd0M1RFU2Jmc2pWUFJZU0FBIiwidmVyIjoiMS4wIn0.EK4xnQ-CGOt1ADV9wF5PPIwsevthxYM7O-tIrVeg_yxzjTjeF1BYDs9mXYFBld8ZfcrPsaC5vufzM8RyD_768PpWjpqacrSoVEvrZzLXxtwyDUGx3dOBvrLZV_cM5ER7w1ORxlJo3Yq4N0WMcdVz9rYNyeDs_gGOutOC3DFK9fuRtTPm6gyL7E-pv1acyR566RXpS8_r1Kb6e6SvR0MaX2JgeDxjdxwYGuA4HMypQwi1JCy6joswNjE-8aPDcrXR13dz_N0efxHm7pb3RkbuYophUITniUCCH0KHKAsZWEhT6c0qNtI4wT6vtwzsAoqFtOCeIRJoiZYRkVt3iwYJUw
+      Content-Length:
+      - '42'
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '0'
+      Expires:
+      - "-1"
+      Location:
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/4e1e4792-9125-40de-a032-9540bf21fe81?monitor=true&api-version=2017-03-30
+      Azure-Asyncoperation:
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/4e1e4792-9125-40de-a032-9540bf21fe81?api-version=2017-03-30
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      X-Ms-Request-Id:
+      - 4e1e4792-9125-40de-a032-9540bf21fe81
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Writes:
+      - '1195'
+      X-Ms-Correlation-Request-Id:
+      - 8a4420bb-a39f-443f-b55c-09cbda174e6b
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153304Z:8a4420bb-a39f-443f-b55c-09cbda174e6b
+      Date:
+      - Wed, 30 Aug 2017 15:33:03 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:04 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/4e1e4792-9125-40de-a032-9540bf21fe81?api-version=2017-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4ODIsIm5iZiI6MTUwNDEwNjg4MiwiZXhwIjoxNTA0MTEwNzgyLCJhaW8iOiJZMkVBZ29tZkdqL3MwV2k0bWp5ejg1NUVZeHNBIiwiYXBwaWQiOiJmYzFjMjIyNS0wNjVmLTRiYTgtODNkOS1kODY2NjJmNTc4YWYiLCJhcHBpZGFjciI6IjEiLCJncm91cHMiOlsiNDA3Mzg5ODYtM2M4Mi00Y2YxLTk5ZmMtMTM0NTdlMzMzMmZjIiwiMGQwMTQzZWEtMzM5ZS00MmUwLWEyNGUtYjVhOGZjNjlmZjE0IiwiZDY1ZjJlNWQtZmJmYi00MTUzLTg2YjItNTk3OWI0ZTZiNTkyIl0sImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ1dGkiOiJwNEJmYzd0M1RFU2Jmc2pWUFJZU0FBIiwidmVyIjoiMS4wIn0.EK4xnQ-CGOt1ADV9wF5PPIwsevthxYM7O-tIrVeg_yxzjTjeF1BYDs9mXYFBld8ZfcrPsaC5vufzM8RyD_768PpWjpqacrSoVEvrZzLXxtwyDUGx3dOBvrLZV_cM5ER7w1ORxlJo3Yq4N0WMcdVz9rYNyeDs_gGOutOC3DFK9fuRtTPm6gyL7E-pv1acyR566RXpS8_r1Kb6e6SvR0MaX2JgeDxjdxwYGuA4HMypQwi1JCy6joswNjE-8aPDcrXR13dz_N0efxHm7pb3RkbuYophUITniUCCH0KHKAsZWEhT6c0qNtI4wT6vtwzsAoqFtOCeIRJoiZYRkVt3iwYJUw
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      X-Ms-Request-Id:
+      - 04f2d6d3-766c-401b-9113-150e21988925
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14942'
+      X-Ms-Correlation-Request-Id:
+      - 39becaab-23fb-4d84-a101-357144e3967e
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153304Z:39becaab-23fb-4d84-a101-357144e3967e
+      Date:
+      - Wed, 30 Aug 2017 15:33:03 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"startTime\": \"2017-08-30T15:33:04.0549247+00:00\",\r\n  \"endTime\":
+        \"2017-08-30T15:33:04.168934+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=2328886d-0f4f-418f-b980-0a9b5f7885bb&sig=45EErce4IthANAmIKZ%2F3XkzVMCVpROP7ettaA0MjfiA%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"4e1e4792-9125-40de-a032-9540bf21fe81\"\r\n}"
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:04 GMT
+- request:
+    method: get
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=2328886d-0f4f-418f-b980-0a9b5f7885bb&sig=45EErce4IthANAmIKZ/3XkzVMCVpROP7ettaA0MjfiA=&sr=b&sv=2016-05-31
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      X-Ms-Range:
+      - bytes=440-443
+      Host:
+      - md-t4jdgqqlgszp.blob.core.windows.net
+  response:
+    status:
+      code: 206
+      message: Partial Content
+    headers:
+      Content-Length:
+      - '4'
+      Content-Type:
+      - application/octet-stream
+      Content-Range:
+      - bytes 440-443/34359738880
+      Last-Modified:
+      - Sat, 15 Jul 2017 14:23:07 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D4CB8D039FC699"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 4da322b8-0001-00fb-39a5-216937000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Meta-Pirtag:
+      - '1'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '20'
+      X-Ms-Copy-Id:
+      - 30cedd78-548a-4fd8-967e-f8344f587e3c
+      X-Ms-Copy-Source:
+      - http://md-t4jdgqqlgszp.blob.core.windows.net:8080/fg25xxtqx0gc/abcd?sv=2016-02-19&sr=b&st=2017-05-04T21%3a06%3a57Z&se=9999-12-31T23%3a59%3a59Z&sp=r&api-version=2016-02-19
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 34359738880/34359738880
+      X-Ms-Copy-Completion-Time:
+      - Thu, 04 May 2017 21:21:56 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Wed, 30 Aug 2017 15:33:04 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        U5MJAA==
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:05 GMT
+recorded_with: VCR 3.0.3

--- a/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_endByteAddr-2.yml
+++ b/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_endByteAddr-2.yml
@@ -39,25 +39,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 735f80a7-77bb-444c-9b7e-c8d53d161200
+      - 31edecc1-0ee2-4316-9f73-d59017411300
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAAA9kTklhVy7SJTGAzR-p1BcIgbUur_CkEZpVZDi_mo8i0Vvn1odl9w3aJUdmnW5LbhIf5F9M4agA7APcmOhk3VUDiQL8Dbrad6dD1jtDgsdnyv801kbme0VHKz4hC81N4DcMpe8zBvbBoFmTs8NQVruY8dI0EREsuFdPJi61CvHJwoBSatRGUE3IggvYJZmYnAgAA;
+      - esctx=AQABAAAAAAA9kTklhVy7SJTGAzR-p1BceN5ET3Re7aTiEbsEBLYI3pnnnIaMrA8f7h6yDGDq_oJVT_u5-5EC7XL7jDJ2h8bCts-GveQuss5QN8gOcEaHUr8-oHci8b-cOlsQDmCiBbWoTmB4NmfoNMVTnvUP4AVLCZ1Yo6PrYan_O7tUapm7a-PY5yEx_rS-GFPwnNao-nsgAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
       - x-ms-gateway-slice=003; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Wed, 30 Aug 2017 15:33:03 GMT
+      - Wed, 30 Aug 2017 17:05:36 GMT
       Content-Length:
-      - '1500'
+      - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1504110782","not_before":"1504106882","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4ODIsIm5iZiI6MTUwNDEwNjg4MiwiZXhwIjoxNTA0MTEwNzgyLCJhaW8iOiJZMkVBZ29tZkdqL3MwV2k0bWp5ejg1NUVZeHNBIiwiYXBwaWQiOiJmYzFjMjIyNS0wNjVmLTRiYTgtODNkOS1kODY2NjJmNTc4YWYiLCJhcHBpZGFjciI6IjEiLCJncm91cHMiOlsiNDA3Mzg5ODYtM2M4Mi00Y2YxLTk5ZmMtMTM0NTdlMzMzMmZjIiwiMGQwMTQzZWEtMzM5ZS00MmUwLWEyNGUtYjVhOGZjNjlmZjE0IiwiZDY1ZjJlNWQtZmJmYi00MTUzLTg2YjItNTk3OWI0ZTZiNTkyIl0sImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ1dGkiOiJwNEJmYzd0M1RFU2Jmc2pWUFJZU0FBIiwidmVyIjoiMS4wIn0.EK4xnQ-CGOt1ADV9wF5PPIwsevthxYM7O-tIrVeg_yxzjTjeF1BYDs9mXYFBld8ZfcrPsaC5vufzM8RyD_768PpWjpqacrSoVEvrZzLXxtwyDUGx3dOBvrLZV_cM5ER7w1ORxlJo3Yq4N0WMcdVz9rYNyeDs_gGOutOC3DFK9fuRtTPm6gyL7E-pv1acyR566RXpS8_r1Kb6e6SvR0MaX2JgeDxjdxwYGuA4HMypQwi1JCy6joswNjE-8aPDcrXR13dz_N0efxHm7pb3RkbuYophUITniUCCH0KHKAsZWEhT6c0qNtI4wT6vtwzsAoqFtOCeIRJoiZYRkVt3iwYJUw"}'
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1504116335","not_before":"1504112435","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MzUsIm5iZiI6MTUwNDExMjQzNSwiZXhwIjoxNTA0MTE2MzM1LCJhaW8iOiJZMkZnWUZnZmExZXc2WXpUUHdPZnRON3U0RVZoQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoid2V6dE1lSU9Ga09mYzlXUUYwRVRBQSIsInZlciI6IjEuMCJ9.GBRKzu6t_VIC0Z9aDnK1nl7cbLV767KWYAx3skYg9-CWgQyRNHaIWes_r69r5NBdCVRe82VFFDRnpQwbIf6vtov5Q-5vfilgZDP0x2pXdHN4l8IorOJhbMNM4XSgtDck4xbUz1hz61aGlBgWIVMEBN6P-Mu1evz7_JFjR3cWJz-93_EomwyskbjvyTkZGNjSYPW9Hh1MRROrHZPvePxs1QuX8g-_EpQicHzapXeTB7t0f3s5AaMnCLXUDkwsvKPmSCcMvFoVxm0X7WghblWPel6ltUuuZDz99Wb2AIe6_th9LWHd3Iy5TJvLmnXyPhNTN_oW9J9zWoWjgr_0w0b6jg"}'
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:33:02 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:34 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -74,7 +74,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4ODIsIm5iZiI6MTUwNDEwNjg4MiwiZXhwIjoxNTA0MTEwNzgyLCJhaW8iOiJZMkVBZ29tZkdqL3MwV2k0bWp5ejg1NUVZeHNBIiwiYXBwaWQiOiJmYzFjMjIyNS0wNjVmLTRiYTgtODNkOS1kODY2NjJmNTc4YWYiLCJhcHBpZGFjciI6IjEiLCJncm91cHMiOlsiNDA3Mzg5ODYtM2M4Mi00Y2YxLTk5ZmMtMTM0NTdlMzMzMmZjIiwiMGQwMTQzZWEtMzM5ZS00MmUwLWEyNGUtYjVhOGZjNjlmZjE0IiwiZDY1ZjJlNWQtZmJmYi00MTUzLTg2YjItNTk3OWI0ZTZiNTkyIl0sImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ1dGkiOiJwNEJmYzd0M1RFU2Jmc2pWUFJZU0FBIiwidmVyIjoiMS4wIn0.EK4xnQ-CGOt1ADV9wF5PPIwsevthxYM7O-tIrVeg_yxzjTjeF1BYDs9mXYFBld8ZfcrPsaC5vufzM8RyD_768PpWjpqacrSoVEvrZzLXxtwyDUGx3dOBvrLZV_cM5ER7w1ORxlJo3Yq4N0WMcdVz9rYNyeDs_gGOutOC3DFK9fuRtTPm6gyL7E-pv1acyR566RXpS8_r1Kb6e6SvR0MaX2JgeDxjdxwYGuA4HMypQwi1JCy6joswNjE-8aPDcrXR13dz_N0efxHm7pb3RkbuYophUITniUCCH0KHKAsZWEhT6c0qNtI4wT6vtwzsAoqFtOCeIRJoiZYRkVt3iwYJUw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MzUsIm5iZiI6MTUwNDExMjQzNSwiZXhwIjoxNTA0MTE2MzM1LCJhaW8iOiJZMkZnWUZnZmExZXc2WXpUUHdPZnRON3U0RVZoQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoid2V6dE1lSU9Ga09mYzlXUUYwRVRBQSIsInZlciI6IjEuMCJ9.GBRKzu6t_VIC0Z9aDnK1nl7cbLV767KWYAx3skYg9-CWgQyRNHaIWes_r69r5NBdCVRe82VFFDRnpQwbIf6vtov5Q-5vfilgZDP0x2pXdHN4l8IorOJhbMNM4XSgtDck4xbUz1hz61aGlBgWIVMEBN6P-Mu1evz7_JFjR3cWJz-93_EomwyskbjvyTkZGNjSYPW9Hh1MRROrHZPvePxs1QuX8g-_EpQicHzapXeTB7t0f3s5AaMnCLXUDkwsvKPmSCcMvFoVxm0X7WghblWPel6ltUuuZDz99Wb2AIe6_th9LWHd3Iy5TJvLmnXyPhNTN_oW9J9zWoWjgr_0w0b6jg
       Host:
       - management.azure.com
   response:
@@ -97,21 +97,21 @@ http_interactions:
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
       - '14997'
       X-Ms-Request-Id:
-      - d6cd401a-de41-4e1e-b438-4042750479c6
+      - 3464f8fa-f902-4dbc-b76d-e40e8d04eed4
       X-Ms-Correlation-Request-Id:
-      - d6cd401a-de41-4e1e-b438-4042750479c6
+      - 3464f8fa-f902-4dbc-b76d-e40e8d04eed4
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153302Z:d6cd401a-de41-4e1e-b438-4042750479c6
+      - EASTUS:20170830T170535Z:3464f8fa-f902-4dbc-b76d-e40e8d04eed4
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 30 Aug 2017 15:33:01 GMT
+      - Wed, 30 Aug 2017 17:05:34 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:33:02 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:34 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/azure_subscription_id/providers?api-version=2015-01-01
@@ -128,7 +128,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4ODIsIm5iZiI6MTUwNDEwNjg4MiwiZXhwIjoxNTA0MTEwNzgyLCJhaW8iOiJZMkVBZ29tZkdqL3MwV2k0bWp5ejg1NUVZeHNBIiwiYXBwaWQiOiJmYzFjMjIyNS0wNjVmLTRiYTgtODNkOS1kODY2NjJmNTc4YWYiLCJhcHBpZGFjciI6IjEiLCJncm91cHMiOlsiNDA3Mzg5ODYtM2M4Mi00Y2YxLTk5ZmMtMTM0NTdlMzMzMmZjIiwiMGQwMTQzZWEtMzM5ZS00MmUwLWEyNGUtYjVhOGZjNjlmZjE0IiwiZDY1ZjJlNWQtZmJmYi00MTUzLTg2YjItNTk3OWI0ZTZiNTkyIl0sImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ1dGkiOiJwNEJmYzd0M1RFU2Jmc2pWUFJZU0FBIiwidmVyIjoiMS4wIn0.EK4xnQ-CGOt1ADV9wF5PPIwsevthxYM7O-tIrVeg_yxzjTjeF1BYDs9mXYFBld8ZfcrPsaC5vufzM8RyD_768PpWjpqacrSoVEvrZzLXxtwyDUGx3dOBvrLZV_cM5ER7w1ORxlJo3Yq4N0WMcdVz9rYNyeDs_gGOutOC3DFK9fuRtTPm6gyL7E-pv1acyR566RXpS8_r1Kb6e6SvR0MaX2JgeDxjdxwYGuA4HMypQwi1JCy6joswNjE-8aPDcrXR13dz_N0efxHm7pb3RkbuYophUITniUCCH0KHKAsZWEhT6c0qNtI4wT6vtwzsAoqFtOCeIRJoiZYRkVt3iwYJUw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MzUsIm5iZiI6MTUwNDExMjQzNSwiZXhwIjoxNTA0MTE2MzM1LCJhaW8iOiJZMkZnWUZnZmExZXc2WXpUUHdPZnRON3U0RVZoQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoid2V6dE1lSU9Ga09mYzlXUUYwRVRBQSIsInZlciI6IjEuMCJ9.GBRKzu6t_VIC0Z9aDnK1nl7cbLV767KWYAx3skYg9-CWgQyRNHaIWes_r69r5NBdCVRe82VFFDRnpQwbIf6vtov5Q-5vfilgZDP0x2pXdHN4l8IorOJhbMNM4XSgtDck4xbUz1hz61aGlBgWIVMEBN6P-Mu1evz7_JFjR3cWJz-93_EomwyskbjvyTkZGNjSYPW9Hh1MRROrHZPvePxs1QuX8g-_EpQicHzapXeTB7t0f3s5AaMnCLXUDkwsvKPmSCcMvFoVxm0X7WghblWPel6ltUuuZDz99Wb2AIe6_th9LWHd3Iy5TJvLmnXyPhNTN_oW9J9zWoWjgr_0w0b6jg
       Host:
       - management.azure.com
   response:
@@ -147,17 +147,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14943'
+      - '14915'
       X-Ms-Request-Id:
-      - 70221b4c-313c-4982-82f3-42762d3e7065
+      - 221f4e44-6fce-4628-8912-af5d065ce804
       X-Ms-Correlation-Request-Id:
-      - 70221b4c-313c-4982-82f3-42762d3e7065
+      - 221f4e44-6fce-4628-8912-af5d065ce804
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153303Z:70221b4c-313c-4982-82f3-42762d3e7065
+      - EASTUS:20170830T170536Z:221f4e44-6fce-4628-8912-af5d065ce804
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 30 Aug 2017 15:33:02 GMT
+      - Wed, 30 Aug 2017 17:05:35 GMT
       Content-Length:
       - '241615'
     body:
@@ -1891,7 +1891,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:33:03 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:35 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
@@ -1908,7 +1908,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4ODIsIm5iZiI6MTUwNDEwNjg4MiwiZXhwIjoxNTA0MTEwNzgyLCJhaW8iOiJZMkVBZ29tZkdqL3MwV2k0bWp5ejg1NUVZeHNBIiwiYXBwaWQiOiJmYzFjMjIyNS0wNjVmLTRiYTgtODNkOS1kODY2NjJmNTc4YWYiLCJhcHBpZGFjciI6IjEiLCJncm91cHMiOlsiNDA3Mzg5ODYtM2M4Mi00Y2YxLTk5ZmMtMTM0NTdlMzMzMmZjIiwiMGQwMTQzZWEtMzM5ZS00MmUwLWEyNGUtYjVhOGZjNjlmZjE0IiwiZDY1ZjJlNWQtZmJmYi00MTUzLTg2YjItNTk3OWI0ZTZiNTkyIl0sImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ1dGkiOiJwNEJmYzd0M1RFU2Jmc2pWUFJZU0FBIiwidmVyIjoiMS4wIn0.EK4xnQ-CGOt1ADV9wF5PPIwsevthxYM7O-tIrVeg_yxzjTjeF1BYDs9mXYFBld8ZfcrPsaC5vufzM8RyD_768PpWjpqacrSoVEvrZzLXxtwyDUGx3dOBvrLZV_cM5ER7w1ORxlJo3Yq4N0WMcdVz9rYNyeDs_gGOutOC3DFK9fuRtTPm6gyL7E-pv1acyR566RXpS8_r1Kb6e6SvR0MaX2JgeDxjdxwYGuA4HMypQwi1JCy6joswNjE-8aPDcrXR13dz_N0efxHm7pb3RkbuYophUITniUCCH0KHKAsZWEhT6c0qNtI4wT6vtwzsAoqFtOCeIRJoiZYRkVt3iwYJUw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MzUsIm5iZiI6MTUwNDExMjQzNSwiZXhwIjoxNTA0MTE2MzM1LCJhaW8iOiJZMkZnWUZnZmExZXc2WXpUUHdPZnRON3U0RVZoQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoid2V6dE1lSU9Ga09mYzlXUUYwRVRBQSIsInZlciI6IjEuMCJ9.GBRKzu6t_VIC0Z9aDnK1nl7cbLV767KWYAx3skYg9-CWgQyRNHaIWes_r69r5NBdCVRe82VFFDRnpQwbIf6vtov5Q-5vfilgZDP0x2pXdHN4l8IorOJhbMNM4XSgtDck4xbUz1hz61aGlBgWIVMEBN6P-Mu1evz7_JFjR3cWJz-93_EomwyskbjvyTkZGNjSYPW9Hh1MRROrHZPvePxs1QuX8g-_EpQicHzapXeTB7t0f3s5AaMnCLXUDkwsvKPmSCcMvFoVxm0X7WghblWPel6ltUuuZDz99Wb2AIe6_th9LWHd3Iy5TJvLmnXyPhNTN_oW9J9zWoWjgr_0w0b6jg
       Content-Length:
       - '42'
       Host:
@@ -1927,34 +1927,34 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/a6250cc9-86a7-4f09-a0f7-c40a7213c7fa?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/02882dee-a641-45bf-9e25-96c252539b53?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/a6250cc9-86a7-4f09-a0f7-c40a7213c7fa?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/02882dee-a641-45bf-9e25-96c252539b53?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
       - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
       X-Ms-Request-Id:
-      - a6250cc9-86a7-4f09-a0f7-c40a7213c7fa
+      - '02882dee-a641-45bf-9e25-96c252539b53'
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
       - '1194'
       X-Ms-Correlation-Request-Id:
-      - 5d1c0695-78f5-4a4c-8d10-8634091e625d
+      - 2f4b3a43-2821-4aa4-a853-8f3ef04e79c3
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153303Z:5d1c0695-78f5-4a4c-8d10-8634091e625d
+      - EASTUS:20170830T170537Z:2f4b3a43-2821-4aa4-a853-8f3ef04e79c3
       Date:
-      - Wed, 30 Aug 2017 15:33:03 GMT
+      - Wed, 30 Aug 2017 17:05:36 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:33:03 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:35 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/a6250cc9-86a7-4f09-a0f7-c40a7213c7fa?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/02882dee-a641-45bf-9e25-96c252539b53?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -1968,7 +1968,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4ODIsIm5iZiI6MTUwNDEwNjg4MiwiZXhwIjoxNTA0MTEwNzgyLCJhaW8iOiJZMkVBZ29tZkdqL3MwV2k0bWp5ejg1NUVZeHNBIiwiYXBwaWQiOiJmYzFjMjIyNS0wNjVmLTRiYTgtODNkOS1kODY2NjJmNTc4YWYiLCJhcHBpZGFjciI6IjEiLCJncm91cHMiOlsiNDA3Mzg5ODYtM2M4Mi00Y2YxLTk5ZmMtMTM0NTdlMzMzMmZjIiwiMGQwMTQzZWEtMzM5ZS00MmUwLWEyNGUtYjVhOGZjNjlmZjE0IiwiZDY1ZjJlNWQtZmJmYi00MTUzLTg2YjItNTk3OWI0ZTZiNTkyIl0sImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ1dGkiOiJwNEJmYzd0M1RFU2Jmc2pWUFJZU0FBIiwidmVyIjoiMS4wIn0.EK4xnQ-CGOt1ADV9wF5PPIwsevthxYM7O-tIrVeg_yxzjTjeF1BYDs9mXYFBld8ZfcrPsaC5vufzM8RyD_768PpWjpqacrSoVEvrZzLXxtwyDUGx3dOBvrLZV_cM5ER7w1ORxlJo3Yq4N0WMcdVz9rYNyeDs_gGOutOC3DFK9fuRtTPm6gyL7E-pv1acyR566RXpS8_r1Kb6e6SvR0MaX2JgeDxjdxwYGuA4HMypQwi1JCy6joswNjE-8aPDcrXR13dz_N0efxHm7pb3RkbuYophUITniUCCH0KHKAsZWEhT6c0qNtI4wT6vtwzsAoqFtOCeIRJoiZYRkVt3iwYJUw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MzUsIm5iZiI6MTUwNDExMjQzNSwiZXhwIjoxNTA0MTE2MzM1LCJhaW8iOiJZMkZnWUZnZmExZXc2WXpUUHdPZnRON3U0RVZoQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoid2V6dE1lSU9Ga09mYzlXUUYwRVRBQSIsInZlciI6IjEuMCJ9.GBRKzu6t_VIC0Z9aDnK1nl7cbLV767KWYAx3skYg9-CWgQyRNHaIWes_r69r5NBdCVRe82VFFDRnpQwbIf6vtov5Q-5vfilgZDP0x2pXdHN4l8IorOJhbMNM4XSgtDck4xbUz1hz61aGlBgWIVMEBN6P-Mu1evz7_JFjR3cWJz-93_EomwyskbjvyTkZGNjSYPW9Hh1MRROrHZPvePxs1QuX8g-_EpQicHzapXeTB7t0f3s5AaMnCLXUDkwsvKPmSCcMvFoVxm0X7WghblWPel6ltUuuZDz99Wb2AIe6_th9LWHd3Iy5TJvLmnXyPhNTN_oW9J9zWoWjgr_0w0b6jg
       Host:
       - management.azure.com
   response:
@@ -1993,29 +1993,29 @@ http_interactions:
       X-Ms-Served-By:
       - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
       X-Ms-Request-Id:
-      - 741cce73-2d24-4c23-aa98-024954c968da
+      - 6845e885-a5cf-4fd0-be56-943ffdd232ed
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14247'
+      - '14875'
       X-Ms-Correlation-Request-Id:
-      - 1f436bde-0919-4ee1-81b8-f09d83314e90
+      - ad66e649-98b5-45a1-9132-ca7db3a4df75
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153304Z:1f436bde-0919-4ee1-81b8-f09d83314e90
+      - EASTUS:20170830T170537Z:ad66e649-98b5-45a1-9132-ca7db3a4df75
       Date:
-      - Wed, 30 Aug 2017 15:33:04 GMT
+      - Wed, 30 Aug 2017 17:05:37 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-08-30T15:33:03.3830837+00:00\",\r\n  \"endTime\":
-        \"2017-08-30T15:33:03.5877005+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=eeb9a981-6e66-4467-8c1f-8632d5115fe8&sig=UbH5gv%2B2R%2BGJBBWMuz77kvi163B%2F3iJrcw93Ln3zmkk%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"a6250cc9-86a7-4f09-a0f7-c40a7213c7fa\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2017-08-30T17:05:36.530268+00:00\",\r\n  \"endTime\":
+        \"2017-08-30T17:05:36.6865731+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=72691cbd-bf4e-4e8c-90d0-2f6f5aa3da85&sig=7wLncarGYq%2F3%2BVJMdZH3KF3l2JnR2MPzZuwtQE6s0pQ%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"02882dee-a641-45bf-9e25-96c252539b53\"\r\n}"
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:33:04 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:36 GMT
 - request:
     method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=eeb9a981-6e66-4467-8c1f-8632d5115fe8&sig=UbH5gv%2B2R%2BGJBBWMuz77kvi163B/3iJrcw93Ln3zmkk=&sr=b&sv=2016-05-31
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=72691cbd-bf4e-4e8c-90d0-2f6f5aa3da85&sig=7wLncarGYq/3%2BVJMdZH3KF3l2JnR2MPzZuwtQE6s0pQ=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2050,7 +2050,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 14bb1f1f-0001-00b5-79a5-21acd2000000
+      - 117ffe3d-0001-0109-77b2-21fdf6000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2076,13 +2076,13 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 30 Aug 2017 15:33:03 GMT
+      - Wed, 30 Aug 2017 17:05:36 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         6w==
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:33:04 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:36 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
@@ -2099,7 +2099,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4ODIsIm5iZiI6MTUwNDEwNjg4MiwiZXhwIjoxNTA0MTEwNzgyLCJhaW8iOiJZMkVBZ29tZkdqL3MwV2k0bWp5ejg1NUVZeHNBIiwiYXBwaWQiOiJmYzFjMjIyNS0wNjVmLTRiYTgtODNkOS1kODY2NjJmNTc4YWYiLCJhcHBpZGFjciI6IjEiLCJncm91cHMiOlsiNDA3Mzg5ODYtM2M4Mi00Y2YxLTk5ZmMtMTM0NTdlMzMzMmZjIiwiMGQwMTQzZWEtMzM5ZS00MmUwLWEyNGUtYjVhOGZjNjlmZjE0IiwiZDY1ZjJlNWQtZmJmYi00MTUzLTg2YjItNTk3OWI0ZTZiNTkyIl0sImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ1dGkiOiJwNEJmYzd0M1RFU2Jmc2pWUFJZU0FBIiwidmVyIjoiMS4wIn0.EK4xnQ-CGOt1ADV9wF5PPIwsevthxYM7O-tIrVeg_yxzjTjeF1BYDs9mXYFBld8ZfcrPsaC5vufzM8RyD_768PpWjpqacrSoVEvrZzLXxtwyDUGx3dOBvrLZV_cM5ER7w1ORxlJo3Yq4N0WMcdVz9rYNyeDs_gGOutOC3DFK9fuRtTPm6gyL7E-pv1acyR566RXpS8_r1Kb6e6SvR0MaX2JgeDxjdxwYGuA4HMypQwi1JCy6joswNjE-8aPDcrXR13dz_N0efxHm7pb3RkbuYophUITniUCCH0KHKAsZWEhT6c0qNtI4wT6vtwzsAoqFtOCeIRJoiZYRkVt3iwYJUw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MzUsIm5iZiI6MTUwNDExMjQzNSwiZXhwIjoxNTA0MTE2MzM1LCJhaW8iOiJZMkZnWUZnZmExZXc2WXpUUHdPZnRON3U0RVZoQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoid2V6dE1lSU9Ga09mYzlXUUYwRVRBQSIsInZlciI6IjEuMCJ9.GBRKzu6t_VIC0Z9aDnK1nl7cbLV767KWYAx3skYg9-CWgQyRNHaIWes_r69r5NBdCVRe82VFFDRnpQwbIf6vtov5Q-5vfilgZDP0x2pXdHN4l8IorOJhbMNM4XSgtDck4xbUz1hz61aGlBgWIVMEBN6P-Mu1evz7_JFjR3cWJz-93_EomwyskbjvyTkZGNjSYPW9Hh1MRROrHZPvePxs1QuX8g-_EpQicHzapXeTB7t0f3s5AaMnCLXUDkwsvKPmSCcMvFoVxm0X7WghblWPel6ltUuuZDz99Wb2AIe6_th9LWHd3Iy5TJvLmnXyPhNTN_oW9J9zWoWjgr_0w0b6jg
       Content-Length:
       - '42'
       Host:
@@ -2118,34 +2118,34 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/4e1e4792-9125-40de-a032-9540bf21fe81?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/4f5eb083-85bd-41df-98b6-1ff698bdbf03?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/4e1e4792-9125-40de-a032-9540bf21fe81?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/4f5eb083-85bd-41df-98b6-1ff698bdbf03?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
       - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
       X-Ms-Request-Id:
-      - 4e1e4792-9125-40de-a032-9540bf21fe81
+      - 4f5eb083-85bd-41df-98b6-1ff698bdbf03
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1195'
+      - '1193'
       X-Ms-Correlation-Request-Id:
-      - 8a4420bb-a39f-443f-b55c-09cbda174e6b
+      - 27fdcc41-0b72-423b-a5e4-faea9e2fa431
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153304Z:8a4420bb-a39f-443f-b55c-09cbda174e6b
+      - EASTUS:20170830T170537Z:27fdcc41-0b72-423b-a5e4-faea9e2fa431
       Date:
-      - Wed, 30 Aug 2017 15:33:03 GMT
+      - Wed, 30 Aug 2017 17:05:37 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:33:04 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:36 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/4e1e4792-9125-40de-a032-9540bf21fe81?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/4f5eb083-85bd-41df-98b6-1ff698bdbf03?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -2159,7 +2159,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4ODIsIm5iZiI6MTUwNDEwNjg4MiwiZXhwIjoxNTA0MTEwNzgyLCJhaW8iOiJZMkVBZ29tZkdqL3MwV2k0bWp5ejg1NUVZeHNBIiwiYXBwaWQiOiJmYzFjMjIyNS0wNjVmLTRiYTgtODNkOS1kODY2NjJmNTc4YWYiLCJhcHBpZGFjciI6IjEiLCJncm91cHMiOlsiNDA3Mzg5ODYtM2M4Mi00Y2YxLTk5ZmMtMTM0NTdlMzMzMmZjIiwiMGQwMTQzZWEtMzM5ZS00MmUwLWEyNGUtYjVhOGZjNjlmZjE0IiwiZDY1ZjJlNWQtZmJmYi00MTUzLTg2YjItNTk3OWI0ZTZiNTkyIl0sImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJvaWQiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJzdWIiOiIzMDZlYjQyYS0zNTg1LTRhMzctOTViNy0zOGJjMGU5ODI4ZDIiLCJ0aWQiOiI3N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUiLCJ1dGkiOiJwNEJmYzd0M1RFU2Jmc2pWUFJZU0FBIiwidmVyIjoiMS4wIn0.EK4xnQ-CGOt1ADV9wF5PPIwsevthxYM7O-tIrVeg_yxzjTjeF1BYDs9mXYFBld8ZfcrPsaC5vufzM8RyD_768PpWjpqacrSoVEvrZzLXxtwyDUGx3dOBvrLZV_cM5ER7w1ORxlJo3Yq4N0WMcdVz9rYNyeDs_gGOutOC3DFK9fuRtTPm6gyL7E-pv1acyR566RXpS8_r1Kb6e6SvR0MaX2JgeDxjdxwYGuA4HMypQwi1JCy6joswNjE-8aPDcrXR13dz_N0efxHm7pb3RkbuYophUITniUCCH0KHKAsZWEhT6c0qNtI4wT6vtwzsAoqFtOCeIRJoiZYRkVt3iwYJUw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MzUsIm5iZiI6MTUwNDExMjQzNSwiZXhwIjoxNTA0MTE2MzM1LCJhaW8iOiJZMkZnWUZnZmExZXc2WXpUUHdPZnRON3U0RVZoQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoid2V6dE1lSU9Ga09mYzlXUUYwRVRBQSIsInZlciI6IjEuMCJ9.GBRKzu6t_VIC0Z9aDnK1nl7cbLV767KWYAx3skYg9-CWgQyRNHaIWes_r69r5NBdCVRe82VFFDRnpQwbIf6vtov5Q-5vfilgZDP0x2pXdHN4l8IorOJhbMNM4XSgtDck4xbUz1hz61aGlBgWIVMEBN6P-Mu1evz7_JFjR3cWJz-93_EomwyskbjvyTkZGNjSYPW9Hh1MRROrHZPvePxs1QuX8g-_EpQicHzapXeTB7t0f3s5AaMnCLXUDkwsvKPmSCcMvFoVxm0X7WghblWPel6ltUuuZDz99Wb2AIe6_th9LWHd3Iy5TJvLmnXyPhNTN_oW9J9zWoWjgr_0w0b6jg
       Host:
       - management.azure.com
   response:
@@ -2184,29 +2184,29 @@ http_interactions:
       X-Ms-Served-By:
       - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
       X-Ms-Request-Id:
-      - 04f2d6d3-766c-401b-9113-150e21988925
+      - 35accc9b-dc9b-4ee4-a742-ab5c2ab2628c
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14942'
+      - '14944'
       X-Ms-Correlation-Request-Id:
-      - 39becaab-23fb-4d84-a101-357144e3967e
+      - cd20fcfc-cca3-4188-be5e-e7f5b12a1c56
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153304Z:39becaab-23fb-4d84-a101-357144e3967e
+      - EASTUS:20170830T170538Z:cd20fcfc-cca3-4188-be5e-e7f5b12a1c56
       Date:
-      - Wed, 30 Aug 2017 15:33:03 GMT
+      - Wed, 30 Aug 2017 17:05:37 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-08-30T15:33:04.0549247+00:00\",\r\n  \"endTime\":
-        \"2017-08-30T15:33:04.168934+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=2328886d-0f4f-418f-b980-0a9b5f7885bb&sig=45EErce4IthANAmIKZ%2F3XkzVMCVpROP7ettaA0MjfiA%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"4e1e4792-9125-40de-a032-9540bf21fe81\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2017-08-30T17:05:37.2369013+00:00\",\r\n  \"endTime\":
+        \"2017-08-30T17:05:37.4550615+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=282c494b-a5fb-4f46-9da1-8e7b9c3312b5&sig=eUulnPVPZuPYIxvvZDVFixMxhYZkEReXxDtcY3m0qDU%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"4f5eb083-85bd-41df-98b6-1ff698bdbf03\"\r\n}"
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:33:04 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:36 GMT
 - request:
     method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=2328886d-0f4f-418f-b980-0a9b5f7885bb&sig=45EErce4IthANAmIKZ/3XkzVMCVpROP7ettaA0MjfiA=&sr=b&sv=2016-05-31
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=282c494b-a5fb-4f46-9da1-8e7b9c3312b5&sig=eUulnPVPZuPYIxvvZDVFixMxhYZkEReXxDtcY3m0qDU=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2241,7 +2241,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 4da322b8-0001-00fb-39a5-216937000000
+      - af4d41e1-0001-0044-2db2-217d41000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2267,11 +2267,11 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 30 Aug 2017 15:33:04 GMT
+      - Wed, 30 Aug 2017 17:05:37 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         U5MJAA==
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:33:05 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:37 GMT
 recorded_with: VCR 3.0.3

--- a/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_getPartitions-1.yml
+++ b/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_getPartitions-1.yml
@@ -1,0 +1,2468 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://login.microsoftonline.com/azure_tenant_id/oauth2/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_key&resource=https%3A%2F%2Fmanagement.azure.com%2F
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - login.microsoftonline.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Server:
+      - Microsoft-IIS/8.5
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Request-Id:
+      - 85768c0a-ecdc-4d28-ab90-bfebfdf10f00
+      P3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Set-Cookie:
+      - esctx=AQABAAAAAAA9kTklhVy7SJTGAzR-p1BcECN_HAlfUdtrNfVGvWSq0uzVl7FAicGZtP1xxBNbDicVp-E4TXJ4PP3PAp1IhDgn5lIR0QLnnJG5yVjzN_OxiuFdIISUe3gad8KA3ecIjSWC7SZGpJC2sV1vWFf0yATZIkKskYcvz8meeC1ZQwI3-Oui80uktzAWQHzTXu6Zs9wgAA;
+        domain=.login.microsoftonline.com; path=/; secure; HttpOnly
+      - stsservicecookie=ests; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=002; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Wed, 30 Aug 2017 15:32:44 GMT
+      Content-Length:
+      - '1505'
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"Bearer","expires_in":"3600","ext_expires_in":"0","expires_on":"1504110764","not_before":"1504106864","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NjQsIm5iZiI6MTUwNDEwNjg2NCwiZXhwIjoxNTA0MTEwNzY0LCJhaW8iOiJZMkZnWVBqLzRYTjFuNkFMejlKNUVwZHI1UEt2QVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ294MmhkenNLRTJya0xfcl9mRVBBQSIsInZlciI6IjEuMCJ9.k4UopyB477zu2YQTSdt6CzZ7RrltPz3eaxWD19cifTMA5bTu_uYZLWe6ZjjUgYlhiJxs0d321kt4QCvrSc154heH9KHA-cPt9LCdE9zLDkQY56xQH8MuRBJbsquyplJkgVIdRWzp4wc-EqWe4syInE7184o4bIueCEASZbHQ5YKQgKw05XEm-bRv3tZYL7zd2fwXEOikY7ZkgDHTdzwhzAuDz-c46JL49N_A-uQUtuJGMztMkiOyhiWOpu1C6oAqWGnCnJ8Ek_qKef-ngjCiazlQhAHaKufLtaB7n0ipcc8G7IwD78gzCIoVC5CPzfnYCdRhp0XyAjnviApEowS3Ag"}'
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:32:41 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions?api-version=2016-06-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NjQsIm5iZiI6MTUwNDEwNjg2NCwiZXhwIjoxNTA0MTEwNzY0LCJhaW8iOiJZMkZnWVBqLzRYTjFuNkFMejlKNUVwZHI1UEt2QVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ294MmhkenNLRTJya0xfcl9mRVBBQSIsInZlciI6IjEuMCJ9.k4UopyB477zu2YQTSdt6CzZ7RrltPz3eaxWD19cifTMA5bTu_uYZLWe6ZjjUgYlhiJxs0d321kt4QCvrSc154heH9KHA-cPt9LCdE9zLDkQY56xQH8MuRBJbsquyplJkgVIdRWzp4wc-EqWe4syInE7184o4bIueCEASZbHQ5YKQgKw05XEm-bRv3tZYL7zd2fwXEOikY7ZkgDHTdzwhzAuDz-c46JL49N_A-uQUtuJGMztMkiOyhiWOpu1C6oAqWGnCnJ8Ek_qKef-ngjCiazlQhAHaKufLtaB7n0ipcc8G7IwD78gzCIoVC5CPzfnYCdRhp0XyAjnviApEowS3Ag
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Tenant-Reads:
+      - '14998'
+      X-Ms-Request-Id:
+      - 437288fe-63f3-4f03-bc4c-d53ea2b83dcf
+      X-Ms-Correlation-Request-Id:
+      - 437288fe-63f3-4f03-bc4c-d53ea2b83dcf
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153243Z:437288fe-63f3-4f03-bc4c-d53ea2b83dcf
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 30 Aug 2017 15:32:42 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
+        Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:32:42 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers?api-version=2015-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NjQsIm5iZiI6MTUwNDEwNjg2NCwiZXhwIjoxNTA0MTEwNzY0LCJhaW8iOiJZMkZnWVBqLzRYTjFuNkFMejlKNUVwZHI1UEt2QVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ294MmhkenNLRTJya0xfcl9mRVBBQSIsInZlciI6IjEuMCJ9.k4UopyB477zu2YQTSdt6CzZ7RrltPz3eaxWD19cifTMA5bTu_uYZLWe6ZjjUgYlhiJxs0d321kt4QCvrSc154heH9KHA-cPt9LCdE9zLDkQY56xQH8MuRBJbsquyplJkgVIdRWzp4wc-EqWe4syInE7184o4bIueCEASZbHQ5YKQgKw05XEm-bRv3tZYL7zd2fwXEOikY7ZkgDHTdzwhzAuDz-c46JL49N_A-uQUtuJGMztMkiOyhiWOpu1C6oAqWGnCnJ8Ek_qKef-ngjCiazlQhAHaKufLtaB7n0ipcc8G7IwD78gzCIoVC5CPzfnYCdRhp0XyAjnviApEowS3Ag
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14945'
+      X-Ms-Request-Id:
+      - e8896fed-1546-485e-b00e-88ea14b0e5cd
+      X-Ms-Correlation-Request-Id:
+      - e8896fed-1546-485e-b00e-88ea14b0e5cd
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153244Z:e8896fed-1546-485e-b00e-88ea14b0e5cd
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 30 Aug 2017 15:32:43 GMT
+      Content-Length:
+      - '241615'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","North Central
+        US","South Central US","West Central US","West US","West US 2","Canada Central","Canada
+        East","North Europe","West Europe","UK South","UK West","East Asia","Southeast
+        Asia","Japan East","Japan West","Korea Central","Korea South","Brazil South","Central
+        India","South India","West India"],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"validateServiceName","locations":[],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"checkServiceNameAvailability","locations":[],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"reportFeedback","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"checkFeedbackRequired","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Automation","namespace":"Microsoft.Automation","authorizations":[{"applicationId":"fc75330b-179d-49af-87dd-3b1acf6827fa","roleDefinitionId":"95fd5de3-d071-4362-92bf-cf341c1de832"}],"resourceTypes":[{"resourceType":"automationAccounts","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
+        South","UK South","West Central US","North Europe","Canada Central","Australia
+        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/runbooks","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
+        South","UK South","West Central US","North Europe","Canada Central","Australia
+        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/configurations","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","North
+        Central US","Brazil South","UK South","West Central US","Central India","Australia
+        Southeast","Canada Central","North Europe"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/webhooks","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
+        South","UK South","West Central US","North Europe","Canada Central","Australia
+        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"operations","locations":["South
+        Central US"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/softwareUpdateConfigurations","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
+        South","UK South","West Central US","North Europe","Canada Central","Australia
+        Southeast","Central India"],"apiVersions":["2017-05-15-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Backup","namespace":"Microsoft.Backup","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"BackupVault","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India"],"apiVersions":["2015-03-15","2014-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Batch","namespace":"Microsoft.Batch","authorization":{"applicationId":"ddbf3205-c6bd-46ae-8127-60eb93363864","roleDefinitionId":"b7f84953-1d03-4eab-9ea4-45f065258ff8"},"resourceTypes":[{"resourceType":"batchAccounts","locations":["West
+        Europe","East US","East US 2","West US","North Central US","Brazil South","North
+        Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
+        West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
+        East","South India","Central India","Canada Central","Canada East","UK South","UK
+        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01","2015-07-01","2014-05-01-privatepreview"]},{"resourceType":"operations","locations":["West
+        Europe","East US","East US 2","West US","North Central US","Brazil South","North
+        Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
+        West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
+        East","South India","Central India","Canada Central","Canada East","UK South","UK
+        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations/quotas","locations":["West
+        Europe","East US","East US 2","West US","North Central US","Brazil South","North
+        Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
+        West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
+        East","South India","Central India","Canada Central","Canada East","UK South","UK
+        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]}],"registrationState":"Unregistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicCompute","namespace":"Microsoft.ClassicCompute","resourceTypes":[{"resourceType":"domainNames","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
+        Central","Canada East","UK South","UK West","West US","Central US","South
+        Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
+        East","Australia Southeast","West US 2","West Central US","South India","Central
+        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
+        Central","Canada East","UK South","UK West","West US","Central US","South
+        Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
+        East","Australia Southeast","West US 2","West Central US","South India","Central
+        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
+        Central US","South Central US","East US","East US 2","Canada Central","Canada
+        East","West US","West US 2","West Central US","Central US","East Asia","Southeast
+        Asia","North Europe","West Europe","UK South","UK West","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operatingSystems","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"operatingSystemFamilies","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicNetwork","namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"virtualNetworks/remoteVirtualNetworkPeeringProxies","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"reservedIps","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicStorage","namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
+        US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
+        Asia","Australia East","Australia Southeast","South India","Central India","West
+        India","West US 2","West Central US","East US","East US 2","North Central
+        US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
+        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
+        US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
+        Asia","Australia East","Australia Southeast","South India","Central India","West
+        India","West US 2","West Central US","East US","East US 2","North Central
+        US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
+        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"vmImages","locations":[],"apiVersions":["2016-11-01"]},{"resourceType":"publicImages","locations":[],"apiVersions":["2016-11-01","2016-04-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"osPlatformImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Compute","namespace":"Microsoft.Compute","authorization":{"applicationId":"60e6cd67-9c8c-4951-9b3c-23c25a2169af","roleDefinitionId":"e4770acb-272e-4dc8-87f3-12f44a612224"},"resourceTypes":[{"resourceType":"availabilitySets","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30"]},{"resourceType":"locations/usages","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"disks","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"snapshots","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"locations/diskoperations","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"images","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
+        US","East US","South Central US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","East Asia","Japan
+        East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/webhooks","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/ping","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/getCallbackConfig","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/listEvents","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"locations","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"locations/operationResults","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/GetCredentials","locations":["West
+        US","East US","South Central US","West Europe"],"apiVersions":["2016-06-27-preview"]},{"resourceType":"registries/listCredentials","locations":["South
+        Central US","East US","West US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","East Asia","Japan
+        East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/regenerateCredential","locations":["South
+        Central US","West US","East US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","East Asia","Japan
+        East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/listUsages","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/regenerateCredentials","locations":["West
+        US","East US","South Central US","West Europe"],"apiVersions":["2016-06-27-preview"]},{"resourceType":"checkNameAvailability","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview","2017-03-01","2016-06-27-preview"]},{"resourceType":"operations","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview","2017-03-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerService","namespace":"Microsoft.ContainerService","authorization":{"applicationId":"7319c514-987d-4e9b-ac3d-d38c4f427f4c","roleDefinitionId":"1b4a0c7f-2217-416f-acfa-cf73452fdc1c"},"resourceTypes":[{"resourceType":"containerServices","locations":["Japan
+        East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
+        East","Australia Southeast","Brazil South","Southeast Asia","West US","North
+        Central US","West Europe","North Europe","East US","UK West","UK South","West
+        Central US","West US 2","South India","Central India","West India","Canada
+        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
+        East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
+        East","Australia Southeast","Brazil South","Southeast Asia","West US","North
+        Central US","West Europe","North Europe","East US","UK West","UK South","West
+        Central US","West US 2","South India","Central India","West India","Canada
+        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DevTestLab","namespace":"Microsoft.DevTestLab","authorization":{"applicationId":"1a14be2a-e903-4cec-99cf-b2e209259a0f","roleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525"},"resourceTypes":[{"resourceType":"labs","locations":["West
+        Central US","Japan East","West US","Australia Southeast","Canada Central","Central
+        India","Central US","East Asia","Korea Central","North Europe","South Central
+        US","UK West","Australia East","Brazil South","Canada East","East US","East
+        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"schedules","locations":["West
+        Central US","Japan East","West US","Australia Southeast","Canada Central","Central
+        India","Central US","East Asia","Korea Central","North Europe","South Central
+        US","UK West","Australia East","Brazil South","Canada East","East US","East
+        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"labs/virtualMachines","locations":["West
+        Central US","Japan East","West US","Australia Southeast","Canada Central","Central
+        India","Central US","East Asia","Korea Central","North Europe","South Central
+        US","UK West","Australia East","Brazil South","Canada East","East US","East
+        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"labs/serviceRunners","locations":["Central
+        US","East US 2","South Central US"],"apiVersions":["2017-04-26-preview","2016-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"locations/operations","locations":["West
+        Central US","Japan East","West US","Australia Southeast","Canada Central","Central
+        India","Central US","East Asia","Korea Central","North Europe","South Central
+        US","UK West","Australia East","Brazil South","Canada East","East US","East
+        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"}],"resourceTypes":[{"resourceType":"components","locations":["East
+        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
+        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01","2014-04-01"]},{"resourceType":"queries","locations":["East
+        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"alertrules","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2016-03-01","2015-04-01","2014-04-01"]},{"resourceType":"autoscalesettings","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2015-04-01","2014-04-01"]},{"resourceType":"eventtypes","locations":[],"apiVersions":["2017-03-01-preview","2016-09-01-preview","2015-04-01","2014-11-01","2014-04-01"]},{"resourceType":"locations","locations":["East
+        US"],"apiVersions":["2015-04-01","2014-04-01"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2015-04-01","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-04-01","2014-06-01","2014-04-01"]},{"resourceType":"automatedExportSettings","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2015-04-01","2014-04-01"]},{"resourceType":"diagnosticSettings","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2017-05-01-preview","2016-09-01","2015-07-01"]},{"resourceType":"diagnosticSettingsCategories","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"extendedDiagnosticSettings","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2017-02-01"]},{"resourceType":"metricDefinitions","locations":["East
+        US","West US","West Europe","East Asia","Southeast Asia","Japan East","Japan
+        West","North Central US","South Central US","East US 2","Canada East","Canada
+        Central","Central US","Australia East","Australia Southeast","Brazil South","South
+        India","Central India","West India","North Europe","West US 2","West Central
+        US","Korea South","Korea Central","UK South","UK West","Global"],"apiVersions":["2017-05-01-preview","2016-03-01","2015-07-01"]},{"resourceType":"logDefinitions","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2015-07-01"]},{"resourceType":"eventCategories","locations":[],"apiVersions":["2015-04-01"]},{"resourceType":"metrics","locations":["East
+        US","West US","West Europe","East Asia","Southeast Asia","Japan East","Japan
+        West","North Central US","South Central US","East US 2","Canada East","Canada
+        Central","Central US","Australia East","Australia Southeast","Brazil South","South
+        India","Central India","West India","North Europe","West US 2","West Central
+        US","Korea South","Korea Central","UK South","UK West"],"apiVersions":["2017-05-01-preview","2016-09-01","2016-06-01"]},{"resourceType":"actiongroups","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]},{"resourceType":"activityLogAlerts","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.KeyVault","namespace":"Microsoft.KeyVault","resourceTypes":[{"resourceType":"vaults","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/accessPolicies","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-10-01","2015-06-01","2014-12-19-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"deletedVaults","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-10-01"]},{"resourceType":"locations/deletedVaults","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorization":{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"routeTables","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2017-04-26-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"]},{"resourceType":"workspaces/dataSources","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"storageInsightConfigs","locations":[],"apiVersions":["2014-10-10"]},{"resourceType":"workspaces/linkedServices","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"linkTargets","locations":["East
+        US"],"apiVersions":["2015-03-20"]},{"resourceType":"operations","locations":[],"apiVersions":["2014-11-10"]},{"resourceType":"devices","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationsManagement","namespace":"Microsoft.OperationsManagement","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"aa249101-6816-4966-aafa-08175d795f14"},"resourceTypes":[{"resourceType":"solutions","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Portal","namespace":"Microsoft.Portal","resourceTypes":[{"resourceType":"dashboards","locations":["Central
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
+        East","West India","South India","Central India","Canada Central","Canada
+        East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"operations","locations":["Central
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
+        East","West India","South India","Central India","Canada Central","Canada
+        East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"consoles","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/consoles","locations":["West
+        US","East US","Central India","North Europe","West Europe","South Central
+        US","Southeast Asia"],"apiVersions":["2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
+        US","East US","Central India","North Europe","West Europe","South Central
+        US","Southeast Asia"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","Canada Central","Canada East","West Central US","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-07-01","2016-12-01","2016-08-10","2016-06-01","2016-05-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"operations","locations":["Southeast
+        Asia"],"apiVersions":["2016-08-10","2016-06-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01"]},{"resourceType":"locations/backupStatus","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]},{"resourceType":"locations/allocatedStamp","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]},{"resourceType":"locations/allocateStamp","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ResourceHealth","namespace":"Microsoft.ResourceHealth","authorization":{"applicationId":"8bdebf23-c0fe-4187-a378-717ad86f6a53","roleDefinitionId":"cc026344-c8b1-4561-83ba-59eba84b27cc"},"resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2017-07-01","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"notifications","locations":["Australia
+        Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Security","namespace":"Microsoft.Security","authorization":{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatuses","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/virtualMachines","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/endpoints","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/subnets","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"tasks","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"alerts","locations":["Central
+        US","East US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"monitoring","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"monitoring/patch","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"monitoring/baseline","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"monitoring/antimalware","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"dataCollectionAgents","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"dataCollectionResults","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"pricings","locations":["Central
+        US","East US"],"apiVersions":["2017-08-01-preview"]},{"resourceType":"complianceResults","locations":["Central
+        US","East US"],"apiVersions":["2017-08-01"]},{"resourceType":"policies","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"appliances","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"webApplicationFirewalls","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/webApplicationFirewalls","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securitySolutions","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/securitySolutions","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securitySolutionsReferenceData","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/securitySolutionsReferenceData","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"jitNetworkAccessPolicies","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/jitNetworkAccessPolicies","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatusesSummaries","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/alerts","locations":["Central
+        US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/tasks","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.SiteRecovery","namespace":"Microsoft.SiteRecovery","authorization":{"applicationId":"b8340c3b-9267-498f-b21a-15d5547fd85e","roleDefinitionId":"8A00C8EA-8F1B-45A7-8F64-F4CC61EEE9B6"},"resourceTypes":[{"resourceType":"SiteRecoveryVault","locations":["East
+        US","West US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","Australia East","Australia Southeast","Brazil South","North
+        Central US","South Central US","Central US","East US 2","Central India","South
+        India"],"apiVersions":["2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Sql","namespace":"Microsoft.Sql","authorizations":[{"applicationId":"e4ab13ed-33cb-41b4-9140-6e264582cf85","roleDefinitionId":"ec3ddc95-44dc-47a2-9926-5e9f5ffd44ec"},{"applicationId":"0130cc9f-7ac5-4026-bd5f-80a08a54e6d9","roleDefinitionId":"45e8abf8-0ec4-44f3-9c37-cff4f7779302"},{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},{"applicationId":"76c7f279-7959-468f-8943-3954880e0d8c","roleDefinitionId":"7f7513a8-73f9-4c5f-97a2-c41f0ea783ef"}],"resourceTypes":[{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/capabilities","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverKeyOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/keys","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/encryptionProtector","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/communicationLinks","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recoverableDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/importExportOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/operationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/firewallrules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/elasticpools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-09-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/dnsAliases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/failoverGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/virtualNetworkRules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/virtualNetworkRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/virtualNetworkRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/databaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/extensions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditRecords","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/VulnerabilityAssessmentScans","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentScans","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups/syncMembers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/syncAgents","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncMemberOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncAgentOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncDatabaseIds","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorization":{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
+        US","West US","West Europe","North Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":["East
+        US","West US","West Europe","North Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Web","namespace":"Microsoft.Web","authorization":{"applicationId":"abfa0a7c-a6b6-4736-8310-5855508787cd","roleDefinitionId":"f47ed98b-b063-4a5b-9e10-4b9b44fa7735"},"resourceTypes":[{"resourceType":"sites/extensions","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots/extensions","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/instances","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots/instances","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/instances/extensions","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots/instances/extensions","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/publicCertificates","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots/publicCertificates","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"publishingUsers","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"ishostnameavailable","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"validate","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"isusernameavailable","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sourceControls","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"availableStacks","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"listSitesAssignedToHostName","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"sites/hostNameBindings","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"sites/domainOwnershipIdentifiers","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"sites/slots/hostNameBindings","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"operations","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"certificates","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms/workers","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"runtimes","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"sites/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"sites/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"sites/slots/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"sites/slots/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"serverFarms/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"serverFarms/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"sites/recommendations","locations":[],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"georegions","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/premieraddons","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01"]},{"resourceType":"hostingEnvironments","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/instances","locations":[],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/instances/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/instances/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/instances","locations":[],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/instances/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/instances/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"deploymentLocations","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"functions","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"deletedSites","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"ishostingenvironmentnameavailable","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"classicMobileServices","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"connections","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/managedApis","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/apiOperations","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"connectionGateways","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/connectionGatewayInstallations","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"checkNameAvailability","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"billingMeters","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/84codes.CloudAMQP","namespace":"84codes.CloudAMQP","resourceTypes":[{"resourceType":"servers","locations":["East
+        US 2","Central US","East US","North Central US","South Central US","West US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast"],"apiVersions":["2016-08-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/AppDynamics.APM","namespace":"AppDynamics.APM","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2016-05-26"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-05-26"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-05-26"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-05-26"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-05-26"]},{"resourceType":"locations/operationResults","locations":["West
+        US"],"apiVersions":["2016-05-26"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Aspera.Transfers","namespace":"Aspera.Transfers","resourceTypes":[{"resourceType":"services","locations":["West
+        US","North Europe","Central US","East US","West Europe","East Asia","Southeast
+        Asia","Japan East","East US 2","Japan West"],"apiVersions":["2016-03-25"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-03-25"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-03-25"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-03-25"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Auth0.Cloud","namespace":"Auth0.Cloud","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-11-23"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Citrix.Cloud","namespace":"Citrix.Cloud","resourceTypes":[{"resourceType":"accounts","locations":["West
+        US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Cloudyn.Analytics","namespace":"Cloudyn.Analytics","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US"],"apiVersions":["2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Conexlink.MyCloudIT","namespace":"Conexlink.MyCloudIT","resourceTypes":[{"resourceType":"accounts","locations":["Central
+        US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Crypteron.DataSecurity","namespace":"Crypteron.DataSecurity","resourceTypes":[{"resourceType":"apps","locations":["West
+        US"],"apiVersions":["2016-08-12"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-12"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-12"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-12"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Dynatrace.DynatraceSaaS","namespace":"Dynatrace.DynatraceSaaS","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-09-27"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Dynatrace.Ruxit","namespace":"Dynatrace.Ruxit","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US"],"apiVersions":["2016-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-09-07","2016-04-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-04-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/LiveArena.Broadcast","namespace":"LiveArena.Broadcast","resourceTypes":[{"resourceType":"services","locations":["West
+        US","North Europe","Japan West","Japan East","East Asia","West Europe","East
+        US","Southeast Asia","Central US"],"apiVersions":["2016-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Lombiq.DotNest","namespace":"Lombiq.DotNest","resourceTypes":[{"resourceType":"sites","locations":["East
+        US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Mailjet.Email","namespace":"Mailjet.Email","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]},{"resourceType":"diagnosticSettings","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"addsservices","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"configuration","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"agents","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"aadsupportcases","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"reports","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"servicehealthmetrics","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"logs","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"anonymousapiusers","locations":["West
+        US"],"apiVersions":["2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AnalysisServices","namespace":"Microsoft.AnalysisServices","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"servers","locations":["West
+        US","North Europe","South Central US","West Europe","West Central US","Southeast
+        Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
+        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/checkNameAvailability","locations":["West
+        US","North Europe","South Central US","West Europe","West Central US","Southeast
+        Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
+        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationresults","locations":["West
+        US","North Europe","South Central US","West Europe","West Central US","Southeast
+        Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
+        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationstatuses","locations":["West
+        US","North Europe","South Central US","West Europe","West Central US","Southeast
+        Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
+        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"operations","locations":["East
+        US 2","West Central US"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AppService","namespace":"Microsoft.AppService","authorization":{"applicationId":"dee7ba80-6a55-4f3b-a86c-746a9231ae49","roleDefinitionId":"6715d172-49c4-46f6-bb21-60512a8689dc"},"resourceTypes":[{"resourceType":"apiapps","locations":["East
+        US","West US","South Central US","North Europe","East Asia","Japan East","West
+        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
+        South","East US 2","Australia Southeast","Australia East","West India","South
+        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"appIdentities","locations":["East
+        US","West US","South Central US","North Europe","East Asia","Japan East","West
+        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
+        South","East US 2","Australia Southeast","Australia East","West India","South
+        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"gateways","locations":["East
+        US","West US","South Central US","North Europe","East Asia","Japan East","West
+        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
+        South","East US 2","Australia Southeast","Australia East","West India","South
+        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"deploymenttemplates","locations":[],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Authorization","namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"roleDefinitions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"classicAdministrators","locations":[],"apiVersions":["2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"permissions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"locks","locations":[],"apiVersions":["2017-04-01","2016-09-01","2015-06-01","2015-05-01-preview","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-01-01","2014-10-01-preview","2014-06-01"]},{"resourceType":"policyDefinitions","locations":[],"apiVersions":["2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"policySetDefinitions","locations":[],"apiVersions":["2017-06-01-preview"]},{"resourceType":"policyAssignments","locations":[],"apiVersions":["2017-06-01-preview","2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"providerOperations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01-preview","2015-07-01"]},{"resourceType":"elevateAccess","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureActiveDirectory","namespace":"Microsoft.AzureActiveDirectory","resourceTypes":[{"resourceType":"b2cDirectories","locations":["Global","United
+        States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureStack","namespace":"Microsoft.AzureStack","resourceTypes":[{"resourceType":"operations","locations":["Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations","locations":["West
+        Central US","Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations/products","locations":["West
+        Central US","Global"],"apiVersions":["2017-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Billing","namespace":"Microsoft.Billing","resourceTypes":[{"resourceType":"BillingPeriods","locations":["Central
+        US"],"apiVersions":["2017-04-24-preview"]},{"resourceType":"Invoices","locations":["Central
+        US"],"apiVersions":["2017-04-24-preview","2017-02-27-preview"]},{"resourceType":"operations","locations":["Central
+        US"],"apiVersions":["2017-04-24-preview","2017-02-27-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BingMaps","namespace":"Microsoft.BingMaps","resourceTypes":[{"resourceType":"mapApis","locations":["West
+        US"],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-18","2015-07-02"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BizTalkServices","namespace":"Microsoft.BizTalkServices","resourceTypes":[{"resourceType":"BizTalk","locations":["East
+        US","West US","North Europe","West Europe","Southeast Asia","East Asia","North
+        Central US","Japan West","Japan East","South Central US"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Cache","namespace":"Microsoft.Cache","authorization":{"applicationId":"96231a05-34ce-4eb4-aa6a-70759cbb5e83","roleDefinitionId":"4f731528-ba85-45c7-acfb-cd0a9b3cf31b"},"resourceTypes":[{"resourceType":"Redis","locations":["North
+        Central US","South Central US","Central US","West Europe","North Europe","West
+        US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
+        Asia","East Asia","Australia East","Australia Southeast","Central India","West
+        India","Canada Central","Canada East","UK South","UK West","West US 2","West
+        Central US","South India","Korea Central","Korea South"],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","South Central US","Central US","West Europe","North Europe","West
+        US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
+        Asia","East Asia","Australia East","Australia Southeast","Central India","West
+        India","South India","Canada Central","Canada East","UK South","UK West","West
+        US 2","West Central US","Korea Central","Korea South"],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01"]},{"resourceType":"Redis/metricDefinitions","locations":["North
+        Central US","South Central US","East US","East US 2","West US","Central US","East
+        Asia","Southeast Asia","North Europe","West Europe","Japan East","Japan West","Brazil
+        South","Australia Southeast","Australia East","Central India","West India","South
+        India","Canada Central","Canada East","UK West","UK South","West US 2","West
+        Central US","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"Redis/diagnosticSettings","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","West
+        US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
+        Asia","Australia East","Australia Southeast","Central India","West India","South
+        India","Canada Central","Canada East","UK West","UK South","West US 2","West
+        Central US","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Cdn","namespace":"Microsoft.Cdn","resourceTypes":[{"resourceType":"profiles","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/origins","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/customdomains","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/originresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/customdomainresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkResourceUsage","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02"]},{"resourceType":"validateProbe","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"edgenodes","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CertificateRegistration","namespace":"Microsoft.CertificateRegistration","authorization":{"applicationId":"f3c21649-0979-4721-ac85-b0216b2cf413","roleDefinitionId":"933fba7e-2ed3-4da8-973d-8bd8298a9b40"},"resourceTypes":[{"resourceType":"certificateOrders","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"certificateOrders/certificates","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"validateCertificateRegistrationInformation","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicSubscription","namespace":"Microsoft.ClassicSubscription","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicInfrastructureMigrate","namespace":"Microsoft.ClassicInfrastructureMigrate","authorization":{"applicationId":"5e5abe2b-83cd-4786-826a-a05653ebb103","roleDefinitionId":"766c4d9b-ef83-4f73-8352-1450a506a69b"},"resourceTypes":[{"resourceType":"classicInfrastructureResources","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","West
+        India","South India"],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CognitiveServices","namespace":"Microsoft.CognitiveServices","authorizations":[{"applicationId":"7d312290-28c8-473c-a0ed-8e53749b6d6d","roleDefinitionId":"5cb87f79-a7c3-4a95-9414-45b65974b51b"}],"resourceTypes":[{"resourceType":"accounts","locations":["Global","West
+        US","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"operations","locations":["Global","West
+        US","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations","locations":["Global","West
+        US","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/checkSkuAvailability","locations":["West
+        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/updateAccountsCreationSettings","locations":["West
+        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/accountsCreationSettings","locations":["West
+        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2016-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Commerce","namespace":"Microsoft.Commerce","resourceTypes":[{"resourceType":"UsageAggregates","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]},{"resourceType":"RateCard","locations":[],"apiVersions":["2016-08-31-preview","2015-06-01-preview","2015-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Consumption","namespace":"Microsoft.Consumption","resourceTypes":[{"resourceType":"reservationsummaries","locations":[],"apiVersions":["2017-01-30"]},{"resourceType":"reservationdetails","locations":[],"apiVersions":["2017-01-30"]},{"resourceType":"UsageDetails","locations":[],"apiVersions":["2017-06-30-preview","2017-04-24-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-30-preview","2017-04-24-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","resourceTypes":[{"resourceType":"containerGroups","locations":["West
+        US","East US","West Europe"],"apiVersions":["2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
+        US"],"apiVersions":["2016-04-08"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CustomerInsights","namespace":"Microsoft.CustomerInsights","authorization":{"applicationId":"38c77d00-5fcb-4cce-9d93-af4738258e3c","roleDefinitionId":"E006F9C7-F333-477C-8AD6-1F3A9FE87F55"},"resourceTypes":[{"resourceType":"hubs","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/profiles","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/interactions","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/authorizationPolicies","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/connectors","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/connectors/mappings","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/kpi","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/views","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/links","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/roleAssignments","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/roles","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/widgetTypes","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/suggestTypeSchema","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"operations","locations":["East
+        US 2"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataCatalog","namespace":"Microsoft.DataCatalog","resourceTypes":[{"resourceType":"catalogs","locations":["East
+        US","West US","Australia East","West Europe","North Europe","Southeast Asia","West
+        Central US"],"apiVersions":["2016-03-30","2015-07-01-preview"]},{"resourceType":"checkNameAvailability","locations":["West
+        Europe"],"apiVersions":["2016-03-30","2015-07-01-preview"]},{"resourceType":"operations","locations":["West
+        Europe"],"apiVersions":["2016-03-30","2015-07-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-03-30","2015-07-01-preview"]},{"resourceType":"locations/jobs","locations":["East
+        US","West US","Australia East","West Europe","North Europe","Southeast Asia","West
+        Central US"],"apiVersions":["2016-03-30","2015-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataFactory","namespace":"Microsoft.DataFactory","resourceTypes":[{"resourceType":"dataFactories","locations":["West
+        US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview","2014-04-01"]},{"resourceType":"factories","locations":["East
+        US"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
+        US"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
+        Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"dataFactories/metricDefinitions","locations":["North
+        Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"checkDataFactoryNameAvailability","locations":[],"apiVersions":["2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"checkAzureDataFactoryNameAvailability","locations":["West
+        US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"dataFactorySchema","locations":["West
+        US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"operations","locations":["West
+        US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeAnalytics","namespace":"Microsoft.DataLakeAnalytics","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/dataLakeStoreAccounts","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers/listSasTokens","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeStore","namespace":"Microsoft.DataLakeStore","authorization":{"applicationId":"e9f49c6b-5ce5-44c8-925d-015017e9f7ad","roleDefinitionId":"17eb9cca-f08a-4499-b2d3-852d175f614f"},"resourceTypes":[{"resourceType":"accounts","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/firewallRules","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","resourceTypes":[{"resourceType":"operations","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforPostgreSQL","namespace":"Microsoft.DBforPostgreSQL","resourceTypes":[{"resourceType":"operations","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
+        US","North Europe","East Asia","East US","West Europe","Southeast Asia","Japan
+        East","Japan West","Australia East","Australia Southeast","West US 2","West
+        Central US","East US 2","Central US","UK South","UK West","South India","Central
+        India"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"databaseAccountNames","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DomainRegistration","namespace":"Microsoft.DomainRegistration","authorization":{"applicationId":"ea2f600a-4980-45b7-89bf-d34da487bda1","roleDefinitionId":"54d7f2e3-5040-48a7-ae90-eebf629cfa0b"},"resourceTypes":[{"resourceType":"domains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"domains/domainOwnershipIdentifiers","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"topLevelDomains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"checkDomainAvailability","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"listDomainRecommendations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"validateDomainRegistrationInformation","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"generateSsoRequest","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DynamicsLcs","namespace":"Microsoft.DynamicsLcs","resourceTypes":[{"resourceType":"lcsprojects","locations":["Brazil
+        South","East Asia","East US","Japan East","Japan West","North Central US","North
+        Europe","South Central US","West Europe","West US","Southeast Asia","Central
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"lcsprojects/connectors","locations":["Brazil
+        South","East Asia","East US","Japan East","Japan West","North Central US","North
+        Europe","South Central US","West Europe","West US","Southeast Asia","Central
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"lcsprojects/clouddeployments","locations":["Brazil
+        South","East Asia","East US","Japan East","Japan West","North Central US","North
+        Europe","South Central US","West Europe","West US","Southeast Asia","Central
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"operations","locations":["Brazil
+        South","East Asia","East US","Japan East","Japan West","North Central US","North
+        Europe","South Central US","West Europe","West US","Southeast Asia","Central
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"topics","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operations","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"clusters/applications","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"clusters/operationresults","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations/capabilities","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations/operationresults","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations/azureasyncoperations","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations/validateCreateRequest","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"operations","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India"],"apiVersions":["2015-03-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ImportExport","namespace":"Microsoft.ImportExport","authorization":{"applicationId":"7de4d5c5-5b32-4235-b8a9-33b34d6bcd2a","roleDefinitionId":"9f7aa6bb-9454-46b6-8c01-a4b0f33ca151"},"resourceTypes":[{"resourceType":"jobs","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","North Central US","North Europe","South Central US","Southeast
+        Asia","South India","UK South","West Central US","West Europe","West India","West
+        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","North Central US","North Europe","South Central US","Southeast
+        Asia","South India","UK South","West Central US","West Europe","West India","West
+        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations/operationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","North Central US","North Europe","South Central US","Southeast
+        Asia","South India","UK South","West Central US","West Europe","West India","West
+        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","North Central US","North Europe","South Central US","Southeast
+        Asia","South India","UK South","West Central US","West Europe","West India","West
+        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Logic","namespace":"Microsoft.Logic","authorization":{"applicationId":"7cd684f4-8a78-49b0-91ec-6a35d38739ba","roleDefinitionId":"cb3ef1fb-6e31-49e2-9d87-ed821053fe58"},"resourceTypes":[{"resourceType":"workflows","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West"],"apiVersions":["2017-07-01","2016-10-01","2016-06-01","2015-08-01-preview","2015-02-01-preview"]},{"resourceType":"locations/workflows","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West"],"apiVersions":["2017-07-01","2016-10-01","2016-06-01","2015-08-01-preview","2015-02-01-preview"]},{"resourceType":"locations","locations":["North
+        Central US"],"apiVersions":["2017-07-01","2016-10-01","2016-06-01","2015-08-01-preview","2015-02-01-preview"]},{"resourceType":"operations","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West"],"apiVersions":["2017-07-01","2016-10-01","2016-06-01","2015-08-01-preview","2015-02-01-preview"]},{"resourceType":"integrationAccounts","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","West Central US"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"operations","locations":["South
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations","locations":["South
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operations","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"commitmentPlans","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
+        Central US","West US"],"apiVersions":["2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Media","namespace":"Microsoft.Media","authorization":{"applicationId":"374b2a64-3b6b-436b-934c-b820eacca870","roleDefinitionId":"aab70789-0cec-44b5-95d7-84b64c9487af"},"resourceTypes":[{"resourceType":"mediaservices","locations":["Japan
+        West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
+        US","West US","Australia East","Australia Southeast","Central US","Brazil
+        South","Central India","West India","South India","South Central US","Canada
+        Central","Canada East","West Central US"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
+        Central US","North Central US","East US 2","West US","West Europe","North
+        Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
+        East","UK South","West India"],"apiVersions":["2016-01-29"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-01-29"]},{"resourceType":"locations/checkNameAvailability","locations":["South
+        Central US","North Central US","East US 2","West US","West Europe","North
+        Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
+        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"operations","locations":["East
+        US 2"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Relay","namespace":"Microsoft.Relay","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US 2","West
+        US","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
+        East","West India","South India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
+        East","West India","South India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
+        Central US","South Central US","North Europe","West Europe","East Asia","Southeast
+        Asia","West US","East US","Japan West","Japan East","Brazil South","Central
+        US","East US 2","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-03-01","2016-01-01","2014-08-01-preview"]},{"resourceType":"operations","locations":["North
+        Central US","South Central US","North Europe","West Europe","East Asia","Southeast
+        Asia","West US","East US","Japan West","Japan East","Brazil South","Central
+        US","East US 2","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-03-01","2016-01-01","2014-08-01-preview"]},{"resourceType":"operationResults","locations":["North
+        Central US","South Central US","North Europe","West Europe","East Asia","Southeast
+        Asia","West US","East US","Japan West","Japan East","Brazil South","Central
+        US","East US 2","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-03-01","2016-01-01","2014-08-01-preview"]},{"resourceType":"flows","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast"],"apiVersions":["2015-08-01-preview","2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Search","namespace":"Microsoft.Search","resourceTypes":[{"resourceType":"searchServices","locations":["West
+        US","East US","North Europe","West Europe","Southeast Asia","East Asia","North
+        Central US","South Central US","Japan West","Australia East","Brazil South","Central
+        India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19","2015-02-28"]},{"resourceType":"checkServiceNameAvailability","locations":[],"apiVersions":["2015-02-28","2014-07-31-Preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2015-08-19"]},{"resourceType":"resourceHealthMetadata","locations":["West
+        US","East US","North Europe","West Europe","Southeast Asia","East Asia","North
+        Central US","South Central US","Japan West","Australia East","Brazil South","Central
+        India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US 2","West
+        US","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"premiumMessagingRegions","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceFabric","namespace":"Microsoft.ServiceFabric","authorization":{"applicationId":"74cb6831-0dbb-4be1-8206-fd4df301cdc2","roleDefinitionId":"e55cc65f-6903-4917-b4ef-f8d4640b57f5"},"resourceTypes":[{"resourceType":"clusters","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/clusterVersions","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operations","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Canada
+        Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","West Central US","Japan East","Japan West","Australia East","Australia
+        Southeast"],"apiVersions":["2017-06-01","2017-05-15","2017-01-01","2016-10-01","2016-06-01","2015-03-15","2014-09-01"]},{"resourceType":"operations","locations":["West
+        Central US","Southeast Asia"],"apiVersions":["2016-10-01","2016-06-01","2015-03-15","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StreamAnalytics","namespace":"Microsoft.StreamAnalytics","resourceTypes":[{"resourceType":"streamingjobs","locations":["Central
+        US","West Europe","East US 2","North Europe","Japan East","West US","Southeast
+        Asia","South Central US","East Asia","Japan West","North Central US","East
+        US","Australia East","Australia Southeast","Brazil South","Central India","West
+        Central US","UK South","UK West","Canada Central","Canada East","West US 2"],"apiVersions":["2017-04-01-preview","2016-03-01","2015-11-01","2015-10-01","2015-09-01","2015-08-01-preview","2015-06-01","2015-05-01","2015-04-01","2015-03-01-preview"]},{"resourceType":"locations","locations":["West
+        Europe","Central US","East US 2","North Europe","Japan East","West US","Southeast
+        Asia","South Central US","East Asia","Japan West","North Central US","East
+        US","Australia East","Australia Southeast","Brazil South","Central India","West
+        Central US","UK South","West US 2","UK West","Canada Central","Canada East"],"apiVersions":["2017-04-01-preview","2016-03-01","2015-11-01","2015-10-01","2015-09-01","2015-08-01-preview","2015-06-01","2015-05-01","2015-04-01","2015-03-01-preview"]},{"resourceType":"locations/quotas","locations":[],"apiVersions":["2017-04-01-preview","2016-03-01","2015-11-01","2015-10-01","2015-09-01","2015-08-01-preview","2015-06-01","2015-05-01","2015-04-01","2015-03-01-preview"]},{"resourceType":"streamingjobs/diagnosticSettings","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","Central
+        India","West Central US","UK South","UK West","Canada Central","Canada East","West
+        US 2","West US","Central US","South Central US","Japan East","Japan West","East
+        Asia","Southeast Asia","Australia East","Australia Southeast"],"apiVersions":["2014-04-01"]},{"resourceType":"streamingjobs/metricDefinitions","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","Central
+        India","West Central US","UK South","UK West","Canada Central","Canada East","West
+        US 2","West US","Central US","South Central US","Japan East","Japan West","East
+        Asia","Southeast Asia","Australia East","Australia Southeast"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":["West
+        Europe","West US","Central US","East US 2","North Europe","Japan East","Southeast
+        Asia","South Central US","East Asia","Japan West","North Central US","East
+        US","Australia East","Australia Southeast","Brazil South","Central India","West
+        Central US","UK South","UK West","Canada Central","Canada East","West US 2"],"apiVersions":["2017-04-01-preview","2016-03-01","2015-11-01","2015-10-01","2015-09-01","2015-08-01-preview","2015-06-01","2015-05-01","2015-04-01","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.support","namespace":"microsoft.support","resourceTypes":[{"resourceType":"operations","locations":["North
+        Central US","South Central US","Central US","West Europe","North Europe","West
+        US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
+        Asia","East Asia","Australia East","Australia Southeast"],"apiVersions":["2015-07-01-Preview","2015-03-01"]},{"resourceType":"supporttickets","locations":["North
+        Central US","South Central US","Central US","West Europe","North Europe","West
+        US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
+        Asia","East Asia","Australia East","Australia Southeast"],"apiVersions":["2015-07-01-Preview","2015-03-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.TimeSeriesInsights","namespace":"Microsoft.TimeSeriesInsights","authorizations":[{"applicationId":"120d688d-1518-4cf7-bd38-182f158850b6","roleDefinitionId":"5a43abdf-bb87-42c4-9e56-1c24bf364150"}],"resourceTypes":[{"resourceType":"environments","locations":["East
+        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/eventsources","locations":["East
+        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/referenceDataSets","locations":["East
+        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/accessPolicies","locations":["East
+        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"operations","locations":["East
+        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/project","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/extension","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"checkNameAvailability","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Myget.PackageManagement","namespace":"Myget.PackageManagement","resourceTypes":[{"resourceType":"services","locations":["West
+        Europe"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/NewRelic.APM","namespace":"NewRelic.APM","authorization":{"allowedThirdPartyExtensions":[{"name":"NewRelic_AzurePortal_APM"}]},"resourceTypes":[{"resourceType":"accounts","locations":["North
+        Central US","South Central US","West US","East US","North Europe","West Europe","Southeast
+        Asia","East Asia","Japan East","Japan West"],"apiVersions":["2014-10-01","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/nuubit.nextgencdn","namespace":"nuubit.nextgencdn","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US","East US 2","North Central US","South Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","West US","Central US"],"apiVersions":["2017-05-05"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-05"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-05-05"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-05-05"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Paraleap.CloudMonix","namespace":"Paraleap.CloudMonix","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2016-08-10"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-10"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-10"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Pokitdok.Platform","namespace":"Pokitdok.Platform","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2016-05-17"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-05-17"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-05-17"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-05-17"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RavenHq.Db","namespace":"RavenHq.Db","resourceTypes":[{"resourceType":"databases","locations":["East
+        US"],"apiVersions":["2016-07-18","2016-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-07-18","2016-06-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-07-18","2016-06-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-07-18","2016-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Raygun.CrashReporting","namespace":"Raygun.CrashReporting","resourceTypes":[{"resourceType":"apps","locations":["East
+        US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RedisLabs.Memcached","namespace":"RedisLabs.Memcached","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-07-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RedisLabs.Redis","namespace":"RedisLabs.Redis","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-07-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RevAPM.MobileCDN","namespace":"RevAPM.MobileCDN","resourceTypes":[{"resourceType":"accounts","locations":["Central
+        US","East US","East US 2","North Central US","South Central US","West US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast"],"apiVersions":["2016-08-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-24","2016-08-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sendgrid.Email","namespace":"Sendgrid.Email","resourceTypes":[{"resourceType":"accounts","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Canada Central","Canada
+        East","West Central US","West US 2","UK South","UK West"],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Signiant.Flight","namespace":"Signiant.Flight","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US","Central US","North Central US","South Central US","West US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast"],"apiVersions":["2015-06-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sparkpost.Basic","namespace":"Sparkpost.Basic","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2016-08-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/stackify.retrace","namespace":"stackify.retrace","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2016-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/SuccessBricks.ClearDB","namespace":"SuccessBricks.ClearDB","resourceTypes":[{"resourceType":"databases","locations":["Brazil
+        South","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","Southeast Asia","West Europe","West
+        US","South Central US","Australia East","Australia Southeast","Canada Central","Canada
+        East","Central India","South India","West India"],"apiVersions":["2014-04-01"]},{"resourceType":"clusters","locations":["Brazil
+        South","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","Southeast Asia","West Europe","West
+        US","Australia Southeast","Australia East","South Central US","Canada Central","Canada
+        East","Central India","South India","West India"],"apiVersions":["2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/TrendMicro.DeepSecurity","namespace":"TrendMicro.DeepSecurity","resourceTypes":[{"resourceType":"accounts","locations":["Central
+        US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
+        Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:32:43 GMT
+- request:
+    method: post
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
+    body:
+      encoding: UTF-8
+      string: '{"access":"read","durationInSeconds":3600}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NjQsIm5iZiI6MTUwNDEwNjg2NCwiZXhwIjoxNTA0MTEwNzY0LCJhaW8iOiJZMkZnWVBqLzRYTjFuNkFMejlKNUVwZHI1UEt2QVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ294MmhkenNLRTJya0xfcl9mRVBBQSIsInZlciI6IjEuMCJ9.k4UopyB477zu2YQTSdt6CzZ7RrltPz3eaxWD19cifTMA5bTu_uYZLWe6ZjjUgYlhiJxs0d321kt4QCvrSc154heH9KHA-cPt9LCdE9zLDkQY56xQH8MuRBJbsquyplJkgVIdRWzp4wc-EqWe4syInE7184o4bIueCEASZbHQ5YKQgKw05XEm-bRv3tZYL7zd2fwXEOikY7ZkgDHTdzwhzAuDz-c46JL49N_A-uQUtuJGMztMkiOyhiWOpu1C6oAqWGnCnJ8Ek_qKef-ngjCiazlQhAHaKufLtaB7n0ipcc8G7IwD78gzCIoVC5CPzfnYCdRhp0XyAjnviApEowS3Ag
+      Content-Length:
+      - '42'
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '0'
+      Expires:
+      - "-1"
+      Location:
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/0dfdf4f2-fc6a-4a5a-bb69-5bca0dd6194a?monitor=true&api-version=2017-03-30
+      Azure-Asyncoperation:
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/0dfdf4f2-fc6a-4a5a-bb69-5bca0dd6194a?api-version=2017-03-30
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      X-Ms-Request-Id:
+      - 0dfdf4f2-fc6a-4a5a-bb69-5bca0dd6194a
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Writes:
+      - '1199'
+      X-Ms-Correlation-Request-Id:
+      - d98812a0-824d-4f18-93ac-9eadbf614bce
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153245Z:d98812a0-824d-4f18-93ac-9eadbf614bce
+      Date:
+      - Wed, 30 Aug 2017 15:32:45 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:32:43 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/0dfdf4f2-fc6a-4a5a-bb69-5bca0dd6194a?api-version=2017-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NjQsIm5iZiI6MTUwNDEwNjg2NCwiZXhwIjoxNTA0MTEwNzY0LCJhaW8iOiJZMkZnWVBqLzRYTjFuNkFMejlKNUVwZHI1UEt2QVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ294MmhkenNLRTJya0xfcl9mRVBBQSIsInZlciI6IjEuMCJ9.k4UopyB477zu2YQTSdt6CzZ7RrltPz3eaxWD19cifTMA5bTu_uYZLWe6ZjjUgYlhiJxs0d321kt4QCvrSc154heH9KHA-cPt9LCdE9zLDkQY56xQH8MuRBJbsquyplJkgVIdRWzp4wc-EqWe4syInE7184o4bIueCEASZbHQ5YKQgKw05XEm-bRv3tZYL7zd2fwXEOikY7ZkgDHTdzwhzAuDz-c46JL49N_A-uQUtuJGMztMkiOyhiWOpu1C6oAqWGnCnJ8Ek_qKef-ngjCiazlQhAHaKufLtaB7n0ipcc8G7IwD78gzCIoVC5CPzfnYCdRhp0XyAjnviApEowS3Ag
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      X-Ms-Request-Id:
+      - 0440c5c2-f684-4519-b374-4659c1d7148d
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14250'
+      X-Ms-Correlation-Request-Id:
+      - c6310fc4-972c-46d0-88c7-446e343556a8
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153245Z:c6310fc4-972c-46d0-88c7-446e343556a8
+      Date:
+      - Wed, 30 Aug 2017 15:32:45 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"startTime\": \"2017-08-30T15:32:44.8708387+00:00\",\r\n  \"endTime\":
+        \"2017-08-30T15:32:45.089597+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=a3ec3e87-1079-4783-9091-72aa44d4825d&sig=OOXHRlrALSzdjcv68aa4diCr3TbHL0fazJ%2BUdTHRw%2Fo%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"0dfdf4f2-fc6a-4a5a-bb69-5bca0dd6194a\"\r\n}"
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:32:44 GMT
+- request:
+    method: get
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=a3ec3e87-1079-4783-9091-72aa44d4825d&sig=OOXHRlrALSzdjcv68aa4diCr3TbHL0fazJ%2BUdTHRw/o=&sr=b&sv=2016-05-31
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      X-Ms-Range:
+      - bytes=0-0
+      Host:
+      - md-t4jdgqqlgszp.blob.core.windows.net
+  response:
+    status:
+      code: 206
+      message: Partial Content
+    headers:
+      Content-Length:
+      - '1'
+      Content-Type:
+      - application/octet-stream
+      Content-Range:
+      - bytes 0-0/34359738880
+      Last-Modified:
+      - Sat, 15 Jul 2017 14:23:07 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D4CB8D039FC699"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - e5943232-0001-0060-80a5-21e40f000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Meta-Pirtag:
+      - '1'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '20'
+      X-Ms-Copy-Id:
+      - 30cedd78-548a-4fd8-967e-f8344f587e3c
+      X-Ms-Copy-Source:
+      - http://md-t4jdgqqlgszp.blob.core.windows.net:8080/fg25xxtqx0gc/abcd?sv=2016-02-19&sr=b&st=2017-05-04T21%3a06%3a57Z&se=9999-12-31T23%3a59%3a59Z&sp=r&api-version=2016-02-19
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 34359738880/34359738880
+      X-Ms-Copy-Completion-Time:
+      - Thu, 04 May 2017 21:21:56 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Wed, 30 Aug 2017 15:32:45 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        6w==
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:32:44 GMT
+- request:
+    method: post
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
+    body:
+      encoding: UTF-8
+      string: '{"access":"read","durationInSeconds":3600}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NjQsIm5iZiI6MTUwNDEwNjg2NCwiZXhwIjoxNTA0MTEwNzY0LCJhaW8iOiJZMkZnWVBqLzRYTjFuNkFMejlKNUVwZHI1UEt2QVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ294MmhkenNLRTJya0xfcl9mRVBBQSIsInZlciI6IjEuMCJ9.k4UopyB477zu2YQTSdt6CzZ7RrltPz3eaxWD19cifTMA5bTu_uYZLWe6ZjjUgYlhiJxs0d321kt4QCvrSc154heH9KHA-cPt9LCdE9zLDkQY56xQH8MuRBJbsquyplJkgVIdRWzp4wc-EqWe4syInE7184o4bIueCEASZbHQ5YKQgKw05XEm-bRv3tZYL7zd2fwXEOikY7ZkgDHTdzwhzAuDz-c46JL49N_A-uQUtuJGMztMkiOyhiWOpu1C6oAqWGnCnJ8Ek_qKef-ngjCiazlQhAHaKufLtaB7n0ipcc8G7IwD78gzCIoVC5CPzfnYCdRhp0XyAjnviApEowS3Ag
+      Content-Length:
+      - '42'
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '0'
+      Expires:
+      - "-1"
+      Location:
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/56d050b4-b018-40ab-bb0f-8cf7636a14ef?monitor=true&api-version=2017-03-30
+      Azure-Asyncoperation:
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/56d050b4-b018-40ab-bb0f-8cf7636a14ef?api-version=2017-03-30
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      X-Ms-Request-Id:
+      - 56d050b4-b018-40ab-bb0f-8cf7636a14ef
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Writes:
+      - '1196'
+      X-Ms-Correlation-Request-Id:
+      - efce6320-d0bc-41b6-9573-e680bd8ed9ce
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153246Z:efce6320-d0bc-41b6-9573-e680bd8ed9ce
+      Date:
+      - Wed, 30 Aug 2017 15:32:45 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:32:44 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/56d050b4-b018-40ab-bb0f-8cf7636a14ef?api-version=2017-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NjQsIm5iZiI6MTUwNDEwNjg2NCwiZXhwIjoxNTA0MTEwNzY0LCJhaW8iOiJZMkZnWVBqLzRYTjFuNkFMejlKNUVwZHI1UEt2QVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ294MmhkenNLRTJya0xfcl9mRVBBQSIsInZlciI6IjEuMCJ9.k4UopyB477zu2YQTSdt6CzZ7RrltPz3eaxWD19cifTMA5bTu_uYZLWe6ZjjUgYlhiJxs0d321kt4QCvrSc154heH9KHA-cPt9LCdE9zLDkQY56xQH8MuRBJbsquyplJkgVIdRWzp4wc-EqWe4syInE7184o4bIueCEASZbHQ5YKQgKw05XEm-bRv3tZYL7zd2fwXEOikY7ZkgDHTdzwhzAuDz-c46JL49N_A-uQUtuJGMztMkiOyhiWOpu1C6oAqWGnCnJ8Ek_qKef-ngjCiazlQhAHaKufLtaB7n0ipcc8G7IwD78gzCIoVC5CPzfnYCdRhp0XyAjnviApEowS3Ag
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      X-Ms-Request-Id:
+      - d8e0ebd3-b72a-46f6-b52f-2ea6fff4d70c
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14939'
+      X-Ms-Correlation-Request-Id:
+      - 1ccc026d-2530-4e74-a0cb-7af45797bafc
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153246Z:1ccc026d-2530-4e74-a0cb-7af45797bafc
+      Date:
+      - Wed, 30 Aug 2017 15:32:46 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"startTime\": \"2017-08-30T15:32:45.7145987+00:00\",\r\n  \"endTime\":
+        \"2017-08-30T15:32:45.9177214+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=f9dfc9b5-b109-46f8-bb83-520d792307af&sig=cEfBukRKE51LpIR7i8zmui277FD%2BskZxe63nNUGV2Ug%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"56d050b4-b018-40ab-bb0f-8cf7636a14ef\"\r\n}"
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:32:44 GMT
+- request:
+    method: get
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=f9dfc9b5-b109-46f8-bb83-520d792307af&sig=cEfBukRKE51LpIR7i8zmui277FD%2BskZxe63nNUGV2Ug=&sr=b&sv=2016-05-31
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      X-Ms-Range:
+      - bytes=440-443
+      Host:
+      - md-t4jdgqqlgszp.blob.core.windows.net
+  response:
+    status:
+      code: 206
+      message: Partial Content
+    headers:
+      Content-Length:
+      - '4'
+      Content-Type:
+      - application/octet-stream
+      Content-Range:
+      - bytes 440-443/34359738880
+      Last-Modified:
+      - Sat, 15 Jul 2017 14:23:07 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D4CB8D039FC699"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 3cc3b64e-0001-0091-01a5-21359c000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Meta-Pirtag:
+      - '1'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '20'
+      X-Ms-Copy-Id:
+      - 30cedd78-548a-4fd8-967e-f8344f587e3c
+      X-Ms-Copy-Source:
+      - http://md-t4jdgqqlgszp.blob.core.windows.net:8080/fg25xxtqx0gc/abcd?sv=2016-02-19&sr=b&st=2017-05-04T21%3a06%3a57Z&se=9999-12-31T23%3a59%3a59Z&sp=r&api-version=2016-02-19
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 34359738880/34359738880
+      X-Ms-Copy-Completion-Time:
+      - Thu, 04 May 2017 21:21:56 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Wed, 30 Aug 2017 15:32:46 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        U5MJAA==
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:32:45 GMT
+- request:
+    method: post
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
+    body:
+      encoding: UTF-8
+      string: '{"access":"read","durationInSeconds":3600}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NjQsIm5iZiI6MTUwNDEwNjg2NCwiZXhwIjoxNTA0MTEwNzY0LCJhaW8iOiJZMkZnWVBqLzRYTjFuNkFMejlKNUVwZHI1UEt2QVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ294MmhkenNLRTJya0xfcl9mRVBBQSIsInZlciI6IjEuMCJ9.k4UopyB477zu2YQTSdt6CzZ7RrltPz3eaxWD19cifTMA5bTu_uYZLWe6ZjjUgYlhiJxs0d321kt4QCvrSc154heH9KHA-cPt9LCdE9zLDkQY56xQH8MuRBJbsquyplJkgVIdRWzp4wc-EqWe4syInE7184o4bIueCEASZbHQ5YKQgKw05XEm-bRv3tZYL7zd2fwXEOikY7ZkgDHTdzwhzAuDz-c46JL49N_A-uQUtuJGMztMkiOyhiWOpu1C6oAqWGnCnJ8Ek_qKef-ngjCiazlQhAHaKufLtaB7n0ipcc8G7IwD78gzCIoVC5CPzfnYCdRhp0XyAjnviApEowS3Ag
+      Content-Length:
+      - '42'
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '0'
+      Expires:
+      - "-1"
+      Location:
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/3f43c282-980e-4ff9-a71c-8ce04f2491d8?monitor=true&api-version=2017-03-30
+      Azure-Asyncoperation:
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/3f43c282-980e-4ff9-a71c-8ce04f2491d8?api-version=2017-03-30
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      X-Ms-Request-Id:
+      - 3f43c282-980e-4ff9-a71c-8ce04f2491d8
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Writes:
+      - '1196'
+      X-Ms-Correlation-Request-Id:
+      - 8e607d5a-2994-4bb9-b73e-740f3510538c
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153246Z:8e607d5a-2994-4bb9-b73e-740f3510538c
+      Date:
+      - Wed, 30 Aug 2017 15:32:46 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:32:45 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/3f43c282-980e-4ff9-a71c-8ce04f2491d8?api-version=2017-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NjQsIm5iZiI6MTUwNDEwNjg2NCwiZXhwIjoxNTA0MTEwNzY0LCJhaW8iOiJZMkZnWVBqLzRYTjFuNkFMejlKNUVwZHI1UEt2QVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ294MmhkenNLRTJya0xfcl9mRVBBQSIsInZlciI6IjEuMCJ9.k4UopyB477zu2YQTSdt6CzZ7RrltPz3eaxWD19cifTMA5bTu_uYZLWe6ZjjUgYlhiJxs0d321kt4QCvrSc154heH9KHA-cPt9LCdE9zLDkQY56xQH8MuRBJbsquyplJkgVIdRWzp4wc-EqWe4syInE7184o4bIueCEASZbHQ5YKQgKw05XEm-bRv3tZYL7zd2fwXEOikY7ZkgDHTdzwhzAuDz-c46JL49N_A-uQUtuJGMztMkiOyhiWOpu1C6oAqWGnCnJ8Ek_qKef-ngjCiazlQhAHaKufLtaB7n0ipcc8G7IwD78gzCIoVC5CPzfnYCdRhp0XyAjnviApEowS3Ag
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      X-Ms-Request-Id:
+      - ec48266f-c237-4319-95e4-230aaf5aceaa
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14944'
+      X-Ms-Correlation-Request-Id:
+      - 63ee316d-6f13-4788-b5ce-d7ac8d5a0cfd
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153247Z:63ee316d-6f13-4788-b5ce-d7ac8d5a0cfd
+      Date:
+      - Wed, 30 Aug 2017 15:32:46 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"startTime\": \"2017-08-30T15:32:46.4020995+00:00\",\r\n  \"endTime\":
+        \"2017-08-30T15:32:46.5427124+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=a7669576-363e-4103-a0e5-5b878e60e372&sig=NPos%2F4XLvV8otyeYoU0E2d2E8qkiwQeN1RKRWmWJ9MM%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"3f43c282-980e-4ff9-a71c-8ce04f2491d8\"\r\n}"
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:32:45 GMT
+- request:
+    method: get
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=a7669576-363e-4103-a0e5-5b878e60e372&sig=NPos/4XLvV8otyeYoU0E2d2E8qkiwQeN1RKRWmWJ9MM=&sr=b&sv=2016-05-31
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      X-Ms-Range:
+      - bytes=0-511
+      Host:
+      - md-t4jdgqqlgszp.blob.core.windows.net
+  response:
+    status:
+      code: 206
+      message: Partial Content
+    headers:
+      Content-Length:
+      - '512'
+      Content-Type:
+      - application/octet-stream
+      Content-Range:
+      - bytes 0-511/34359738880
+      Last-Modified:
+      - Sat, 15 Jul 2017 14:23:07 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D4CB8D039FC699"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 0ea0e40c-0001-00c0-4aa5-212b69000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Meta-Pirtag:
+      - '1'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '20'
+      X-Ms-Copy-Id:
+      - 30cedd78-548a-4fd8-967e-f8344f587e3c
+      X-Ms-Copy-Source:
+      - http://md-t4jdgqqlgszp.blob.core.windows.net:8080/fg25xxtqx0gc/abcd?sv=2016-02-19&sr=b&st=2017-05-04T21%3a06%3a57Z&se=9999-12-31T23%3a59%3a59Z&sp=r&api-version=2016-02-19
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 34359738880/34359738880
+      X-Ms-Copy-Completion-Time:
+      - Thu, 04 May 2017 21:21:56 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Wed, 30 Aug 2017 15:32:47 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        62OQEI7QvACwuAAAjtiOwPu+AHy/AAa5AALzpOohBgAAvr4HOAR1C4PGEIH+/gd18+sWtAKwAbsAfLKAinQBi0wCzRPqAHwAAOv+AAAAAAAAAAAAAAAAAAAAAIABAAAAAAAAAP/6kJD2woB0BfbCcHQCsoDqeXwAADHAjtiO0LwAIPugZHw8/3QCiMJSvgV8tEG7qlXNE1pScj2B+1WqdTeD4QF0MjHAiUQEQIhE/4lEAscEEABmix5cfGaJXAhmix5gfGaJXAzHRAYAcLRCzRNyBbsAcOt2tAjNE3MNWoTSD4PeAL6FfemCAGYPtsaIZP9AZolEBA+20cHiAojoiPRAiUQID7bCwOgCZokEZqFgfGYJwHVOZqFcfGYx0mb3NIjRMdJm93QEO0QIfTf+wYjFMMDB6AIIwYjQWojGuwBwjsMx27gBAs0Tch6Mw2AeuQABjtsx9r8AgI7G/POlH2H/Jlp8voB96wO+j33oNAC+lH3oLgDNGOv+R1JVQiAAR2VvbQBIYXJkIERpc2sAUmVhZAAgRXJyb3INCgC7AQC0Ds0QrDwAdfTDAAAAAAAAAAAAAAAAAABTkwkAAACAICEAg90ePwAIAAAAoA8AAN0fP4P+//8AqA8AAFjwAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVao=
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:32:45 GMT
+recorded_with: VCR 3.0.3

--- a/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_getPartitions-1.yml
+++ b/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_getPartitions-1.yml
@@ -39,25 +39,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 85768c0a-ecdc-4d28-ab90-bfebfdf10f00
+      - c113d331-f1f1-4005-889d-e55e61e11100
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAAA9kTklhVy7SJTGAzR-p1BcECN_HAlfUdtrNfVGvWSq0uzVl7FAicGZtP1xxBNbDicVp-E4TXJ4PP3PAp1IhDgn5lIR0QLnnJG5yVjzN_OxiuFdIISUe3gad8KA3ecIjSWC7SZGpJC2sV1vWFf0yATZIkKskYcvz8meeC1ZQwI3-Oui80uktzAWQHzTXu6Zs9wgAA;
+      - esctx=AQABAAAAAAA9kTklhVy7SJTGAzR-p1Bcj-aR0E-SxQelLCsRAurhm8mG_UEUIULjwOZcC3q8YW5lzea-r3xtl4YkFK7UZ-HCKjcXp1P5nD8EIWSWNTHgy_zKWepzSRkGo1rSeTHSBfZiL7q2-REXc6gyxYx3wQLtiLfthbOHsrYEjsQYyApdUtRNy6gxsjKw4N3t-YLW_dcgAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
       - x-ms-gateway-slice=002; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Wed, 30 Aug 2017 15:32:44 GMT
+      - Wed, 30 Aug 2017 17:05:27 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3600","ext_expires_in":"0","expires_on":"1504110764","not_before":"1504106864","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NjQsIm5iZiI6MTUwNDEwNjg2NCwiZXhwIjoxNTA0MTEwNzY0LCJhaW8iOiJZMkZnWVBqLzRYTjFuNkFMejlKNUVwZHI1UEt2QVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ294MmhkenNLRTJya0xfcl9mRVBBQSIsInZlciI6IjEuMCJ9.k4UopyB477zu2YQTSdt6CzZ7RrltPz3eaxWD19cifTMA5bTu_uYZLWe6ZjjUgYlhiJxs0d321kt4QCvrSc154heH9KHA-cPt9LCdE9zLDkQY56xQH8MuRBJbsquyplJkgVIdRWzp4wc-EqWe4syInE7184o4bIueCEASZbHQ5YKQgKw05XEm-bRv3tZYL7zd2fwXEOikY7ZkgDHTdzwhzAuDz-c46JL49N_A-uQUtuJGMztMkiOyhiWOpu1C6oAqWGnCnJ8Ek_qKef-ngjCiazlQhAHaKufLtaB7n0ipcc8G7IwD78gzCIoVC5CPzfnYCdRhp0XyAjnviApEowS3Ag"}'
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1504116327","not_before":"1504112427","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MjcsIm5iZiI6MTUwNDExMjQyNywiZXhwIjoxNTA0MTE2MzI3LCJhaW8iOiJZMkZnWUZoNnRDd3VhRUZqOG1sMTNpbU8yWngzQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTWRNVHdmSHhCVUNJbmVWZVllRVJBQSIsInZlciI6IjEuMCJ9.fS6RpMUoJj8GLNYXejCZzHlO4VAvCJkriDrkw_ZNDxB5cOKdjwkRXWRVkgE8t9Nh9GxLFcBtmWgdunT0vjD7BIvR2cmh6terDfn7WIqsSW1mkAHbHU84dU7zn1EbP95viS_7PkNnqfps-6pg_ndvsNzEW2YDKKEbSvxZko0twbPUto5rAxKRzob55-tu8Lw_zFGmT_q8IywkVw0qkn3iPwX4MEjby3hiCMbHjoutTwuE3DTDSlO8SjJZVdARLDWJG1pEZ81QpjY1SUgqENJA__MWUsWSJsjsg0seJF5PVVPfvvT2Ze_I9J3OJmwI44CDEYkxe5rrd2-h2VCeJobaLw"}'
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:32:41 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:26 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -74,7 +74,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NjQsIm5iZiI6MTUwNDEwNjg2NCwiZXhwIjoxNTA0MTEwNzY0LCJhaW8iOiJZMkZnWVBqLzRYTjFuNkFMejlKNUVwZHI1UEt2QVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ294MmhkenNLRTJya0xfcl9mRVBBQSIsInZlciI6IjEuMCJ9.k4UopyB477zu2YQTSdt6CzZ7RrltPz3eaxWD19cifTMA5bTu_uYZLWe6ZjjUgYlhiJxs0d321kt4QCvrSc154heH9KHA-cPt9LCdE9zLDkQY56xQH8MuRBJbsquyplJkgVIdRWzp4wc-EqWe4syInE7184o4bIueCEASZbHQ5YKQgKw05XEm-bRv3tZYL7zd2fwXEOikY7ZkgDHTdzwhzAuDz-c46JL49N_A-uQUtuJGMztMkiOyhiWOpu1C6oAqWGnCnJ8Ek_qKef-ngjCiazlQhAHaKufLtaB7n0ipcc8G7IwD78gzCIoVC5CPzfnYCdRhp0XyAjnviApEowS3Ag
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MjcsIm5iZiI6MTUwNDExMjQyNywiZXhwIjoxNTA0MTE2MzI3LCJhaW8iOiJZMkZnWUZoNnRDd3VhRUZqOG1sMTNpbU8yWngzQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTWRNVHdmSHhCVUNJbmVWZVllRVJBQSIsInZlciI6IjEuMCJ9.fS6RpMUoJj8GLNYXejCZzHlO4VAvCJkriDrkw_ZNDxB5cOKdjwkRXWRVkgE8t9Nh9GxLFcBtmWgdunT0vjD7BIvR2cmh6terDfn7WIqsSW1mkAHbHU84dU7zn1EbP95viS_7PkNnqfps-6pg_ndvsNzEW2YDKKEbSvxZko0twbPUto5rAxKRzob55-tu8Lw_zFGmT_q8IywkVw0qkn3iPwX4MEjby3hiCMbHjoutTwuE3DTDSlO8SjJZVdARLDWJG1pEZ81QpjY1SUgqENJA__MWUsWSJsjsg0seJF5PVVPfvvT2Ze_I9J3OJmwI44CDEYkxe5rrd2-h2VCeJobaLw
       Host:
       - management.azure.com
   response:
@@ -95,23 +95,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14998'
+      - '14996'
       X-Ms-Request-Id:
-      - 437288fe-63f3-4f03-bc4c-d53ea2b83dcf
+      - 9f1004c8-46d4-488b-ac73-5c4fefe680a9
       X-Ms-Correlation-Request-Id:
-      - 437288fe-63f3-4f03-bc4c-d53ea2b83dcf
+      - 9f1004c8-46d4-488b-ac73-5c4fefe680a9
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153243Z:437288fe-63f3-4f03-bc4c-d53ea2b83dcf
+      - EASTUS:20170830T170527Z:9f1004c8-46d4-488b-ac73-5c4fefe680a9
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 30 Aug 2017 15:32:42 GMT
+      - Wed, 30 Aug 2017 17:05:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:32:42 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:26 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/azure_subscription_id/providers?api-version=2015-01-01
@@ -128,7 +128,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NjQsIm5iZiI6MTUwNDEwNjg2NCwiZXhwIjoxNTA0MTEwNzY0LCJhaW8iOiJZMkZnWVBqLzRYTjFuNkFMejlKNUVwZHI1UEt2QVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ294MmhkenNLRTJya0xfcl9mRVBBQSIsInZlciI6IjEuMCJ9.k4UopyB477zu2YQTSdt6CzZ7RrltPz3eaxWD19cifTMA5bTu_uYZLWe6ZjjUgYlhiJxs0d321kt4QCvrSc154heH9KHA-cPt9LCdE9zLDkQY56xQH8MuRBJbsquyplJkgVIdRWzp4wc-EqWe4syInE7184o4bIueCEASZbHQ5YKQgKw05XEm-bRv3tZYL7zd2fwXEOikY7ZkgDHTdzwhzAuDz-c46JL49N_A-uQUtuJGMztMkiOyhiWOpu1C6oAqWGnCnJ8Ek_qKef-ngjCiazlQhAHaKufLtaB7n0ipcc8G7IwD78gzCIoVC5CPzfnYCdRhp0XyAjnviApEowS3Ag
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MjcsIm5iZiI6MTUwNDExMjQyNywiZXhwIjoxNTA0MTE2MzI3LCJhaW8iOiJZMkZnWUZoNnRDd3VhRUZqOG1sMTNpbU8yWngzQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTWRNVHdmSHhCVUNJbmVWZVllRVJBQSIsInZlciI6IjEuMCJ9.fS6RpMUoJj8GLNYXejCZzHlO4VAvCJkriDrkw_ZNDxB5cOKdjwkRXWRVkgE8t9Nh9GxLFcBtmWgdunT0vjD7BIvR2cmh6terDfn7WIqsSW1mkAHbHU84dU7zn1EbP95viS_7PkNnqfps-6pg_ndvsNzEW2YDKKEbSvxZko0twbPUto5rAxKRzob55-tu8Lw_zFGmT_q8IywkVw0qkn3iPwX4MEjby3hiCMbHjoutTwuE3DTDSlO8SjJZVdARLDWJG1pEZ81QpjY1SUgqENJA__MWUsWSJsjsg0seJF5PVVPfvvT2Ze_I9J3OJmwI44CDEYkxe5rrd2-h2VCeJobaLw
       Host:
       - management.azure.com
   response:
@@ -147,17 +147,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14945'
+      - '14940'
       X-Ms-Request-Id:
-      - e8896fed-1546-485e-b00e-88ea14b0e5cd
+      - d1769e4c-d056-46d9-8ad8-11754da502a5
       X-Ms-Correlation-Request-Id:
-      - e8896fed-1546-485e-b00e-88ea14b0e5cd
+      - d1769e4c-d056-46d9-8ad8-11754da502a5
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153244Z:e8896fed-1546-485e-b00e-88ea14b0e5cd
+      - EASTUS:20170830T170527Z:d1769e4c-d056-46d9-8ad8-11754da502a5
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 30 Aug 2017 15:32:43 GMT
+      - Wed, 30 Aug 2017 17:05:26 GMT
       Content-Length:
       - '241615'
     body:
@@ -1891,7 +1891,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:32:43 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:26 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
@@ -1908,7 +1908,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NjQsIm5iZiI6MTUwNDEwNjg2NCwiZXhwIjoxNTA0MTEwNzY0LCJhaW8iOiJZMkZnWVBqLzRYTjFuNkFMejlKNUVwZHI1UEt2QVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ294MmhkenNLRTJya0xfcl9mRVBBQSIsInZlciI6IjEuMCJ9.k4UopyB477zu2YQTSdt6CzZ7RrltPz3eaxWD19cifTMA5bTu_uYZLWe6ZjjUgYlhiJxs0d321kt4QCvrSc154heH9KHA-cPt9LCdE9zLDkQY56xQH8MuRBJbsquyplJkgVIdRWzp4wc-EqWe4syInE7184o4bIueCEASZbHQ5YKQgKw05XEm-bRv3tZYL7zd2fwXEOikY7ZkgDHTdzwhzAuDz-c46JL49N_A-uQUtuJGMztMkiOyhiWOpu1C6oAqWGnCnJ8Ek_qKef-ngjCiazlQhAHaKufLtaB7n0ipcc8G7IwD78gzCIoVC5CPzfnYCdRhp0XyAjnviApEowS3Ag
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MjcsIm5iZiI6MTUwNDExMjQyNywiZXhwIjoxNTA0MTE2MzI3LCJhaW8iOiJZMkZnWUZoNnRDd3VhRUZqOG1sMTNpbU8yWngzQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTWRNVHdmSHhCVUNJbmVWZVllRVJBQSIsInZlciI6IjEuMCJ9.fS6RpMUoJj8GLNYXejCZzHlO4VAvCJkriDrkw_ZNDxB5cOKdjwkRXWRVkgE8t9Nh9GxLFcBtmWgdunT0vjD7BIvR2cmh6terDfn7WIqsSW1mkAHbHU84dU7zn1EbP95viS_7PkNnqfps-6pg_ndvsNzEW2YDKKEbSvxZko0twbPUto5rAxKRzob55-tu8Lw_zFGmT_q8IywkVw0qkn3iPwX4MEjby3hiCMbHjoutTwuE3DTDSlO8SjJZVdARLDWJG1pEZ81QpjY1SUgqENJA__MWUsWSJsjsg0seJF5PVVPfvvT2Ze_I9J3OJmwI44CDEYkxe5rrd2-h2VCeJobaLw
       Content-Length:
       - '42'
       Host:
@@ -1927,34 +1927,34 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/0dfdf4f2-fc6a-4a5a-bb69-5bca0dd6194a?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/b680307b-2a01-4988-9992-4b40414caff8?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/0dfdf4f2-fc6a-4a5a-bb69-5bca0dd6194a?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/b680307b-2a01-4988-9992-4b40414caff8?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
       - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
       X-Ms-Request-Id:
-      - 0dfdf4f2-fc6a-4a5a-bb69-5bca0dd6194a
+      - b680307b-2a01-4988-9992-4b40414caff8
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1199'
+      - '1194'
       X-Ms-Correlation-Request-Id:
-      - d98812a0-824d-4f18-93ac-9eadbf614bce
+      - 19521447-4984-4c1d-a5f9-f5a7f3afa8d7
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153245Z:d98812a0-824d-4f18-93ac-9eadbf614bce
+      - EASTUS:20170830T170528Z:19521447-4984-4c1d-a5f9-f5a7f3afa8d7
       Date:
-      - Wed, 30 Aug 2017 15:32:45 GMT
+      - Wed, 30 Aug 2017 17:05:28 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:32:43 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:27 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/0dfdf4f2-fc6a-4a5a-bb69-5bca0dd6194a?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/b680307b-2a01-4988-9992-4b40414caff8?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -1968,7 +1968,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NjQsIm5iZiI6MTUwNDEwNjg2NCwiZXhwIjoxNTA0MTEwNzY0LCJhaW8iOiJZMkZnWVBqLzRYTjFuNkFMejlKNUVwZHI1UEt2QVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ294MmhkenNLRTJya0xfcl9mRVBBQSIsInZlciI6IjEuMCJ9.k4UopyB477zu2YQTSdt6CzZ7RrltPz3eaxWD19cifTMA5bTu_uYZLWe6ZjjUgYlhiJxs0d321kt4QCvrSc154heH9KHA-cPt9LCdE9zLDkQY56xQH8MuRBJbsquyplJkgVIdRWzp4wc-EqWe4syInE7184o4bIueCEASZbHQ5YKQgKw05XEm-bRv3tZYL7zd2fwXEOikY7ZkgDHTdzwhzAuDz-c46JL49N_A-uQUtuJGMztMkiOyhiWOpu1C6oAqWGnCnJ8Ek_qKef-ngjCiazlQhAHaKufLtaB7n0ipcc8G7IwD78gzCIoVC5CPzfnYCdRhp0XyAjnviApEowS3Ag
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MjcsIm5iZiI6MTUwNDExMjQyNywiZXhwIjoxNTA0MTE2MzI3LCJhaW8iOiJZMkZnWUZoNnRDd3VhRUZqOG1sMTNpbU8yWngzQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTWRNVHdmSHhCVUNJbmVWZVllRVJBQSIsInZlciI6IjEuMCJ9.fS6RpMUoJj8GLNYXejCZzHlO4VAvCJkriDrkw_ZNDxB5cOKdjwkRXWRVkgE8t9Nh9GxLFcBtmWgdunT0vjD7BIvR2cmh6terDfn7WIqsSW1mkAHbHU84dU7zn1EbP95viS_7PkNnqfps-6pg_ndvsNzEW2YDKKEbSvxZko0twbPUto5rAxKRzob55-tu8Lw_zFGmT_q8IywkVw0qkn3iPwX4MEjby3hiCMbHjoutTwuE3DTDSlO8SjJZVdARLDWJG1pEZ81QpjY1SUgqENJA__MWUsWSJsjsg0seJF5PVVPfvvT2Ze_I9J3OJmwI44CDEYkxe5rrd2-h2VCeJobaLw
       Host:
       - management.azure.com
   response:
@@ -1993,29 +1993,29 @@ http_interactions:
       X-Ms-Served-By:
       - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
       X-Ms-Request-Id:
-      - 0440c5c2-f684-4519-b374-4659c1d7148d
+      - 29af642b-a27c-4608-990f-b22501e1afd8
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14250'
+      - '14925'
       X-Ms-Correlation-Request-Id:
-      - c6310fc4-972c-46d0-88c7-446e343556a8
+      - fd247a6a-1ec4-4bcb-9a0d-30b4c3b12b0c
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153245Z:c6310fc4-972c-46d0-88c7-446e343556a8
+      - EASTUS:20170830T170528Z:fd247a6a-1ec4-4bcb-9a0d-30b4c3b12b0c
       Date:
-      - Wed, 30 Aug 2017 15:32:45 GMT
+      - Wed, 30 Aug 2017 17:05:28 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-08-30T15:32:44.8708387+00:00\",\r\n  \"endTime\":
-        \"2017-08-30T15:32:45.089597+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=a3ec3e87-1079-4783-9091-72aa44d4825d&sig=OOXHRlrALSzdjcv68aa4diCr3TbHL0fazJ%2BUdTHRw%2Fo%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"0dfdf4f2-fc6a-4a5a-bb69-5bca0dd6194a\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2017-08-30T17:05:27.9216483+00:00\",\r\n  \"endTime\":
+        \"2017-08-30T17:05:28.0622372+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=65225d80-aa0f-4431-b3b8-43324789aef3&sig=Qtsp2dFNqOGAsB1kQRpeOWX65Vp0ShYyQGgn%2FAfUWEU%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"b680307b-2a01-4988-9992-4b40414caff8\"\r\n}"
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:32:44 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:27 GMT
 - request:
     method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=a3ec3e87-1079-4783-9091-72aa44d4825d&sig=OOXHRlrALSzdjcv68aa4diCr3TbHL0fazJ%2BUdTHRw/o=&sr=b&sv=2016-05-31
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=65225d80-aa0f-4431-b3b8-43324789aef3&sig=Qtsp2dFNqOGAsB1kQRpeOWX65Vp0ShYyQGgn/AfUWEU=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2050,7 +2050,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - e5943232-0001-0060-80a5-21e40f000000
+      - f9d2be10-0001-00b3-51b2-215baa000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2076,13 +2076,13 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 30 Aug 2017 15:32:45 GMT
+      - Wed, 30 Aug 2017 17:05:27 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         6w==
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:32:44 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:27 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
@@ -2099,7 +2099,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NjQsIm5iZiI6MTUwNDEwNjg2NCwiZXhwIjoxNTA0MTEwNzY0LCJhaW8iOiJZMkZnWVBqLzRYTjFuNkFMejlKNUVwZHI1UEt2QVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ294MmhkenNLRTJya0xfcl9mRVBBQSIsInZlciI6IjEuMCJ9.k4UopyB477zu2YQTSdt6CzZ7RrltPz3eaxWD19cifTMA5bTu_uYZLWe6ZjjUgYlhiJxs0d321kt4QCvrSc154heH9KHA-cPt9LCdE9zLDkQY56xQH8MuRBJbsquyplJkgVIdRWzp4wc-EqWe4syInE7184o4bIueCEASZbHQ5YKQgKw05XEm-bRv3tZYL7zd2fwXEOikY7ZkgDHTdzwhzAuDz-c46JL49N_A-uQUtuJGMztMkiOyhiWOpu1C6oAqWGnCnJ8Ek_qKef-ngjCiazlQhAHaKufLtaB7n0ipcc8G7IwD78gzCIoVC5CPzfnYCdRhp0XyAjnviApEowS3Ag
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MjcsIm5iZiI6MTUwNDExMjQyNywiZXhwIjoxNTA0MTE2MzI3LCJhaW8iOiJZMkZnWUZoNnRDd3VhRUZqOG1sMTNpbU8yWngzQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTWRNVHdmSHhCVUNJbmVWZVllRVJBQSIsInZlciI6IjEuMCJ9.fS6RpMUoJj8GLNYXejCZzHlO4VAvCJkriDrkw_ZNDxB5cOKdjwkRXWRVkgE8t9Nh9GxLFcBtmWgdunT0vjD7BIvR2cmh6terDfn7WIqsSW1mkAHbHU84dU7zn1EbP95viS_7PkNnqfps-6pg_ndvsNzEW2YDKKEbSvxZko0twbPUto5rAxKRzob55-tu8Lw_zFGmT_q8IywkVw0qkn3iPwX4MEjby3hiCMbHjoutTwuE3DTDSlO8SjJZVdARLDWJG1pEZ81QpjY1SUgqENJA__MWUsWSJsjsg0seJF5PVVPfvvT2Ze_I9J3OJmwI44CDEYkxe5rrd2-h2VCeJobaLw
       Content-Length:
       - '42'
       Host:
@@ -2118,34 +2118,34 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/56d050b4-b018-40ab-bb0f-8cf7636a14ef?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/3c6f828e-c4b3-4f60-97ff-c1d074de33fb?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/56d050b4-b018-40ab-bb0f-8cf7636a14ef?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/3c6f828e-c4b3-4f60-97ff-c1d074de33fb?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
       - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
       X-Ms-Request-Id:
-      - 56d050b4-b018-40ab-bb0f-8cf7636a14ef
+      - 3c6f828e-c4b3-4f60-97ff-c1d074de33fb
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1196'
+      - '1197'
       X-Ms-Correlation-Request-Id:
-      - efce6320-d0bc-41b6-9573-e680bd8ed9ce
+      - 85d1e885-ea0e-49d3-bbed-95e33ce8edba
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153246Z:efce6320-d0bc-41b6-9573-e680bd8ed9ce
+      - EASTUS:20170830T170529Z:85d1e885-ea0e-49d3-bbed-95e33ce8edba
       Date:
-      - Wed, 30 Aug 2017 15:32:45 GMT
+      - Wed, 30 Aug 2017 17:05:28 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:32:44 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:28 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/56d050b4-b018-40ab-bb0f-8cf7636a14ef?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/3c6f828e-c4b3-4f60-97ff-c1d074de33fb?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -2159,7 +2159,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NjQsIm5iZiI6MTUwNDEwNjg2NCwiZXhwIjoxNTA0MTEwNzY0LCJhaW8iOiJZMkZnWVBqLzRYTjFuNkFMejlKNUVwZHI1UEt2QVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ294MmhkenNLRTJya0xfcl9mRVBBQSIsInZlciI6IjEuMCJ9.k4UopyB477zu2YQTSdt6CzZ7RrltPz3eaxWD19cifTMA5bTu_uYZLWe6ZjjUgYlhiJxs0d321kt4QCvrSc154heH9KHA-cPt9LCdE9zLDkQY56xQH8MuRBJbsquyplJkgVIdRWzp4wc-EqWe4syInE7184o4bIueCEASZbHQ5YKQgKw05XEm-bRv3tZYL7zd2fwXEOikY7ZkgDHTdzwhzAuDz-c46JL49N_A-uQUtuJGMztMkiOyhiWOpu1C6oAqWGnCnJ8Ek_qKef-ngjCiazlQhAHaKufLtaB7n0ipcc8G7IwD78gzCIoVC5CPzfnYCdRhp0XyAjnviApEowS3Ag
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MjcsIm5iZiI6MTUwNDExMjQyNywiZXhwIjoxNTA0MTE2MzI3LCJhaW8iOiJZMkZnWUZoNnRDd3VhRUZqOG1sMTNpbU8yWngzQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTWRNVHdmSHhCVUNJbmVWZVllRVJBQSIsInZlciI6IjEuMCJ9.fS6RpMUoJj8GLNYXejCZzHlO4VAvCJkriDrkw_ZNDxB5cOKdjwkRXWRVkgE8t9Nh9GxLFcBtmWgdunT0vjD7BIvR2cmh6terDfn7WIqsSW1mkAHbHU84dU7zn1EbP95viS_7PkNnqfps-6pg_ndvsNzEW2YDKKEbSvxZko0twbPUto5rAxKRzob55-tu8Lw_zFGmT_q8IywkVw0qkn3iPwX4MEjby3hiCMbHjoutTwuE3DTDSlO8SjJZVdARLDWJG1pEZ81QpjY1SUgqENJA__MWUsWSJsjsg0seJF5PVVPfvvT2Ze_I9J3OJmwI44CDEYkxe5rrd2-h2VCeJobaLw
       Host:
       - management.azure.com
   response:
@@ -2184,29 +2184,29 @@ http_interactions:
       X-Ms-Served-By:
       - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
       X-Ms-Request-Id:
-      - d8e0ebd3-b72a-46f6-b52f-2ea6fff4d70c
+      - bc9211ce-610c-4235-9581-2dcf07a48e4a
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
       - '14939'
       X-Ms-Correlation-Request-Id:
-      - 1ccc026d-2530-4e74-a0cb-7af45797bafc
+      - c6a8010d-1446-43fc-bb46-e6da09c48817
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153246Z:1ccc026d-2530-4e74-a0cb-7af45797bafc
+      - EASTUS:20170830T170529Z:c6a8010d-1446-43fc-bb46-e6da09c48817
       Date:
-      - Wed, 30 Aug 2017 15:32:46 GMT
+      - Wed, 30 Aug 2017 17:05:28 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-08-30T15:32:45.7145987+00:00\",\r\n  \"endTime\":
-        \"2017-08-30T15:32:45.9177214+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=f9dfc9b5-b109-46f8-bb83-520d792307af&sig=cEfBukRKE51LpIR7i8zmui277FD%2BskZxe63nNUGV2Ug%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"56d050b4-b018-40ab-bb0f-8cf7636a14ef\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2017-08-30T17:05:28.6788131+00:00\",\r\n  \"endTime\":
+        \"2017-08-30T17:05:28.8507041+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=e882ec47-5ae9-4679-b68b-7f11d07d3e65&sig=GkW6bicxzCqVzbmql4HixZImc%2Ba33eeWTtGyML8Ffb0%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"3c6f828e-c4b3-4f60-97ff-c1d074de33fb\"\r\n}"
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:32:44 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:28 GMT
 - request:
     method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=f9dfc9b5-b109-46f8-bb83-520d792307af&sig=cEfBukRKE51LpIR7i8zmui277FD%2BskZxe63nNUGV2Ug=&sr=b&sv=2016-05-31
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=e882ec47-5ae9-4679-b68b-7f11d07d3e65&sig=GkW6bicxzCqVzbmql4HixZImc%2Ba33eeWTtGyML8Ffb0=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2241,7 +2241,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 3cc3b64e-0001-0091-01a5-21359c000000
+      - fd509e84-0001-0038-46b2-21e074000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2267,13 +2267,13 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 30 Aug 2017 15:32:46 GMT
+      - Wed, 30 Aug 2017 17:05:28 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         U5MJAA==
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:32:45 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:28 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
@@ -2290,7 +2290,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NjQsIm5iZiI6MTUwNDEwNjg2NCwiZXhwIjoxNTA0MTEwNzY0LCJhaW8iOiJZMkZnWVBqLzRYTjFuNkFMejlKNUVwZHI1UEt2QVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ294MmhkenNLRTJya0xfcl9mRVBBQSIsInZlciI6IjEuMCJ9.k4UopyB477zu2YQTSdt6CzZ7RrltPz3eaxWD19cifTMA5bTu_uYZLWe6ZjjUgYlhiJxs0d321kt4QCvrSc154heH9KHA-cPt9LCdE9zLDkQY56xQH8MuRBJbsquyplJkgVIdRWzp4wc-EqWe4syInE7184o4bIueCEASZbHQ5YKQgKw05XEm-bRv3tZYL7zd2fwXEOikY7ZkgDHTdzwhzAuDz-c46JL49N_A-uQUtuJGMztMkiOyhiWOpu1C6oAqWGnCnJ8Ek_qKef-ngjCiazlQhAHaKufLtaB7n0ipcc8G7IwD78gzCIoVC5CPzfnYCdRhp0XyAjnviApEowS3Ag
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MjcsIm5iZiI6MTUwNDExMjQyNywiZXhwIjoxNTA0MTE2MzI3LCJhaW8iOiJZMkZnWUZoNnRDd3VhRUZqOG1sMTNpbU8yWngzQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTWRNVHdmSHhCVUNJbmVWZVllRVJBQSIsInZlciI6IjEuMCJ9.fS6RpMUoJj8GLNYXejCZzHlO4VAvCJkriDrkw_ZNDxB5cOKdjwkRXWRVkgE8t9Nh9GxLFcBtmWgdunT0vjD7BIvR2cmh6terDfn7WIqsSW1mkAHbHU84dU7zn1EbP95viS_7PkNnqfps-6pg_ndvsNzEW2YDKKEbSvxZko0twbPUto5rAxKRzob55-tu8Lw_zFGmT_q8IywkVw0qkn3iPwX4MEjby3hiCMbHjoutTwuE3DTDSlO8SjJZVdARLDWJG1pEZ81QpjY1SUgqENJA__MWUsWSJsjsg0seJF5PVVPfvvT2Ze_I9J3OJmwI44CDEYkxe5rrd2-h2VCeJobaLw
       Content-Length:
       - '42'
       Host:
@@ -2309,34 +2309,34 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/3f43c282-980e-4ff9-a71c-8ce04f2491d8?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/2c2e42a3-8efe-4257-ad14-cfc0c272e5ed?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/3f43c282-980e-4ff9-a71c-8ce04f2491d8?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/2c2e42a3-8efe-4257-ad14-cfc0c272e5ed?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
       - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
       X-Ms-Request-Id:
-      - 3f43c282-980e-4ff9-a71c-8ce04f2491d8
+      - 2c2e42a3-8efe-4257-ad14-cfc0c272e5ed
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1196'
+      - '1190'
       X-Ms-Correlation-Request-Id:
-      - 8e607d5a-2994-4bb9-b73e-740f3510538c
+      - 6b6a5b0b-9756-4a11-94b6-46c2be0f8503
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153246Z:8e607d5a-2994-4bb9-b73e-740f3510538c
+      - EASTUS:20170830T170529Z:6b6a5b0b-9756-4a11-94b6-46c2be0f8503
       Date:
-      - Wed, 30 Aug 2017 15:32:46 GMT
+      - Wed, 30 Aug 2017 17:05:29 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:32:45 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:28 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/3f43c282-980e-4ff9-a71c-8ce04f2491d8?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/2c2e42a3-8efe-4257-ad14-cfc0c272e5ed?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -2350,7 +2350,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NjQsIm5iZiI6MTUwNDEwNjg2NCwiZXhwIjoxNTA0MTEwNzY0LCJhaW8iOiJZMkZnWVBqLzRYTjFuNkFMejlKNUVwZHI1UEt2QVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ294MmhkenNLRTJya0xfcl9mRVBBQSIsInZlciI6IjEuMCJ9.k4UopyB477zu2YQTSdt6CzZ7RrltPz3eaxWD19cifTMA5bTu_uYZLWe6ZjjUgYlhiJxs0d321kt4QCvrSc154heH9KHA-cPt9LCdE9zLDkQY56xQH8MuRBJbsquyplJkgVIdRWzp4wc-EqWe4syInE7184o4bIueCEASZbHQ5YKQgKw05XEm-bRv3tZYL7zd2fwXEOikY7ZkgDHTdzwhzAuDz-c46JL49N_A-uQUtuJGMztMkiOyhiWOpu1C6oAqWGnCnJ8Ek_qKef-ngjCiazlQhAHaKufLtaB7n0ipcc8G7IwD78gzCIoVC5CPzfnYCdRhp0XyAjnviApEowS3Ag
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MjcsIm5iZiI6MTUwNDExMjQyNywiZXhwIjoxNTA0MTE2MzI3LCJhaW8iOiJZMkZnWUZoNnRDd3VhRUZqOG1sMTNpbU8yWngzQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTWRNVHdmSHhCVUNJbmVWZVllRVJBQSIsInZlciI6IjEuMCJ9.fS6RpMUoJj8GLNYXejCZzHlO4VAvCJkriDrkw_ZNDxB5cOKdjwkRXWRVkgE8t9Nh9GxLFcBtmWgdunT0vjD7BIvR2cmh6terDfn7WIqsSW1mkAHbHU84dU7zn1EbP95viS_7PkNnqfps-6pg_ndvsNzEW2YDKKEbSvxZko0twbPUto5rAxKRzob55-tu8Lw_zFGmT_q8IywkVw0qkn3iPwX4MEjby3hiCMbHjoutTwuE3DTDSlO8SjJZVdARLDWJG1pEZ81QpjY1SUgqENJA__MWUsWSJsjsg0seJF5PVVPfvvT2Ze_I9J3OJmwI44CDEYkxe5rrd2-h2VCeJobaLw
       Host:
       - management.azure.com
   response:
@@ -2375,29 +2375,29 @@ http_interactions:
       X-Ms-Served-By:
       - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
       X-Ms-Request-Id:
-      - ec48266f-c237-4319-95e4-230aaf5aceaa
+      - 2d74e235-1aa4-47bb-83f4-54b265b0ff04
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14944'
+      - '14916'
       X-Ms-Correlation-Request-Id:
-      - 63ee316d-6f13-4788-b5ce-d7ac8d5a0cfd
+      - ca02d6bd-2db1-4075-9371-304ea8a566b1
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153247Z:63ee316d-6f13-4788-b5ce-d7ac8d5a0cfd
+      - EASTUS:20170830T170530Z:ca02d6bd-2db1-4075-9371-304ea8a566b1
       Date:
-      - Wed, 30 Aug 2017 15:32:46 GMT
+      - Wed, 30 Aug 2017 17:05:29 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-08-30T15:32:46.4020995+00:00\",\r\n  \"endTime\":
-        \"2017-08-30T15:32:46.5427124+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=a7669576-363e-4103-a0e5-5b878e60e372&sig=NPos%2F4XLvV8otyeYoU0E2d2E8qkiwQeN1RKRWmWJ9MM%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"3f43c282-980e-4ff9-a71c-8ce04f2491d8\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2017-08-30T17:05:29.3350428+00:00\",\r\n  \"endTime\":
+        \"2017-08-30T17:05:29.5074679+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=2e08f0eb-6da1-44c0-981a-6e31656c46b8&sig=ha89M%2BUETh1FhisF4UllAVXt%2F%2FZBz6pGbu1jrWyb32I%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"2c2e42a3-8efe-4257-ad14-cfc0c272e5ed\"\r\n}"
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:32:45 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:28 GMT
 - request:
     method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=a7669576-363e-4103-a0e5-5b878e60e372&sig=NPos/4XLvV8otyeYoU0E2d2E8qkiwQeN1RKRWmWJ9MM=&sr=b&sv=2016-05-31
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=2e08f0eb-6da1-44c0-981a-6e31656c46b8&sig=ha89M%2BUETh1FhisF4UllAVXt//ZBz6pGbu1jrWyb32I=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2432,7 +2432,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 0ea0e40c-0001-00c0-4aa5-212b69000000
+      - c28e0d52-0001-00b4-72b2-21ad2f000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2458,11 +2458,11 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 30 Aug 2017 15:32:47 GMT
+      - Wed, 30 Aug 2017 17:05:28 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         62OQEI7QvACwuAAAjtiOwPu+AHy/AAa5AALzpOohBgAAvr4HOAR1C4PGEIH+/gd18+sWtAKwAbsAfLKAinQBi0wCzRPqAHwAAOv+AAAAAAAAAAAAAAAAAAAAAIABAAAAAAAAAP/6kJD2woB0BfbCcHQCsoDqeXwAADHAjtiO0LwAIPugZHw8/3QCiMJSvgV8tEG7qlXNE1pScj2B+1WqdTeD4QF0MjHAiUQEQIhE/4lEAscEEABmix5cfGaJXAhmix5gfGaJXAzHRAYAcLRCzRNyBbsAcOt2tAjNE3MNWoTSD4PeAL6FfemCAGYPtsaIZP9AZolEBA+20cHiAojoiPRAiUQID7bCwOgCZokEZqFgfGYJwHVOZqFcfGYx0mb3NIjRMdJm93QEO0QIfTf+wYjFMMDB6AIIwYjQWojGuwBwjsMx27gBAs0Tch6Mw2AeuQABjtsx9r8AgI7G/POlH2H/Jlp8voB96wO+j33oNAC+lH3oLgDNGOv+R1JVQiAAR2VvbQBIYXJkIERpc2sAUmVhZAAgRXJyb3INCgC7AQC0Ds0QrDwAdfTDAAAAAAAAAAAAAAAAAABTkwkAAACAICEAg90ePwAIAAAAoA8AAN0fP4P+//8AqA8AAFjwAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVao=
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:32:45 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:29 GMT
 recorded_with: VCR 3.0.3

--- a/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_lbaEnd-1.yml
+++ b/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_lbaEnd-1.yml
@@ -39,25 +39,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - d58afa46-5fa0-41b2-8fbf-8aeb72561100
+      - c6e2cbd8-d93b-4bea-977e-af9810221100
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAAA9kTklhVy7SJTGAzR-p1BcuhzImy9DFZLoLQzIt26LnO4l_fUgajLWCjrm1KhXM9WuRa2j_GZHKGrxYrjuRzB7DSLuffcWIQQ1P-ajZIXHC8B8URUT9PE5P7Qbi-zVh__GzHjeHP4OS_WfZLjdSAUwPoQIm24pvYQCVNaD6tLTipRhd2522Y6uWsjT1JHsoxogAA;
+      - esctx=AQABAAAAAAA9kTklhVy7SJTGAzR-p1Bcaph5SsevOv-ft6gttlqASJtfBIoO2E9PQf-IcXjxDRxeL5BmOOs0oVQj0MzO5E-ubVH96_Dkfh7eyJEmGSJY0sDDtu1D6N8f0vEt9mM2S3RWdWyQ_oIsYBnz0ztq-fDC-6gbW9FU3oqM8uBYI8dy-rEse63mwr31Mg2VeKm4vX8gAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=003; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=002; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Wed, 30 Aug 2017 15:33:32 GMT
+      - Wed, 30 Aug 2017 17:05:15 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1504110812","not_before":"1504106912","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY5MTIsIm5iZiI6MTUwNDEwNjkxMiwiZXhwIjoxNTA0MTEwODEyLCJhaW8iOiJZMkZnWURBUUs1LzNQRkNkUDBscXJrSnduOTFtQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUnZxSzFhQmZza0dQdjRycmNsWVJBQSIsInZlciI6IjEuMCJ9.Gnl60wrkF29_vnpRpxzyZjZ2YYaEzLyaibDpmhMCHtNxfTsp_GzxLOCIW47NxTesbPad1ZQvODsVipcp0STUFbjpOy8X9FnO91NnUAycXAyi7KuU_WGiwiyC8QExU-BX6UCrsjhyHoikRe6Rz63m4QcZiqHG0rvM9aO1ugN7032-rfLj64lQk9EIWMoiyfT07w6BL9B3GDUJXbJVKqE4SHsltEAA-5cNA_bfxR0IYQsWO6XCgAISaaxxfMBx-9_8iC_OGI1UmFP2aLn4hDMHSFOdFMRihlhcwhlHs6O1pRlkaClUP_GqGYwmVY28ornNlOpTDl6pjtPWz6HlPVYCtA"}'
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1504116314","not_before":"1504112414","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MTQsIm5iZiI6MTUwNDExMjQxNCwiZXhwIjoxNTA0MTE2MzE0LCJhaW8iOiJZMkZnWVBCeS9lUjNYdnFaWnJxZTIzU1hMNU9LQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMk12aXhqdlo2a3VYZnEtWUVDSVJBQSIsInZlciI6IjEuMCJ9.Nsry4VtoqmP6SCSf7FWQFG7Hed4HoMuLBxuCZFNX2pWp86cc4dSxEcdyH3vUF6gqlmLgbiEejfB_I4SfkfkbWqbiV1PUTpStiAfkWedEVlGKC55j0VsCWJbJ1sVVuMy-BPiCa5tckm_oFNP-nzk90hPAU0r9dXBtVXuXT5t7vHddWCcI5M-tRPgrlJrDkd6UVv3vnuFVToko1vGprHBg331tm1fdIIxzdaP2jehgj2_swvz5xGYvnlv9QGo_qNlgbIsJ2fgkr-Hcg7FOsvBTgTpRNyyi8yJ8LzW5ubkrbiW7yL9QYsS2kIEJml8Ce__RKp0RKj7OxcYVUmeP1Th0lg"}'
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:33:32 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:13 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -74,7 +74,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY5MTIsIm5iZiI6MTUwNDEwNjkxMiwiZXhwIjoxNTA0MTEwODEyLCJhaW8iOiJZMkZnWURBUUs1LzNQRkNkUDBscXJrSnduOTFtQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUnZxSzFhQmZza0dQdjRycmNsWVJBQSIsInZlciI6IjEuMCJ9.Gnl60wrkF29_vnpRpxzyZjZ2YYaEzLyaibDpmhMCHtNxfTsp_GzxLOCIW47NxTesbPad1ZQvODsVipcp0STUFbjpOy8X9FnO91NnUAycXAyi7KuU_WGiwiyC8QExU-BX6UCrsjhyHoikRe6Rz63m4QcZiqHG0rvM9aO1ugN7032-rfLj64lQk9EIWMoiyfT07w6BL9B3GDUJXbJVKqE4SHsltEAA-5cNA_bfxR0IYQsWO6XCgAISaaxxfMBx-9_8iC_OGI1UmFP2aLn4hDMHSFOdFMRihlhcwhlHs6O1pRlkaClUP_GqGYwmVY28ornNlOpTDl6pjtPWz6HlPVYCtA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MTQsIm5iZiI6MTUwNDExMjQxNCwiZXhwIjoxNTA0MTE2MzE0LCJhaW8iOiJZMkZnWVBCeS9lUjNYdnFaWnJxZTIzU1hMNU9LQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMk12aXhqdlo2a3VYZnEtWUVDSVJBQSIsInZlciI6IjEuMCJ9.Nsry4VtoqmP6SCSf7FWQFG7Hed4HoMuLBxuCZFNX2pWp86cc4dSxEcdyH3vUF6gqlmLgbiEejfB_I4SfkfkbWqbiV1PUTpStiAfkWedEVlGKC55j0VsCWJbJ1sVVuMy-BPiCa5tckm_oFNP-nzk90hPAU0r9dXBtVXuXT5t7vHddWCcI5M-tRPgrlJrDkd6UVv3vnuFVToko1vGprHBg331tm1fdIIxzdaP2jehgj2_swvz5xGYvnlv9QGo_qNlgbIsJ2fgkr-Hcg7FOsvBTgTpRNyyi8yJ8LzW5ubkrbiW7yL9QYsS2kIEJml8Ce__RKp0RKj7OxcYVUmeP1Th0lg
       Host:
       - management.azure.com
   response:
@@ -97,21 +97,21 @@ http_interactions:
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
       - '14998'
       X-Ms-Request-Id:
-      - 7576a534-2166-4e26-b70a-d162a8c1d3dc
+      - 6b452c46-4d25-4d7f-9419-95fd984d99a9
       X-Ms-Correlation-Request-Id:
-      - 7576a534-2166-4e26-b70a-d162a8c1d3dc
+      - 6b452c46-4d25-4d7f-9419-95fd984d99a9
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153333Z:7576a534-2166-4e26-b70a-d162a8c1d3dc
+      - EASTUS:20170830T170514Z:6b452c46-4d25-4d7f-9419-95fd984d99a9
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 30 Aug 2017 15:33:33 GMT
+      - Wed, 30 Aug 2017 17:05:14 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:33:32 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:13 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/azure_subscription_id/providers?api-version=2015-01-01
@@ -128,7 +128,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY5MTIsIm5iZiI6MTUwNDEwNjkxMiwiZXhwIjoxNTA0MTEwODEyLCJhaW8iOiJZMkZnWURBUUs1LzNQRkNkUDBscXJrSnduOTFtQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUnZxSzFhQmZza0dQdjRycmNsWVJBQSIsInZlciI6IjEuMCJ9.Gnl60wrkF29_vnpRpxzyZjZ2YYaEzLyaibDpmhMCHtNxfTsp_GzxLOCIW47NxTesbPad1ZQvODsVipcp0STUFbjpOy8X9FnO91NnUAycXAyi7KuU_WGiwiyC8QExU-BX6UCrsjhyHoikRe6Rz63m4QcZiqHG0rvM9aO1ugN7032-rfLj64lQk9EIWMoiyfT07w6BL9B3GDUJXbJVKqE4SHsltEAA-5cNA_bfxR0IYQsWO6XCgAISaaxxfMBx-9_8iC_OGI1UmFP2aLn4hDMHSFOdFMRihlhcwhlHs6O1pRlkaClUP_GqGYwmVY28ornNlOpTDl6pjtPWz6HlPVYCtA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MTQsIm5iZiI6MTUwNDExMjQxNCwiZXhwIjoxNTA0MTE2MzE0LCJhaW8iOiJZMkZnWVBCeS9lUjNYdnFaWnJxZTIzU1hMNU9LQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMk12aXhqdlo2a3VYZnEtWUVDSVJBQSIsInZlciI6IjEuMCJ9.Nsry4VtoqmP6SCSf7FWQFG7Hed4HoMuLBxuCZFNX2pWp86cc4dSxEcdyH3vUF6gqlmLgbiEejfB_I4SfkfkbWqbiV1PUTpStiAfkWedEVlGKC55j0VsCWJbJ1sVVuMy-BPiCa5tckm_oFNP-nzk90hPAU0r9dXBtVXuXT5t7vHddWCcI5M-tRPgrlJrDkd6UVv3vnuFVToko1vGprHBg331tm1fdIIxzdaP2jehgj2_swvz5xGYvnlv9QGo_qNlgbIsJ2fgkr-Hcg7FOsvBTgTpRNyyi8yJ8LzW5ubkrbiW7yL9QYsS2kIEJml8Ce__RKp0RKj7OxcYVUmeP1Th0lg
       Host:
       - management.azure.com
   response:
@@ -147,17 +147,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14938'
+      - '14921'
       X-Ms-Request-Id:
-      - 58927946-c983-44ac-8907-60660513acd5
+      - 290f3ad8-ea9a-41e9-bd2d-84012ab9cee7
       X-Ms-Correlation-Request-Id:
-      - 58927946-c983-44ac-8907-60660513acd5
+      - 290f3ad8-ea9a-41e9-bd2d-84012ab9cee7
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153333Z:58927946-c983-44ac-8907-60660513acd5
+      - EASTUS:20170830T170515Z:290f3ad8-ea9a-41e9-bd2d-84012ab9cee7
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 30 Aug 2017 15:33:33 GMT
+      - Wed, 30 Aug 2017 17:05:14 GMT
       Content-Length:
       - '241615'
     body:
@@ -1891,7 +1891,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:33:33 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:14 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
@@ -1908,7 +1908,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY5MTIsIm5iZiI6MTUwNDEwNjkxMiwiZXhwIjoxNTA0MTEwODEyLCJhaW8iOiJZMkZnWURBUUs1LzNQRkNkUDBscXJrSnduOTFtQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUnZxSzFhQmZza0dQdjRycmNsWVJBQSIsInZlciI6IjEuMCJ9.Gnl60wrkF29_vnpRpxzyZjZ2YYaEzLyaibDpmhMCHtNxfTsp_GzxLOCIW47NxTesbPad1ZQvODsVipcp0STUFbjpOy8X9FnO91NnUAycXAyi7KuU_WGiwiyC8QExU-BX6UCrsjhyHoikRe6Rz63m4QcZiqHG0rvM9aO1ugN7032-rfLj64lQk9EIWMoiyfT07w6BL9B3GDUJXbJVKqE4SHsltEAA-5cNA_bfxR0IYQsWO6XCgAISaaxxfMBx-9_8iC_OGI1UmFP2aLn4hDMHSFOdFMRihlhcwhlHs6O1pRlkaClUP_GqGYwmVY28ornNlOpTDl6pjtPWz6HlPVYCtA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MTQsIm5iZiI6MTUwNDExMjQxNCwiZXhwIjoxNTA0MTE2MzE0LCJhaW8iOiJZMkZnWVBCeS9lUjNYdnFaWnJxZTIzU1hMNU9LQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMk12aXhqdlo2a3VYZnEtWUVDSVJBQSIsInZlciI6IjEuMCJ9.Nsry4VtoqmP6SCSf7FWQFG7Hed4HoMuLBxuCZFNX2pWp86cc4dSxEcdyH3vUF6gqlmLgbiEejfB_I4SfkfkbWqbiV1PUTpStiAfkWedEVlGKC55j0VsCWJbJ1sVVuMy-BPiCa5tckm_oFNP-nzk90hPAU0r9dXBtVXuXT5t7vHddWCcI5M-tRPgrlJrDkd6UVv3vnuFVToko1vGprHBg331tm1fdIIxzdaP2jehgj2_swvz5xGYvnlv9QGo_qNlgbIsJ2fgkr-Hcg7FOsvBTgTpRNyyi8yJ8LzW5ubkrbiW7yL9QYsS2kIEJml8Ce__RKp0RKj7OxcYVUmeP1Th0lg
       Content-Length:
       - '42'
       Host:
@@ -1927,34 +1927,34 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/2bd29d77-0fb4-4995-9d0d-735d021032ab?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/bef69d46-299d-4616-b675-9e6041c14187?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/2bd29d77-0fb4-4995-9d0d-735d021032ab?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/bef69d46-299d-4616-b675-9e6041c14187?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
       - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
       X-Ms-Request-Id:
-      - 2bd29d77-0fb4-4995-9d0d-735d021032ab
+      - bef69d46-299d-4616-b675-9e6041c14187
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
       - '1196'
       X-Ms-Correlation-Request-Id:
-      - 929cf0ff-e378-47ab-82c4-d70cd5a83a35
+      - 30bec479-aa0a-4084-8c72-36f1fb214e6f
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153334Z:929cf0ff-e378-47ab-82c4-d70cd5a83a35
+      - EASTUS:20170830T170515Z:30bec479-aa0a-4084-8c72-36f1fb214e6f
       Date:
-      - Wed, 30 Aug 2017 15:33:33 GMT
+      - Wed, 30 Aug 2017 17:05:15 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:33:33 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:15 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/2bd29d77-0fb4-4995-9d0d-735d021032ab?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/bef69d46-299d-4616-b675-9e6041c14187?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -1968,7 +1968,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY5MTIsIm5iZiI6MTUwNDEwNjkxMiwiZXhwIjoxNTA0MTEwODEyLCJhaW8iOiJZMkZnWURBUUs1LzNQRkNkUDBscXJrSnduOTFtQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUnZxSzFhQmZza0dQdjRycmNsWVJBQSIsInZlciI6IjEuMCJ9.Gnl60wrkF29_vnpRpxzyZjZ2YYaEzLyaibDpmhMCHtNxfTsp_GzxLOCIW47NxTesbPad1ZQvODsVipcp0STUFbjpOy8X9FnO91NnUAycXAyi7KuU_WGiwiyC8QExU-BX6UCrsjhyHoikRe6Rz63m4QcZiqHG0rvM9aO1ugN7032-rfLj64lQk9EIWMoiyfT07w6BL9B3GDUJXbJVKqE4SHsltEAA-5cNA_bfxR0IYQsWO6XCgAISaaxxfMBx-9_8iC_OGI1UmFP2aLn4hDMHSFOdFMRihlhcwhlHs6O1pRlkaClUP_GqGYwmVY28ornNlOpTDl6pjtPWz6HlPVYCtA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MTQsIm5iZiI6MTUwNDExMjQxNCwiZXhwIjoxNTA0MTE2MzE0LCJhaW8iOiJZMkZnWVBCeS9lUjNYdnFaWnJxZTIzU1hMNU9LQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMk12aXhqdlo2a3VYZnEtWUVDSVJBQSIsInZlciI6IjEuMCJ9.Nsry4VtoqmP6SCSf7FWQFG7Hed4HoMuLBxuCZFNX2pWp86cc4dSxEcdyH3vUF6gqlmLgbiEejfB_I4SfkfkbWqbiV1PUTpStiAfkWedEVlGKC55j0VsCWJbJ1sVVuMy-BPiCa5tckm_oFNP-nzk90hPAU0r9dXBtVXuXT5t7vHddWCcI5M-tRPgrlJrDkd6UVv3vnuFVToko1vGprHBg331tm1fdIIxzdaP2jehgj2_swvz5xGYvnlv9QGo_qNlgbIsJ2fgkr-Hcg7FOsvBTgTpRNyyi8yJ8LzW5ubkrbiW7yL9QYsS2kIEJml8Ce__RKp0RKj7OxcYVUmeP1Th0lg
       Host:
       - management.azure.com
   response:
@@ -1993,29 +1993,29 @@ http_interactions:
       X-Ms-Served-By:
       - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
       X-Ms-Request-Id:
-      - 2f5400d2-4b58-4eb0-8ce7-3a4e0f06c75c
+      - 50d9f992-e2c9-417d-99dd-d21ab00b0942
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14937'
+      - '14918'
       X-Ms-Correlation-Request-Id:
-      - 822c35f4-39e1-448c-ba3f-596164b48df4
+      - '08c88aa3-af92-4d75-bd32-3c6e49e2ea5b'
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153334Z:822c35f4-39e1-448c-ba3f-596164b48df4
+      - EASTUS:20170830T170515Z:08c88aa3-af92-4d75-bd32-3c6e49e2ea5b
       Date:
-      - Wed, 30 Aug 2017 15:33:33 GMT
+      - Wed, 30 Aug 2017 17:05:15 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-08-30T15:33:34.0160609+00:00\",\r\n  \"endTime\":
-        \"2017-08-30T15:33:34.2660495+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=febdb61b-8bf4-452b-8dfd-74356f9a3e95&sig=8ZIGSdrvKMyMlYudytdtlx7FcHv%2BG3BjvjbcwlU41tg%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"2bd29d77-0fb4-4995-9d0d-735d021032ab\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2017-08-30T17:05:15.1139814+00:00\",\r\n  \"endTime\":
+        \"2017-08-30T17:05:15.332724+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=7fdb5d81-81fd-47f0-9cf6-87c0b93f0088&sig=QhQw5ZrmllUrKia2v5EneX%2BB0wF7TcH1wIrzJW1NVzY%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"bef69d46-299d-4616-b675-9e6041c14187\"\r\n}"
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:33:34 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:15 GMT
 - request:
     method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=febdb61b-8bf4-452b-8dfd-74356f9a3e95&sig=8ZIGSdrvKMyMlYudytdtlx7FcHv%2BG3BjvjbcwlU41tg=&sr=b&sv=2016-05-31
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=7fdb5d81-81fd-47f0-9cf6-87c0b93f0088&sig=QhQw5ZrmllUrKia2v5EneX%2BB0wF7TcH1wIrzJW1NVzY=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2050,7 +2050,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 441fc7a8-0001-0130-28a5-21bd52000000
+      - d1f4f7ce-0001-0049-74b2-21924d000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2076,13 +2076,13 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 30 Aug 2017 15:33:33 GMT
+      - Wed, 30 Aug 2017 17:05:14 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         6w==
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:33:34 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:15 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
@@ -2099,7 +2099,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY5MTIsIm5iZiI6MTUwNDEwNjkxMiwiZXhwIjoxNTA0MTEwODEyLCJhaW8iOiJZMkZnWURBUUs1LzNQRkNkUDBscXJrSnduOTFtQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUnZxSzFhQmZza0dQdjRycmNsWVJBQSIsInZlciI6IjEuMCJ9.Gnl60wrkF29_vnpRpxzyZjZ2YYaEzLyaibDpmhMCHtNxfTsp_GzxLOCIW47NxTesbPad1ZQvODsVipcp0STUFbjpOy8X9FnO91NnUAycXAyi7KuU_WGiwiyC8QExU-BX6UCrsjhyHoikRe6Rz63m4QcZiqHG0rvM9aO1ugN7032-rfLj64lQk9EIWMoiyfT07w6BL9B3GDUJXbJVKqE4SHsltEAA-5cNA_bfxR0IYQsWO6XCgAISaaxxfMBx-9_8iC_OGI1UmFP2aLn4hDMHSFOdFMRihlhcwhlHs6O1pRlkaClUP_GqGYwmVY28ornNlOpTDl6pjtPWz6HlPVYCtA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MTQsIm5iZiI6MTUwNDExMjQxNCwiZXhwIjoxNTA0MTE2MzE0LCJhaW8iOiJZMkZnWVBCeS9lUjNYdnFaWnJxZTIzU1hMNU9LQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMk12aXhqdlo2a3VYZnEtWUVDSVJBQSIsInZlciI6IjEuMCJ9.Nsry4VtoqmP6SCSf7FWQFG7Hed4HoMuLBxuCZFNX2pWp86cc4dSxEcdyH3vUF6gqlmLgbiEejfB_I4SfkfkbWqbiV1PUTpStiAfkWedEVlGKC55j0VsCWJbJ1sVVuMy-BPiCa5tckm_oFNP-nzk90hPAU0r9dXBtVXuXT5t7vHddWCcI5M-tRPgrlJrDkd6UVv3vnuFVToko1vGprHBg331tm1fdIIxzdaP2jehgj2_swvz5xGYvnlv9QGo_qNlgbIsJ2fgkr-Hcg7FOsvBTgTpRNyyi8yJ8LzW5ubkrbiW7yL9QYsS2kIEJml8Ce__RKp0RKj7OxcYVUmeP1Th0lg
       Content-Length:
       - '42'
       Host:
@@ -2118,34 +2118,34 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/8b7b79e4-774b-4dfe-9ae7-491ce28f755f?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/93c4899d-ce08-4610-8876-28c00c566a59?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/8b7b79e4-774b-4dfe-9ae7-491ce28f755f?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/93c4899d-ce08-4610-8876-28c00c566a59?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
       - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
       X-Ms-Request-Id:
-      - 8b7b79e4-774b-4dfe-9ae7-491ce28f755f
+      - 93c4899d-ce08-4610-8876-28c00c566a59
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
       - '1194'
       X-Ms-Correlation-Request-Id:
-      - 4e611714-daec-4d24-8df2-6618713c7176
+      - de90c554-4efb-4c7a-bb47-87be138617e0
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153335Z:4e611714-daec-4d24-8df2-6618713c7176
+      - EASTUS:20170830T170516Z:de90c554-4efb-4c7a-bb47-87be138617e0
       Date:
-      - Wed, 30 Aug 2017 15:33:35 GMT
+      - Wed, 30 Aug 2017 17:05:16 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:33:34 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:15 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/8b7b79e4-774b-4dfe-9ae7-491ce28f755f?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/93c4899d-ce08-4610-8876-28c00c566a59?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -2159,7 +2159,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY5MTIsIm5iZiI6MTUwNDEwNjkxMiwiZXhwIjoxNTA0MTEwODEyLCJhaW8iOiJZMkZnWURBUUs1LzNQRkNkUDBscXJrSnduOTFtQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUnZxSzFhQmZza0dQdjRycmNsWVJBQSIsInZlciI6IjEuMCJ9.Gnl60wrkF29_vnpRpxzyZjZ2YYaEzLyaibDpmhMCHtNxfTsp_GzxLOCIW47NxTesbPad1ZQvODsVipcp0STUFbjpOy8X9FnO91NnUAycXAyi7KuU_WGiwiyC8QExU-BX6UCrsjhyHoikRe6Rz63m4QcZiqHG0rvM9aO1ugN7032-rfLj64lQk9EIWMoiyfT07w6BL9B3GDUJXbJVKqE4SHsltEAA-5cNA_bfxR0IYQsWO6XCgAISaaxxfMBx-9_8iC_OGI1UmFP2aLn4hDMHSFOdFMRihlhcwhlHs6O1pRlkaClUP_GqGYwmVY28ornNlOpTDl6pjtPWz6HlPVYCtA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MTQsIm5iZiI6MTUwNDExMjQxNCwiZXhwIjoxNTA0MTE2MzE0LCJhaW8iOiJZMkZnWVBCeS9lUjNYdnFaWnJxZTIzU1hMNU9LQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMk12aXhqdlo2a3VYZnEtWUVDSVJBQSIsInZlciI6IjEuMCJ9.Nsry4VtoqmP6SCSf7FWQFG7Hed4HoMuLBxuCZFNX2pWp86cc4dSxEcdyH3vUF6gqlmLgbiEejfB_I4SfkfkbWqbiV1PUTpStiAfkWedEVlGKC55j0VsCWJbJ1sVVuMy-BPiCa5tckm_oFNP-nzk90hPAU0r9dXBtVXuXT5t7vHddWCcI5M-tRPgrlJrDkd6UVv3vnuFVToko1vGprHBg331tm1fdIIxzdaP2jehgj2_swvz5xGYvnlv9QGo_qNlgbIsJ2fgkr-Hcg7FOsvBTgTpRNyyi8yJ8LzW5ubkrbiW7yL9QYsS2kIEJml8Ce__RKp0RKj7OxcYVUmeP1Th0lg
       Host:
       - management.azure.com
   response:
@@ -2184,29 +2184,29 @@ http_interactions:
       X-Ms-Served-By:
       - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
       X-Ms-Request-Id:
-      - 7fef96d9-03bf-4d58-8395-d043974afc7e
+      - 10729555-9427-44ae-bb5d-febacc180928
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14941'
+      - '14263'
       X-Ms-Correlation-Request-Id:
-      - aa8d34b3-8449-4b3d-bead-9a1ddebffc7c
+      - 2f3d55ee-bc66-478b-bca6-3000ec4b2577
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153335Z:aa8d34b3-8449-4b3d-bead-9a1ddebffc7c
+      - EASTUS:20170830T170516Z:2f3d55ee-bc66-478b-bca6-3000ec4b2577
       Date:
-      - Wed, 30 Aug 2017 15:33:34 GMT
+      - Wed, 30 Aug 2017 17:05:15 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-08-30T15:33:34.7192083+00:00\",\r\n  \"endTime\":
-        \"2017-08-30T15:33:34.9691912+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=b7569729-2165-4cb1-be0f-cdf72dd5407f&sig=gwDCLtSV2zcKzCBJknHQll58Fy2tl8eFPArcB5ZjNBA%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"8b7b79e4-774b-4dfe-9ae7-491ce28f755f\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2017-08-30T17:05:15.7702204+00:00\",\r\n  \"endTime\":
+        \"2017-08-30T17:05:15.9733639+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=7193667c-5892-44af-a3e7-6d8765435332&sig=QuEYvqxfiz8cc5zVx1iYQIyUBSjl6wtk%2Ft7EoajGb98%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"93c4899d-ce08-4610-8876-28c00c566a59\"\r\n}"
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:33:34 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:15 GMT
 - request:
     method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=b7569729-2165-4cb1-be0f-cdf72dd5407f&sig=gwDCLtSV2zcKzCBJknHQll58Fy2tl8eFPArcB5ZjNBA=&sr=b&sv=2016-05-31
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=7193667c-5892-44af-a3e7-6d8765435332&sig=QuEYvqxfiz8cc5zVx1iYQIyUBSjl6wtk/t7EoajGb98=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2241,7 +2241,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 0ea1833e-0001-00c0-02a5-212b69000000
+      - e024562f-0001-00eb-80b2-215fd1000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2267,11 +2267,11 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 30 Aug 2017 15:33:35 GMT
+      - Wed, 30 Aug 2017 17:05:16 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         U5MJAA==
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:33:34 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:16 GMT
 recorded_with: VCR 3.0.3

--- a/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_lbaEnd-1.yml
+++ b/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_lbaEnd-1.yml
@@ -1,0 +1,2277 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://login.microsoftonline.com/azure_tenant_id/oauth2/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_key&resource=https%3A%2F%2Fmanagement.azure.com%2F
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - login.microsoftonline.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Server:
+      - Microsoft-IIS/8.5
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Request-Id:
+      - d58afa46-5fa0-41b2-8fbf-8aeb72561100
+      P3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Set-Cookie:
+      - esctx=AQABAAAAAAA9kTklhVy7SJTGAzR-p1BcuhzImy9DFZLoLQzIt26LnO4l_fUgajLWCjrm1KhXM9WuRa2j_GZHKGrxYrjuRzB7DSLuffcWIQQ1P-ajZIXHC8B8URUT9PE5P7Qbi-zVh__GzHjeHP4OS_WfZLjdSAUwPoQIm24pvYQCVNaD6tLTipRhd2522Y6uWsjT1JHsoxogAA;
+        domain=.login.microsoftonline.com; path=/; secure; HttpOnly
+      - stsservicecookie=ests; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=003; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Wed, 30 Aug 2017 15:33:32 GMT
+      Content-Length:
+      - '1505'
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1504110812","not_before":"1504106912","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY5MTIsIm5iZiI6MTUwNDEwNjkxMiwiZXhwIjoxNTA0MTEwODEyLCJhaW8iOiJZMkZnWURBUUs1LzNQRkNkUDBscXJrSnduOTFtQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUnZxSzFhQmZza0dQdjRycmNsWVJBQSIsInZlciI6IjEuMCJ9.Gnl60wrkF29_vnpRpxzyZjZ2YYaEzLyaibDpmhMCHtNxfTsp_GzxLOCIW47NxTesbPad1ZQvODsVipcp0STUFbjpOy8X9FnO91NnUAycXAyi7KuU_WGiwiyC8QExU-BX6UCrsjhyHoikRe6Rz63m4QcZiqHG0rvM9aO1ugN7032-rfLj64lQk9EIWMoiyfT07w6BL9B3GDUJXbJVKqE4SHsltEAA-5cNA_bfxR0IYQsWO6XCgAISaaxxfMBx-9_8iC_OGI1UmFP2aLn4hDMHSFOdFMRihlhcwhlHs6O1pRlkaClUP_GqGYwmVY28ornNlOpTDl6pjtPWz6HlPVYCtA"}'
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:32 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions?api-version=2016-06-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY5MTIsIm5iZiI6MTUwNDEwNjkxMiwiZXhwIjoxNTA0MTEwODEyLCJhaW8iOiJZMkZnWURBUUs1LzNQRkNkUDBscXJrSnduOTFtQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUnZxSzFhQmZza0dQdjRycmNsWVJBQSIsInZlciI6IjEuMCJ9.Gnl60wrkF29_vnpRpxzyZjZ2YYaEzLyaibDpmhMCHtNxfTsp_GzxLOCIW47NxTesbPad1ZQvODsVipcp0STUFbjpOy8X9FnO91NnUAycXAyi7KuU_WGiwiyC8QExU-BX6UCrsjhyHoikRe6Rz63m4QcZiqHG0rvM9aO1ugN7032-rfLj64lQk9EIWMoiyfT07w6BL9B3GDUJXbJVKqE4SHsltEAA-5cNA_bfxR0IYQsWO6XCgAISaaxxfMBx-9_8iC_OGI1UmFP2aLn4hDMHSFOdFMRihlhcwhlHs6O1pRlkaClUP_GqGYwmVY28ornNlOpTDl6pjtPWz6HlPVYCtA
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Tenant-Reads:
+      - '14998'
+      X-Ms-Request-Id:
+      - 7576a534-2166-4e26-b70a-d162a8c1d3dc
+      X-Ms-Correlation-Request-Id:
+      - 7576a534-2166-4e26-b70a-d162a8c1d3dc
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153333Z:7576a534-2166-4e26-b70a-d162a8c1d3dc
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 30 Aug 2017 15:33:33 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
+        Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:32 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers?api-version=2015-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY5MTIsIm5iZiI6MTUwNDEwNjkxMiwiZXhwIjoxNTA0MTEwODEyLCJhaW8iOiJZMkZnWURBUUs1LzNQRkNkUDBscXJrSnduOTFtQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUnZxSzFhQmZza0dQdjRycmNsWVJBQSIsInZlciI6IjEuMCJ9.Gnl60wrkF29_vnpRpxzyZjZ2YYaEzLyaibDpmhMCHtNxfTsp_GzxLOCIW47NxTesbPad1ZQvODsVipcp0STUFbjpOy8X9FnO91NnUAycXAyi7KuU_WGiwiyC8QExU-BX6UCrsjhyHoikRe6Rz63m4QcZiqHG0rvM9aO1ugN7032-rfLj64lQk9EIWMoiyfT07w6BL9B3GDUJXbJVKqE4SHsltEAA-5cNA_bfxR0IYQsWO6XCgAISaaxxfMBx-9_8iC_OGI1UmFP2aLn4hDMHSFOdFMRihlhcwhlHs6O1pRlkaClUP_GqGYwmVY28ornNlOpTDl6pjtPWz6HlPVYCtA
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14938'
+      X-Ms-Request-Id:
+      - 58927946-c983-44ac-8907-60660513acd5
+      X-Ms-Correlation-Request-Id:
+      - 58927946-c983-44ac-8907-60660513acd5
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153333Z:58927946-c983-44ac-8907-60660513acd5
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 30 Aug 2017 15:33:33 GMT
+      Content-Length:
+      - '241615'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","North Central
+        US","South Central US","West Central US","West US","West US 2","Canada Central","Canada
+        East","North Europe","West Europe","UK South","UK West","East Asia","Southeast
+        Asia","Japan East","Japan West","Korea Central","Korea South","Brazil South","Central
+        India","South India","West India"],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"validateServiceName","locations":[],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"checkServiceNameAvailability","locations":[],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"reportFeedback","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"checkFeedbackRequired","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Automation","namespace":"Microsoft.Automation","authorizations":[{"applicationId":"fc75330b-179d-49af-87dd-3b1acf6827fa","roleDefinitionId":"95fd5de3-d071-4362-92bf-cf341c1de832"}],"resourceTypes":[{"resourceType":"automationAccounts","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
+        South","UK South","West Central US","North Europe","Canada Central","Australia
+        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/runbooks","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
+        South","UK South","West Central US","North Europe","Canada Central","Australia
+        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/configurations","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","North
+        Central US","Brazil South","UK South","West Central US","Central India","Australia
+        Southeast","Canada Central","North Europe"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/webhooks","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
+        South","UK South","West Central US","North Europe","Canada Central","Australia
+        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"operations","locations":["South
+        Central US"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/softwareUpdateConfigurations","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
+        South","UK South","West Central US","North Europe","Canada Central","Australia
+        Southeast","Central India"],"apiVersions":["2017-05-15-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Backup","namespace":"Microsoft.Backup","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"BackupVault","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India"],"apiVersions":["2015-03-15","2014-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Batch","namespace":"Microsoft.Batch","authorization":{"applicationId":"ddbf3205-c6bd-46ae-8127-60eb93363864","roleDefinitionId":"b7f84953-1d03-4eab-9ea4-45f065258ff8"},"resourceTypes":[{"resourceType":"batchAccounts","locations":["West
+        Europe","East US","East US 2","West US","North Central US","Brazil South","North
+        Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
+        West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
+        East","South India","Central India","Canada Central","Canada East","UK South","UK
+        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01","2015-07-01","2014-05-01-privatepreview"]},{"resourceType":"operations","locations":["West
+        Europe","East US","East US 2","West US","North Central US","Brazil South","North
+        Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
+        West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
+        East","South India","Central India","Canada Central","Canada East","UK South","UK
+        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations/quotas","locations":["West
+        Europe","East US","East US 2","West US","North Central US","Brazil South","North
+        Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
+        West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
+        East","South India","Central India","Canada Central","Canada East","UK South","UK
+        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]}],"registrationState":"Unregistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicCompute","namespace":"Microsoft.ClassicCompute","resourceTypes":[{"resourceType":"domainNames","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
+        Central","Canada East","UK South","UK West","West US","Central US","South
+        Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
+        East","Australia Southeast","West US 2","West Central US","South India","Central
+        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
+        Central","Canada East","UK South","UK West","West US","Central US","South
+        Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
+        East","Australia Southeast","West US 2","West Central US","South India","Central
+        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
+        Central US","South Central US","East US","East US 2","Canada Central","Canada
+        East","West US","West US 2","West Central US","Central US","East Asia","Southeast
+        Asia","North Europe","West Europe","UK South","UK West","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operatingSystems","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"operatingSystemFamilies","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicNetwork","namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"virtualNetworks/remoteVirtualNetworkPeeringProxies","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"reservedIps","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicStorage","namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
+        US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
+        Asia","Australia East","Australia Southeast","South India","Central India","West
+        India","West US 2","West Central US","East US","East US 2","North Central
+        US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
+        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
+        US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
+        Asia","Australia East","Australia Southeast","South India","Central India","West
+        India","West US 2","West Central US","East US","East US 2","North Central
+        US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
+        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"vmImages","locations":[],"apiVersions":["2016-11-01"]},{"resourceType":"publicImages","locations":[],"apiVersions":["2016-11-01","2016-04-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"osPlatformImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Compute","namespace":"Microsoft.Compute","authorization":{"applicationId":"60e6cd67-9c8c-4951-9b3c-23c25a2169af","roleDefinitionId":"e4770acb-272e-4dc8-87f3-12f44a612224"},"resourceTypes":[{"resourceType":"availabilitySets","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30"]},{"resourceType":"locations/usages","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"disks","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"snapshots","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"locations/diskoperations","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"images","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
+        US","East US","South Central US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","East Asia","Japan
+        East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/webhooks","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/ping","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/getCallbackConfig","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/listEvents","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"locations","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"locations/operationResults","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/GetCredentials","locations":["West
+        US","East US","South Central US","West Europe"],"apiVersions":["2016-06-27-preview"]},{"resourceType":"registries/listCredentials","locations":["South
+        Central US","East US","West US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","East Asia","Japan
+        East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/regenerateCredential","locations":["South
+        Central US","West US","East US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","East Asia","Japan
+        East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/listUsages","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/regenerateCredentials","locations":["West
+        US","East US","South Central US","West Europe"],"apiVersions":["2016-06-27-preview"]},{"resourceType":"checkNameAvailability","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview","2017-03-01","2016-06-27-preview"]},{"resourceType":"operations","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview","2017-03-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerService","namespace":"Microsoft.ContainerService","authorization":{"applicationId":"7319c514-987d-4e9b-ac3d-d38c4f427f4c","roleDefinitionId":"1b4a0c7f-2217-416f-acfa-cf73452fdc1c"},"resourceTypes":[{"resourceType":"containerServices","locations":["Japan
+        East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
+        East","Australia Southeast","Brazil South","Southeast Asia","West US","North
+        Central US","West Europe","North Europe","East US","UK West","UK South","West
+        Central US","West US 2","South India","Central India","West India","Canada
+        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
+        East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
+        East","Australia Southeast","Brazil South","Southeast Asia","West US","North
+        Central US","West Europe","North Europe","East US","UK West","UK South","West
+        Central US","West US 2","South India","Central India","West India","Canada
+        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DevTestLab","namespace":"Microsoft.DevTestLab","authorization":{"applicationId":"1a14be2a-e903-4cec-99cf-b2e209259a0f","roleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525"},"resourceTypes":[{"resourceType":"labs","locations":["West
+        Central US","Japan East","West US","Australia Southeast","Canada Central","Central
+        India","Central US","East Asia","Korea Central","North Europe","South Central
+        US","UK West","Australia East","Brazil South","Canada East","East US","East
+        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"schedules","locations":["West
+        Central US","Japan East","West US","Australia Southeast","Canada Central","Central
+        India","Central US","East Asia","Korea Central","North Europe","South Central
+        US","UK West","Australia East","Brazil South","Canada East","East US","East
+        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"labs/virtualMachines","locations":["West
+        Central US","Japan East","West US","Australia Southeast","Canada Central","Central
+        India","Central US","East Asia","Korea Central","North Europe","South Central
+        US","UK West","Australia East","Brazil South","Canada East","East US","East
+        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"labs/serviceRunners","locations":["Central
+        US","East US 2","South Central US"],"apiVersions":["2017-04-26-preview","2016-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"locations/operations","locations":["West
+        Central US","Japan East","West US","Australia Southeast","Canada Central","Central
+        India","Central US","East Asia","Korea Central","North Europe","South Central
+        US","UK West","Australia East","Brazil South","Canada East","East US","East
+        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"}],"resourceTypes":[{"resourceType":"components","locations":["East
+        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
+        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01","2014-04-01"]},{"resourceType":"queries","locations":["East
+        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"alertrules","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2016-03-01","2015-04-01","2014-04-01"]},{"resourceType":"autoscalesettings","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2015-04-01","2014-04-01"]},{"resourceType":"eventtypes","locations":[],"apiVersions":["2017-03-01-preview","2016-09-01-preview","2015-04-01","2014-11-01","2014-04-01"]},{"resourceType":"locations","locations":["East
+        US"],"apiVersions":["2015-04-01","2014-04-01"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2015-04-01","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-04-01","2014-06-01","2014-04-01"]},{"resourceType":"automatedExportSettings","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2015-04-01","2014-04-01"]},{"resourceType":"diagnosticSettings","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2017-05-01-preview","2016-09-01","2015-07-01"]},{"resourceType":"diagnosticSettingsCategories","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"extendedDiagnosticSettings","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2017-02-01"]},{"resourceType":"metricDefinitions","locations":["East
+        US","West US","West Europe","East Asia","Southeast Asia","Japan East","Japan
+        West","North Central US","South Central US","East US 2","Canada East","Canada
+        Central","Central US","Australia East","Australia Southeast","Brazil South","South
+        India","Central India","West India","North Europe","West US 2","West Central
+        US","Korea South","Korea Central","UK South","UK West","Global"],"apiVersions":["2017-05-01-preview","2016-03-01","2015-07-01"]},{"resourceType":"logDefinitions","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2015-07-01"]},{"resourceType":"eventCategories","locations":[],"apiVersions":["2015-04-01"]},{"resourceType":"metrics","locations":["East
+        US","West US","West Europe","East Asia","Southeast Asia","Japan East","Japan
+        West","North Central US","South Central US","East US 2","Canada East","Canada
+        Central","Central US","Australia East","Australia Southeast","Brazil South","South
+        India","Central India","West India","North Europe","West US 2","West Central
+        US","Korea South","Korea Central","UK South","UK West"],"apiVersions":["2017-05-01-preview","2016-09-01","2016-06-01"]},{"resourceType":"actiongroups","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]},{"resourceType":"activityLogAlerts","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.KeyVault","namespace":"Microsoft.KeyVault","resourceTypes":[{"resourceType":"vaults","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/accessPolicies","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-10-01","2015-06-01","2014-12-19-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"deletedVaults","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-10-01"]},{"resourceType":"locations/deletedVaults","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorization":{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"routeTables","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2017-04-26-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"]},{"resourceType":"workspaces/dataSources","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"storageInsightConfigs","locations":[],"apiVersions":["2014-10-10"]},{"resourceType":"workspaces/linkedServices","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"linkTargets","locations":["East
+        US"],"apiVersions":["2015-03-20"]},{"resourceType":"operations","locations":[],"apiVersions":["2014-11-10"]},{"resourceType":"devices","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationsManagement","namespace":"Microsoft.OperationsManagement","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"aa249101-6816-4966-aafa-08175d795f14"},"resourceTypes":[{"resourceType":"solutions","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Portal","namespace":"Microsoft.Portal","resourceTypes":[{"resourceType":"dashboards","locations":["Central
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
+        East","West India","South India","Central India","Canada Central","Canada
+        East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"operations","locations":["Central
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
+        East","West India","South India","Central India","Canada Central","Canada
+        East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"consoles","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/consoles","locations":["West
+        US","East US","Central India","North Europe","West Europe","South Central
+        US","Southeast Asia"],"apiVersions":["2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
+        US","East US","Central India","North Europe","West Europe","South Central
+        US","Southeast Asia"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","Canada Central","Canada East","West Central US","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-07-01","2016-12-01","2016-08-10","2016-06-01","2016-05-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"operations","locations":["Southeast
+        Asia"],"apiVersions":["2016-08-10","2016-06-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01"]},{"resourceType":"locations/backupStatus","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]},{"resourceType":"locations/allocatedStamp","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]},{"resourceType":"locations/allocateStamp","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ResourceHealth","namespace":"Microsoft.ResourceHealth","authorization":{"applicationId":"8bdebf23-c0fe-4187-a378-717ad86f6a53","roleDefinitionId":"cc026344-c8b1-4561-83ba-59eba84b27cc"},"resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2017-07-01","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"notifications","locations":["Australia
+        Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Security","namespace":"Microsoft.Security","authorization":{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatuses","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/virtualMachines","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/endpoints","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/subnets","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"tasks","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"alerts","locations":["Central
+        US","East US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"monitoring","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"monitoring/patch","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"monitoring/baseline","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"monitoring/antimalware","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"dataCollectionAgents","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"dataCollectionResults","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"pricings","locations":["Central
+        US","East US"],"apiVersions":["2017-08-01-preview"]},{"resourceType":"complianceResults","locations":["Central
+        US","East US"],"apiVersions":["2017-08-01"]},{"resourceType":"policies","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"appliances","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"webApplicationFirewalls","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/webApplicationFirewalls","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securitySolutions","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/securitySolutions","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securitySolutionsReferenceData","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/securitySolutionsReferenceData","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"jitNetworkAccessPolicies","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/jitNetworkAccessPolicies","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatusesSummaries","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/alerts","locations":["Central
+        US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/tasks","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.SiteRecovery","namespace":"Microsoft.SiteRecovery","authorization":{"applicationId":"b8340c3b-9267-498f-b21a-15d5547fd85e","roleDefinitionId":"8A00C8EA-8F1B-45A7-8F64-F4CC61EEE9B6"},"resourceTypes":[{"resourceType":"SiteRecoveryVault","locations":["East
+        US","West US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","Australia East","Australia Southeast","Brazil South","North
+        Central US","South Central US","Central US","East US 2","Central India","South
+        India"],"apiVersions":["2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Sql","namespace":"Microsoft.Sql","authorizations":[{"applicationId":"e4ab13ed-33cb-41b4-9140-6e264582cf85","roleDefinitionId":"ec3ddc95-44dc-47a2-9926-5e9f5ffd44ec"},{"applicationId":"0130cc9f-7ac5-4026-bd5f-80a08a54e6d9","roleDefinitionId":"45e8abf8-0ec4-44f3-9c37-cff4f7779302"},{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},{"applicationId":"76c7f279-7959-468f-8943-3954880e0d8c","roleDefinitionId":"7f7513a8-73f9-4c5f-97a2-c41f0ea783ef"}],"resourceTypes":[{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/capabilities","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverKeyOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/keys","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/encryptionProtector","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/communicationLinks","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recoverableDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/importExportOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/operationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/firewallrules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/elasticpools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-09-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/dnsAliases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/failoverGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/virtualNetworkRules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/virtualNetworkRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/virtualNetworkRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/databaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/extensions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditRecords","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/VulnerabilityAssessmentScans","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentScans","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups/syncMembers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/syncAgents","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncMemberOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncAgentOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncDatabaseIds","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorization":{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
+        US","West US","West Europe","North Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":["East
+        US","West US","West Europe","North Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Web","namespace":"Microsoft.Web","authorization":{"applicationId":"abfa0a7c-a6b6-4736-8310-5855508787cd","roleDefinitionId":"f47ed98b-b063-4a5b-9e10-4b9b44fa7735"},"resourceTypes":[{"resourceType":"sites/extensions","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots/extensions","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/instances","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots/instances","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/instances/extensions","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots/instances/extensions","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/publicCertificates","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots/publicCertificates","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"publishingUsers","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"ishostnameavailable","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"validate","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"isusernameavailable","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sourceControls","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"availableStacks","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"listSitesAssignedToHostName","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"sites/hostNameBindings","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"sites/domainOwnershipIdentifiers","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"sites/slots/hostNameBindings","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"operations","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"certificates","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms/workers","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"runtimes","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"sites/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"sites/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"sites/slots/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"sites/slots/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"serverFarms/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"serverFarms/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"sites/recommendations","locations":[],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"georegions","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/premieraddons","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01"]},{"resourceType":"hostingEnvironments","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/instances","locations":[],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/instances/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/instances/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/instances","locations":[],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/instances/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/instances/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"deploymentLocations","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"functions","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"deletedSites","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"ishostingenvironmentnameavailable","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"classicMobileServices","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"connections","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/managedApis","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/apiOperations","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"connectionGateways","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/connectionGatewayInstallations","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"checkNameAvailability","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"billingMeters","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/84codes.CloudAMQP","namespace":"84codes.CloudAMQP","resourceTypes":[{"resourceType":"servers","locations":["East
+        US 2","Central US","East US","North Central US","South Central US","West US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast"],"apiVersions":["2016-08-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/AppDynamics.APM","namespace":"AppDynamics.APM","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2016-05-26"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-05-26"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-05-26"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-05-26"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-05-26"]},{"resourceType":"locations/operationResults","locations":["West
+        US"],"apiVersions":["2016-05-26"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Aspera.Transfers","namespace":"Aspera.Transfers","resourceTypes":[{"resourceType":"services","locations":["West
+        US","North Europe","Central US","East US","West Europe","East Asia","Southeast
+        Asia","Japan East","East US 2","Japan West"],"apiVersions":["2016-03-25"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-03-25"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-03-25"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-03-25"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Auth0.Cloud","namespace":"Auth0.Cloud","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-11-23"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Citrix.Cloud","namespace":"Citrix.Cloud","resourceTypes":[{"resourceType":"accounts","locations":["West
+        US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Cloudyn.Analytics","namespace":"Cloudyn.Analytics","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US"],"apiVersions":["2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Conexlink.MyCloudIT","namespace":"Conexlink.MyCloudIT","resourceTypes":[{"resourceType":"accounts","locations":["Central
+        US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Crypteron.DataSecurity","namespace":"Crypteron.DataSecurity","resourceTypes":[{"resourceType":"apps","locations":["West
+        US"],"apiVersions":["2016-08-12"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-12"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-12"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-12"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Dynatrace.DynatraceSaaS","namespace":"Dynatrace.DynatraceSaaS","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-09-27"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Dynatrace.Ruxit","namespace":"Dynatrace.Ruxit","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US"],"apiVersions":["2016-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-09-07","2016-04-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-04-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/LiveArena.Broadcast","namespace":"LiveArena.Broadcast","resourceTypes":[{"resourceType":"services","locations":["West
+        US","North Europe","Japan West","Japan East","East Asia","West Europe","East
+        US","Southeast Asia","Central US"],"apiVersions":["2016-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Lombiq.DotNest","namespace":"Lombiq.DotNest","resourceTypes":[{"resourceType":"sites","locations":["East
+        US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Mailjet.Email","namespace":"Mailjet.Email","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]},{"resourceType":"diagnosticSettings","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"addsservices","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"configuration","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"agents","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"aadsupportcases","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"reports","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"servicehealthmetrics","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"logs","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"anonymousapiusers","locations":["West
+        US"],"apiVersions":["2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AnalysisServices","namespace":"Microsoft.AnalysisServices","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"servers","locations":["West
+        US","North Europe","South Central US","West Europe","West Central US","Southeast
+        Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
+        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/checkNameAvailability","locations":["West
+        US","North Europe","South Central US","West Europe","West Central US","Southeast
+        Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
+        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationresults","locations":["West
+        US","North Europe","South Central US","West Europe","West Central US","Southeast
+        Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
+        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationstatuses","locations":["West
+        US","North Europe","South Central US","West Europe","West Central US","Southeast
+        Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
+        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"operations","locations":["East
+        US 2","West Central US"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AppService","namespace":"Microsoft.AppService","authorization":{"applicationId":"dee7ba80-6a55-4f3b-a86c-746a9231ae49","roleDefinitionId":"6715d172-49c4-46f6-bb21-60512a8689dc"},"resourceTypes":[{"resourceType":"apiapps","locations":["East
+        US","West US","South Central US","North Europe","East Asia","Japan East","West
+        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
+        South","East US 2","Australia Southeast","Australia East","West India","South
+        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"appIdentities","locations":["East
+        US","West US","South Central US","North Europe","East Asia","Japan East","West
+        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
+        South","East US 2","Australia Southeast","Australia East","West India","South
+        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"gateways","locations":["East
+        US","West US","South Central US","North Europe","East Asia","Japan East","West
+        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
+        South","East US 2","Australia Southeast","Australia East","West India","South
+        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"deploymenttemplates","locations":[],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Authorization","namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"roleDefinitions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"classicAdministrators","locations":[],"apiVersions":["2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"permissions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"locks","locations":[],"apiVersions":["2017-04-01","2016-09-01","2015-06-01","2015-05-01-preview","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-01-01","2014-10-01-preview","2014-06-01"]},{"resourceType":"policyDefinitions","locations":[],"apiVersions":["2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"policySetDefinitions","locations":[],"apiVersions":["2017-06-01-preview"]},{"resourceType":"policyAssignments","locations":[],"apiVersions":["2017-06-01-preview","2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"providerOperations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01-preview","2015-07-01"]},{"resourceType":"elevateAccess","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureActiveDirectory","namespace":"Microsoft.AzureActiveDirectory","resourceTypes":[{"resourceType":"b2cDirectories","locations":["Global","United
+        States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureStack","namespace":"Microsoft.AzureStack","resourceTypes":[{"resourceType":"operations","locations":["Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations","locations":["West
+        Central US","Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations/products","locations":["West
+        Central US","Global"],"apiVersions":["2017-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Billing","namespace":"Microsoft.Billing","resourceTypes":[{"resourceType":"BillingPeriods","locations":["Central
+        US"],"apiVersions":["2017-04-24-preview"]},{"resourceType":"Invoices","locations":["Central
+        US"],"apiVersions":["2017-04-24-preview","2017-02-27-preview"]},{"resourceType":"operations","locations":["Central
+        US"],"apiVersions":["2017-04-24-preview","2017-02-27-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BingMaps","namespace":"Microsoft.BingMaps","resourceTypes":[{"resourceType":"mapApis","locations":["West
+        US"],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-18","2015-07-02"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BizTalkServices","namespace":"Microsoft.BizTalkServices","resourceTypes":[{"resourceType":"BizTalk","locations":["East
+        US","West US","North Europe","West Europe","Southeast Asia","East Asia","North
+        Central US","Japan West","Japan East","South Central US"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Cache","namespace":"Microsoft.Cache","authorization":{"applicationId":"96231a05-34ce-4eb4-aa6a-70759cbb5e83","roleDefinitionId":"4f731528-ba85-45c7-acfb-cd0a9b3cf31b"},"resourceTypes":[{"resourceType":"Redis","locations":["North
+        Central US","South Central US","Central US","West Europe","North Europe","West
+        US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
+        Asia","East Asia","Australia East","Australia Southeast","Central India","West
+        India","Canada Central","Canada East","UK South","UK West","West US 2","West
+        Central US","South India","Korea Central","Korea South"],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","South Central US","Central US","West Europe","North Europe","West
+        US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
+        Asia","East Asia","Australia East","Australia Southeast","Central India","West
+        India","South India","Canada Central","Canada East","UK South","UK West","West
+        US 2","West Central US","Korea Central","Korea South"],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01"]},{"resourceType":"Redis/metricDefinitions","locations":["North
+        Central US","South Central US","East US","East US 2","West US","Central US","East
+        Asia","Southeast Asia","North Europe","West Europe","Japan East","Japan West","Brazil
+        South","Australia Southeast","Australia East","Central India","West India","South
+        India","Canada Central","Canada East","UK West","UK South","West US 2","West
+        Central US","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"Redis/diagnosticSettings","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","West
+        US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
+        Asia","Australia East","Australia Southeast","Central India","West India","South
+        India","Canada Central","Canada East","UK West","UK South","West US 2","West
+        Central US","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Cdn","namespace":"Microsoft.Cdn","resourceTypes":[{"resourceType":"profiles","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/origins","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/customdomains","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/originresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/customdomainresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkResourceUsage","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02"]},{"resourceType":"validateProbe","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"edgenodes","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CertificateRegistration","namespace":"Microsoft.CertificateRegistration","authorization":{"applicationId":"f3c21649-0979-4721-ac85-b0216b2cf413","roleDefinitionId":"933fba7e-2ed3-4da8-973d-8bd8298a9b40"},"resourceTypes":[{"resourceType":"certificateOrders","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"certificateOrders/certificates","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"validateCertificateRegistrationInformation","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicSubscription","namespace":"Microsoft.ClassicSubscription","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicInfrastructureMigrate","namespace":"Microsoft.ClassicInfrastructureMigrate","authorization":{"applicationId":"5e5abe2b-83cd-4786-826a-a05653ebb103","roleDefinitionId":"766c4d9b-ef83-4f73-8352-1450a506a69b"},"resourceTypes":[{"resourceType":"classicInfrastructureResources","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","West
+        India","South India"],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CognitiveServices","namespace":"Microsoft.CognitiveServices","authorizations":[{"applicationId":"7d312290-28c8-473c-a0ed-8e53749b6d6d","roleDefinitionId":"5cb87f79-a7c3-4a95-9414-45b65974b51b"}],"resourceTypes":[{"resourceType":"accounts","locations":["Global","West
+        US","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"operations","locations":["Global","West
+        US","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations","locations":["Global","West
+        US","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/checkSkuAvailability","locations":["West
+        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/updateAccountsCreationSettings","locations":["West
+        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/accountsCreationSettings","locations":["West
+        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2016-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Commerce","namespace":"Microsoft.Commerce","resourceTypes":[{"resourceType":"UsageAggregates","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]},{"resourceType":"RateCard","locations":[],"apiVersions":["2016-08-31-preview","2015-06-01-preview","2015-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Consumption","namespace":"Microsoft.Consumption","resourceTypes":[{"resourceType":"reservationsummaries","locations":[],"apiVersions":["2017-01-30"]},{"resourceType":"reservationdetails","locations":[],"apiVersions":["2017-01-30"]},{"resourceType":"UsageDetails","locations":[],"apiVersions":["2017-06-30-preview","2017-04-24-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-30-preview","2017-04-24-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","resourceTypes":[{"resourceType":"containerGroups","locations":["West
+        US","East US","West Europe"],"apiVersions":["2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
+        US"],"apiVersions":["2016-04-08"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CustomerInsights","namespace":"Microsoft.CustomerInsights","authorization":{"applicationId":"38c77d00-5fcb-4cce-9d93-af4738258e3c","roleDefinitionId":"E006F9C7-F333-477C-8AD6-1F3A9FE87F55"},"resourceTypes":[{"resourceType":"hubs","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/profiles","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/interactions","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/authorizationPolicies","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/connectors","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/connectors/mappings","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/kpi","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/views","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/links","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/roleAssignments","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/roles","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/widgetTypes","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/suggestTypeSchema","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"operations","locations":["East
+        US 2"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataCatalog","namespace":"Microsoft.DataCatalog","resourceTypes":[{"resourceType":"catalogs","locations":["East
+        US","West US","Australia East","West Europe","North Europe","Southeast Asia","West
+        Central US"],"apiVersions":["2016-03-30","2015-07-01-preview"]},{"resourceType":"checkNameAvailability","locations":["West
+        Europe"],"apiVersions":["2016-03-30","2015-07-01-preview"]},{"resourceType":"operations","locations":["West
+        Europe"],"apiVersions":["2016-03-30","2015-07-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-03-30","2015-07-01-preview"]},{"resourceType":"locations/jobs","locations":["East
+        US","West US","Australia East","West Europe","North Europe","Southeast Asia","West
+        Central US"],"apiVersions":["2016-03-30","2015-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataFactory","namespace":"Microsoft.DataFactory","resourceTypes":[{"resourceType":"dataFactories","locations":["West
+        US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview","2014-04-01"]},{"resourceType":"factories","locations":["East
+        US"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
+        US"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
+        Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"dataFactories/metricDefinitions","locations":["North
+        Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"checkDataFactoryNameAvailability","locations":[],"apiVersions":["2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"checkAzureDataFactoryNameAvailability","locations":["West
+        US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"dataFactorySchema","locations":["West
+        US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"operations","locations":["West
+        US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeAnalytics","namespace":"Microsoft.DataLakeAnalytics","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/dataLakeStoreAccounts","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers/listSasTokens","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeStore","namespace":"Microsoft.DataLakeStore","authorization":{"applicationId":"e9f49c6b-5ce5-44c8-925d-015017e9f7ad","roleDefinitionId":"17eb9cca-f08a-4499-b2d3-852d175f614f"},"resourceTypes":[{"resourceType":"accounts","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/firewallRules","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","resourceTypes":[{"resourceType":"operations","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforPostgreSQL","namespace":"Microsoft.DBforPostgreSQL","resourceTypes":[{"resourceType":"operations","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
+        US","North Europe","East Asia","East US","West Europe","Southeast Asia","Japan
+        East","Japan West","Australia East","Australia Southeast","West US 2","West
+        Central US","East US 2","Central US","UK South","UK West","South India","Central
+        India"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"databaseAccountNames","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DomainRegistration","namespace":"Microsoft.DomainRegistration","authorization":{"applicationId":"ea2f600a-4980-45b7-89bf-d34da487bda1","roleDefinitionId":"54d7f2e3-5040-48a7-ae90-eebf629cfa0b"},"resourceTypes":[{"resourceType":"domains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"domains/domainOwnershipIdentifiers","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"topLevelDomains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"checkDomainAvailability","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"listDomainRecommendations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"validateDomainRegistrationInformation","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"generateSsoRequest","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DynamicsLcs","namespace":"Microsoft.DynamicsLcs","resourceTypes":[{"resourceType":"lcsprojects","locations":["Brazil
+        South","East Asia","East US","Japan East","Japan West","North Central US","North
+        Europe","South Central US","West Europe","West US","Southeast Asia","Central
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"lcsprojects/connectors","locations":["Brazil
+        South","East Asia","East US","Japan East","Japan West","North Central US","North
+        Europe","South Central US","West Europe","West US","Southeast Asia","Central
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"lcsprojects/clouddeployments","locations":["Brazil
+        South","East Asia","East US","Japan East","Japan West","North Central US","North
+        Europe","South Central US","West Europe","West US","Southeast Asia","Central
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"operations","locations":["Brazil
+        South","East Asia","East US","Japan East","Japan West","North Central US","North
+        Europe","South Central US","West Europe","West US","Southeast Asia","Central
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"topics","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operations","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"clusters/applications","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"clusters/operationresults","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations/capabilities","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations/operationresults","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations/azureasyncoperations","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations/validateCreateRequest","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"operations","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India"],"apiVersions":["2015-03-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ImportExport","namespace":"Microsoft.ImportExport","authorization":{"applicationId":"7de4d5c5-5b32-4235-b8a9-33b34d6bcd2a","roleDefinitionId":"9f7aa6bb-9454-46b6-8c01-a4b0f33ca151"},"resourceTypes":[{"resourceType":"jobs","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","North Central US","North Europe","South Central US","Southeast
+        Asia","South India","UK South","West Central US","West Europe","West India","West
+        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","North Central US","North Europe","South Central US","Southeast
+        Asia","South India","UK South","West Central US","West Europe","West India","West
+        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations/operationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","North Central US","North Europe","South Central US","Southeast
+        Asia","South India","UK South","West Central US","West Europe","West India","West
+        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","North Central US","North Europe","South Central US","Southeast
+        Asia","South India","UK South","West Central US","West Europe","West India","West
+        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Logic","namespace":"Microsoft.Logic","authorization":{"applicationId":"7cd684f4-8a78-49b0-91ec-6a35d38739ba","roleDefinitionId":"cb3ef1fb-6e31-49e2-9d87-ed821053fe58"},"resourceTypes":[{"resourceType":"workflows","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West"],"apiVersions":["2017-07-01","2016-10-01","2016-06-01","2015-08-01-preview","2015-02-01-preview"]},{"resourceType":"locations/workflows","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West"],"apiVersions":["2017-07-01","2016-10-01","2016-06-01","2015-08-01-preview","2015-02-01-preview"]},{"resourceType":"locations","locations":["North
+        Central US"],"apiVersions":["2017-07-01","2016-10-01","2016-06-01","2015-08-01-preview","2015-02-01-preview"]},{"resourceType":"operations","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West"],"apiVersions":["2017-07-01","2016-10-01","2016-06-01","2015-08-01-preview","2015-02-01-preview"]},{"resourceType":"integrationAccounts","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","West Central US"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"operations","locations":["South
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations","locations":["South
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operations","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"commitmentPlans","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
+        Central US","West US"],"apiVersions":["2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Media","namespace":"Microsoft.Media","authorization":{"applicationId":"374b2a64-3b6b-436b-934c-b820eacca870","roleDefinitionId":"aab70789-0cec-44b5-95d7-84b64c9487af"},"resourceTypes":[{"resourceType":"mediaservices","locations":["Japan
+        West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
+        US","West US","Australia East","Australia Southeast","Central US","Brazil
+        South","Central India","West India","South India","South Central US","Canada
+        Central","Canada East","West Central US"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
+        Central US","North Central US","East US 2","West US","West Europe","North
+        Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
+        East","UK South","West India"],"apiVersions":["2016-01-29"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-01-29"]},{"resourceType":"locations/checkNameAvailability","locations":["South
+        Central US","North Central US","East US 2","West US","West Europe","North
+        Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
+        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"operations","locations":["East
+        US 2"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Relay","namespace":"Microsoft.Relay","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US 2","West
+        US","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
+        East","West India","South India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
+        East","West India","South India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
+        Central US","South Central US","North Europe","West Europe","East Asia","Southeast
+        Asia","West US","East US","Japan West","Japan East","Brazil South","Central
+        US","East US 2","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-03-01","2016-01-01","2014-08-01-preview"]},{"resourceType":"operations","locations":["North
+        Central US","South Central US","North Europe","West Europe","East Asia","Southeast
+        Asia","West US","East US","Japan West","Japan East","Brazil South","Central
+        US","East US 2","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-03-01","2016-01-01","2014-08-01-preview"]},{"resourceType":"operationResults","locations":["North
+        Central US","South Central US","North Europe","West Europe","East Asia","Southeast
+        Asia","West US","East US","Japan West","Japan East","Brazil South","Central
+        US","East US 2","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-03-01","2016-01-01","2014-08-01-preview"]},{"resourceType":"flows","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast"],"apiVersions":["2015-08-01-preview","2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Search","namespace":"Microsoft.Search","resourceTypes":[{"resourceType":"searchServices","locations":["West
+        US","East US","North Europe","West Europe","Southeast Asia","East Asia","North
+        Central US","South Central US","Japan West","Australia East","Brazil South","Central
+        India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19","2015-02-28"]},{"resourceType":"checkServiceNameAvailability","locations":[],"apiVersions":["2015-02-28","2014-07-31-Preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2015-08-19"]},{"resourceType":"resourceHealthMetadata","locations":["West
+        US","East US","North Europe","West Europe","Southeast Asia","East Asia","North
+        Central US","South Central US","Japan West","Australia East","Brazil South","Central
+        India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US 2","West
+        US","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"premiumMessagingRegions","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceFabric","namespace":"Microsoft.ServiceFabric","authorization":{"applicationId":"74cb6831-0dbb-4be1-8206-fd4df301cdc2","roleDefinitionId":"e55cc65f-6903-4917-b4ef-f8d4640b57f5"},"resourceTypes":[{"resourceType":"clusters","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/clusterVersions","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operations","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Canada
+        Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","West Central US","Japan East","Japan West","Australia East","Australia
+        Southeast"],"apiVersions":["2017-06-01","2017-05-15","2017-01-01","2016-10-01","2016-06-01","2015-03-15","2014-09-01"]},{"resourceType":"operations","locations":["West
+        Central US","Southeast Asia"],"apiVersions":["2016-10-01","2016-06-01","2015-03-15","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StreamAnalytics","namespace":"Microsoft.StreamAnalytics","resourceTypes":[{"resourceType":"streamingjobs","locations":["Central
+        US","West Europe","East US 2","North Europe","Japan East","West US","Southeast
+        Asia","South Central US","East Asia","Japan West","North Central US","East
+        US","Australia East","Australia Southeast","Brazil South","Central India","West
+        Central US","UK South","UK West","Canada Central","Canada East","West US 2"],"apiVersions":["2017-04-01-preview","2016-03-01","2015-11-01","2015-10-01","2015-09-01","2015-08-01-preview","2015-06-01","2015-05-01","2015-04-01","2015-03-01-preview"]},{"resourceType":"locations","locations":["West
+        Europe","Central US","East US 2","North Europe","Japan East","West US","Southeast
+        Asia","South Central US","East Asia","Japan West","North Central US","East
+        US","Australia East","Australia Southeast","Brazil South","Central India","West
+        Central US","UK South","West US 2","UK West","Canada Central","Canada East"],"apiVersions":["2017-04-01-preview","2016-03-01","2015-11-01","2015-10-01","2015-09-01","2015-08-01-preview","2015-06-01","2015-05-01","2015-04-01","2015-03-01-preview"]},{"resourceType":"locations/quotas","locations":[],"apiVersions":["2017-04-01-preview","2016-03-01","2015-11-01","2015-10-01","2015-09-01","2015-08-01-preview","2015-06-01","2015-05-01","2015-04-01","2015-03-01-preview"]},{"resourceType":"streamingjobs/diagnosticSettings","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","Central
+        India","West Central US","UK South","UK West","Canada Central","Canada East","West
+        US 2","West US","Central US","South Central US","Japan East","Japan West","East
+        Asia","Southeast Asia","Australia East","Australia Southeast"],"apiVersions":["2014-04-01"]},{"resourceType":"streamingjobs/metricDefinitions","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","Central
+        India","West Central US","UK South","UK West","Canada Central","Canada East","West
+        US 2","West US","Central US","South Central US","Japan East","Japan West","East
+        Asia","Southeast Asia","Australia East","Australia Southeast"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":["West
+        Europe","West US","Central US","East US 2","North Europe","Japan East","Southeast
+        Asia","South Central US","East Asia","Japan West","North Central US","East
+        US","Australia East","Australia Southeast","Brazil South","Central India","West
+        Central US","UK South","UK West","Canada Central","Canada East","West US 2"],"apiVersions":["2017-04-01-preview","2016-03-01","2015-11-01","2015-10-01","2015-09-01","2015-08-01-preview","2015-06-01","2015-05-01","2015-04-01","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.support","namespace":"microsoft.support","resourceTypes":[{"resourceType":"operations","locations":["North
+        Central US","South Central US","Central US","West Europe","North Europe","West
+        US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
+        Asia","East Asia","Australia East","Australia Southeast"],"apiVersions":["2015-07-01-Preview","2015-03-01"]},{"resourceType":"supporttickets","locations":["North
+        Central US","South Central US","Central US","West Europe","North Europe","West
+        US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
+        Asia","East Asia","Australia East","Australia Southeast"],"apiVersions":["2015-07-01-Preview","2015-03-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.TimeSeriesInsights","namespace":"Microsoft.TimeSeriesInsights","authorizations":[{"applicationId":"120d688d-1518-4cf7-bd38-182f158850b6","roleDefinitionId":"5a43abdf-bb87-42c4-9e56-1c24bf364150"}],"resourceTypes":[{"resourceType":"environments","locations":["East
+        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/eventsources","locations":["East
+        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/referenceDataSets","locations":["East
+        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/accessPolicies","locations":["East
+        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"operations","locations":["East
+        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/project","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/extension","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"checkNameAvailability","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Myget.PackageManagement","namespace":"Myget.PackageManagement","resourceTypes":[{"resourceType":"services","locations":["West
+        Europe"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/NewRelic.APM","namespace":"NewRelic.APM","authorization":{"allowedThirdPartyExtensions":[{"name":"NewRelic_AzurePortal_APM"}]},"resourceTypes":[{"resourceType":"accounts","locations":["North
+        Central US","South Central US","West US","East US","North Europe","West Europe","Southeast
+        Asia","East Asia","Japan East","Japan West"],"apiVersions":["2014-10-01","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/nuubit.nextgencdn","namespace":"nuubit.nextgencdn","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US","East US 2","North Central US","South Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","West US","Central US"],"apiVersions":["2017-05-05"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-05"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-05-05"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-05-05"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Paraleap.CloudMonix","namespace":"Paraleap.CloudMonix","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2016-08-10"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-10"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-10"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Pokitdok.Platform","namespace":"Pokitdok.Platform","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2016-05-17"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-05-17"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-05-17"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-05-17"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RavenHq.Db","namespace":"RavenHq.Db","resourceTypes":[{"resourceType":"databases","locations":["East
+        US"],"apiVersions":["2016-07-18","2016-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-07-18","2016-06-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-07-18","2016-06-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-07-18","2016-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Raygun.CrashReporting","namespace":"Raygun.CrashReporting","resourceTypes":[{"resourceType":"apps","locations":["East
+        US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RedisLabs.Memcached","namespace":"RedisLabs.Memcached","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-07-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RedisLabs.Redis","namespace":"RedisLabs.Redis","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-07-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RevAPM.MobileCDN","namespace":"RevAPM.MobileCDN","resourceTypes":[{"resourceType":"accounts","locations":["Central
+        US","East US","East US 2","North Central US","South Central US","West US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast"],"apiVersions":["2016-08-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-24","2016-08-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sendgrid.Email","namespace":"Sendgrid.Email","resourceTypes":[{"resourceType":"accounts","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Canada Central","Canada
+        East","West Central US","West US 2","UK South","UK West"],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Signiant.Flight","namespace":"Signiant.Flight","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US","Central US","North Central US","South Central US","West US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast"],"apiVersions":["2015-06-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sparkpost.Basic","namespace":"Sparkpost.Basic","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2016-08-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/stackify.retrace","namespace":"stackify.retrace","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2016-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/SuccessBricks.ClearDB","namespace":"SuccessBricks.ClearDB","resourceTypes":[{"resourceType":"databases","locations":["Brazil
+        South","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","Southeast Asia","West Europe","West
+        US","South Central US","Australia East","Australia Southeast","Canada Central","Canada
+        East","Central India","South India","West India"],"apiVersions":["2014-04-01"]},{"resourceType":"clusters","locations":["Brazil
+        South","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","Southeast Asia","West Europe","West
+        US","Australia Southeast","Australia East","South Central US","Canada Central","Canada
+        East","Central India","South India","West India"],"apiVersions":["2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/TrendMicro.DeepSecurity","namespace":"TrendMicro.DeepSecurity","resourceTypes":[{"resourceType":"accounts","locations":["Central
+        US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
+        Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:33 GMT
+- request:
+    method: post
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
+    body:
+      encoding: UTF-8
+      string: '{"access":"read","durationInSeconds":3600}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY5MTIsIm5iZiI6MTUwNDEwNjkxMiwiZXhwIjoxNTA0MTEwODEyLCJhaW8iOiJZMkZnWURBUUs1LzNQRkNkUDBscXJrSnduOTFtQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUnZxSzFhQmZza0dQdjRycmNsWVJBQSIsInZlciI6IjEuMCJ9.Gnl60wrkF29_vnpRpxzyZjZ2YYaEzLyaibDpmhMCHtNxfTsp_GzxLOCIW47NxTesbPad1ZQvODsVipcp0STUFbjpOy8X9FnO91NnUAycXAyi7KuU_WGiwiyC8QExU-BX6UCrsjhyHoikRe6Rz63m4QcZiqHG0rvM9aO1ugN7032-rfLj64lQk9EIWMoiyfT07w6BL9B3GDUJXbJVKqE4SHsltEAA-5cNA_bfxR0IYQsWO6XCgAISaaxxfMBx-9_8iC_OGI1UmFP2aLn4hDMHSFOdFMRihlhcwhlHs6O1pRlkaClUP_GqGYwmVY28ornNlOpTDl6pjtPWz6HlPVYCtA
+      Content-Length:
+      - '42'
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '0'
+      Expires:
+      - "-1"
+      Location:
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/2bd29d77-0fb4-4995-9d0d-735d021032ab?monitor=true&api-version=2017-03-30
+      Azure-Asyncoperation:
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/2bd29d77-0fb4-4995-9d0d-735d021032ab?api-version=2017-03-30
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      X-Ms-Request-Id:
+      - 2bd29d77-0fb4-4995-9d0d-735d021032ab
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Writes:
+      - '1196'
+      X-Ms-Correlation-Request-Id:
+      - 929cf0ff-e378-47ab-82c4-d70cd5a83a35
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153334Z:929cf0ff-e378-47ab-82c4-d70cd5a83a35
+      Date:
+      - Wed, 30 Aug 2017 15:33:33 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:33 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/2bd29d77-0fb4-4995-9d0d-735d021032ab?api-version=2017-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY5MTIsIm5iZiI6MTUwNDEwNjkxMiwiZXhwIjoxNTA0MTEwODEyLCJhaW8iOiJZMkZnWURBUUs1LzNQRkNkUDBscXJrSnduOTFtQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUnZxSzFhQmZza0dQdjRycmNsWVJBQSIsInZlciI6IjEuMCJ9.Gnl60wrkF29_vnpRpxzyZjZ2YYaEzLyaibDpmhMCHtNxfTsp_GzxLOCIW47NxTesbPad1ZQvODsVipcp0STUFbjpOy8X9FnO91NnUAycXAyi7KuU_WGiwiyC8QExU-BX6UCrsjhyHoikRe6Rz63m4QcZiqHG0rvM9aO1ugN7032-rfLj64lQk9EIWMoiyfT07w6BL9B3GDUJXbJVKqE4SHsltEAA-5cNA_bfxR0IYQsWO6XCgAISaaxxfMBx-9_8iC_OGI1UmFP2aLn4hDMHSFOdFMRihlhcwhlHs6O1pRlkaClUP_GqGYwmVY28ornNlOpTDl6pjtPWz6HlPVYCtA
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      X-Ms-Request-Id:
+      - 2f5400d2-4b58-4eb0-8ce7-3a4e0f06c75c
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14937'
+      X-Ms-Correlation-Request-Id:
+      - 822c35f4-39e1-448c-ba3f-596164b48df4
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153334Z:822c35f4-39e1-448c-ba3f-596164b48df4
+      Date:
+      - Wed, 30 Aug 2017 15:33:33 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"startTime\": \"2017-08-30T15:33:34.0160609+00:00\",\r\n  \"endTime\":
+        \"2017-08-30T15:33:34.2660495+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=febdb61b-8bf4-452b-8dfd-74356f9a3e95&sig=8ZIGSdrvKMyMlYudytdtlx7FcHv%2BG3BjvjbcwlU41tg%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"2bd29d77-0fb4-4995-9d0d-735d021032ab\"\r\n}"
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:34 GMT
+- request:
+    method: get
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=febdb61b-8bf4-452b-8dfd-74356f9a3e95&sig=8ZIGSdrvKMyMlYudytdtlx7FcHv%2BG3BjvjbcwlU41tg=&sr=b&sv=2016-05-31
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      X-Ms-Range:
+      - bytes=0-0
+      Host:
+      - md-t4jdgqqlgszp.blob.core.windows.net
+  response:
+    status:
+      code: 206
+      message: Partial Content
+    headers:
+      Content-Length:
+      - '1'
+      Content-Type:
+      - application/octet-stream
+      Content-Range:
+      - bytes 0-0/34359738880
+      Last-Modified:
+      - Sat, 15 Jul 2017 14:23:07 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D4CB8D039FC699"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 441fc7a8-0001-0130-28a5-21bd52000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Meta-Pirtag:
+      - '1'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '20'
+      X-Ms-Copy-Id:
+      - 30cedd78-548a-4fd8-967e-f8344f587e3c
+      X-Ms-Copy-Source:
+      - http://md-t4jdgqqlgszp.blob.core.windows.net:8080/fg25xxtqx0gc/abcd?sv=2016-02-19&sr=b&st=2017-05-04T21%3a06%3a57Z&se=9999-12-31T23%3a59%3a59Z&sp=r&api-version=2016-02-19
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 34359738880/34359738880
+      X-Ms-Copy-Completion-Time:
+      - Thu, 04 May 2017 21:21:56 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Wed, 30 Aug 2017 15:33:33 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        6w==
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:34 GMT
+- request:
+    method: post
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
+    body:
+      encoding: UTF-8
+      string: '{"access":"read","durationInSeconds":3600}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY5MTIsIm5iZiI6MTUwNDEwNjkxMiwiZXhwIjoxNTA0MTEwODEyLCJhaW8iOiJZMkZnWURBUUs1LzNQRkNkUDBscXJrSnduOTFtQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUnZxSzFhQmZza0dQdjRycmNsWVJBQSIsInZlciI6IjEuMCJ9.Gnl60wrkF29_vnpRpxzyZjZ2YYaEzLyaibDpmhMCHtNxfTsp_GzxLOCIW47NxTesbPad1ZQvODsVipcp0STUFbjpOy8X9FnO91NnUAycXAyi7KuU_WGiwiyC8QExU-BX6UCrsjhyHoikRe6Rz63m4QcZiqHG0rvM9aO1ugN7032-rfLj64lQk9EIWMoiyfT07w6BL9B3GDUJXbJVKqE4SHsltEAA-5cNA_bfxR0IYQsWO6XCgAISaaxxfMBx-9_8iC_OGI1UmFP2aLn4hDMHSFOdFMRihlhcwhlHs6O1pRlkaClUP_GqGYwmVY28ornNlOpTDl6pjtPWz6HlPVYCtA
+      Content-Length:
+      - '42'
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '0'
+      Expires:
+      - "-1"
+      Location:
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/8b7b79e4-774b-4dfe-9ae7-491ce28f755f?monitor=true&api-version=2017-03-30
+      Azure-Asyncoperation:
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/8b7b79e4-774b-4dfe-9ae7-491ce28f755f?api-version=2017-03-30
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      X-Ms-Request-Id:
+      - 8b7b79e4-774b-4dfe-9ae7-491ce28f755f
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Writes:
+      - '1194'
+      X-Ms-Correlation-Request-Id:
+      - 4e611714-daec-4d24-8df2-6618713c7176
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153335Z:4e611714-daec-4d24-8df2-6618713c7176
+      Date:
+      - Wed, 30 Aug 2017 15:33:35 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:34 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/8b7b79e4-774b-4dfe-9ae7-491ce28f755f?api-version=2017-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY5MTIsIm5iZiI6MTUwNDEwNjkxMiwiZXhwIjoxNTA0MTEwODEyLCJhaW8iOiJZMkZnWURBUUs1LzNQRkNkUDBscXJrSnduOTFtQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUnZxSzFhQmZza0dQdjRycmNsWVJBQSIsInZlciI6IjEuMCJ9.Gnl60wrkF29_vnpRpxzyZjZ2YYaEzLyaibDpmhMCHtNxfTsp_GzxLOCIW47NxTesbPad1ZQvODsVipcp0STUFbjpOy8X9FnO91NnUAycXAyi7KuU_WGiwiyC8QExU-BX6UCrsjhyHoikRe6Rz63m4QcZiqHG0rvM9aO1ugN7032-rfLj64lQk9EIWMoiyfT07w6BL9B3GDUJXbJVKqE4SHsltEAA-5cNA_bfxR0IYQsWO6XCgAISaaxxfMBx-9_8iC_OGI1UmFP2aLn4hDMHSFOdFMRihlhcwhlHs6O1pRlkaClUP_GqGYwmVY28ornNlOpTDl6pjtPWz6HlPVYCtA
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      X-Ms-Request-Id:
+      - 7fef96d9-03bf-4d58-8395-d043974afc7e
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14941'
+      X-Ms-Correlation-Request-Id:
+      - aa8d34b3-8449-4b3d-bead-9a1ddebffc7c
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153335Z:aa8d34b3-8449-4b3d-bead-9a1ddebffc7c
+      Date:
+      - Wed, 30 Aug 2017 15:33:34 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"startTime\": \"2017-08-30T15:33:34.7192083+00:00\",\r\n  \"endTime\":
+        \"2017-08-30T15:33:34.9691912+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=b7569729-2165-4cb1-be0f-cdf72dd5407f&sig=gwDCLtSV2zcKzCBJknHQll58Fy2tl8eFPArcB5ZjNBA%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"8b7b79e4-774b-4dfe-9ae7-491ce28f755f\"\r\n}"
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:34 GMT
+- request:
+    method: get
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=b7569729-2165-4cb1-be0f-cdf72dd5407f&sig=gwDCLtSV2zcKzCBJknHQll58Fy2tl8eFPArcB5ZjNBA=&sr=b&sv=2016-05-31
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      X-Ms-Range:
+      - bytes=440-443
+      Host:
+      - md-t4jdgqqlgszp.blob.core.windows.net
+  response:
+    status:
+      code: 206
+      message: Partial Content
+    headers:
+      Content-Length:
+      - '4'
+      Content-Type:
+      - application/octet-stream
+      Content-Range:
+      - bytes 440-443/34359738880
+      Last-Modified:
+      - Sat, 15 Jul 2017 14:23:07 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D4CB8D039FC699"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 0ea1833e-0001-00c0-02a5-212b69000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Meta-Pirtag:
+      - '1'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '20'
+      X-Ms-Copy-Id:
+      - 30cedd78-548a-4fd8-967e-f8344f587e3c
+      X-Ms-Copy-Source:
+      - http://md-t4jdgqqlgszp.blob.core.windows.net:8080/fg25xxtqx0gc/abcd?sv=2016-02-19&sr=b&st=2017-05-04T21%3a06%3a57Z&se=9999-12-31T23%3a59%3a59Z&sp=r&api-version=2016-02-19
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 34359738880/34359738880
+      X-Ms-Copy-Completion-Time:
+      - Thu, 04 May 2017 21:21:56 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Wed, 30 Aug 2017 15:33:35 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        U5MJAA==
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:34 GMT
+recorded_with: VCR 3.0.3

--- a/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_lbaStart-1.yml
+++ b/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_lbaStart-1.yml
@@ -39,25 +39,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - b969ab35-1028-4e66-8186-509af56f1300
+      - e0db3172-c5f9-4d3b-808a-e0c3ab9c1300
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAAA9kTklhVy7SJTGAzR-p1BciGWT9n7tYhMCaTYBMuUUAO3IympRba7DHtskJFqbi5W7nCZRbEbWPYkZIzWv-xrZiCsKw7XnkAeJXaTYOYbAepY0lwzEa60qPRfphDDlJmLne_fDAZS6QyIEmuShjUXQBH-DKgrDcJaK4qmEuBiOOBRjq9Dk1nBbooMIoUXC-QAgAA;
+      - esctx=AQABAAAAAAA9kTklhVy7SJTGAzR-p1Bc6iKBnrG-XvSVCFBYGZTKjHMo6fdvHNXGugDRrO6fGmGSnGVteGo0zfBIVsiuSdvumi7xyE4L7mhvp5jYb3ZbP31R4rZgjCi2bgfUJ1xgRHEcFk2DOn2maa31stk6rkztrtL2Nz9Au9a3HyvZURSZ0lpV3peeLCbkG578i26uL9ggAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=008; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=005; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Wed, 30 Aug 2017 15:33:04 GMT
+      - Wed, 30 Aug 2017 17:05:21 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1504110785","not_before":"1504106885","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4ODUsIm5iZiI6MTUwNDEwNjg4NSwiZXhwIjoxNTA0MTEwNzg1LCJhaW8iOiJZMkZnWUFqbS9Od1p0bjFuNm1ISEJhZERiTi9GQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTmF0cHVTZ1FaazZCaGxDYTlXOFRBQSIsInZlciI6IjEuMCJ9.FfrMZoMTdUc3iphl1Omm08jxJnnBo44pmQQEhrsuVj5AKpcNxgMkt4ntZQ6DuK338G_LobcDSLTKa4AYwwfgl99oHwNYIp7E1oPk_1BZu9jn1CJPmSFthl6rmRI_6cEg4BTQjiyve3oKeMcpSFNfzNscOUPUTRGy21yAwaSkYE6SfHkb9xsREZwcIcftru0shIVl8kyqlVXLpQmqIuNmZ29vTcfTC0put2Qp-KHH_pati3_2VlHSNsCScygDAoLnQe8s_cHdVr0BS4UQZjdbgML-2-qrO5IUowAJPeqItPP5nQy4KNRo4geEP7cEzRSqiMyY-elJH4HzM8L_bsfu6A"}'
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1504116320","not_before":"1504112420","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MjAsIm5iZiI6MTUwNDExMjQyMCwiZXhwIjoxNTA0MTE2MzIwLCJhaW8iOiJZMkZnWUFqVnUvdlpZMi9ZZnE1MzZlVjFUN1hkQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiY2pIYjRQbkZPMDJBaXVERHE1d1RBQSIsInZlciI6IjEuMCJ9.Da6DG7IENjEOzClUlApAW03-nrblQUMAoGr-vxpAO6lklz-gWApqHZ9uxpn5xJNvR4MyGwwk1ddLMr4JpzEfsdnGb5DHhc_WXIT-eHsq6cAeNNNnQKtzJGfym8j9L28paCIJHaVQ1HylJgDLGLqt9pNxkqx4pIddxkaSOckb7NZ_xAyj8y_MXbOaqNLTWO31IjpzsxTEmfuR1yn6P8WlGUMwftPnYrRI-QLcjQHAMj4Vasv-XJuvEBYBnXsGF62dxamid6QVnQl0vBQGafaQ3yKArz4Pe6N86mKdRHZlbjcOF0Uo3-vguGJoJO9IwsAsCVwHnlu2u4pdX8Skdj5EUQ"}'
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:33:05 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:19 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -74,7 +74,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4ODUsIm5iZiI6MTUwNDEwNjg4NSwiZXhwIjoxNTA0MTEwNzg1LCJhaW8iOiJZMkZnWUFqbS9Od1p0bjFuNm1ISEJhZERiTi9GQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTmF0cHVTZ1FaazZCaGxDYTlXOFRBQSIsInZlciI6IjEuMCJ9.FfrMZoMTdUc3iphl1Omm08jxJnnBo44pmQQEhrsuVj5AKpcNxgMkt4ntZQ6DuK338G_LobcDSLTKa4AYwwfgl99oHwNYIp7E1oPk_1BZu9jn1CJPmSFthl6rmRI_6cEg4BTQjiyve3oKeMcpSFNfzNscOUPUTRGy21yAwaSkYE6SfHkb9xsREZwcIcftru0shIVl8kyqlVXLpQmqIuNmZ29vTcfTC0put2Qp-KHH_pati3_2VlHSNsCScygDAoLnQe8s_cHdVr0BS4UQZjdbgML-2-qrO5IUowAJPeqItPP5nQy4KNRo4geEP7cEzRSqiMyY-elJH4HzM8L_bsfu6A
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MjAsIm5iZiI6MTUwNDExMjQyMCwiZXhwIjoxNTA0MTE2MzIwLCJhaW8iOiJZMkZnWUFqVnUvdlpZMi9ZZnE1MzZlVjFUN1hkQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiY2pIYjRQbkZPMDJBaXVERHE1d1RBQSIsInZlciI6IjEuMCJ9.Da6DG7IENjEOzClUlApAW03-nrblQUMAoGr-vxpAO6lklz-gWApqHZ9uxpn5xJNvR4MyGwwk1ddLMr4JpzEfsdnGb5DHhc_WXIT-eHsq6cAeNNNnQKtzJGfym8j9L28paCIJHaVQ1HylJgDLGLqt9pNxkqx4pIddxkaSOckb7NZ_xAyj8y_MXbOaqNLTWO31IjpzsxTEmfuR1yn6P8WlGUMwftPnYrRI-QLcjQHAMj4Vasv-XJuvEBYBnXsGF62dxamid6QVnQl0vBQGafaQ3yKArz4Pe6N86mKdRHZlbjcOF0Uo3-vguGJoJO9IwsAsCVwHnlu2u4pdX8Skdj5EUQ
       Host:
       - management.azure.com
   response:
@@ -95,23 +95,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14998'
+      - '14996'
       X-Ms-Request-Id:
-      - ae3a3f87-5d62-46b5-8241-d1ff9c28b4e5
+      - 403617a3-5c5d-43aa-a779-cd6e7271fc7f
       X-Ms-Correlation-Request-Id:
-      - ae3a3f87-5d62-46b5-8241-d1ff9c28b4e5
+      - 403617a3-5c5d-43aa-a779-cd6e7271fc7f
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153305Z:ae3a3f87-5d62-46b5-8241-d1ff9c28b4e5
+      - EASTUS:20170830T170520Z:403617a3-5c5d-43aa-a779-cd6e7271fc7f
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 30 Aug 2017 15:33:04 GMT
+      - Wed, 30 Aug 2017 17:05:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:33:05 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:19 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/azure_subscription_id/providers?api-version=2015-01-01
@@ -128,7 +128,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4ODUsIm5iZiI6MTUwNDEwNjg4NSwiZXhwIjoxNTA0MTEwNzg1LCJhaW8iOiJZMkZnWUFqbS9Od1p0bjFuNm1ISEJhZERiTi9GQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTmF0cHVTZ1FaazZCaGxDYTlXOFRBQSIsInZlciI6IjEuMCJ9.FfrMZoMTdUc3iphl1Omm08jxJnnBo44pmQQEhrsuVj5AKpcNxgMkt4ntZQ6DuK338G_LobcDSLTKa4AYwwfgl99oHwNYIp7E1oPk_1BZu9jn1CJPmSFthl6rmRI_6cEg4BTQjiyve3oKeMcpSFNfzNscOUPUTRGy21yAwaSkYE6SfHkb9xsREZwcIcftru0shIVl8kyqlVXLpQmqIuNmZ29vTcfTC0put2Qp-KHH_pati3_2VlHSNsCScygDAoLnQe8s_cHdVr0BS4UQZjdbgML-2-qrO5IUowAJPeqItPP5nQy4KNRo4geEP7cEzRSqiMyY-elJH4HzM8L_bsfu6A
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MjAsIm5iZiI6MTUwNDExMjQyMCwiZXhwIjoxNTA0MTE2MzIwLCJhaW8iOiJZMkZnWUFqVnUvdlpZMi9ZZnE1MzZlVjFUN1hkQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiY2pIYjRQbkZPMDJBaXVERHE1d1RBQSIsInZlciI6IjEuMCJ9.Da6DG7IENjEOzClUlApAW03-nrblQUMAoGr-vxpAO6lklz-gWApqHZ9uxpn5xJNvR4MyGwwk1ddLMr4JpzEfsdnGb5DHhc_WXIT-eHsq6cAeNNNnQKtzJGfym8j9L28paCIJHaVQ1HylJgDLGLqt9pNxkqx4pIddxkaSOckb7NZ_xAyj8y_MXbOaqNLTWO31IjpzsxTEmfuR1yn6P8WlGUMwftPnYrRI-QLcjQHAMj4Vasv-XJuvEBYBnXsGF62dxamid6QVnQl0vBQGafaQ3yKArz4Pe6N86mKdRHZlbjcOF0Uo3-vguGJoJO9IwsAsCVwHnlu2u4pdX8Skdj5EUQ
       Host:
       - management.azure.com
   response:
@@ -147,17 +147,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14931'
+      - '14946'
       X-Ms-Request-Id:
-      - d0ee2d0b-ede5-43cc-bf61-d18fe6fc9255
+      - 10a3f461-1129-4c75-8ff7-74111624df1b
       X-Ms-Correlation-Request-Id:
-      - d0ee2d0b-ede5-43cc-bf61-d18fe6fc9255
+      - 10a3f461-1129-4c75-8ff7-74111624df1b
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153306Z:d0ee2d0b-ede5-43cc-bf61-d18fe6fc9255
+      - EASTUS:20170830T170521Z:10a3f461-1129-4c75-8ff7-74111624df1b
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 30 Aug 2017 15:33:06 GMT
+      - Wed, 30 Aug 2017 17:05:21 GMT
       Content-Length:
       - '241615'
     body:
@@ -1891,7 +1891,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:33:06 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:20 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
@@ -1908,7 +1908,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4ODUsIm5iZiI6MTUwNDEwNjg4NSwiZXhwIjoxNTA0MTEwNzg1LCJhaW8iOiJZMkZnWUFqbS9Od1p0bjFuNm1ISEJhZERiTi9GQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTmF0cHVTZ1FaazZCaGxDYTlXOFRBQSIsInZlciI6IjEuMCJ9.FfrMZoMTdUc3iphl1Omm08jxJnnBo44pmQQEhrsuVj5AKpcNxgMkt4ntZQ6DuK338G_LobcDSLTKa4AYwwfgl99oHwNYIp7E1oPk_1BZu9jn1CJPmSFthl6rmRI_6cEg4BTQjiyve3oKeMcpSFNfzNscOUPUTRGy21yAwaSkYE6SfHkb9xsREZwcIcftru0shIVl8kyqlVXLpQmqIuNmZ29vTcfTC0put2Qp-KHH_pati3_2VlHSNsCScygDAoLnQe8s_cHdVr0BS4UQZjdbgML-2-qrO5IUowAJPeqItPP5nQy4KNRo4geEP7cEzRSqiMyY-elJH4HzM8L_bsfu6A
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MjAsIm5iZiI6MTUwNDExMjQyMCwiZXhwIjoxNTA0MTE2MzIwLCJhaW8iOiJZMkZnWUFqVnUvdlpZMi9ZZnE1MzZlVjFUN1hkQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiY2pIYjRQbkZPMDJBaXVERHE1d1RBQSIsInZlciI6IjEuMCJ9.Da6DG7IENjEOzClUlApAW03-nrblQUMAoGr-vxpAO6lklz-gWApqHZ9uxpn5xJNvR4MyGwwk1ddLMr4JpzEfsdnGb5DHhc_WXIT-eHsq6cAeNNNnQKtzJGfym8j9L28paCIJHaVQ1HylJgDLGLqt9pNxkqx4pIddxkaSOckb7NZ_xAyj8y_MXbOaqNLTWO31IjpzsxTEmfuR1yn6P8WlGUMwftPnYrRI-QLcjQHAMj4Vasv-XJuvEBYBnXsGF62dxamid6QVnQl0vBQGafaQ3yKArz4Pe6N86mKdRHZlbjcOF0Uo3-vguGJoJO9IwsAsCVwHnlu2u4pdX8Skdj5EUQ
       Content-Length:
       - '42'
       Host:
@@ -1927,34 +1927,34 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/89e21989-ce64-4eab-aa16-c995cb6ad7bc?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/f77bbcc0-102b-48a1-a53a-beaa4dc7ed6e?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/89e21989-ce64-4eab-aa16-c995cb6ad7bc?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/f77bbcc0-102b-48a1-a53a-beaa4dc7ed6e?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
       - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
       X-Ms-Request-Id:
-      - 89e21989-ce64-4eab-aa16-c995cb6ad7bc
+      - f77bbcc0-102b-48a1-a53a-beaa4dc7ed6e
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
       - '1196'
       X-Ms-Correlation-Request-Id:
-      - e2998506-6969-43bd-b715-da1911e91c41
+      - d65c8066-6701-4f13-8071-bd52840a2892
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153307Z:e2998506-6969-43bd-b715-da1911e91c41
+      - EASTUS:20170830T170522Z:d65c8066-6701-4f13-8071-bd52840a2892
       Date:
-      - Wed, 30 Aug 2017 15:33:06 GMT
+      - Wed, 30 Aug 2017 17:05:22 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:33:07 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:21 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/89e21989-ce64-4eab-aa16-c995cb6ad7bc?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/f77bbcc0-102b-48a1-a53a-beaa4dc7ed6e?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -1968,7 +1968,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4ODUsIm5iZiI6MTUwNDEwNjg4NSwiZXhwIjoxNTA0MTEwNzg1LCJhaW8iOiJZMkZnWUFqbS9Od1p0bjFuNm1ISEJhZERiTi9GQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTmF0cHVTZ1FaazZCaGxDYTlXOFRBQSIsInZlciI6IjEuMCJ9.FfrMZoMTdUc3iphl1Omm08jxJnnBo44pmQQEhrsuVj5AKpcNxgMkt4ntZQ6DuK338G_LobcDSLTKa4AYwwfgl99oHwNYIp7E1oPk_1BZu9jn1CJPmSFthl6rmRI_6cEg4BTQjiyve3oKeMcpSFNfzNscOUPUTRGy21yAwaSkYE6SfHkb9xsREZwcIcftru0shIVl8kyqlVXLpQmqIuNmZ29vTcfTC0put2Qp-KHH_pati3_2VlHSNsCScygDAoLnQe8s_cHdVr0BS4UQZjdbgML-2-qrO5IUowAJPeqItPP5nQy4KNRo4geEP7cEzRSqiMyY-elJH4HzM8L_bsfu6A
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MjAsIm5iZiI6MTUwNDExMjQyMCwiZXhwIjoxNTA0MTE2MzIwLCJhaW8iOiJZMkZnWUFqVnUvdlpZMi9ZZnE1MzZlVjFUN1hkQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiY2pIYjRQbkZPMDJBaXVERHE1d1RBQSIsInZlciI6IjEuMCJ9.Da6DG7IENjEOzClUlApAW03-nrblQUMAoGr-vxpAO6lklz-gWApqHZ9uxpn5xJNvR4MyGwwk1ddLMr4JpzEfsdnGb5DHhc_WXIT-eHsq6cAeNNNnQKtzJGfym8j9L28paCIJHaVQ1HylJgDLGLqt9pNxkqx4pIddxkaSOckb7NZ_xAyj8y_MXbOaqNLTWO31IjpzsxTEmfuR1yn6P8WlGUMwftPnYrRI-QLcjQHAMj4Vasv-XJuvEBYBnXsGF62dxamid6QVnQl0vBQGafaQ3yKArz4Pe6N86mKdRHZlbjcOF0Uo3-vguGJoJO9IwsAsCVwHnlu2u4pdX8Skdj5EUQ
       Host:
       - management.azure.com
   response:
@@ -1993,29 +1993,29 @@ http_interactions:
       X-Ms-Served-By:
       - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
       X-Ms-Request-Id:
-      - fb51aae2-3d6e-4ada-ace4-1c924fe1b986
+      - 33880b11-ce5d-4970-9373-04bbdb0417fe
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14907'
+      - '14935'
       X-Ms-Correlation-Request-Id:
-      - bc3f465e-f1ec-4ead-af1c-a2bb41730d54
+      - fa49e0ab-dc15-4ce9-89f0-a9873371a54b
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153307Z:bc3f465e-f1ec-4ead-af1c-a2bb41730d54
+      - EASTUS:20170830T170522Z:fa49e0ab-dc15-4ce9-89f0-a9873371a54b
       Date:
-      - Wed, 30 Aug 2017 15:33:07 GMT
+      - Wed, 30 Aug 2017 17:05:21 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-08-30T15:33:06.7388601+00:00\",\r\n  \"endTime\":
-        \"2017-08-30T15:33:06.8950849+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=f0d79d02-ba7a-4040-949b-ae4f8193e514&sig=fCVdvag5JQ04El8oWCZ2y4NHIALrQUkS08Ix6MYoCKE%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"89e21989-ce64-4eab-aa16-c995cb6ad7bc\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2017-08-30T17:05:21.8122713+00:00\",\r\n  \"endTime\":
+        \"2017-08-30T17:05:21.9841215+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=a6ed9910-54cc-42b8-9b22-1f24e29b39bd&sig=F%2F77t3KnOHvnxLe8fn%2B93xUgwsB%2FUDx7jFl3lXt7wiA%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"f77bbcc0-102b-48a1-a53a-beaa4dc7ed6e\"\r\n}"
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:33:07 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:21 GMT
 - request:
     method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=f0d79d02-ba7a-4040-949b-ae4f8193e514&sig=fCVdvag5JQ04El8oWCZ2y4NHIALrQUkS08Ix6MYoCKE=&sr=b&sv=2016-05-31
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=a6ed9910-54cc-42b8-9b22-1f24e29b39bd&sig=F/77t3KnOHvnxLe8fn%2B93xUgwsB/UDx7jFl3lXt7wiA=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2050,7 +2050,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - caa3a566-0001-0063-66a5-21e708000000
+      - 684fe427-0001-00d6-49b2-21eaf7000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2076,13 +2076,13 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 30 Aug 2017 15:33:07 GMT
+      - Wed, 30 Aug 2017 17:05:23 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         6w==
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:33:07 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:22 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
@@ -2099,7 +2099,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4ODUsIm5iZiI6MTUwNDEwNjg4NSwiZXhwIjoxNTA0MTEwNzg1LCJhaW8iOiJZMkZnWUFqbS9Od1p0bjFuNm1ISEJhZERiTi9GQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTmF0cHVTZ1FaazZCaGxDYTlXOFRBQSIsInZlciI6IjEuMCJ9.FfrMZoMTdUc3iphl1Omm08jxJnnBo44pmQQEhrsuVj5AKpcNxgMkt4ntZQ6DuK338G_LobcDSLTKa4AYwwfgl99oHwNYIp7E1oPk_1BZu9jn1CJPmSFthl6rmRI_6cEg4BTQjiyve3oKeMcpSFNfzNscOUPUTRGy21yAwaSkYE6SfHkb9xsREZwcIcftru0shIVl8kyqlVXLpQmqIuNmZ29vTcfTC0put2Qp-KHH_pati3_2VlHSNsCScygDAoLnQe8s_cHdVr0BS4UQZjdbgML-2-qrO5IUowAJPeqItPP5nQy4KNRo4geEP7cEzRSqiMyY-elJH4HzM8L_bsfu6A
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MjAsIm5iZiI6MTUwNDExMjQyMCwiZXhwIjoxNTA0MTE2MzIwLCJhaW8iOiJZMkZnWUFqVnUvdlpZMi9ZZnE1MzZlVjFUN1hkQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiY2pIYjRQbkZPMDJBaXVERHE1d1RBQSIsInZlciI6IjEuMCJ9.Da6DG7IENjEOzClUlApAW03-nrblQUMAoGr-vxpAO6lklz-gWApqHZ9uxpn5xJNvR4MyGwwk1ddLMr4JpzEfsdnGb5DHhc_WXIT-eHsq6cAeNNNnQKtzJGfym8j9L28paCIJHaVQ1HylJgDLGLqt9pNxkqx4pIddxkaSOckb7NZ_xAyj8y_MXbOaqNLTWO31IjpzsxTEmfuR1yn6P8WlGUMwftPnYrRI-QLcjQHAMj4Vasv-XJuvEBYBnXsGF62dxamid6QVnQl0vBQGafaQ3yKArz4Pe6N86mKdRHZlbjcOF0Uo3-vguGJoJO9IwsAsCVwHnlu2u4pdX8Skdj5EUQ
       Content-Length:
       - '42'
       Host:
@@ -2118,34 +2118,34 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/a82f4892-e42d-42e9-9d79-686b8c1baaa6?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/b2f6ed93-b302-40fb-ab3d-abd9d331f141?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/a82f4892-e42d-42e9-9d79-686b8c1baaa6?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/b2f6ed93-b302-40fb-ab3d-abd9d331f141?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
       - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
       X-Ms-Request-Id:
-      - a82f4892-e42d-42e9-9d79-686b8c1baaa6
+      - b2f6ed93-b302-40fb-ab3d-abd9d331f141
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
       - '1197'
       X-Ms-Correlation-Request-Id:
-      - 9ae16137-59cc-42a5-945e-e904f9b9196f
+      - 7a7c7eb8-4cc3-4602-80b5-79ae7dd1b94a
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153308Z:9ae16137-59cc-42a5-945e-e904f9b9196f
+      - EASTUS:20170830T170523Z:7a7c7eb8-4cc3-4602-80b5-79ae7dd1b94a
       Date:
-      - Wed, 30 Aug 2017 15:33:07 GMT
+      - Wed, 30 Aug 2017 17:05:22 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:33:08 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:22 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/a82f4892-e42d-42e9-9d79-686b8c1baaa6?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/b2f6ed93-b302-40fb-ab3d-abd9d331f141?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -2159,7 +2159,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4ODUsIm5iZiI6MTUwNDEwNjg4NSwiZXhwIjoxNTA0MTEwNzg1LCJhaW8iOiJZMkZnWUFqbS9Od1p0bjFuNm1ISEJhZERiTi9GQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTmF0cHVTZ1FaazZCaGxDYTlXOFRBQSIsInZlciI6IjEuMCJ9.FfrMZoMTdUc3iphl1Omm08jxJnnBo44pmQQEhrsuVj5AKpcNxgMkt4ntZQ6DuK338G_LobcDSLTKa4AYwwfgl99oHwNYIp7E1oPk_1BZu9jn1CJPmSFthl6rmRI_6cEg4BTQjiyve3oKeMcpSFNfzNscOUPUTRGy21yAwaSkYE6SfHkb9xsREZwcIcftru0shIVl8kyqlVXLpQmqIuNmZ29vTcfTC0put2Qp-KHH_pati3_2VlHSNsCScygDAoLnQe8s_cHdVr0BS4UQZjdbgML-2-qrO5IUowAJPeqItPP5nQy4KNRo4geEP7cEzRSqiMyY-elJH4HzM8L_bsfu6A
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MjAsIm5iZiI6MTUwNDExMjQyMCwiZXhwIjoxNTA0MTE2MzIwLCJhaW8iOiJZMkZnWUFqVnUvdlpZMi9ZZnE1MzZlVjFUN1hkQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiY2pIYjRQbkZPMDJBaXVERHE1d1RBQSIsInZlciI6IjEuMCJ9.Da6DG7IENjEOzClUlApAW03-nrblQUMAoGr-vxpAO6lklz-gWApqHZ9uxpn5xJNvR4MyGwwk1ddLMr4JpzEfsdnGb5DHhc_WXIT-eHsq6cAeNNNnQKtzJGfym8j9L28paCIJHaVQ1HylJgDLGLqt9pNxkqx4pIddxkaSOckb7NZ_xAyj8y_MXbOaqNLTWO31IjpzsxTEmfuR1yn6P8WlGUMwftPnYrRI-QLcjQHAMj4Vasv-XJuvEBYBnXsGF62dxamid6QVnQl0vBQGafaQ3yKArz4Pe6N86mKdRHZlbjcOF0Uo3-vguGJoJO9IwsAsCVwHnlu2u4pdX8Skdj5EUQ
       Host:
       - management.azure.com
   response:
@@ -2184,29 +2184,29 @@ http_interactions:
       X-Ms-Served-By:
       - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
       X-Ms-Request-Id:
-      - f9dadc6f-e858-41d8-8ba6-b3fbe3f25d60
+      - 18c2698b-fa92-4452-b878-9f45c6b9df25
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14866'
+      - '14930'
       X-Ms-Correlation-Request-Id:
-      - 4dffaa20-8d3c-4149-b9a5-cf991edee094
+      - c5e5570d-c6b9-4ce6-921d-3050ad75a88a
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153308Z:4dffaa20-8d3c-4149-b9a5-cf991edee094
+      - EASTUS:20170830T170523Z:c5e5570d-c6b9-4ce6-921d-3050ad75a88a
       Date:
-      - Wed, 30 Aug 2017 15:33:07 GMT
+      - Wed, 30 Aug 2017 17:05:23 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-08-30T15:33:07.6607534+00:00\",\r\n  \"endTime\":
-        \"2017-08-30T15:33:07.8638532+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=b0f54b3d-3d55-476d-96ef-16bcee0a59c7&sig=Q%2FM3NZw6Dy3iOWS%2BgnyBy4g%2BzGxwbfu4XZXQESS5Hic%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"a82f4892-e42d-42e9-9d79-686b8c1baaa6\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2017-08-30T17:05:22.5466538+00:00\",\r\n  \"endTime\":
+        \"2017-08-30T17:05:22.7341193+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=57a6267e-9d8d-482a-939c-2b3b0c5b51d8&sig=HGevLLuJWMdG95gEhVIcxwMly84cHErQXc2QcQJDjFs%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"b2f6ed93-b302-40fb-ab3d-abd9d331f141\"\r\n}"
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:33:08 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:22 GMT
 - request:
     method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=b0f54b3d-3d55-476d-96ef-16bcee0a59c7&sig=Q/M3NZw6Dy3iOWS%2BgnyBy4g%2BzGxwbfu4XZXQESS5Hic=&sr=b&sv=2016-05-31
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=57a6267e-9d8d-482a-939c-2b3b0c5b51d8&sig=HGevLLuJWMdG95gEhVIcxwMly84cHErQXc2QcQJDjFs=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2241,7 +2241,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 493d9288-0001-00bc-62a5-21b65c000000
+      - 5ca311de-0001-00e8-6db2-215cd6000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2267,11 +2267,11 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 30 Aug 2017 15:33:07 GMT
+      - Wed, 30 Aug 2017 17:05:23 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         U5MJAA==
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:33:08 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:22 GMT
 recorded_with: VCR 3.0.3

--- a/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_lbaStart-1.yml
+++ b/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_lbaStart-1.yml
@@ -1,0 +1,2277 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://login.microsoftonline.com/azure_tenant_id/oauth2/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_key&resource=https%3A%2F%2Fmanagement.azure.com%2F
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - login.microsoftonline.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Server:
+      - Microsoft-IIS/8.5
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Request-Id:
+      - b969ab35-1028-4e66-8186-509af56f1300
+      P3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Set-Cookie:
+      - esctx=AQABAAAAAAA9kTklhVy7SJTGAzR-p1BciGWT9n7tYhMCaTYBMuUUAO3IympRba7DHtskJFqbi5W7nCZRbEbWPYkZIzWv-xrZiCsKw7XnkAeJXaTYOYbAepY0lwzEa60qPRfphDDlJmLne_fDAZS6QyIEmuShjUXQBH-DKgrDcJaK4qmEuBiOOBRjq9Dk1nBbooMIoUXC-QAgAA;
+        domain=.login.microsoftonline.com; path=/; secure; HttpOnly
+      - stsservicecookie=ests; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=008; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Wed, 30 Aug 2017 15:33:04 GMT
+      Content-Length:
+      - '1505'
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1504110785","not_before":"1504106885","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4ODUsIm5iZiI6MTUwNDEwNjg4NSwiZXhwIjoxNTA0MTEwNzg1LCJhaW8iOiJZMkZnWUFqbS9Od1p0bjFuNm1ISEJhZERiTi9GQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTmF0cHVTZ1FaazZCaGxDYTlXOFRBQSIsInZlciI6IjEuMCJ9.FfrMZoMTdUc3iphl1Omm08jxJnnBo44pmQQEhrsuVj5AKpcNxgMkt4ntZQ6DuK338G_LobcDSLTKa4AYwwfgl99oHwNYIp7E1oPk_1BZu9jn1CJPmSFthl6rmRI_6cEg4BTQjiyve3oKeMcpSFNfzNscOUPUTRGy21yAwaSkYE6SfHkb9xsREZwcIcftru0shIVl8kyqlVXLpQmqIuNmZ29vTcfTC0put2Qp-KHH_pati3_2VlHSNsCScygDAoLnQe8s_cHdVr0BS4UQZjdbgML-2-qrO5IUowAJPeqItPP5nQy4KNRo4geEP7cEzRSqiMyY-elJH4HzM8L_bsfu6A"}'
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:05 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions?api-version=2016-06-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4ODUsIm5iZiI6MTUwNDEwNjg4NSwiZXhwIjoxNTA0MTEwNzg1LCJhaW8iOiJZMkZnWUFqbS9Od1p0bjFuNm1ISEJhZERiTi9GQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTmF0cHVTZ1FaazZCaGxDYTlXOFRBQSIsInZlciI6IjEuMCJ9.FfrMZoMTdUc3iphl1Omm08jxJnnBo44pmQQEhrsuVj5AKpcNxgMkt4ntZQ6DuK338G_LobcDSLTKa4AYwwfgl99oHwNYIp7E1oPk_1BZu9jn1CJPmSFthl6rmRI_6cEg4BTQjiyve3oKeMcpSFNfzNscOUPUTRGy21yAwaSkYE6SfHkb9xsREZwcIcftru0shIVl8kyqlVXLpQmqIuNmZ29vTcfTC0put2Qp-KHH_pati3_2VlHSNsCScygDAoLnQe8s_cHdVr0BS4UQZjdbgML-2-qrO5IUowAJPeqItPP5nQy4KNRo4geEP7cEzRSqiMyY-elJH4HzM8L_bsfu6A
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Tenant-Reads:
+      - '14998'
+      X-Ms-Request-Id:
+      - ae3a3f87-5d62-46b5-8241-d1ff9c28b4e5
+      X-Ms-Correlation-Request-Id:
+      - ae3a3f87-5d62-46b5-8241-d1ff9c28b4e5
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153305Z:ae3a3f87-5d62-46b5-8241-d1ff9c28b4e5
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 30 Aug 2017 15:33:04 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
+        Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:05 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers?api-version=2015-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4ODUsIm5iZiI6MTUwNDEwNjg4NSwiZXhwIjoxNTA0MTEwNzg1LCJhaW8iOiJZMkZnWUFqbS9Od1p0bjFuNm1ISEJhZERiTi9GQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTmF0cHVTZ1FaazZCaGxDYTlXOFRBQSIsInZlciI6IjEuMCJ9.FfrMZoMTdUc3iphl1Omm08jxJnnBo44pmQQEhrsuVj5AKpcNxgMkt4ntZQ6DuK338G_LobcDSLTKa4AYwwfgl99oHwNYIp7E1oPk_1BZu9jn1CJPmSFthl6rmRI_6cEg4BTQjiyve3oKeMcpSFNfzNscOUPUTRGy21yAwaSkYE6SfHkb9xsREZwcIcftru0shIVl8kyqlVXLpQmqIuNmZ29vTcfTC0put2Qp-KHH_pati3_2VlHSNsCScygDAoLnQe8s_cHdVr0BS4UQZjdbgML-2-qrO5IUowAJPeqItPP5nQy4KNRo4geEP7cEzRSqiMyY-elJH4HzM8L_bsfu6A
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14931'
+      X-Ms-Request-Id:
+      - d0ee2d0b-ede5-43cc-bf61-d18fe6fc9255
+      X-Ms-Correlation-Request-Id:
+      - d0ee2d0b-ede5-43cc-bf61-d18fe6fc9255
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153306Z:d0ee2d0b-ede5-43cc-bf61-d18fe6fc9255
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 30 Aug 2017 15:33:06 GMT
+      Content-Length:
+      - '241615'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","North Central
+        US","South Central US","West Central US","West US","West US 2","Canada Central","Canada
+        East","North Europe","West Europe","UK South","UK West","East Asia","Southeast
+        Asia","Japan East","Japan West","Korea Central","Korea South","Brazil South","Central
+        India","South India","West India"],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"validateServiceName","locations":[],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"checkServiceNameAvailability","locations":[],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"reportFeedback","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"checkFeedbackRequired","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Automation","namespace":"Microsoft.Automation","authorizations":[{"applicationId":"fc75330b-179d-49af-87dd-3b1acf6827fa","roleDefinitionId":"95fd5de3-d071-4362-92bf-cf341c1de832"}],"resourceTypes":[{"resourceType":"automationAccounts","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
+        South","UK South","West Central US","North Europe","Canada Central","Australia
+        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/runbooks","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
+        South","UK South","West Central US","North Europe","Canada Central","Australia
+        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/configurations","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","North
+        Central US","Brazil South","UK South","West Central US","Central India","Australia
+        Southeast","Canada Central","North Europe"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/webhooks","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
+        South","UK South","West Central US","North Europe","Canada Central","Australia
+        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"operations","locations":["South
+        Central US"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/softwareUpdateConfigurations","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
+        South","UK South","West Central US","North Europe","Canada Central","Australia
+        Southeast","Central India"],"apiVersions":["2017-05-15-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Backup","namespace":"Microsoft.Backup","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"BackupVault","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India"],"apiVersions":["2015-03-15","2014-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Batch","namespace":"Microsoft.Batch","authorization":{"applicationId":"ddbf3205-c6bd-46ae-8127-60eb93363864","roleDefinitionId":"b7f84953-1d03-4eab-9ea4-45f065258ff8"},"resourceTypes":[{"resourceType":"batchAccounts","locations":["West
+        Europe","East US","East US 2","West US","North Central US","Brazil South","North
+        Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
+        West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
+        East","South India","Central India","Canada Central","Canada East","UK South","UK
+        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01","2015-07-01","2014-05-01-privatepreview"]},{"resourceType":"operations","locations":["West
+        Europe","East US","East US 2","West US","North Central US","Brazil South","North
+        Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
+        West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
+        East","South India","Central India","Canada Central","Canada East","UK South","UK
+        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations/quotas","locations":["West
+        Europe","East US","East US 2","West US","North Central US","Brazil South","North
+        Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
+        West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
+        East","South India","Central India","Canada Central","Canada East","UK South","UK
+        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]}],"registrationState":"Unregistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicCompute","namespace":"Microsoft.ClassicCompute","resourceTypes":[{"resourceType":"domainNames","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
+        Central","Canada East","UK South","UK West","West US","Central US","South
+        Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
+        East","Australia Southeast","West US 2","West Central US","South India","Central
+        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
+        Central","Canada East","UK South","UK West","West US","Central US","South
+        Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
+        East","Australia Southeast","West US 2","West Central US","South India","Central
+        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
+        Central US","South Central US","East US","East US 2","Canada Central","Canada
+        East","West US","West US 2","West Central US","Central US","East Asia","Southeast
+        Asia","North Europe","West Europe","UK South","UK West","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operatingSystems","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"operatingSystemFamilies","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicNetwork","namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"virtualNetworks/remoteVirtualNetworkPeeringProxies","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"reservedIps","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicStorage","namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
+        US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
+        Asia","Australia East","Australia Southeast","South India","Central India","West
+        India","West US 2","West Central US","East US","East US 2","North Central
+        US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
+        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
+        US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
+        Asia","Australia East","Australia Southeast","South India","Central India","West
+        India","West US 2","West Central US","East US","East US 2","North Central
+        US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
+        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"vmImages","locations":[],"apiVersions":["2016-11-01"]},{"resourceType":"publicImages","locations":[],"apiVersions":["2016-11-01","2016-04-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"osPlatformImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Compute","namespace":"Microsoft.Compute","authorization":{"applicationId":"60e6cd67-9c8c-4951-9b3c-23c25a2169af","roleDefinitionId":"e4770acb-272e-4dc8-87f3-12f44a612224"},"resourceTypes":[{"resourceType":"availabilitySets","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30"]},{"resourceType":"locations/usages","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"disks","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"snapshots","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"locations/diskoperations","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"images","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
+        US","East US","South Central US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","East Asia","Japan
+        East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/webhooks","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/ping","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/getCallbackConfig","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/listEvents","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"locations","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"locations/operationResults","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/GetCredentials","locations":["West
+        US","East US","South Central US","West Europe"],"apiVersions":["2016-06-27-preview"]},{"resourceType":"registries/listCredentials","locations":["South
+        Central US","East US","West US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","East Asia","Japan
+        East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/regenerateCredential","locations":["South
+        Central US","West US","East US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","East Asia","Japan
+        East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/listUsages","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/regenerateCredentials","locations":["West
+        US","East US","South Central US","West Europe"],"apiVersions":["2016-06-27-preview"]},{"resourceType":"checkNameAvailability","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview","2017-03-01","2016-06-27-preview"]},{"resourceType":"operations","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview","2017-03-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerService","namespace":"Microsoft.ContainerService","authorization":{"applicationId":"7319c514-987d-4e9b-ac3d-d38c4f427f4c","roleDefinitionId":"1b4a0c7f-2217-416f-acfa-cf73452fdc1c"},"resourceTypes":[{"resourceType":"containerServices","locations":["Japan
+        East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
+        East","Australia Southeast","Brazil South","Southeast Asia","West US","North
+        Central US","West Europe","North Europe","East US","UK West","UK South","West
+        Central US","West US 2","South India","Central India","West India","Canada
+        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
+        East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
+        East","Australia Southeast","Brazil South","Southeast Asia","West US","North
+        Central US","West Europe","North Europe","East US","UK West","UK South","West
+        Central US","West US 2","South India","Central India","West India","Canada
+        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DevTestLab","namespace":"Microsoft.DevTestLab","authorization":{"applicationId":"1a14be2a-e903-4cec-99cf-b2e209259a0f","roleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525"},"resourceTypes":[{"resourceType":"labs","locations":["West
+        Central US","Japan East","West US","Australia Southeast","Canada Central","Central
+        India","Central US","East Asia","Korea Central","North Europe","South Central
+        US","UK West","Australia East","Brazil South","Canada East","East US","East
+        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"schedules","locations":["West
+        Central US","Japan East","West US","Australia Southeast","Canada Central","Central
+        India","Central US","East Asia","Korea Central","North Europe","South Central
+        US","UK West","Australia East","Brazil South","Canada East","East US","East
+        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"labs/virtualMachines","locations":["West
+        Central US","Japan East","West US","Australia Southeast","Canada Central","Central
+        India","Central US","East Asia","Korea Central","North Europe","South Central
+        US","UK West","Australia East","Brazil South","Canada East","East US","East
+        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"labs/serviceRunners","locations":["Central
+        US","East US 2","South Central US"],"apiVersions":["2017-04-26-preview","2016-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"locations/operations","locations":["West
+        Central US","Japan East","West US","Australia Southeast","Canada Central","Central
+        India","Central US","East Asia","Korea Central","North Europe","South Central
+        US","UK West","Australia East","Brazil South","Canada East","East US","East
+        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"}],"resourceTypes":[{"resourceType":"components","locations":["East
+        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
+        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01","2014-04-01"]},{"resourceType":"queries","locations":["East
+        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"alertrules","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2016-03-01","2015-04-01","2014-04-01"]},{"resourceType":"autoscalesettings","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2015-04-01","2014-04-01"]},{"resourceType":"eventtypes","locations":[],"apiVersions":["2017-03-01-preview","2016-09-01-preview","2015-04-01","2014-11-01","2014-04-01"]},{"resourceType":"locations","locations":["East
+        US"],"apiVersions":["2015-04-01","2014-04-01"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2015-04-01","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-04-01","2014-06-01","2014-04-01"]},{"resourceType":"automatedExportSettings","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2015-04-01","2014-04-01"]},{"resourceType":"diagnosticSettings","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2017-05-01-preview","2016-09-01","2015-07-01"]},{"resourceType":"diagnosticSettingsCategories","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"extendedDiagnosticSettings","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2017-02-01"]},{"resourceType":"metricDefinitions","locations":["East
+        US","West US","West Europe","East Asia","Southeast Asia","Japan East","Japan
+        West","North Central US","South Central US","East US 2","Canada East","Canada
+        Central","Central US","Australia East","Australia Southeast","Brazil South","South
+        India","Central India","West India","North Europe","West US 2","West Central
+        US","Korea South","Korea Central","UK South","UK West","Global"],"apiVersions":["2017-05-01-preview","2016-03-01","2015-07-01"]},{"resourceType":"logDefinitions","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2015-07-01"]},{"resourceType":"eventCategories","locations":[],"apiVersions":["2015-04-01"]},{"resourceType":"metrics","locations":["East
+        US","West US","West Europe","East Asia","Southeast Asia","Japan East","Japan
+        West","North Central US","South Central US","East US 2","Canada East","Canada
+        Central","Central US","Australia East","Australia Southeast","Brazil South","South
+        India","Central India","West India","North Europe","West US 2","West Central
+        US","Korea South","Korea Central","UK South","UK West"],"apiVersions":["2017-05-01-preview","2016-09-01","2016-06-01"]},{"resourceType":"actiongroups","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]},{"resourceType":"activityLogAlerts","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.KeyVault","namespace":"Microsoft.KeyVault","resourceTypes":[{"resourceType":"vaults","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/accessPolicies","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-10-01","2015-06-01","2014-12-19-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"deletedVaults","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-10-01"]},{"resourceType":"locations/deletedVaults","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorization":{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"routeTables","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2017-04-26-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"]},{"resourceType":"workspaces/dataSources","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"storageInsightConfigs","locations":[],"apiVersions":["2014-10-10"]},{"resourceType":"workspaces/linkedServices","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"linkTargets","locations":["East
+        US"],"apiVersions":["2015-03-20"]},{"resourceType":"operations","locations":[],"apiVersions":["2014-11-10"]},{"resourceType":"devices","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationsManagement","namespace":"Microsoft.OperationsManagement","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"aa249101-6816-4966-aafa-08175d795f14"},"resourceTypes":[{"resourceType":"solutions","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Portal","namespace":"Microsoft.Portal","resourceTypes":[{"resourceType":"dashboards","locations":["Central
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
+        East","West India","South India","Central India","Canada Central","Canada
+        East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"operations","locations":["Central
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
+        East","West India","South India","Central India","Canada Central","Canada
+        East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"consoles","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/consoles","locations":["West
+        US","East US","Central India","North Europe","West Europe","South Central
+        US","Southeast Asia"],"apiVersions":["2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
+        US","East US","Central India","North Europe","West Europe","South Central
+        US","Southeast Asia"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","Canada Central","Canada East","West Central US","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-07-01","2016-12-01","2016-08-10","2016-06-01","2016-05-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"operations","locations":["Southeast
+        Asia"],"apiVersions":["2016-08-10","2016-06-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01"]},{"resourceType":"locations/backupStatus","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]},{"resourceType":"locations/allocatedStamp","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]},{"resourceType":"locations/allocateStamp","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ResourceHealth","namespace":"Microsoft.ResourceHealth","authorization":{"applicationId":"8bdebf23-c0fe-4187-a378-717ad86f6a53","roleDefinitionId":"cc026344-c8b1-4561-83ba-59eba84b27cc"},"resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2017-07-01","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"notifications","locations":["Australia
+        Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Security","namespace":"Microsoft.Security","authorization":{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatuses","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/virtualMachines","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/endpoints","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/subnets","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"tasks","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"alerts","locations":["Central
+        US","East US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"monitoring","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"monitoring/patch","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"monitoring/baseline","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"monitoring/antimalware","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"dataCollectionAgents","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"dataCollectionResults","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"pricings","locations":["Central
+        US","East US"],"apiVersions":["2017-08-01-preview"]},{"resourceType":"complianceResults","locations":["Central
+        US","East US"],"apiVersions":["2017-08-01"]},{"resourceType":"policies","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"appliances","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"webApplicationFirewalls","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/webApplicationFirewalls","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securitySolutions","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/securitySolutions","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securitySolutionsReferenceData","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/securitySolutionsReferenceData","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"jitNetworkAccessPolicies","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/jitNetworkAccessPolicies","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatusesSummaries","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/alerts","locations":["Central
+        US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/tasks","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.SiteRecovery","namespace":"Microsoft.SiteRecovery","authorization":{"applicationId":"b8340c3b-9267-498f-b21a-15d5547fd85e","roleDefinitionId":"8A00C8EA-8F1B-45A7-8F64-F4CC61EEE9B6"},"resourceTypes":[{"resourceType":"SiteRecoveryVault","locations":["East
+        US","West US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","Australia East","Australia Southeast","Brazil South","North
+        Central US","South Central US","Central US","East US 2","Central India","South
+        India"],"apiVersions":["2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Sql","namespace":"Microsoft.Sql","authorizations":[{"applicationId":"e4ab13ed-33cb-41b4-9140-6e264582cf85","roleDefinitionId":"ec3ddc95-44dc-47a2-9926-5e9f5ffd44ec"},{"applicationId":"0130cc9f-7ac5-4026-bd5f-80a08a54e6d9","roleDefinitionId":"45e8abf8-0ec4-44f3-9c37-cff4f7779302"},{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},{"applicationId":"76c7f279-7959-468f-8943-3954880e0d8c","roleDefinitionId":"7f7513a8-73f9-4c5f-97a2-c41f0ea783ef"}],"resourceTypes":[{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/capabilities","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverKeyOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/keys","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/encryptionProtector","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/communicationLinks","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recoverableDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/importExportOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/operationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/firewallrules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/elasticpools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-09-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/dnsAliases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/failoverGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/virtualNetworkRules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/virtualNetworkRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/virtualNetworkRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/databaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/extensions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditRecords","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/VulnerabilityAssessmentScans","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentScans","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups/syncMembers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/syncAgents","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncMemberOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncAgentOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncDatabaseIds","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorization":{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
+        US","West US","West Europe","North Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":["East
+        US","West US","West Europe","North Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Web","namespace":"Microsoft.Web","authorization":{"applicationId":"abfa0a7c-a6b6-4736-8310-5855508787cd","roleDefinitionId":"f47ed98b-b063-4a5b-9e10-4b9b44fa7735"},"resourceTypes":[{"resourceType":"sites/extensions","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots/extensions","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/instances","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots/instances","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/instances/extensions","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots/instances/extensions","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/publicCertificates","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots/publicCertificates","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"publishingUsers","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"ishostnameavailable","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"validate","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"isusernameavailable","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sourceControls","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"availableStacks","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"listSitesAssignedToHostName","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"sites/hostNameBindings","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"sites/domainOwnershipIdentifiers","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"sites/slots/hostNameBindings","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"operations","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"certificates","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms/workers","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"runtimes","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"sites/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"sites/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"sites/slots/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"sites/slots/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"serverFarms/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"serverFarms/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"sites/recommendations","locations":[],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"georegions","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/premieraddons","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01"]},{"resourceType":"hostingEnvironments","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/instances","locations":[],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/instances/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/instances/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/instances","locations":[],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/instances/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/instances/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"deploymentLocations","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"functions","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"deletedSites","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"ishostingenvironmentnameavailable","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"classicMobileServices","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"connections","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/managedApis","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/apiOperations","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"connectionGateways","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/connectionGatewayInstallations","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"checkNameAvailability","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"billingMeters","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/84codes.CloudAMQP","namespace":"84codes.CloudAMQP","resourceTypes":[{"resourceType":"servers","locations":["East
+        US 2","Central US","East US","North Central US","South Central US","West US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast"],"apiVersions":["2016-08-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/AppDynamics.APM","namespace":"AppDynamics.APM","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2016-05-26"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-05-26"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-05-26"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-05-26"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-05-26"]},{"resourceType":"locations/operationResults","locations":["West
+        US"],"apiVersions":["2016-05-26"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Aspera.Transfers","namespace":"Aspera.Transfers","resourceTypes":[{"resourceType":"services","locations":["West
+        US","North Europe","Central US","East US","West Europe","East Asia","Southeast
+        Asia","Japan East","East US 2","Japan West"],"apiVersions":["2016-03-25"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-03-25"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-03-25"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-03-25"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Auth0.Cloud","namespace":"Auth0.Cloud","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-11-23"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Citrix.Cloud","namespace":"Citrix.Cloud","resourceTypes":[{"resourceType":"accounts","locations":["West
+        US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Cloudyn.Analytics","namespace":"Cloudyn.Analytics","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US"],"apiVersions":["2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Conexlink.MyCloudIT","namespace":"Conexlink.MyCloudIT","resourceTypes":[{"resourceType":"accounts","locations":["Central
+        US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Crypteron.DataSecurity","namespace":"Crypteron.DataSecurity","resourceTypes":[{"resourceType":"apps","locations":["West
+        US"],"apiVersions":["2016-08-12"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-12"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-12"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-12"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Dynatrace.DynatraceSaaS","namespace":"Dynatrace.DynatraceSaaS","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-09-27"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Dynatrace.Ruxit","namespace":"Dynatrace.Ruxit","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US"],"apiVersions":["2016-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-09-07","2016-04-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-04-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/LiveArena.Broadcast","namespace":"LiveArena.Broadcast","resourceTypes":[{"resourceType":"services","locations":["West
+        US","North Europe","Japan West","Japan East","East Asia","West Europe","East
+        US","Southeast Asia","Central US"],"apiVersions":["2016-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Lombiq.DotNest","namespace":"Lombiq.DotNest","resourceTypes":[{"resourceType":"sites","locations":["East
+        US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Mailjet.Email","namespace":"Mailjet.Email","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]},{"resourceType":"diagnosticSettings","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"addsservices","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"configuration","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"agents","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"aadsupportcases","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"reports","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"servicehealthmetrics","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"logs","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"anonymousapiusers","locations":["West
+        US"],"apiVersions":["2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AnalysisServices","namespace":"Microsoft.AnalysisServices","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"servers","locations":["West
+        US","North Europe","South Central US","West Europe","West Central US","Southeast
+        Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
+        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/checkNameAvailability","locations":["West
+        US","North Europe","South Central US","West Europe","West Central US","Southeast
+        Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
+        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationresults","locations":["West
+        US","North Europe","South Central US","West Europe","West Central US","Southeast
+        Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
+        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationstatuses","locations":["West
+        US","North Europe","South Central US","West Europe","West Central US","Southeast
+        Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
+        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"operations","locations":["East
+        US 2","West Central US"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AppService","namespace":"Microsoft.AppService","authorization":{"applicationId":"dee7ba80-6a55-4f3b-a86c-746a9231ae49","roleDefinitionId":"6715d172-49c4-46f6-bb21-60512a8689dc"},"resourceTypes":[{"resourceType":"apiapps","locations":["East
+        US","West US","South Central US","North Europe","East Asia","Japan East","West
+        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
+        South","East US 2","Australia Southeast","Australia East","West India","South
+        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"appIdentities","locations":["East
+        US","West US","South Central US","North Europe","East Asia","Japan East","West
+        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
+        South","East US 2","Australia Southeast","Australia East","West India","South
+        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"gateways","locations":["East
+        US","West US","South Central US","North Europe","East Asia","Japan East","West
+        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
+        South","East US 2","Australia Southeast","Australia East","West India","South
+        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"deploymenttemplates","locations":[],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Authorization","namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"roleDefinitions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"classicAdministrators","locations":[],"apiVersions":["2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"permissions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"locks","locations":[],"apiVersions":["2017-04-01","2016-09-01","2015-06-01","2015-05-01-preview","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-01-01","2014-10-01-preview","2014-06-01"]},{"resourceType":"policyDefinitions","locations":[],"apiVersions":["2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"policySetDefinitions","locations":[],"apiVersions":["2017-06-01-preview"]},{"resourceType":"policyAssignments","locations":[],"apiVersions":["2017-06-01-preview","2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"providerOperations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01-preview","2015-07-01"]},{"resourceType":"elevateAccess","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureActiveDirectory","namespace":"Microsoft.AzureActiveDirectory","resourceTypes":[{"resourceType":"b2cDirectories","locations":["Global","United
+        States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureStack","namespace":"Microsoft.AzureStack","resourceTypes":[{"resourceType":"operations","locations":["Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations","locations":["West
+        Central US","Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations/products","locations":["West
+        Central US","Global"],"apiVersions":["2017-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Billing","namespace":"Microsoft.Billing","resourceTypes":[{"resourceType":"BillingPeriods","locations":["Central
+        US"],"apiVersions":["2017-04-24-preview"]},{"resourceType":"Invoices","locations":["Central
+        US"],"apiVersions":["2017-04-24-preview","2017-02-27-preview"]},{"resourceType":"operations","locations":["Central
+        US"],"apiVersions":["2017-04-24-preview","2017-02-27-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BingMaps","namespace":"Microsoft.BingMaps","resourceTypes":[{"resourceType":"mapApis","locations":["West
+        US"],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-18","2015-07-02"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BizTalkServices","namespace":"Microsoft.BizTalkServices","resourceTypes":[{"resourceType":"BizTalk","locations":["East
+        US","West US","North Europe","West Europe","Southeast Asia","East Asia","North
+        Central US","Japan West","Japan East","South Central US"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Cache","namespace":"Microsoft.Cache","authorization":{"applicationId":"96231a05-34ce-4eb4-aa6a-70759cbb5e83","roleDefinitionId":"4f731528-ba85-45c7-acfb-cd0a9b3cf31b"},"resourceTypes":[{"resourceType":"Redis","locations":["North
+        Central US","South Central US","Central US","West Europe","North Europe","West
+        US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
+        Asia","East Asia","Australia East","Australia Southeast","Central India","West
+        India","Canada Central","Canada East","UK South","UK West","West US 2","West
+        Central US","South India","Korea Central","Korea South"],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","South Central US","Central US","West Europe","North Europe","West
+        US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
+        Asia","East Asia","Australia East","Australia Southeast","Central India","West
+        India","South India","Canada Central","Canada East","UK South","UK West","West
+        US 2","West Central US","Korea Central","Korea South"],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01"]},{"resourceType":"Redis/metricDefinitions","locations":["North
+        Central US","South Central US","East US","East US 2","West US","Central US","East
+        Asia","Southeast Asia","North Europe","West Europe","Japan East","Japan West","Brazil
+        South","Australia Southeast","Australia East","Central India","West India","South
+        India","Canada Central","Canada East","UK West","UK South","West US 2","West
+        Central US","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"Redis/diagnosticSettings","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","West
+        US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
+        Asia","Australia East","Australia Southeast","Central India","West India","South
+        India","Canada Central","Canada East","UK West","UK South","West US 2","West
+        Central US","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Cdn","namespace":"Microsoft.Cdn","resourceTypes":[{"resourceType":"profiles","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/origins","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/customdomains","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/originresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/customdomainresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkResourceUsage","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02"]},{"resourceType":"validateProbe","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"edgenodes","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CertificateRegistration","namespace":"Microsoft.CertificateRegistration","authorization":{"applicationId":"f3c21649-0979-4721-ac85-b0216b2cf413","roleDefinitionId":"933fba7e-2ed3-4da8-973d-8bd8298a9b40"},"resourceTypes":[{"resourceType":"certificateOrders","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"certificateOrders/certificates","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"validateCertificateRegistrationInformation","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicSubscription","namespace":"Microsoft.ClassicSubscription","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicInfrastructureMigrate","namespace":"Microsoft.ClassicInfrastructureMigrate","authorization":{"applicationId":"5e5abe2b-83cd-4786-826a-a05653ebb103","roleDefinitionId":"766c4d9b-ef83-4f73-8352-1450a506a69b"},"resourceTypes":[{"resourceType":"classicInfrastructureResources","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","West
+        India","South India"],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CognitiveServices","namespace":"Microsoft.CognitiveServices","authorizations":[{"applicationId":"7d312290-28c8-473c-a0ed-8e53749b6d6d","roleDefinitionId":"5cb87f79-a7c3-4a95-9414-45b65974b51b"}],"resourceTypes":[{"resourceType":"accounts","locations":["Global","West
+        US","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"operations","locations":["Global","West
+        US","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations","locations":["Global","West
+        US","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/checkSkuAvailability","locations":["West
+        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/updateAccountsCreationSettings","locations":["West
+        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/accountsCreationSettings","locations":["West
+        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2016-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Commerce","namespace":"Microsoft.Commerce","resourceTypes":[{"resourceType":"UsageAggregates","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]},{"resourceType":"RateCard","locations":[],"apiVersions":["2016-08-31-preview","2015-06-01-preview","2015-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Consumption","namespace":"Microsoft.Consumption","resourceTypes":[{"resourceType":"reservationsummaries","locations":[],"apiVersions":["2017-01-30"]},{"resourceType":"reservationdetails","locations":[],"apiVersions":["2017-01-30"]},{"resourceType":"UsageDetails","locations":[],"apiVersions":["2017-06-30-preview","2017-04-24-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-30-preview","2017-04-24-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","resourceTypes":[{"resourceType":"containerGroups","locations":["West
+        US","East US","West Europe"],"apiVersions":["2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
+        US"],"apiVersions":["2016-04-08"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CustomerInsights","namespace":"Microsoft.CustomerInsights","authorization":{"applicationId":"38c77d00-5fcb-4cce-9d93-af4738258e3c","roleDefinitionId":"E006F9C7-F333-477C-8AD6-1F3A9FE87F55"},"resourceTypes":[{"resourceType":"hubs","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/profiles","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/interactions","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/authorizationPolicies","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/connectors","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/connectors/mappings","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/kpi","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/views","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/links","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/roleAssignments","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/roles","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/widgetTypes","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/suggestTypeSchema","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"operations","locations":["East
+        US 2"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataCatalog","namespace":"Microsoft.DataCatalog","resourceTypes":[{"resourceType":"catalogs","locations":["East
+        US","West US","Australia East","West Europe","North Europe","Southeast Asia","West
+        Central US"],"apiVersions":["2016-03-30","2015-07-01-preview"]},{"resourceType":"checkNameAvailability","locations":["West
+        Europe"],"apiVersions":["2016-03-30","2015-07-01-preview"]},{"resourceType":"operations","locations":["West
+        Europe"],"apiVersions":["2016-03-30","2015-07-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-03-30","2015-07-01-preview"]},{"resourceType":"locations/jobs","locations":["East
+        US","West US","Australia East","West Europe","North Europe","Southeast Asia","West
+        Central US"],"apiVersions":["2016-03-30","2015-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataFactory","namespace":"Microsoft.DataFactory","resourceTypes":[{"resourceType":"dataFactories","locations":["West
+        US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview","2014-04-01"]},{"resourceType":"factories","locations":["East
+        US"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
+        US"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
+        Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"dataFactories/metricDefinitions","locations":["North
+        Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"checkDataFactoryNameAvailability","locations":[],"apiVersions":["2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"checkAzureDataFactoryNameAvailability","locations":["West
+        US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"dataFactorySchema","locations":["West
+        US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"operations","locations":["West
+        US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeAnalytics","namespace":"Microsoft.DataLakeAnalytics","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/dataLakeStoreAccounts","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers/listSasTokens","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeStore","namespace":"Microsoft.DataLakeStore","authorization":{"applicationId":"e9f49c6b-5ce5-44c8-925d-015017e9f7ad","roleDefinitionId":"17eb9cca-f08a-4499-b2d3-852d175f614f"},"resourceTypes":[{"resourceType":"accounts","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/firewallRules","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","resourceTypes":[{"resourceType":"operations","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforPostgreSQL","namespace":"Microsoft.DBforPostgreSQL","resourceTypes":[{"resourceType":"operations","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
+        US","North Europe","East Asia","East US","West Europe","Southeast Asia","Japan
+        East","Japan West","Australia East","Australia Southeast","West US 2","West
+        Central US","East US 2","Central US","UK South","UK West","South India","Central
+        India"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"databaseAccountNames","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DomainRegistration","namespace":"Microsoft.DomainRegistration","authorization":{"applicationId":"ea2f600a-4980-45b7-89bf-d34da487bda1","roleDefinitionId":"54d7f2e3-5040-48a7-ae90-eebf629cfa0b"},"resourceTypes":[{"resourceType":"domains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"domains/domainOwnershipIdentifiers","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"topLevelDomains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"checkDomainAvailability","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"listDomainRecommendations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"validateDomainRegistrationInformation","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"generateSsoRequest","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DynamicsLcs","namespace":"Microsoft.DynamicsLcs","resourceTypes":[{"resourceType":"lcsprojects","locations":["Brazil
+        South","East Asia","East US","Japan East","Japan West","North Central US","North
+        Europe","South Central US","West Europe","West US","Southeast Asia","Central
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"lcsprojects/connectors","locations":["Brazil
+        South","East Asia","East US","Japan East","Japan West","North Central US","North
+        Europe","South Central US","West Europe","West US","Southeast Asia","Central
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"lcsprojects/clouddeployments","locations":["Brazil
+        South","East Asia","East US","Japan East","Japan West","North Central US","North
+        Europe","South Central US","West Europe","West US","Southeast Asia","Central
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"operations","locations":["Brazil
+        South","East Asia","East US","Japan East","Japan West","North Central US","North
+        Europe","South Central US","West Europe","West US","Southeast Asia","Central
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"topics","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operations","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"clusters/applications","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"clusters/operationresults","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations/capabilities","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations/operationresults","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations/azureasyncoperations","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations/validateCreateRequest","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"operations","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India"],"apiVersions":["2015-03-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ImportExport","namespace":"Microsoft.ImportExport","authorization":{"applicationId":"7de4d5c5-5b32-4235-b8a9-33b34d6bcd2a","roleDefinitionId":"9f7aa6bb-9454-46b6-8c01-a4b0f33ca151"},"resourceTypes":[{"resourceType":"jobs","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","North Central US","North Europe","South Central US","Southeast
+        Asia","South India","UK South","West Central US","West Europe","West India","West
+        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","North Central US","North Europe","South Central US","Southeast
+        Asia","South India","UK South","West Central US","West Europe","West India","West
+        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations/operationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","North Central US","North Europe","South Central US","Southeast
+        Asia","South India","UK South","West Central US","West Europe","West India","West
+        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","North Central US","North Europe","South Central US","Southeast
+        Asia","South India","UK South","West Central US","West Europe","West India","West
+        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Logic","namespace":"Microsoft.Logic","authorization":{"applicationId":"7cd684f4-8a78-49b0-91ec-6a35d38739ba","roleDefinitionId":"cb3ef1fb-6e31-49e2-9d87-ed821053fe58"},"resourceTypes":[{"resourceType":"workflows","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West"],"apiVersions":["2017-07-01","2016-10-01","2016-06-01","2015-08-01-preview","2015-02-01-preview"]},{"resourceType":"locations/workflows","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West"],"apiVersions":["2017-07-01","2016-10-01","2016-06-01","2015-08-01-preview","2015-02-01-preview"]},{"resourceType":"locations","locations":["North
+        Central US"],"apiVersions":["2017-07-01","2016-10-01","2016-06-01","2015-08-01-preview","2015-02-01-preview"]},{"resourceType":"operations","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West"],"apiVersions":["2017-07-01","2016-10-01","2016-06-01","2015-08-01-preview","2015-02-01-preview"]},{"resourceType":"integrationAccounts","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","West Central US"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"operations","locations":["South
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations","locations":["South
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operations","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"commitmentPlans","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
+        Central US","West US"],"apiVersions":["2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Media","namespace":"Microsoft.Media","authorization":{"applicationId":"374b2a64-3b6b-436b-934c-b820eacca870","roleDefinitionId":"aab70789-0cec-44b5-95d7-84b64c9487af"},"resourceTypes":[{"resourceType":"mediaservices","locations":["Japan
+        West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
+        US","West US","Australia East","Australia Southeast","Central US","Brazil
+        South","Central India","West India","South India","South Central US","Canada
+        Central","Canada East","West Central US"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
+        Central US","North Central US","East US 2","West US","West Europe","North
+        Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
+        East","UK South","West India"],"apiVersions":["2016-01-29"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-01-29"]},{"resourceType":"locations/checkNameAvailability","locations":["South
+        Central US","North Central US","East US 2","West US","West Europe","North
+        Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
+        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"operations","locations":["East
+        US 2"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Relay","namespace":"Microsoft.Relay","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US 2","West
+        US","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
+        East","West India","South India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
+        East","West India","South India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
+        Central US","South Central US","North Europe","West Europe","East Asia","Southeast
+        Asia","West US","East US","Japan West","Japan East","Brazil South","Central
+        US","East US 2","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-03-01","2016-01-01","2014-08-01-preview"]},{"resourceType":"operations","locations":["North
+        Central US","South Central US","North Europe","West Europe","East Asia","Southeast
+        Asia","West US","East US","Japan West","Japan East","Brazil South","Central
+        US","East US 2","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-03-01","2016-01-01","2014-08-01-preview"]},{"resourceType":"operationResults","locations":["North
+        Central US","South Central US","North Europe","West Europe","East Asia","Southeast
+        Asia","West US","East US","Japan West","Japan East","Brazil South","Central
+        US","East US 2","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-03-01","2016-01-01","2014-08-01-preview"]},{"resourceType":"flows","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast"],"apiVersions":["2015-08-01-preview","2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Search","namespace":"Microsoft.Search","resourceTypes":[{"resourceType":"searchServices","locations":["West
+        US","East US","North Europe","West Europe","Southeast Asia","East Asia","North
+        Central US","South Central US","Japan West","Australia East","Brazil South","Central
+        India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19","2015-02-28"]},{"resourceType":"checkServiceNameAvailability","locations":[],"apiVersions":["2015-02-28","2014-07-31-Preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2015-08-19"]},{"resourceType":"resourceHealthMetadata","locations":["West
+        US","East US","North Europe","West Europe","Southeast Asia","East Asia","North
+        Central US","South Central US","Japan West","Australia East","Brazil South","Central
+        India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US 2","West
+        US","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"premiumMessagingRegions","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceFabric","namespace":"Microsoft.ServiceFabric","authorization":{"applicationId":"74cb6831-0dbb-4be1-8206-fd4df301cdc2","roleDefinitionId":"e55cc65f-6903-4917-b4ef-f8d4640b57f5"},"resourceTypes":[{"resourceType":"clusters","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/clusterVersions","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operations","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Canada
+        Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","West Central US","Japan East","Japan West","Australia East","Australia
+        Southeast"],"apiVersions":["2017-06-01","2017-05-15","2017-01-01","2016-10-01","2016-06-01","2015-03-15","2014-09-01"]},{"resourceType":"operations","locations":["West
+        Central US","Southeast Asia"],"apiVersions":["2016-10-01","2016-06-01","2015-03-15","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StreamAnalytics","namespace":"Microsoft.StreamAnalytics","resourceTypes":[{"resourceType":"streamingjobs","locations":["Central
+        US","West Europe","East US 2","North Europe","Japan East","West US","Southeast
+        Asia","South Central US","East Asia","Japan West","North Central US","East
+        US","Australia East","Australia Southeast","Brazil South","Central India","West
+        Central US","UK South","UK West","Canada Central","Canada East","West US 2"],"apiVersions":["2017-04-01-preview","2016-03-01","2015-11-01","2015-10-01","2015-09-01","2015-08-01-preview","2015-06-01","2015-05-01","2015-04-01","2015-03-01-preview"]},{"resourceType":"locations","locations":["West
+        Europe","Central US","East US 2","North Europe","Japan East","West US","Southeast
+        Asia","South Central US","East Asia","Japan West","North Central US","East
+        US","Australia East","Australia Southeast","Brazil South","Central India","West
+        Central US","UK South","West US 2","UK West","Canada Central","Canada East"],"apiVersions":["2017-04-01-preview","2016-03-01","2015-11-01","2015-10-01","2015-09-01","2015-08-01-preview","2015-06-01","2015-05-01","2015-04-01","2015-03-01-preview"]},{"resourceType":"locations/quotas","locations":[],"apiVersions":["2017-04-01-preview","2016-03-01","2015-11-01","2015-10-01","2015-09-01","2015-08-01-preview","2015-06-01","2015-05-01","2015-04-01","2015-03-01-preview"]},{"resourceType":"streamingjobs/diagnosticSettings","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","Central
+        India","West Central US","UK South","UK West","Canada Central","Canada East","West
+        US 2","West US","Central US","South Central US","Japan East","Japan West","East
+        Asia","Southeast Asia","Australia East","Australia Southeast"],"apiVersions":["2014-04-01"]},{"resourceType":"streamingjobs/metricDefinitions","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","Central
+        India","West Central US","UK South","UK West","Canada Central","Canada East","West
+        US 2","West US","Central US","South Central US","Japan East","Japan West","East
+        Asia","Southeast Asia","Australia East","Australia Southeast"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":["West
+        Europe","West US","Central US","East US 2","North Europe","Japan East","Southeast
+        Asia","South Central US","East Asia","Japan West","North Central US","East
+        US","Australia East","Australia Southeast","Brazil South","Central India","West
+        Central US","UK South","UK West","Canada Central","Canada East","West US 2"],"apiVersions":["2017-04-01-preview","2016-03-01","2015-11-01","2015-10-01","2015-09-01","2015-08-01-preview","2015-06-01","2015-05-01","2015-04-01","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.support","namespace":"microsoft.support","resourceTypes":[{"resourceType":"operations","locations":["North
+        Central US","South Central US","Central US","West Europe","North Europe","West
+        US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
+        Asia","East Asia","Australia East","Australia Southeast"],"apiVersions":["2015-07-01-Preview","2015-03-01"]},{"resourceType":"supporttickets","locations":["North
+        Central US","South Central US","Central US","West Europe","North Europe","West
+        US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
+        Asia","East Asia","Australia East","Australia Southeast"],"apiVersions":["2015-07-01-Preview","2015-03-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.TimeSeriesInsights","namespace":"Microsoft.TimeSeriesInsights","authorizations":[{"applicationId":"120d688d-1518-4cf7-bd38-182f158850b6","roleDefinitionId":"5a43abdf-bb87-42c4-9e56-1c24bf364150"}],"resourceTypes":[{"resourceType":"environments","locations":["East
+        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/eventsources","locations":["East
+        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/referenceDataSets","locations":["East
+        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/accessPolicies","locations":["East
+        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"operations","locations":["East
+        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/project","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/extension","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"checkNameAvailability","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Myget.PackageManagement","namespace":"Myget.PackageManagement","resourceTypes":[{"resourceType":"services","locations":["West
+        Europe"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/NewRelic.APM","namespace":"NewRelic.APM","authorization":{"allowedThirdPartyExtensions":[{"name":"NewRelic_AzurePortal_APM"}]},"resourceTypes":[{"resourceType":"accounts","locations":["North
+        Central US","South Central US","West US","East US","North Europe","West Europe","Southeast
+        Asia","East Asia","Japan East","Japan West"],"apiVersions":["2014-10-01","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/nuubit.nextgencdn","namespace":"nuubit.nextgencdn","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US","East US 2","North Central US","South Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","West US","Central US"],"apiVersions":["2017-05-05"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-05"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-05-05"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-05-05"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Paraleap.CloudMonix","namespace":"Paraleap.CloudMonix","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2016-08-10"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-10"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-10"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Pokitdok.Platform","namespace":"Pokitdok.Platform","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2016-05-17"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-05-17"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-05-17"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-05-17"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RavenHq.Db","namespace":"RavenHq.Db","resourceTypes":[{"resourceType":"databases","locations":["East
+        US"],"apiVersions":["2016-07-18","2016-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-07-18","2016-06-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-07-18","2016-06-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-07-18","2016-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Raygun.CrashReporting","namespace":"Raygun.CrashReporting","resourceTypes":[{"resourceType":"apps","locations":["East
+        US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RedisLabs.Memcached","namespace":"RedisLabs.Memcached","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-07-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RedisLabs.Redis","namespace":"RedisLabs.Redis","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-07-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RevAPM.MobileCDN","namespace":"RevAPM.MobileCDN","resourceTypes":[{"resourceType":"accounts","locations":["Central
+        US","East US","East US 2","North Central US","South Central US","West US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast"],"apiVersions":["2016-08-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-24","2016-08-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sendgrid.Email","namespace":"Sendgrid.Email","resourceTypes":[{"resourceType":"accounts","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Canada Central","Canada
+        East","West Central US","West US 2","UK South","UK West"],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Signiant.Flight","namespace":"Signiant.Flight","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US","Central US","North Central US","South Central US","West US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast"],"apiVersions":["2015-06-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sparkpost.Basic","namespace":"Sparkpost.Basic","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2016-08-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/stackify.retrace","namespace":"stackify.retrace","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2016-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/SuccessBricks.ClearDB","namespace":"SuccessBricks.ClearDB","resourceTypes":[{"resourceType":"databases","locations":["Brazil
+        South","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","Southeast Asia","West Europe","West
+        US","South Central US","Australia East","Australia Southeast","Canada Central","Canada
+        East","Central India","South India","West India"],"apiVersions":["2014-04-01"]},{"resourceType":"clusters","locations":["Brazil
+        South","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","Southeast Asia","West Europe","West
+        US","Australia Southeast","Australia East","South Central US","Canada Central","Canada
+        East","Central India","South India","West India"],"apiVersions":["2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/TrendMicro.DeepSecurity","namespace":"TrendMicro.DeepSecurity","resourceTypes":[{"resourceType":"accounts","locations":["Central
+        US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
+        Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:06 GMT
+- request:
+    method: post
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
+    body:
+      encoding: UTF-8
+      string: '{"access":"read","durationInSeconds":3600}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4ODUsIm5iZiI6MTUwNDEwNjg4NSwiZXhwIjoxNTA0MTEwNzg1LCJhaW8iOiJZMkZnWUFqbS9Od1p0bjFuNm1ISEJhZERiTi9GQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTmF0cHVTZ1FaazZCaGxDYTlXOFRBQSIsInZlciI6IjEuMCJ9.FfrMZoMTdUc3iphl1Omm08jxJnnBo44pmQQEhrsuVj5AKpcNxgMkt4ntZQ6DuK338G_LobcDSLTKa4AYwwfgl99oHwNYIp7E1oPk_1BZu9jn1CJPmSFthl6rmRI_6cEg4BTQjiyve3oKeMcpSFNfzNscOUPUTRGy21yAwaSkYE6SfHkb9xsREZwcIcftru0shIVl8kyqlVXLpQmqIuNmZ29vTcfTC0put2Qp-KHH_pati3_2VlHSNsCScygDAoLnQe8s_cHdVr0BS4UQZjdbgML-2-qrO5IUowAJPeqItPP5nQy4KNRo4geEP7cEzRSqiMyY-elJH4HzM8L_bsfu6A
+      Content-Length:
+      - '42'
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '0'
+      Expires:
+      - "-1"
+      Location:
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/89e21989-ce64-4eab-aa16-c995cb6ad7bc?monitor=true&api-version=2017-03-30
+      Azure-Asyncoperation:
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/89e21989-ce64-4eab-aa16-c995cb6ad7bc?api-version=2017-03-30
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      X-Ms-Request-Id:
+      - 89e21989-ce64-4eab-aa16-c995cb6ad7bc
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Writes:
+      - '1196'
+      X-Ms-Correlation-Request-Id:
+      - e2998506-6969-43bd-b715-da1911e91c41
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153307Z:e2998506-6969-43bd-b715-da1911e91c41
+      Date:
+      - Wed, 30 Aug 2017 15:33:06 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:07 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/89e21989-ce64-4eab-aa16-c995cb6ad7bc?api-version=2017-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4ODUsIm5iZiI6MTUwNDEwNjg4NSwiZXhwIjoxNTA0MTEwNzg1LCJhaW8iOiJZMkZnWUFqbS9Od1p0bjFuNm1ISEJhZERiTi9GQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTmF0cHVTZ1FaazZCaGxDYTlXOFRBQSIsInZlciI6IjEuMCJ9.FfrMZoMTdUc3iphl1Omm08jxJnnBo44pmQQEhrsuVj5AKpcNxgMkt4ntZQ6DuK338G_LobcDSLTKa4AYwwfgl99oHwNYIp7E1oPk_1BZu9jn1CJPmSFthl6rmRI_6cEg4BTQjiyve3oKeMcpSFNfzNscOUPUTRGy21yAwaSkYE6SfHkb9xsREZwcIcftru0shIVl8kyqlVXLpQmqIuNmZ29vTcfTC0put2Qp-KHH_pati3_2VlHSNsCScygDAoLnQe8s_cHdVr0BS4UQZjdbgML-2-qrO5IUowAJPeqItPP5nQy4KNRo4geEP7cEzRSqiMyY-elJH4HzM8L_bsfu6A
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      X-Ms-Request-Id:
+      - fb51aae2-3d6e-4ada-ace4-1c924fe1b986
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14907'
+      X-Ms-Correlation-Request-Id:
+      - bc3f465e-f1ec-4ead-af1c-a2bb41730d54
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153307Z:bc3f465e-f1ec-4ead-af1c-a2bb41730d54
+      Date:
+      - Wed, 30 Aug 2017 15:33:07 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"startTime\": \"2017-08-30T15:33:06.7388601+00:00\",\r\n  \"endTime\":
+        \"2017-08-30T15:33:06.8950849+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=f0d79d02-ba7a-4040-949b-ae4f8193e514&sig=fCVdvag5JQ04El8oWCZ2y4NHIALrQUkS08Ix6MYoCKE%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"89e21989-ce64-4eab-aa16-c995cb6ad7bc\"\r\n}"
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:07 GMT
+- request:
+    method: get
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=f0d79d02-ba7a-4040-949b-ae4f8193e514&sig=fCVdvag5JQ04El8oWCZ2y4NHIALrQUkS08Ix6MYoCKE=&sr=b&sv=2016-05-31
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      X-Ms-Range:
+      - bytes=0-0
+      Host:
+      - md-t4jdgqqlgszp.blob.core.windows.net
+  response:
+    status:
+      code: 206
+      message: Partial Content
+    headers:
+      Content-Length:
+      - '1'
+      Content-Type:
+      - application/octet-stream
+      Content-Range:
+      - bytes 0-0/34359738880
+      Last-Modified:
+      - Sat, 15 Jul 2017 14:23:07 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D4CB8D039FC699"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - caa3a566-0001-0063-66a5-21e708000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Meta-Pirtag:
+      - '1'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '20'
+      X-Ms-Copy-Id:
+      - 30cedd78-548a-4fd8-967e-f8344f587e3c
+      X-Ms-Copy-Source:
+      - http://md-t4jdgqqlgszp.blob.core.windows.net:8080/fg25xxtqx0gc/abcd?sv=2016-02-19&sr=b&st=2017-05-04T21%3a06%3a57Z&se=9999-12-31T23%3a59%3a59Z&sp=r&api-version=2016-02-19
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 34359738880/34359738880
+      X-Ms-Copy-Completion-Time:
+      - Thu, 04 May 2017 21:21:56 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Wed, 30 Aug 2017 15:33:07 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        6w==
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:07 GMT
+- request:
+    method: post
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
+    body:
+      encoding: UTF-8
+      string: '{"access":"read","durationInSeconds":3600}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4ODUsIm5iZiI6MTUwNDEwNjg4NSwiZXhwIjoxNTA0MTEwNzg1LCJhaW8iOiJZMkZnWUFqbS9Od1p0bjFuNm1ISEJhZERiTi9GQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTmF0cHVTZ1FaazZCaGxDYTlXOFRBQSIsInZlciI6IjEuMCJ9.FfrMZoMTdUc3iphl1Omm08jxJnnBo44pmQQEhrsuVj5AKpcNxgMkt4ntZQ6DuK338G_LobcDSLTKa4AYwwfgl99oHwNYIp7E1oPk_1BZu9jn1CJPmSFthl6rmRI_6cEg4BTQjiyve3oKeMcpSFNfzNscOUPUTRGy21yAwaSkYE6SfHkb9xsREZwcIcftru0shIVl8kyqlVXLpQmqIuNmZ29vTcfTC0put2Qp-KHH_pati3_2VlHSNsCScygDAoLnQe8s_cHdVr0BS4UQZjdbgML-2-qrO5IUowAJPeqItPP5nQy4KNRo4geEP7cEzRSqiMyY-elJH4HzM8L_bsfu6A
+      Content-Length:
+      - '42'
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '0'
+      Expires:
+      - "-1"
+      Location:
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/a82f4892-e42d-42e9-9d79-686b8c1baaa6?monitor=true&api-version=2017-03-30
+      Azure-Asyncoperation:
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/a82f4892-e42d-42e9-9d79-686b8c1baaa6?api-version=2017-03-30
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      X-Ms-Request-Id:
+      - a82f4892-e42d-42e9-9d79-686b8c1baaa6
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Writes:
+      - '1197'
+      X-Ms-Correlation-Request-Id:
+      - 9ae16137-59cc-42a5-945e-e904f9b9196f
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153308Z:9ae16137-59cc-42a5-945e-e904f9b9196f
+      Date:
+      - Wed, 30 Aug 2017 15:33:07 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:08 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/a82f4892-e42d-42e9-9d79-686b8c1baaa6?api-version=2017-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4ODUsIm5iZiI6MTUwNDEwNjg4NSwiZXhwIjoxNTA0MTEwNzg1LCJhaW8iOiJZMkZnWUFqbS9Od1p0bjFuNm1ISEJhZERiTi9GQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTmF0cHVTZ1FaazZCaGxDYTlXOFRBQSIsInZlciI6IjEuMCJ9.FfrMZoMTdUc3iphl1Omm08jxJnnBo44pmQQEhrsuVj5AKpcNxgMkt4ntZQ6DuK338G_LobcDSLTKa4AYwwfgl99oHwNYIp7E1oPk_1BZu9jn1CJPmSFthl6rmRI_6cEg4BTQjiyve3oKeMcpSFNfzNscOUPUTRGy21yAwaSkYE6SfHkb9xsREZwcIcftru0shIVl8kyqlVXLpQmqIuNmZ29vTcfTC0put2Qp-KHH_pati3_2VlHSNsCScygDAoLnQe8s_cHdVr0BS4UQZjdbgML-2-qrO5IUowAJPeqItPP5nQy4KNRo4geEP7cEzRSqiMyY-elJH4HzM8L_bsfu6A
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      X-Ms-Request-Id:
+      - f9dadc6f-e858-41d8-8ba6-b3fbe3f25d60
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14866'
+      X-Ms-Correlation-Request-Id:
+      - 4dffaa20-8d3c-4149-b9a5-cf991edee094
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153308Z:4dffaa20-8d3c-4149-b9a5-cf991edee094
+      Date:
+      - Wed, 30 Aug 2017 15:33:07 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"startTime\": \"2017-08-30T15:33:07.6607534+00:00\",\r\n  \"endTime\":
+        \"2017-08-30T15:33:07.8638532+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=b0f54b3d-3d55-476d-96ef-16bcee0a59c7&sig=Q%2FM3NZw6Dy3iOWS%2BgnyBy4g%2BzGxwbfu4XZXQESS5Hic%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"a82f4892-e42d-42e9-9d79-686b8c1baaa6\"\r\n}"
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:08 GMT
+- request:
+    method: get
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=b0f54b3d-3d55-476d-96ef-16bcee0a59c7&sig=Q/M3NZw6Dy3iOWS%2BgnyBy4g%2BzGxwbfu4XZXQESS5Hic=&sr=b&sv=2016-05-31
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      X-Ms-Range:
+      - bytes=440-443
+      Host:
+      - md-t4jdgqqlgszp.blob.core.windows.net
+  response:
+    status:
+      code: 206
+      message: Partial Content
+    headers:
+      Content-Length:
+      - '4'
+      Content-Type:
+      - application/octet-stream
+      Content-Range:
+      - bytes 440-443/34359738880
+      Last-Modified:
+      - Sat, 15 Jul 2017 14:23:07 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D4CB8D039FC699"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 493d9288-0001-00bc-62a5-21b65c000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Meta-Pirtag:
+      - '1'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '20'
+      X-Ms-Copy-Id:
+      - 30cedd78-548a-4fd8-967e-f8344f587e3c
+      X-Ms-Copy-Source:
+      - http://md-t4jdgqqlgszp.blob.core.windows.net:8080/fg25xxtqx0gc/abcd?sv=2016-02-19&sr=b&st=2017-05-04T21%3a06%3a57Z&se=9999-12-31T23%3a59%3a59Z&sp=r&api-version=2016-02-19
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 34359738880/34359738880
+      X-Ms-Copy-Completion-Time:
+      - Thu, 04 May 2017 21:21:56 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Wed, 30 Aug 2017 15:33:07 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        U5MJAA==
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:08 GMT
+recorded_with: VCR 3.0.3

--- a/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_new-1.yml
+++ b/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_new-1.yml
@@ -1,0 +1,1949 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://login.microsoftonline.com/azure_tenant_id/oauth2/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_key&resource=https%3A%2F%2Fmanagement.azure.com%2F
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - login.microsoftonline.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Server:
+      - Microsoft-IIS/8.5
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Request-Id:
+      - ee46e047-2b9d-4ac4-b9cd-6b7710f81100
+      P3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Set-Cookie:
+      - esctx=AQABAAAAAAA9kTklhVy7SJTGAzR-p1Bc3oUuayb-OkLBchDftbiAUa8ip2XkHI_9uaM1Y4FRWhXDlgXPTDvzMmkye1Q8jytG0Pe_Jf8bRsT9AXIsFriJSUUdFPt0jI9TjS5Pol_c4B3uy6ljDJDGTnRP9QVnhJS-NAg4Ffni5IG08xEC1eumkfSj5WFXRMOuiHNrxSqRRcAgAA;
+        domain=.login.microsoftonline.com; path=/; secure; HttpOnly
+      - stsservicecookie=ests; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=004; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Wed, 30 Aug 2017 15:32:37 GMT
+      Content-Length:
+      - '1505'
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1504110757","not_before":"1504106857","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NTcsIm5iZiI6MTUwNDEwNjg1NywiZXhwIjoxNTA0MTEwNzU3LCJhaW8iOiJZMkZnWUtpWnhzWEc2Sy95bXZQUW5NTnV1Ynd6QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUi1CRzdwMHJ4RXE1eld0M0VQZ1JBQSIsInZlciI6IjEuMCJ9.FynHByy1VebBUQ_C9OoxTAZeBecs37zkRnHNJTKfbhK2w-6YNdl9BB_No0Rznbncxo0eFPD1n_pYcrCzFIOcWqA1BdP5ACoYUx4bKLPlh7QDDd9Max0E33lSw-Ann--Aqm4jG6-a5x2A3EQgAm823z8_q08ubSc-Iv3l6wVLI09itM5bg9pIvAVNaKBfAk_w_YgrSv6Zl9ulW0KWxenNgLslq4PonqPU4dn7M37rHuO-3OHI90Gfn0wSD3yeK7eLybB37VfNsT_xUXPrEtDRS85ec9aXMI03gMZuzN7Tw2d-yklrT2m86zCe6T3O003cGzysP7vbZ6cmObb4OBc9EA"}'
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:32:36 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions?api-version=2016-06-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NTcsIm5iZiI6MTUwNDEwNjg1NywiZXhwIjoxNTA0MTEwNzU3LCJhaW8iOiJZMkZnWUtpWnhzWEc2Sy95bXZQUW5NTnV1Ynd6QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUi1CRzdwMHJ4RXE1eld0M0VQZ1JBQSIsInZlciI6IjEuMCJ9.FynHByy1VebBUQ_C9OoxTAZeBecs37zkRnHNJTKfbhK2w-6YNdl9BB_No0Rznbncxo0eFPD1n_pYcrCzFIOcWqA1BdP5ACoYUx4bKLPlh7QDDd9Max0E33lSw-Ann--Aqm4jG6-a5x2A3EQgAm823z8_q08ubSc-Iv3l6wVLI09itM5bg9pIvAVNaKBfAk_w_YgrSv6Zl9ulW0KWxenNgLslq4PonqPU4dn7M37rHuO-3OHI90Gfn0wSD3yeK7eLybB37VfNsT_xUXPrEtDRS85ec9aXMI03gMZuzN7Tw2d-yklrT2m86zCe6T3O003cGzysP7vbZ6cmObb4OBc9EA
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Tenant-Reads:
+      - '14997'
+      X-Ms-Request-Id:
+      - 625a9309-1a4f-4c02-a4be-4b6f565ef0d3
+      X-Ms-Correlation-Request-Id:
+      - 625a9309-1a4f-4c02-a4be-4b6f565ef0d3
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153237Z:625a9309-1a4f-4c02-a4be-4b6f565ef0d3
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 30 Aug 2017 15:32:36 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
+        Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:32:36 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers?api-version=2015-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NTcsIm5iZiI6MTUwNDEwNjg1NywiZXhwIjoxNTA0MTEwNzU3LCJhaW8iOiJZMkZnWUtpWnhzWEc2Sy95bXZQUW5NTnV1Ynd6QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUi1CRzdwMHJ4RXE1eld0M0VQZ1JBQSIsInZlciI6IjEuMCJ9.FynHByy1VebBUQ_C9OoxTAZeBecs37zkRnHNJTKfbhK2w-6YNdl9BB_No0Rznbncxo0eFPD1n_pYcrCzFIOcWqA1BdP5ACoYUx4bKLPlh7QDDd9Max0E33lSw-Ann--Aqm4jG6-a5x2A3EQgAm823z8_q08ubSc-Iv3l6wVLI09itM5bg9pIvAVNaKBfAk_w_YgrSv6Zl9ulW0KWxenNgLslq4PonqPU4dn7M37rHuO-3OHI90Gfn0wSD3yeK7eLybB37VfNsT_xUXPrEtDRS85ec9aXMI03gMZuzN7Tw2d-yklrT2m86zCe6T3O003cGzysP7vbZ6cmObb4OBc9EA
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14867'
+      X-Ms-Request-Id:
+      - 61697f74-ce21-42f6-8f0c-4d84266c651e
+      X-Ms-Correlation-Request-Id:
+      - 61697f74-ce21-42f6-8f0c-4d84266c651e
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153238Z:61697f74-ce21-42f6-8f0c-4d84266c651e
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 30 Aug 2017 15:32:38 GMT
+      Content-Length:
+      - '241615'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","North Central
+        US","South Central US","West Central US","West US","West US 2","Canada Central","Canada
+        East","North Europe","West Europe","UK South","UK West","East Asia","Southeast
+        Asia","Japan East","Japan West","Korea Central","Korea South","Brazil South","Central
+        India","South India","West India"],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"validateServiceName","locations":[],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"checkServiceNameAvailability","locations":[],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"reportFeedback","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"checkFeedbackRequired","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Automation","namespace":"Microsoft.Automation","authorizations":[{"applicationId":"fc75330b-179d-49af-87dd-3b1acf6827fa","roleDefinitionId":"95fd5de3-d071-4362-92bf-cf341c1de832"}],"resourceTypes":[{"resourceType":"automationAccounts","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
+        South","UK South","West Central US","North Europe","Canada Central","Australia
+        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/runbooks","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
+        South","UK South","West Central US","North Europe","Canada Central","Australia
+        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/configurations","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","North
+        Central US","Brazil South","UK South","West Central US","Central India","Australia
+        Southeast","Canada Central","North Europe"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/webhooks","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
+        South","UK South","West Central US","North Europe","Canada Central","Australia
+        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"operations","locations":["South
+        Central US"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/softwareUpdateConfigurations","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
+        South","UK South","West Central US","North Europe","Canada Central","Australia
+        Southeast","Central India"],"apiVersions":["2017-05-15-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Backup","namespace":"Microsoft.Backup","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"BackupVault","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India"],"apiVersions":["2015-03-15","2014-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Batch","namespace":"Microsoft.Batch","authorization":{"applicationId":"ddbf3205-c6bd-46ae-8127-60eb93363864","roleDefinitionId":"b7f84953-1d03-4eab-9ea4-45f065258ff8"},"resourceTypes":[{"resourceType":"batchAccounts","locations":["West
+        Europe","East US","East US 2","West US","North Central US","Brazil South","North
+        Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
+        West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
+        East","South India","Central India","Canada Central","Canada East","UK South","UK
+        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01","2015-07-01","2014-05-01-privatepreview"]},{"resourceType":"operations","locations":["West
+        Europe","East US","East US 2","West US","North Central US","Brazil South","North
+        Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
+        West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
+        East","South India","Central India","Canada Central","Canada East","UK South","UK
+        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations/quotas","locations":["West
+        Europe","East US","East US 2","West US","North Central US","Brazil South","North
+        Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
+        West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
+        East","South India","Central India","Canada Central","Canada East","UK South","UK
+        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]}],"registrationState":"Unregistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicCompute","namespace":"Microsoft.ClassicCompute","resourceTypes":[{"resourceType":"domainNames","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
+        Central","Canada East","UK South","UK West","West US","Central US","South
+        Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
+        East","Australia Southeast","West US 2","West Central US","South India","Central
+        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
+        Central","Canada East","UK South","UK West","West US","Central US","South
+        Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
+        East","Australia Southeast","West US 2","West Central US","South India","Central
+        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
+        Central US","South Central US","East US","East US 2","Canada Central","Canada
+        East","West US","West US 2","West Central US","Central US","East Asia","Southeast
+        Asia","North Europe","West Europe","UK South","UK West","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operatingSystems","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"operatingSystemFamilies","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicNetwork","namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"virtualNetworks/remoteVirtualNetworkPeeringProxies","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"reservedIps","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicStorage","namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
+        US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
+        Asia","Australia East","Australia Southeast","South India","Central India","West
+        India","West US 2","West Central US","East US","East US 2","North Central
+        US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
+        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
+        US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
+        Asia","Australia East","Australia Southeast","South India","Central India","West
+        India","West US 2","West Central US","East US","East US 2","North Central
+        US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
+        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"vmImages","locations":[],"apiVersions":["2016-11-01"]},{"resourceType":"publicImages","locations":[],"apiVersions":["2016-11-01","2016-04-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"osPlatformImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Compute","namespace":"Microsoft.Compute","authorization":{"applicationId":"60e6cd67-9c8c-4951-9b3c-23c25a2169af","roleDefinitionId":"e4770acb-272e-4dc8-87f3-12f44a612224"},"resourceTypes":[{"resourceType":"availabilitySets","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30"]},{"resourceType":"locations/usages","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"disks","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"snapshots","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"locations/diskoperations","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"images","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
+        US","East US","South Central US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","East Asia","Japan
+        East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/webhooks","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/ping","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/getCallbackConfig","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/listEvents","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"locations","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"locations/operationResults","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/GetCredentials","locations":["West
+        US","East US","South Central US","West Europe"],"apiVersions":["2016-06-27-preview"]},{"resourceType":"registries/listCredentials","locations":["South
+        Central US","East US","West US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","East Asia","Japan
+        East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/regenerateCredential","locations":["South
+        Central US","West US","East US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","East Asia","Japan
+        East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/listUsages","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/regenerateCredentials","locations":["West
+        US","East US","South Central US","West Europe"],"apiVersions":["2016-06-27-preview"]},{"resourceType":"checkNameAvailability","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview","2017-03-01","2016-06-27-preview"]},{"resourceType":"operations","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview","2017-03-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerService","namespace":"Microsoft.ContainerService","authorization":{"applicationId":"7319c514-987d-4e9b-ac3d-d38c4f427f4c","roleDefinitionId":"1b4a0c7f-2217-416f-acfa-cf73452fdc1c"},"resourceTypes":[{"resourceType":"containerServices","locations":["Japan
+        East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
+        East","Australia Southeast","Brazil South","Southeast Asia","West US","North
+        Central US","West Europe","North Europe","East US","UK West","UK South","West
+        Central US","West US 2","South India","Central India","West India","Canada
+        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
+        East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
+        East","Australia Southeast","Brazil South","Southeast Asia","West US","North
+        Central US","West Europe","North Europe","East US","UK West","UK South","West
+        Central US","West US 2","South India","Central India","West India","Canada
+        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DevTestLab","namespace":"Microsoft.DevTestLab","authorization":{"applicationId":"1a14be2a-e903-4cec-99cf-b2e209259a0f","roleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525"},"resourceTypes":[{"resourceType":"labs","locations":["West
+        Central US","Japan East","West US","Australia Southeast","Canada Central","Central
+        India","Central US","East Asia","Korea Central","North Europe","South Central
+        US","UK West","Australia East","Brazil South","Canada East","East US","East
+        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"schedules","locations":["West
+        Central US","Japan East","West US","Australia Southeast","Canada Central","Central
+        India","Central US","East Asia","Korea Central","North Europe","South Central
+        US","UK West","Australia East","Brazil South","Canada East","East US","East
+        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"labs/virtualMachines","locations":["West
+        Central US","Japan East","West US","Australia Southeast","Canada Central","Central
+        India","Central US","East Asia","Korea Central","North Europe","South Central
+        US","UK West","Australia East","Brazil South","Canada East","East US","East
+        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"labs/serviceRunners","locations":["Central
+        US","East US 2","South Central US"],"apiVersions":["2017-04-26-preview","2016-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"locations/operations","locations":["West
+        Central US","Japan East","West US","Australia Southeast","Canada Central","Central
+        India","Central US","East Asia","Korea Central","North Europe","South Central
+        US","UK West","Australia East","Brazil South","Canada East","East US","East
+        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"}],"resourceTypes":[{"resourceType":"components","locations":["East
+        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
+        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01","2014-04-01"]},{"resourceType":"queries","locations":["East
+        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"alertrules","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2016-03-01","2015-04-01","2014-04-01"]},{"resourceType":"autoscalesettings","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2015-04-01","2014-04-01"]},{"resourceType":"eventtypes","locations":[],"apiVersions":["2017-03-01-preview","2016-09-01-preview","2015-04-01","2014-11-01","2014-04-01"]},{"resourceType":"locations","locations":["East
+        US"],"apiVersions":["2015-04-01","2014-04-01"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2015-04-01","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-04-01","2014-06-01","2014-04-01"]},{"resourceType":"automatedExportSettings","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2015-04-01","2014-04-01"]},{"resourceType":"diagnosticSettings","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2017-05-01-preview","2016-09-01","2015-07-01"]},{"resourceType":"diagnosticSettingsCategories","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"extendedDiagnosticSettings","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2017-02-01"]},{"resourceType":"metricDefinitions","locations":["East
+        US","West US","West Europe","East Asia","Southeast Asia","Japan East","Japan
+        West","North Central US","South Central US","East US 2","Canada East","Canada
+        Central","Central US","Australia East","Australia Southeast","Brazil South","South
+        India","Central India","West India","North Europe","West US 2","West Central
+        US","Korea South","Korea Central","UK South","UK West","Global"],"apiVersions":["2017-05-01-preview","2016-03-01","2015-07-01"]},{"resourceType":"logDefinitions","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2015-07-01"]},{"resourceType":"eventCategories","locations":[],"apiVersions":["2015-04-01"]},{"resourceType":"metrics","locations":["East
+        US","West US","West Europe","East Asia","Southeast Asia","Japan East","Japan
+        West","North Central US","South Central US","East US 2","Canada East","Canada
+        Central","Central US","Australia East","Australia Southeast","Brazil South","South
+        India","Central India","West India","North Europe","West US 2","West Central
+        US","Korea South","Korea Central","UK South","UK West"],"apiVersions":["2017-05-01-preview","2016-09-01","2016-06-01"]},{"resourceType":"actiongroups","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]},{"resourceType":"activityLogAlerts","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.KeyVault","namespace":"Microsoft.KeyVault","resourceTypes":[{"resourceType":"vaults","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/accessPolicies","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-10-01","2015-06-01","2014-12-19-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"deletedVaults","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-10-01"]},{"resourceType":"locations/deletedVaults","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorization":{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"routeTables","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2017-04-26-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"]},{"resourceType":"workspaces/dataSources","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"storageInsightConfigs","locations":[],"apiVersions":["2014-10-10"]},{"resourceType":"workspaces/linkedServices","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"linkTargets","locations":["East
+        US"],"apiVersions":["2015-03-20"]},{"resourceType":"operations","locations":[],"apiVersions":["2014-11-10"]},{"resourceType":"devices","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationsManagement","namespace":"Microsoft.OperationsManagement","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"aa249101-6816-4966-aafa-08175d795f14"},"resourceTypes":[{"resourceType":"solutions","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Portal","namespace":"Microsoft.Portal","resourceTypes":[{"resourceType":"dashboards","locations":["Central
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
+        East","West India","South India","Central India","Canada Central","Canada
+        East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"operations","locations":["Central
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
+        East","West India","South India","Central India","Canada Central","Canada
+        East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"consoles","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/consoles","locations":["West
+        US","East US","Central India","North Europe","West Europe","South Central
+        US","Southeast Asia"],"apiVersions":["2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
+        US","East US","Central India","North Europe","West Europe","South Central
+        US","Southeast Asia"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","Canada Central","Canada East","West Central US","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-07-01","2016-12-01","2016-08-10","2016-06-01","2016-05-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"operations","locations":["Southeast
+        Asia"],"apiVersions":["2016-08-10","2016-06-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01"]},{"resourceType":"locations/backupStatus","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]},{"resourceType":"locations/allocatedStamp","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]},{"resourceType":"locations/allocateStamp","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ResourceHealth","namespace":"Microsoft.ResourceHealth","authorization":{"applicationId":"8bdebf23-c0fe-4187-a378-717ad86f6a53","roleDefinitionId":"cc026344-c8b1-4561-83ba-59eba84b27cc"},"resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2017-07-01","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"notifications","locations":["Australia
+        Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Security","namespace":"Microsoft.Security","authorization":{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatuses","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/virtualMachines","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/endpoints","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/subnets","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"tasks","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"alerts","locations":["Central
+        US","East US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"monitoring","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"monitoring/patch","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"monitoring/baseline","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"monitoring/antimalware","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"dataCollectionAgents","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"dataCollectionResults","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"pricings","locations":["Central
+        US","East US"],"apiVersions":["2017-08-01-preview"]},{"resourceType":"complianceResults","locations":["Central
+        US","East US"],"apiVersions":["2017-08-01"]},{"resourceType":"policies","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"appliances","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"webApplicationFirewalls","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/webApplicationFirewalls","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securitySolutions","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/securitySolutions","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securitySolutionsReferenceData","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/securitySolutionsReferenceData","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"jitNetworkAccessPolicies","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/jitNetworkAccessPolicies","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatusesSummaries","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/alerts","locations":["Central
+        US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/tasks","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.SiteRecovery","namespace":"Microsoft.SiteRecovery","authorization":{"applicationId":"b8340c3b-9267-498f-b21a-15d5547fd85e","roleDefinitionId":"8A00C8EA-8F1B-45A7-8F64-F4CC61EEE9B6"},"resourceTypes":[{"resourceType":"SiteRecoveryVault","locations":["East
+        US","West US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","Australia East","Australia Southeast","Brazil South","North
+        Central US","South Central US","Central US","East US 2","Central India","South
+        India"],"apiVersions":["2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Sql","namespace":"Microsoft.Sql","authorizations":[{"applicationId":"e4ab13ed-33cb-41b4-9140-6e264582cf85","roleDefinitionId":"ec3ddc95-44dc-47a2-9926-5e9f5ffd44ec"},{"applicationId":"0130cc9f-7ac5-4026-bd5f-80a08a54e6d9","roleDefinitionId":"45e8abf8-0ec4-44f3-9c37-cff4f7779302"},{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},{"applicationId":"76c7f279-7959-468f-8943-3954880e0d8c","roleDefinitionId":"7f7513a8-73f9-4c5f-97a2-c41f0ea783ef"}],"resourceTypes":[{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/capabilities","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverKeyOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/keys","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/encryptionProtector","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/communicationLinks","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recoverableDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/importExportOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/operationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/firewallrules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/elasticpools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-09-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/dnsAliases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/failoverGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/virtualNetworkRules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/virtualNetworkRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/virtualNetworkRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/databaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/extensions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditRecords","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/VulnerabilityAssessmentScans","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentScans","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups/syncMembers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/syncAgents","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncMemberOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncAgentOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncDatabaseIds","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorization":{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
+        US","West US","West Europe","North Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":["East
+        US","West US","West Europe","North Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Web","namespace":"Microsoft.Web","authorization":{"applicationId":"abfa0a7c-a6b6-4736-8310-5855508787cd","roleDefinitionId":"f47ed98b-b063-4a5b-9e10-4b9b44fa7735"},"resourceTypes":[{"resourceType":"sites/extensions","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots/extensions","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/instances","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots/instances","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/instances/extensions","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots/instances/extensions","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/publicCertificates","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots/publicCertificates","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"publishingUsers","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"ishostnameavailable","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"validate","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"isusernameavailable","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sourceControls","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"availableStacks","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"listSitesAssignedToHostName","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"sites/hostNameBindings","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"sites/domainOwnershipIdentifiers","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"sites/slots/hostNameBindings","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"operations","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"certificates","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms/workers","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"runtimes","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"sites/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"sites/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"sites/slots/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"sites/slots/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"serverFarms/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"serverFarms/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"sites/recommendations","locations":[],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"georegions","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/premieraddons","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01"]},{"resourceType":"hostingEnvironments","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/instances","locations":[],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/instances/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/instances/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/instances","locations":[],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/instances/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/instances/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"deploymentLocations","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"functions","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"deletedSites","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"ishostingenvironmentnameavailable","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"classicMobileServices","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"connections","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/managedApis","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/apiOperations","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"connectionGateways","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/connectionGatewayInstallations","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"checkNameAvailability","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"billingMeters","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/84codes.CloudAMQP","namespace":"84codes.CloudAMQP","resourceTypes":[{"resourceType":"servers","locations":["East
+        US 2","Central US","East US","North Central US","South Central US","West US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast"],"apiVersions":["2016-08-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/AppDynamics.APM","namespace":"AppDynamics.APM","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2016-05-26"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-05-26"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-05-26"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-05-26"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-05-26"]},{"resourceType":"locations/operationResults","locations":["West
+        US"],"apiVersions":["2016-05-26"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Aspera.Transfers","namespace":"Aspera.Transfers","resourceTypes":[{"resourceType":"services","locations":["West
+        US","North Europe","Central US","East US","West Europe","East Asia","Southeast
+        Asia","Japan East","East US 2","Japan West"],"apiVersions":["2016-03-25"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-03-25"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-03-25"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-03-25"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Auth0.Cloud","namespace":"Auth0.Cloud","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-11-23"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Citrix.Cloud","namespace":"Citrix.Cloud","resourceTypes":[{"resourceType":"accounts","locations":["West
+        US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Cloudyn.Analytics","namespace":"Cloudyn.Analytics","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US"],"apiVersions":["2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Conexlink.MyCloudIT","namespace":"Conexlink.MyCloudIT","resourceTypes":[{"resourceType":"accounts","locations":["Central
+        US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Crypteron.DataSecurity","namespace":"Crypteron.DataSecurity","resourceTypes":[{"resourceType":"apps","locations":["West
+        US"],"apiVersions":["2016-08-12"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-12"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-12"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-12"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Dynatrace.DynatraceSaaS","namespace":"Dynatrace.DynatraceSaaS","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-09-27"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Dynatrace.Ruxit","namespace":"Dynatrace.Ruxit","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US"],"apiVersions":["2016-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-09-07","2016-04-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-04-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/LiveArena.Broadcast","namespace":"LiveArena.Broadcast","resourceTypes":[{"resourceType":"services","locations":["West
+        US","North Europe","Japan West","Japan East","East Asia","West Europe","East
+        US","Southeast Asia","Central US"],"apiVersions":["2016-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Lombiq.DotNest","namespace":"Lombiq.DotNest","resourceTypes":[{"resourceType":"sites","locations":["East
+        US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Mailjet.Email","namespace":"Mailjet.Email","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]},{"resourceType":"diagnosticSettings","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"addsservices","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"configuration","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"agents","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"aadsupportcases","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"reports","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"servicehealthmetrics","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"logs","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"anonymousapiusers","locations":["West
+        US"],"apiVersions":["2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AnalysisServices","namespace":"Microsoft.AnalysisServices","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"servers","locations":["West
+        US","North Europe","South Central US","West Europe","West Central US","Southeast
+        Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
+        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/checkNameAvailability","locations":["West
+        US","North Europe","South Central US","West Europe","West Central US","Southeast
+        Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
+        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationresults","locations":["West
+        US","North Europe","South Central US","West Europe","West Central US","Southeast
+        Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
+        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationstatuses","locations":["West
+        US","North Europe","South Central US","West Europe","West Central US","Southeast
+        Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
+        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"operations","locations":["East
+        US 2","West Central US"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AppService","namespace":"Microsoft.AppService","authorization":{"applicationId":"dee7ba80-6a55-4f3b-a86c-746a9231ae49","roleDefinitionId":"6715d172-49c4-46f6-bb21-60512a8689dc"},"resourceTypes":[{"resourceType":"apiapps","locations":["East
+        US","West US","South Central US","North Europe","East Asia","Japan East","West
+        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
+        South","East US 2","Australia Southeast","Australia East","West India","South
+        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"appIdentities","locations":["East
+        US","West US","South Central US","North Europe","East Asia","Japan East","West
+        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
+        South","East US 2","Australia Southeast","Australia East","West India","South
+        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"gateways","locations":["East
+        US","West US","South Central US","North Europe","East Asia","Japan East","West
+        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
+        South","East US 2","Australia Southeast","Australia East","West India","South
+        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"deploymenttemplates","locations":[],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Authorization","namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"roleDefinitions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"classicAdministrators","locations":[],"apiVersions":["2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"permissions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"locks","locations":[],"apiVersions":["2017-04-01","2016-09-01","2015-06-01","2015-05-01-preview","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-01-01","2014-10-01-preview","2014-06-01"]},{"resourceType":"policyDefinitions","locations":[],"apiVersions":["2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"policySetDefinitions","locations":[],"apiVersions":["2017-06-01-preview"]},{"resourceType":"policyAssignments","locations":[],"apiVersions":["2017-06-01-preview","2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"providerOperations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01-preview","2015-07-01"]},{"resourceType":"elevateAccess","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureActiveDirectory","namespace":"Microsoft.AzureActiveDirectory","resourceTypes":[{"resourceType":"b2cDirectories","locations":["Global","United
+        States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureStack","namespace":"Microsoft.AzureStack","resourceTypes":[{"resourceType":"operations","locations":["Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations","locations":["West
+        Central US","Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations/products","locations":["West
+        Central US","Global"],"apiVersions":["2017-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Billing","namespace":"Microsoft.Billing","resourceTypes":[{"resourceType":"BillingPeriods","locations":["Central
+        US"],"apiVersions":["2017-04-24-preview"]},{"resourceType":"Invoices","locations":["Central
+        US"],"apiVersions":["2017-04-24-preview","2017-02-27-preview"]},{"resourceType":"operations","locations":["Central
+        US"],"apiVersions":["2017-04-24-preview","2017-02-27-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BingMaps","namespace":"Microsoft.BingMaps","resourceTypes":[{"resourceType":"mapApis","locations":["West
+        US"],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-18","2015-07-02"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BizTalkServices","namespace":"Microsoft.BizTalkServices","resourceTypes":[{"resourceType":"BizTalk","locations":["East
+        US","West US","North Europe","West Europe","Southeast Asia","East Asia","North
+        Central US","Japan West","Japan East","South Central US"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Cache","namespace":"Microsoft.Cache","authorization":{"applicationId":"96231a05-34ce-4eb4-aa6a-70759cbb5e83","roleDefinitionId":"4f731528-ba85-45c7-acfb-cd0a9b3cf31b"},"resourceTypes":[{"resourceType":"Redis","locations":["North
+        Central US","South Central US","Central US","West Europe","North Europe","West
+        US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
+        Asia","East Asia","Australia East","Australia Southeast","Central India","West
+        India","Canada Central","Canada East","UK South","UK West","West US 2","West
+        Central US","South India","Korea Central","Korea South"],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","South Central US","Central US","West Europe","North Europe","West
+        US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
+        Asia","East Asia","Australia East","Australia Southeast","Central India","West
+        India","South India","Canada Central","Canada East","UK South","UK West","West
+        US 2","West Central US","Korea Central","Korea South"],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01"]},{"resourceType":"Redis/metricDefinitions","locations":["North
+        Central US","South Central US","East US","East US 2","West US","Central US","East
+        Asia","Southeast Asia","North Europe","West Europe","Japan East","Japan West","Brazil
+        South","Australia Southeast","Australia East","Central India","West India","South
+        India","Canada Central","Canada East","UK West","UK South","West US 2","West
+        Central US","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"Redis/diagnosticSettings","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","West
+        US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
+        Asia","Australia East","Australia Southeast","Central India","West India","South
+        India","Canada Central","Canada East","UK West","UK South","West US 2","West
+        Central US","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Cdn","namespace":"Microsoft.Cdn","resourceTypes":[{"resourceType":"profiles","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/origins","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/customdomains","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/originresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/customdomainresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkResourceUsage","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02"]},{"resourceType":"validateProbe","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"edgenodes","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CertificateRegistration","namespace":"Microsoft.CertificateRegistration","authorization":{"applicationId":"f3c21649-0979-4721-ac85-b0216b2cf413","roleDefinitionId":"933fba7e-2ed3-4da8-973d-8bd8298a9b40"},"resourceTypes":[{"resourceType":"certificateOrders","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"certificateOrders/certificates","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"validateCertificateRegistrationInformation","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicSubscription","namespace":"Microsoft.ClassicSubscription","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicInfrastructureMigrate","namespace":"Microsoft.ClassicInfrastructureMigrate","authorization":{"applicationId":"5e5abe2b-83cd-4786-826a-a05653ebb103","roleDefinitionId":"766c4d9b-ef83-4f73-8352-1450a506a69b"},"resourceTypes":[{"resourceType":"classicInfrastructureResources","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","West
+        India","South India"],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CognitiveServices","namespace":"Microsoft.CognitiveServices","authorizations":[{"applicationId":"7d312290-28c8-473c-a0ed-8e53749b6d6d","roleDefinitionId":"5cb87f79-a7c3-4a95-9414-45b65974b51b"}],"resourceTypes":[{"resourceType":"accounts","locations":["Global","West
+        US","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"operations","locations":["Global","West
+        US","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations","locations":["Global","West
+        US","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/checkSkuAvailability","locations":["West
+        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/updateAccountsCreationSettings","locations":["West
+        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/accountsCreationSettings","locations":["West
+        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2016-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Commerce","namespace":"Microsoft.Commerce","resourceTypes":[{"resourceType":"UsageAggregates","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]},{"resourceType":"RateCard","locations":[],"apiVersions":["2016-08-31-preview","2015-06-01-preview","2015-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Consumption","namespace":"Microsoft.Consumption","resourceTypes":[{"resourceType":"reservationsummaries","locations":[],"apiVersions":["2017-01-30"]},{"resourceType":"reservationdetails","locations":[],"apiVersions":["2017-01-30"]},{"resourceType":"UsageDetails","locations":[],"apiVersions":["2017-06-30-preview","2017-04-24-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-30-preview","2017-04-24-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","resourceTypes":[{"resourceType":"containerGroups","locations":["West
+        US","East US","West Europe"],"apiVersions":["2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
+        US"],"apiVersions":["2016-04-08"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CustomerInsights","namespace":"Microsoft.CustomerInsights","authorization":{"applicationId":"38c77d00-5fcb-4cce-9d93-af4738258e3c","roleDefinitionId":"E006F9C7-F333-477C-8AD6-1F3A9FE87F55"},"resourceTypes":[{"resourceType":"hubs","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/profiles","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/interactions","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/authorizationPolicies","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/connectors","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/connectors/mappings","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/kpi","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/views","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/links","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/roleAssignments","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/roles","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/widgetTypes","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/suggestTypeSchema","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"operations","locations":["East
+        US 2"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataCatalog","namespace":"Microsoft.DataCatalog","resourceTypes":[{"resourceType":"catalogs","locations":["East
+        US","West US","Australia East","West Europe","North Europe","Southeast Asia","West
+        Central US"],"apiVersions":["2016-03-30","2015-07-01-preview"]},{"resourceType":"checkNameAvailability","locations":["West
+        Europe"],"apiVersions":["2016-03-30","2015-07-01-preview"]},{"resourceType":"operations","locations":["West
+        Europe"],"apiVersions":["2016-03-30","2015-07-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-03-30","2015-07-01-preview"]},{"resourceType":"locations/jobs","locations":["East
+        US","West US","Australia East","West Europe","North Europe","Southeast Asia","West
+        Central US"],"apiVersions":["2016-03-30","2015-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataFactory","namespace":"Microsoft.DataFactory","resourceTypes":[{"resourceType":"dataFactories","locations":["West
+        US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview","2014-04-01"]},{"resourceType":"factories","locations":["East
+        US"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
+        US"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
+        Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"dataFactories/metricDefinitions","locations":["North
+        Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"checkDataFactoryNameAvailability","locations":[],"apiVersions":["2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"checkAzureDataFactoryNameAvailability","locations":["West
+        US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"dataFactorySchema","locations":["West
+        US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"operations","locations":["West
+        US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeAnalytics","namespace":"Microsoft.DataLakeAnalytics","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/dataLakeStoreAccounts","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers/listSasTokens","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeStore","namespace":"Microsoft.DataLakeStore","authorization":{"applicationId":"e9f49c6b-5ce5-44c8-925d-015017e9f7ad","roleDefinitionId":"17eb9cca-f08a-4499-b2d3-852d175f614f"},"resourceTypes":[{"resourceType":"accounts","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/firewallRules","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","resourceTypes":[{"resourceType":"operations","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforPostgreSQL","namespace":"Microsoft.DBforPostgreSQL","resourceTypes":[{"resourceType":"operations","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
+        US","North Europe","East Asia","East US","West Europe","Southeast Asia","Japan
+        East","Japan West","Australia East","Australia Southeast","West US 2","West
+        Central US","East US 2","Central US","UK South","UK West","South India","Central
+        India"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"databaseAccountNames","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DomainRegistration","namespace":"Microsoft.DomainRegistration","authorization":{"applicationId":"ea2f600a-4980-45b7-89bf-d34da487bda1","roleDefinitionId":"54d7f2e3-5040-48a7-ae90-eebf629cfa0b"},"resourceTypes":[{"resourceType":"domains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"domains/domainOwnershipIdentifiers","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"topLevelDomains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"checkDomainAvailability","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"listDomainRecommendations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"validateDomainRegistrationInformation","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"generateSsoRequest","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DynamicsLcs","namespace":"Microsoft.DynamicsLcs","resourceTypes":[{"resourceType":"lcsprojects","locations":["Brazil
+        South","East Asia","East US","Japan East","Japan West","North Central US","North
+        Europe","South Central US","West Europe","West US","Southeast Asia","Central
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"lcsprojects/connectors","locations":["Brazil
+        South","East Asia","East US","Japan East","Japan West","North Central US","North
+        Europe","South Central US","West Europe","West US","Southeast Asia","Central
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"lcsprojects/clouddeployments","locations":["Brazil
+        South","East Asia","East US","Japan East","Japan West","North Central US","North
+        Europe","South Central US","West Europe","West US","Southeast Asia","Central
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"operations","locations":["Brazil
+        South","East Asia","East US","Japan East","Japan West","North Central US","North
+        Europe","South Central US","West Europe","West US","Southeast Asia","Central
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"topics","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operations","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"clusters/applications","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"clusters/operationresults","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations/capabilities","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations/operationresults","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations/azureasyncoperations","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations/validateCreateRequest","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"operations","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India"],"apiVersions":["2015-03-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ImportExport","namespace":"Microsoft.ImportExport","authorization":{"applicationId":"7de4d5c5-5b32-4235-b8a9-33b34d6bcd2a","roleDefinitionId":"9f7aa6bb-9454-46b6-8c01-a4b0f33ca151"},"resourceTypes":[{"resourceType":"jobs","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","North Central US","North Europe","South Central US","Southeast
+        Asia","South India","UK South","West Central US","West Europe","West India","West
+        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","North Central US","North Europe","South Central US","Southeast
+        Asia","South India","UK South","West Central US","West Europe","West India","West
+        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations/operationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","North Central US","North Europe","South Central US","Southeast
+        Asia","South India","UK South","West Central US","West Europe","West India","West
+        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","North Central US","North Europe","South Central US","Southeast
+        Asia","South India","UK South","West Central US","West Europe","West India","West
+        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Logic","namespace":"Microsoft.Logic","authorization":{"applicationId":"7cd684f4-8a78-49b0-91ec-6a35d38739ba","roleDefinitionId":"cb3ef1fb-6e31-49e2-9d87-ed821053fe58"},"resourceTypes":[{"resourceType":"workflows","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West"],"apiVersions":["2017-07-01","2016-10-01","2016-06-01","2015-08-01-preview","2015-02-01-preview"]},{"resourceType":"locations/workflows","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West"],"apiVersions":["2017-07-01","2016-10-01","2016-06-01","2015-08-01-preview","2015-02-01-preview"]},{"resourceType":"locations","locations":["North
+        Central US"],"apiVersions":["2017-07-01","2016-10-01","2016-06-01","2015-08-01-preview","2015-02-01-preview"]},{"resourceType":"operations","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West"],"apiVersions":["2017-07-01","2016-10-01","2016-06-01","2015-08-01-preview","2015-02-01-preview"]},{"resourceType":"integrationAccounts","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","West Central US"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"operations","locations":["South
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations","locations":["South
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operations","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"commitmentPlans","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
+        Central US","West US"],"apiVersions":["2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Media","namespace":"Microsoft.Media","authorization":{"applicationId":"374b2a64-3b6b-436b-934c-b820eacca870","roleDefinitionId":"aab70789-0cec-44b5-95d7-84b64c9487af"},"resourceTypes":[{"resourceType":"mediaservices","locations":["Japan
+        West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
+        US","West US","Australia East","Australia Southeast","Central US","Brazil
+        South","Central India","West India","South India","South Central US","Canada
+        Central","Canada East","West Central US"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
+        Central US","North Central US","East US 2","West US","West Europe","North
+        Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
+        East","UK South","West India"],"apiVersions":["2016-01-29"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-01-29"]},{"resourceType":"locations/checkNameAvailability","locations":["South
+        Central US","North Central US","East US 2","West US","West Europe","North
+        Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
+        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"operations","locations":["East
+        US 2"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Relay","namespace":"Microsoft.Relay","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US 2","West
+        US","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
+        East","West India","South India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
+        East","West India","South India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
+        Central US","South Central US","North Europe","West Europe","East Asia","Southeast
+        Asia","West US","East US","Japan West","Japan East","Brazil South","Central
+        US","East US 2","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-03-01","2016-01-01","2014-08-01-preview"]},{"resourceType":"operations","locations":["North
+        Central US","South Central US","North Europe","West Europe","East Asia","Southeast
+        Asia","West US","East US","Japan West","Japan East","Brazil South","Central
+        US","East US 2","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-03-01","2016-01-01","2014-08-01-preview"]},{"resourceType":"operationResults","locations":["North
+        Central US","South Central US","North Europe","West Europe","East Asia","Southeast
+        Asia","West US","East US","Japan West","Japan East","Brazil South","Central
+        US","East US 2","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-03-01","2016-01-01","2014-08-01-preview"]},{"resourceType":"flows","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast"],"apiVersions":["2015-08-01-preview","2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Search","namespace":"Microsoft.Search","resourceTypes":[{"resourceType":"searchServices","locations":["West
+        US","East US","North Europe","West Europe","Southeast Asia","East Asia","North
+        Central US","South Central US","Japan West","Australia East","Brazil South","Central
+        India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19","2015-02-28"]},{"resourceType":"checkServiceNameAvailability","locations":[],"apiVersions":["2015-02-28","2014-07-31-Preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2015-08-19"]},{"resourceType":"resourceHealthMetadata","locations":["West
+        US","East US","North Europe","West Europe","Southeast Asia","East Asia","North
+        Central US","South Central US","Japan West","Australia East","Brazil South","Central
+        India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US 2","West
+        US","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"premiumMessagingRegions","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceFabric","namespace":"Microsoft.ServiceFabric","authorization":{"applicationId":"74cb6831-0dbb-4be1-8206-fd4df301cdc2","roleDefinitionId":"e55cc65f-6903-4917-b4ef-f8d4640b57f5"},"resourceTypes":[{"resourceType":"clusters","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/clusterVersions","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operations","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Canada
+        Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","West Central US","Japan East","Japan West","Australia East","Australia
+        Southeast"],"apiVersions":["2017-06-01","2017-05-15","2017-01-01","2016-10-01","2016-06-01","2015-03-15","2014-09-01"]},{"resourceType":"operations","locations":["West
+        Central US","Southeast Asia"],"apiVersions":["2016-10-01","2016-06-01","2015-03-15","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StreamAnalytics","namespace":"Microsoft.StreamAnalytics","resourceTypes":[{"resourceType":"streamingjobs","locations":["Central
+        US","West Europe","East US 2","North Europe","Japan East","West US","Southeast
+        Asia","South Central US","East Asia","Japan West","North Central US","East
+        US","Australia East","Australia Southeast","Brazil South","Central India","West
+        Central US","UK South","UK West","Canada Central","Canada East","West US 2"],"apiVersions":["2017-04-01-preview","2016-03-01","2015-11-01","2015-10-01","2015-09-01","2015-08-01-preview","2015-06-01","2015-05-01","2015-04-01","2015-03-01-preview"]},{"resourceType":"locations","locations":["West
+        Europe","Central US","East US 2","North Europe","Japan East","West US","Southeast
+        Asia","South Central US","East Asia","Japan West","North Central US","East
+        US","Australia East","Australia Southeast","Brazil South","Central India","West
+        Central US","UK South","West US 2","UK West","Canada Central","Canada East"],"apiVersions":["2017-04-01-preview","2016-03-01","2015-11-01","2015-10-01","2015-09-01","2015-08-01-preview","2015-06-01","2015-05-01","2015-04-01","2015-03-01-preview"]},{"resourceType":"locations/quotas","locations":[],"apiVersions":["2017-04-01-preview","2016-03-01","2015-11-01","2015-10-01","2015-09-01","2015-08-01-preview","2015-06-01","2015-05-01","2015-04-01","2015-03-01-preview"]},{"resourceType":"streamingjobs/diagnosticSettings","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","Central
+        India","West Central US","UK South","UK West","Canada Central","Canada East","West
+        US 2","West US","Central US","South Central US","Japan East","Japan West","East
+        Asia","Southeast Asia","Australia East","Australia Southeast"],"apiVersions":["2014-04-01"]},{"resourceType":"streamingjobs/metricDefinitions","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","Central
+        India","West Central US","UK South","UK West","Canada Central","Canada East","West
+        US 2","West US","Central US","South Central US","Japan East","Japan West","East
+        Asia","Southeast Asia","Australia East","Australia Southeast"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":["West
+        Europe","West US","Central US","East US 2","North Europe","Japan East","Southeast
+        Asia","South Central US","East Asia","Japan West","North Central US","East
+        US","Australia East","Australia Southeast","Brazil South","Central India","West
+        Central US","UK South","UK West","Canada Central","Canada East","West US 2"],"apiVersions":["2017-04-01-preview","2016-03-01","2015-11-01","2015-10-01","2015-09-01","2015-08-01-preview","2015-06-01","2015-05-01","2015-04-01","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.support","namespace":"microsoft.support","resourceTypes":[{"resourceType":"operations","locations":["North
+        Central US","South Central US","Central US","West Europe","North Europe","West
+        US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
+        Asia","East Asia","Australia East","Australia Southeast"],"apiVersions":["2015-07-01-Preview","2015-03-01"]},{"resourceType":"supporttickets","locations":["North
+        Central US","South Central US","Central US","West Europe","North Europe","West
+        US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
+        Asia","East Asia","Australia East","Australia Southeast"],"apiVersions":["2015-07-01-Preview","2015-03-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.TimeSeriesInsights","namespace":"Microsoft.TimeSeriesInsights","authorizations":[{"applicationId":"120d688d-1518-4cf7-bd38-182f158850b6","roleDefinitionId":"5a43abdf-bb87-42c4-9e56-1c24bf364150"}],"resourceTypes":[{"resourceType":"environments","locations":["East
+        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/eventsources","locations":["East
+        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/referenceDataSets","locations":["East
+        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/accessPolicies","locations":["East
+        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"operations","locations":["East
+        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/project","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/extension","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"checkNameAvailability","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Myget.PackageManagement","namespace":"Myget.PackageManagement","resourceTypes":[{"resourceType":"services","locations":["West
+        Europe"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/NewRelic.APM","namespace":"NewRelic.APM","authorization":{"allowedThirdPartyExtensions":[{"name":"NewRelic_AzurePortal_APM"}]},"resourceTypes":[{"resourceType":"accounts","locations":["North
+        Central US","South Central US","West US","East US","North Europe","West Europe","Southeast
+        Asia","East Asia","Japan East","Japan West"],"apiVersions":["2014-10-01","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/nuubit.nextgencdn","namespace":"nuubit.nextgencdn","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US","East US 2","North Central US","South Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","West US","Central US"],"apiVersions":["2017-05-05"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-05"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-05-05"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-05-05"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Paraleap.CloudMonix","namespace":"Paraleap.CloudMonix","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2016-08-10"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-10"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-10"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Pokitdok.Platform","namespace":"Pokitdok.Platform","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2016-05-17"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-05-17"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-05-17"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-05-17"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RavenHq.Db","namespace":"RavenHq.Db","resourceTypes":[{"resourceType":"databases","locations":["East
+        US"],"apiVersions":["2016-07-18","2016-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-07-18","2016-06-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-07-18","2016-06-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-07-18","2016-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Raygun.CrashReporting","namespace":"Raygun.CrashReporting","resourceTypes":[{"resourceType":"apps","locations":["East
+        US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RedisLabs.Memcached","namespace":"RedisLabs.Memcached","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-07-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RedisLabs.Redis","namespace":"RedisLabs.Redis","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-07-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RevAPM.MobileCDN","namespace":"RevAPM.MobileCDN","resourceTypes":[{"resourceType":"accounts","locations":["Central
+        US","East US","East US 2","North Central US","South Central US","West US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast"],"apiVersions":["2016-08-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-24","2016-08-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sendgrid.Email","namespace":"Sendgrid.Email","resourceTypes":[{"resourceType":"accounts","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Canada Central","Canada
+        East","West Central US","West US 2","UK South","UK West"],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Signiant.Flight","namespace":"Signiant.Flight","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US","Central US","North Central US","South Central US","West US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast"],"apiVersions":["2015-06-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sparkpost.Basic","namespace":"Sparkpost.Basic","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2016-08-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/stackify.retrace","namespace":"stackify.retrace","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2016-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/SuccessBricks.ClearDB","namespace":"SuccessBricks.ClearDB","resourceTypes":[{"resourceType":"databases","locations":["Brazil
+        South","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","Southeast Asia","West Europe","West
+        US","South Central US","Australia East","Australia Southeast","Canada Central","Canada
+        East","Central India","South India","West India"],"apiVersions":["2014-04-01"]},{"resourceType":"clusters","locations":["Brazil
+        South","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","Southeast Asia","West Europe","West
+        US","Australia Southeast","Australia East","South Central US","Canada Central","Canada
+        East","Central India","South India","West India"],"apiVersions":["2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/TrendMicro.DeepSecurity","namespace":"TrendMicro.DeepSecurity","resourceTypes":[{"resourceType":"accounts","locations":["Central
+        US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
+        Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:32:37 GMT
+- request:
+    method: post
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/this_is_not_a_disk_name/BeginGetAccess?api-version=2017-03-30
+    body:
+      encoding: UTF-8
+      string: '{"access":"read","durationInSeconds":3600}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NTcsIm5iZiI6MTUwNDEwNjg1NywiZXhwIjoxNTA0MTEwNzU3LCJhaW8iOiJZMkZnWUtpWnhzWEc2Sy95bXZQUW5NTnV1Ynd6QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUi1CRzdwMHJ4RXE1eld0M0VQZ1JBQSIsInZlciI6IjEuMCJ9.FynHByy1VebBUQ_C9OoxTAZeBecs37zkRnHNJTKfbhK2w-6YNdl9BB_No0Rznbncxo0eFPD1n_pYcrCzFIOcWqA1BdP5ACoYUx4bKLPlh7QDDd9Max0E33lSw-Ann--Aqm4jG6-a5x2A3EQgAm823z8_q08ubSc-Iv3l6wVLI09itM5bg9pIvAVNaKBfAk_w_YgrSv6Zl9ulW0KWxenNgLslq4PonqPU4dn7M37rHuO-3OHI90Gfn0wSD3yeK7eLybB37VfNsT_xUXPrEtDRS85ec9aXMI03gMZuzN7Tw2d-yklrT2m86zCe6T3O003cGzysP7vbZ6cmObb4OBc9EA
+      Content-Length:
+      - '42'
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      X-Ms-Failure-Cause:
+      - gateway
+      X-Ms-Request-Id:
+      - 9f715b56-c396-4c9c-ada9-09a96df10920
+      X-Ms-Correlation-Request-Id:
+      - 9f715b56-c396-4c9c-ada9-09a96df10920
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153238Z:9f715b56-c396-4c9c-ada9-09a96df10920
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 30 Aug 2017 15:32:38 GMT
+      Content-Length:
+      - '166'
+    body:
+      encoding: UTF-8
+      string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Compute/disks/this_is_not_a_disk_name''
+        under resource group ''my-azure-resource-group'' was not found."}}'
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:32:37 GMT
+recorded_with: VCR 3.0.3

--- a/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_new-1.yml
+++ b/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_new-1.yml
@@ -39,25 +39,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - ee46e047-2b9d-4ac4-b9cd-6b7710f81100
+      - e8dd1789-5c78-4e80-a29a-ae6442dd1300
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAAA9kTklhVy7SJTGAzR-p1Bc3oUuayb-OkLBchDftbiAUa8ip2XkHI_9uaM1Y4FRWhXDlgXPTDvzMmkye1Q8jytG0Pe_Jf8bRsT9AXIsFriJSUUdFPt0jI9TjS5Pol_c4B3uy6ljDJDGTnRP9QVnhJS-NAg4Ffni5IG08xEC1eumkfSj5WFXRMOuiHNrxSqRRcAgAA;
+      - esctx=AQABAAAAAAA9kTklhVy7SJTGAzR-p1BcZU_zr9EZeFM48HNDQmH1n9IFXKznhGqc9uNHlFUJ6bx3wfUbG-INZotdpQYItNjoLveuBMfiaJwcj-Qt_XmpXduDNG8xsHw86FLrKcSPhhGhCi0zbSYh1cXakYtmNoe5cRr7b3rKfVClDsXDMpX38mg7eYOoDwnyeVIz33j4554gAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=004; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=008; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Wed, 30 Aug 2017 15:32:37 GMT
+      - Wed, 30 Aug 2017 17:05:05 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1504110757","not_before":"1504106857","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NTcsIm5iZiI6MTUwNDEwNjg1NywiZXhwIjoxNTA0MTEwNzU3LCJhaW8iOiJZMkZnWUtpWnhzWEc2Sy95bXZQUW5NTnV1Ynd6QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUi1CRzdwMHJ4RXE1eld0M0VQZ1JBQSIsInZlciI6IjEuMCJ9.FynHByy1VebBUQ_C9OoxTAZeBecs37zkRnHNJTKfbhK2w-6YNdl9BB_No0Rznbncxo0eFPD1n_pYcrCzFIOcWqA1BdP5ACoYUx4bKLPlh7QDDd9Max0E33lSw-Ann--Aqm4jG6-a5x2A3EQgAm823z8_q08ubSc-Iv3l6wVLI09itM5bg9pIvAVNaKBfAk_w_YgrSv6Zl9ulW0KWxenNgLslq4PonqPU4dn7M37rHuO-3OHI90Gfn0wSD3yeK7eLybB37VfNsT_xUXPrEtDRS85ec9aXMI03gMZuzN7Tw2d-yklrT2m86zCe6T3O003cGzysP7vbZ6cmObb4OBc9EA"}'
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1504116304","not_before":"1504112404","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MDQsIm5iZiI6MTUwNDExMjQwNCwiZXhwIjoxNTA0MTE2MzA0LCJhaW8iOiJZMkZnWURpVDI1RzQ1TUxuVzltL2R4MzBtcUhuRFFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiaVJmZDZIaGNnRTZpbXE1a1F0MFRBQSIsInZlciI6IjEuMCJ9.hmChdW3RDn_6eFqAWWIyelnopUBEstBzcCYNA5DeYC5ZHqotuNS1Q4Q7JPKJv-K5o2dqpxU3FDMeeqByvJ_b1eAT5EczsQX8A5bTDI0nxWLvegSc6WUqf4gG5nPcITrpdiRU29Rn9RqKn8VhS1Imyc3eSBBCYRj09HMRfeK9vncM-0dkb-lJLOI3N4a3kBa6eJKgxInljPSdl9CiBkYD6sPZhOYYRaY82dQ2tBZEL9mrfq7mV1ze7UldH48EwO2RsPvCtRzm-MB8kGHiRkTnNh2Xr5Zf851I3SPKnfyU_mU_hUcZuY-OnweFnwy3rWDTpY0yBbce1TBmvl3FiROTLA"}'
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:32:36 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:04 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -74,7 +74,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NTcsIm5iZiI6MTUwNDEwNjg1NywiZXhwIjoxNTA0MTEwNzU3LCJhaW8iOiJZMkZnWUtpWnhzWEc2Sy95bXZQUW5NTnV1Ynd6QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUi1CRzdwMHJ4RXE1eld0M0VQZ1JBQSIsInZlciI6IjEuMCJ9.FynHByy1VebBUQ_C9OoxTAZeBecs37zkRnHNJTKfbhK2w-6YNdl9BB_No0Rznbncxo0eFPD1n_pYcrCzFIOcWqA1BdP5ACoYUx4bKLPlh7QDDd9Max0E33lSw-Ann--Aqm4jG6-a5x2A3EQgAm823z8_q08ubSc-Iv3l6wVLI09itM5bg9pIvAVNaKBfAk_w_YgrSv6Zl9ulW0KWxenNgLslq4PonqPU4dn7M37rHuO-3OHI90Gfn0wSD3yeK7eLybB37VfNsT_xUXPrEtDRS85ec9aXMI03gMZuzN7Tw2d-yklrT2m86zCe6T3O003cGzysP7vbZ6cmObb4OBc9EA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MDQsIm5iZiI6MTUwNDExMjQwNCwiZXhwIjoxNTA0MTE2MzA0LCJhaW8iOiJZMkZnWURpVDI1RzQ1TUxuVzltL2R4MzBtcUhuRFFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiaVJmZDZIaGNnRTZpbXE1a1F0MFRBQSIsInZlciI6IjEuMCJ9.hmChdW3RDn_6eFqAWWIyelnopUBEstBzcCYNA5DeYC5ZHqotuNS1Q4Q7JPKJv-K5o2dqpxU3FDMeeqByvJ_b1eAT5EczsQX8A5bTDI0nxWLvegSc6WUqf4gG5nPcITrpdiRU29Rn9RqKn8VhS1Imyc3eSBBCYRj09HMRfeK9vncM-0dkb-lJLOI3N4a3kBa6eJKgxInljPSdl9CiBkYD6sPZhOYYRaY82dQ2tBZEL9mrfq7mV1ze7UldH48EwO2RsPvCtRzm-MB8kGHiRkTnNh2Xr5Zf851I3SPKnfyU_mU_hUcZuY-OnweFnwy3rWDTpY0yBbce1TBmvl3FiROTLA
       Host:
       - management.azure.com
   response:
@@ -95,23 +95,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14997'
+      - '14998'
       X-Ms-Request-Id:
-      - 625a9309-1a4f-4c02-a4be-4b6f565ef0d3
+      - 12b0e9d8-7241-4591-b143-409fed335f2b
       X-Ms-Correlation-Request-Id:
-      - 625a9309-1a4f-4c02-a4be-4b6f565ef0d3
+      - 12b0e9d8-7241-4591-b143-409fed335f2b
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153237Z:625a9309-1a4f-4c02-a4be-4b6f565ef0d3
+      - EASTUS:20170830T170505Z:12b0e9d8-7241-4591-b143-409fed335f2b
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 30 Aug 2017 15:32:36 GMT
+      - Wed, 30 Aug 2017 17:05:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:32:36 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:05 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/azure_subscription_id/providers?api-version=2015-01-01
@@ -128,7 +128,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NTcsIm5iZiI6MTUwNDEwNjg1NywiZXhwIjoxNTA0MTEwNzU3LCJhaW8iOiJZMkZnWUtpWnhzWEc2Sy95bXZQUW5NTnV1Ynd6QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUi1CRzdwMHJ4RXE1eld0M0VQZ1JBQSIsInZlciI6IjEuMCJ9.FynHByy1VebBUQ_C9OoxTAZeBecs37zkRnHNJTKfbhK2w-6YNdl9BB_No0Rznbncxo0eFPD1n_pYcrCzFIOcWqA1BdP5ACoYUx4bKLPlh7QDDd9Max0E33lSw-Ann--Aqm4jG6-a5x2A3EQgAm823z8_q08ubSc-Iv3l6wVLI09itM5bg9pIvAVNaKBfAk_w_YgrSv6Zl9ulW0KWxenNgLslq4PonqPU4dn7M37rHuO-3OHI90Gfn0wSD3yeK7eLybB37VfNsT_xUXPrEtDRS85ec9aXMI03gMZuzN7Tw2d-yklrT2m86zCe6T3O003cGzysP7vbZ6cmObb4OBc9EA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MDQsIm5iZiI6MTUwNDExMjQwNCwiZXhwIjoxNTA0MTE2MzA0LCJhaW8iOiJZMkZnWURpVDI1RzQ1TUxuVzltL2R4MzBtcUhuRFFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiaVJmZDZIaGNnRTZpbXE1a1F0MFRBQSIsInZlciI6IjEuMCJ9.hmChdW3RDn_6eFqAWWIyelnopUBEstBzcCYNA5DeYC5ZHqotuNS1Q4Q7JPKJv-K5o2dqpxU3FDMeeqByvJ_b1eAT5EczsQX8A5bTDI0nxWLvegSc6WUqf4gG5nPcITrpdiRU29Rn9RqKn8VhS1Imyc3eSBBCYRj09HMRfeK9vncM-0dkb-lJLOI3N4a3kBa6eJKgxInljPSdl9CiBkYD6sPZhOYYRaY82dQ2tBZEL9mrfq7mV1ze7UldH48EwO2RsPvCtRzm-MB8kGHiRkTnNh2Xr5Zf851I3SPKnfyU_mU_hUcZuY-OnweFnwy3rWDTpY0yBbce1TBmvl3FiROTLA
       Host:
       - management.azure.com
   response:
@@ -147,17 +147,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14867'
+      - '14922'
       X-Ms-Request-Id:
-      - 61697f74-ce21-42f6-8f0c-4d84266c651e
+      - a9baacde-bdad-4157-98de-45833d92771b
       X-Ms-Correlation-Request-Id:
-      - 61697f74-ce21-42f6-8f0c-4d84266c651e
+      - a9baacde-bdad-4157-98de-45833d92771b
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153238Z:61697f74-ce21-42f6-8f0c-4d84266c651e
+      - EASTUS:20170830T170505Z:a9baacde-bdad-4157-98de-45833d92771b
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 30 Aug 2017 15:32:38 GMT
+      - Wed, 30 Aug 2017 17:05:05 GMT
       Content-Length:
       - '241615'
     body:
@@ -1891,7 +1891,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:32:37 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:05 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/this_is_not_a_disk_name/BeginGetAccess?api-version=2017-03-30
@@ -1908,7 +1908,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NTcsIm5iZiI6MTUwNDEwNjg1NywiZXhwIjoxNTA0MTEwNzU3LCJhaW8iOiJZMkZnWUtpWnhzWEc2Sy95bXZQUW5NTnV1Ynd6QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUi1CRzdwMHJ4RXE1eld0M0VQZ1JBQSIsInZlciI6IjEuMCJ9.FynHByy1VebBUQ_C9OoxTAZeBecs37zkRnHNJTKfbhK2w-6YNdl9BB_No0Rznbncxo0eFPD1n_pYcrCzFIOcWqA1BdP5ACoYUx4bKLPlh7QDDd9Max0E33lSw-Ann--Aqm4jG6-a5x2A3EQgAm823z8_q08ubSc-Iv3l6wVLI09itM5bg9pIvAVNaKBfAk_w_YgrSv6Zl9ulW0KWxenNgLslq4PonqPU4dn7M37rHuO-3OHI90Gfn0wSD3yeK7eLybB37VfNsT_xUXPrEtDRS85ec9aXMI03gMZuzN7Tw2d-yklrT2m86zCe6T3O003cGzysP7vbZ6cmObb4OBc9EA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MDQsIm5iZiI6MTUwNDExMjQwNCwiZXhwIjoxNTA0MTE2MzA0LCJhaW8iOiJZMkZnWURpVDI1RzQ1TUxuVzltL2R4MzBtcUhuRFFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiaVJmZDZIaGNnRTZpbXE1a1F0MFRBQSIsInZlciI6IjEuMCJ9.hmChdW3RDn_6eFqAWWIyelnopUBEstBzcCYNA5DeYC5ZHqotuNS1Q4Q7JPKJv-K5o2dqpxU3FDMeeqByvJ_b1eAT5EczsQX8A5bTDI0nxWLvegSc6WUqf4gG5nPcITrpdiRU29Rn9RqKn8VhS1Imyc3eSBBCYRj09HMRfeK9vncM-0dkb-lJLOI3N4a3kBa6eJKgxInljPSdl9CiBkYD6sPZhOYYRaY82dQ2tBZEL9mrfq7mV1ze7UldH48EwO2RsPvCtRzm-MB8kGHiRkTnNh2Xr5Zf851I3SPKnfyU_mU_hUcZuY-OnweFnwy3rWDTpY0yBbce1TBmvl3FiROTLA
       Content-Length:
       - '42'
       Host:
@@ -1929,15 +1929,15 @@ http_interactions:
       X-Ms-Failure-Cause:
       - gateway
       X-Ms-Request-Id:
-      - 9f715b56-c396-4c9c-ada9-09a96df10920
+      - f7c92015-0cf3-4723-8f66-e91484cb461f
       X-Ms-Correlation-Request-Id:
-      - 9f715b56-c396-4c9c-ada9-09a96df10920
+      - f7c92015-0cf3-4723-8f66-e91484cb461f
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153238Z:9f715b56-c396-4c9c-ada9-09a96df10920
+      - EASTUS:20170830T170510Z:f7c92015-0cf3-4723-8f66-e91484cb461f
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 30 Aug 2017 15:32:38 GMT
+      - Wed, 30 Aug 2017 17:05:09 GMT
       Content-Length:
       - '166'
     body:
@@ -1945,5 +1945,5 @@ http_interactions:
       string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Compute/disks/this_is_not_a_disk_name''
         under resource group ''my-azure-resource-group'' was not found."}}'
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:32:37 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:09 GMT
 recorded_with: VCR 3.0.3

--- a/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_new-2.yml
+++ b/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_new-2.yml
@@ -1,0 +1,2277 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://login.microsoftonline.com/azure_tenant_id/oauth2/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_key&resource=https%3A%2F%2Fmanagement.azure.com%2F
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - login.microsoftonline.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Server:
+      - Microsoft-IIS/8.5
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Request-Id:
+      - c5600f08-c32f-4835-9ac7-7079e4d91100
+      P3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Set-Cookie:
+      - esctx=AQABAAAAAAA9kTklhVy7SJTGAzR-p1BcWJTxYspgz5B3Q-YOrxxdU5gWqWPNGm_oCvTsHY0RGrIjDPf8ovopVFHUZ4T1XQQtAH6ddxDX4ZvPtNYbAMbwwBoBZ3BIRENZl9ogYUOeK636KtLxD2I5_OiiLd-AD2UARVR6bmdQkt_qOct57FQA3Yie1TiVFIoEKA2grNKiBiEgAA;
+        domain=.login.microsoftonline.com; path=/; secure; HttpOnly
+      - stsservicecookie=ests; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=005; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Wed, 30 Aug 2017 15:32:37 GMT
+      Content-Length:
+      - '1505'
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1504110759","not_before":"1504106859","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NTksIm5iZiI6MTUwNDEwNjg1OSwiZXhwIjoxNTA0MTEwNzU5LCJhaW8iOiJZMkZnWVBqLzRYTjFuNkFMejlKNUVwZHI1UEt2QVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ0E5Z3hTX0ROVWlheDNCNTVOa1JBQSIsInZlciI6IjEuMCJ9.oxGm4SO5Jl4w7HzwE_SxjzfoYBBKTotYxIzCbvtK6jXAeT9MeHmuFSySpw_artOtHxhbcNphere9DcgGPF97B0t9cNHl0Tb-w3EPpYGiKRT4YeOKNlmQuaFdchlydmbBnqFlc9fzExSyLM-pzh1rOblVV1UC64gS8NprmI36wCQAOmXisBUnFB6qceFzN5EU9jpFiCXR9JlSZOxyo6AR5ms7-zfTKmDDahDCVryCyyyQV9z-q9YgrYyX-xj5hLDot7tHtbGi77l2ViCxoc67BUYjFay9Ff-oJlu3km94vHPcnhRD9W_dkcurtQwDjNM2Lblgkj7nDOS-S0SkW4-2ow"}'
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:32:38 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions?api-version=2016-06-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NTksIm5iZiI6MTUwNDEwNjg1OSwiZXhwIjoxNTA0MTEwNzU5LCJhaW8iOiJZMkZnWVBqLzRYTjFuNkFMejlKNUVwZHI1UEt2QVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ0E5Z3hTX0ROVWlheDNCNTVOa1JBQSIsInZlciI6IjEuMCJ9.oxGm4SO5Jl4w7HzwE_SxjzfoYBBKTotYxIzCbvtK6jXAeT9MeHmuFSySpw_artOtHxhbcNphere9DcgGPF97B0t9cNHl0Tb-w3EPpYGiKRT4YeOKNlmQuaFdchlydmbBnqFlc9fzExSyLM-pzh1rOblVV1UC64gS8NprmI36wCQAOmXisBUnFB6qceFzN5EU9jpFiCXR9JlSZOxyo6AR5ms7-zfTKmDDahDCVryCyyyQV9z-q9YgrYyX-xj5hLDot7tHtbGi77l2ViCxoc67BUYjFay9Ff-oJlu3km94vHPcnhRD9W_dkcurtQwDjNM2Lblgkj7nDOS-S0SkW4-2ow
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Tenant-Reads:
+      - '14999'
+      X-Ms-Request-Id:
+      - 8b63cdb1-5407-4814-81f9-c34d5df3ca94
+      X-Ms-Correlation-Request-Id:
+      - 8b63cdb1-5407-4814-81f9-c34d5df3ca94
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153239Z:8b63cdb1-5407-4814-81f9-c34d5df3ca94
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 30 Aug 2017 15:32:39 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
+        Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:32:38 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers?api-version=2015-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NTksIm5iZiI6MTUwNDEwNjg1OSwiZXhwIjoxNTA0MTEwNzU5LCJhaW8iOiJZMkZnWVBqLzRYTjFuNkFMejlKNUVwZHI1UEt2QVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ0E5Z3hTX0ROVWlheDNCNTVOa1JBQSIsInZlciI6IjEuMCJ9.oxGm4SO5Jl4w7HzwE_SxjzfoYBBKTotYxIzCbvtK6jXAeT9MeHmuFSySpw_artOtHxhbcNphere9DcgGPF97B0t9cNHl0Tb-w3EPpYGiKRT4YeOKNlmQuaFdchlydmbBnqFlc9fzExSyLM-pzh1rOblVV1UC64gS8NprmI36wCQAOmXisBUnFB6qceFzN5EU9jpFiCXR9JlSZOxyo6AR5ms7-zfTKmDDahDCVryCyyyQV9z-q9YgrYyX-xj5hLDot7tHtbGi77l2ViCxoc67BUYjFay9Ff-oJlu3km94vHPcnhRD9W_dkcurtQwDjNM2Lblgkj7nDOS-S0SkW4-2ow
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14951'
+      X-Ms-Request-Id:
+      - 6cd48d21-c1e7-422f-8570-4cfd744cd271
+      X-Ms-Correlation-Request-Id:
+      - 6cd48d21-c1e7-422f-8570-4cfd744cd271
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153240Z:6cd48d21-c1e7-422f-8570-4cfd744cd271
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 30 Aug 2017 15:32:40 GMT
+      Content-Length:
+      - '241615'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","North Central
+        US","South Central US","West Central US","West US","West US 2","Canada Central","Canada
+        East","North Europe","West Europe","UK South","UK West","East Asia","Southeast
+        Asia","Japan East","Japan West","Korea Central","Korea South","Brazil South","Central
+        India","South India","West India"],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"validateServiceName","locations":[],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"checkServiceNameAvailability","locations":[],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"reportFeedback","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"checkFeedbackRequired","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Automation","namespace":"Microsoft.Automation","authorizations":[{"applicationId":"fc75330b-179d-49af-87dd-3b1acf6827fa","roleDefinitionId":"95fd5de3-d071-4362-92bf-cf341c1de832"}],"resourceTypes":[{"resourceType":"automationAccounts","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
+        South","UK South","West Central US","North Europe","Canada Central","Australia
+        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/runbooks","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
+        South","UK South","West Central US","North Europe","Canada Central","Australia
+        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/configurations","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","North
+        Central US","Brazil South","UK South","West Central US","Central India","Australia
+        Southeast","Canada Central","North Europe"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/webhooks","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
+        South","UK South","West Central US","North Europe","Canada Central","Australia
+        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"operations","locations":["South
+        Central US"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/softwareUpdateConfigurations","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
+        South","UK South","West Central US","North Europe","Canada Central","Australia
+        Southeast","Central India"],"apiVersions":["2017-05-15-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Backup","namespace":"Microsoft.Backup","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"BackupVault","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India"],"apiVersions":["2015-03-15","2014-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Batch","namespace":"Microsoft.Batch","authorization":{"applicationId":"ddbf3205-c6bd-46ae-8127-60eb93363864","roleDefinitionId":"b7f84953-1d03-4eab-9ea4-45f065258ff8"},"resourceTypes":[{"resourceType":"batchAccounts","locations":["West
+        Europe","East US","East US 2","West US","North Central US","Brazil South","North
+        Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
+        West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
+        East","South India","Central India","Canada Central","Canada East","UK South","UK
+        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01","2015-07-01","2014-05-01-privatepreview"]},{"resourceType":"operations","locations":["West
+        Europe","East US","East US 2","West US","North Central US","Brazil South","North
+        Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
+        West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
+        East","South India","Central India","Canada Central","Canada East","UK South","UK
+        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations/quotas","locations":["West
+        Europe","East US","East US 2","West US","North Central US","Brazil South","North
+        Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
+        West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
+        East","South India","Central India","Canada Central","Canada East","UK South","UK
+        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]}],"registrationState":"Unregistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicCompute","namespace":"Microsoft.ClassicCompute","resourceTypes":[{"resourceType":"domainNames","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
+        Central","Canada East","UK South","UK West","West US","Central US","South
+        Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
+        East","Australia Southeast","West US 2","West Central US","South India","Central
+        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
+        Central","Canada East","UK South","UK West","West US","Central US","South
+        Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
+        East","Australia Southeast","West US 2","West Central US","South India","Central
+        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
+        Central US","South Central US","East US","East US 2","Canada Central","Canada
+        East","West US","West US 2","West Central US","Central US","East Asia","Southeast
+        Asia","North Europe","West Europe","UK South","UK West","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operatingSystems","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"operatingSystemFamilies","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicNetwork","namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"virtualNetworks/remoteVirtualNetworkPeeringProxies","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"reservedIps","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicStorage","namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
+        US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
+        Asia","Australia East","Australia Southeast","South India","Central India","West
+        India","West US 2","West Central US","East US","East US 2","North Central
+        US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
+        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
+        US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
+        Asia","Australia East","Australia Southeast","South India","Central India","West
+        India","West US 2","West Central US","East US","East US 2","North Central
+        US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
+        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"vmImages","locations":[],"apiVersions":["2016-11-01"]},{"resourceType":"publicImages","locations":[],"apiVersions":["2016-11-01","2016-04-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"osPlatformImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Compute","namespace":"Microsoft.Compute","authorization":{"applicationId":"60e6cd67-9c8c-4951-9b3c-23c25a2169af","roleDefinitionId":"e4770acb-272e-4dc8-87f3-12f44a612224"},"resourceTypes":[{"resourceType":"availabilitySets","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30"]},{"resourceType":"locations/usages","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"disks","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"snapshots","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"locations/diskoperations","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"images","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
+        US","East US","South Central US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","East Asia","Japan
+        East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/webhooks","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/ping","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/getCallbackConfig","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/listEvents","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"locations","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"locations/operationResults","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/GetCredentials","locations":["West
+        US","East US","South Central US","West Europe"],"apiVersions":["2016-06-27-preview"]},{"resourceType":"registries/listCredentials","locations":["South
+        Central US","East US","West US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","East Asia","Japan
+        East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/regenerateCredential","locations":["South
+        Central US","West US","East US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","East Asia","Japan
+        East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/listUsages","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/regenerateCredentials","locations":["West
+        US","East US","South Central US","West Europe"],"apiVersions":["2016-06-27-preview"]},{"resourceType":"checkNameAvailability","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview","2017-03-01","2016-06-27-preview"]},{"resourceType":"operations","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview","2017-03-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerService","namespace":"Microsoft.ContainerService","authorization":{"applicationId":"7319c514-987d-4e9b-ac3d-d38c4f427f4c","roleDefinitionId":"1b4a0c7f-2217-416f-acfa-cf73452fdc1c"},"resourceTypes":[{"resourceType":"containerServices","locations":["Japan
+        East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
+        East","Australia Southeast","Brazil South","Southeast Asia","West US","North
+        Central US","West Europe","North Europe","East US","UK West","UK South","West
+        Central US","West US 2","South India","Central India","West India","Canada
+        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
+        East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
+        East","Australia Southeast","Brazil South","Southeast Asia","West US","North
+        Central US","West Europe","North Europe","East US","UK West","UK South","West
+        Central US","West US 2","South India","Central India","West India","Canada
+        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DevTestLab","namespace":"Microsoft.DevTestLab","authorization":{"applicationId":"1a14be2a-e903-4cec-99cf-b2e209259a0f","roleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525"},"resourceTypes":[{"resourceType":"labs","locations":["West
+        Central US","Japan East","West US","Australia Southeast","Canada Central","Central
+        India","Central US","East Asia","Korea Central","North Europe","South Central
+        US","UK West","Australia East","Brazil South","Canada East","East US","East
+        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"schedules","locations":["West
+        Central US","Japan East","West US","Australia Southeast","Canada Central","Central
+        India","Central US","East Asia","Korea Central","North Europe","South Central
+        US","UK West","Australia East","Brazil South","Canada East","East US","East
+        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"labs/virtualMachines","locations":["West
+        Central US","Japan East","West US","Australia Southeast","Canada Central","Central
+        India","Central US","East Asia","Korea Central","North Europe","South Central
+        US","UK West","Australia East","Brazil South","Canada East","East US","East
+        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"labs/serviceRunners","locations":["Central
+        US","East US 2","South Central US"],"apiVersions":["2017-04-26-preview","2016-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"locations/operations","locations":["West
+        Central US","Japan East","West US","Australia Southeast","Canada Central","Central
+        India","Central US","East Asia","Korea Central","North Europe","South Central
+        US","UK West","Australia East","Brazil South","Canada East","East US","East
+        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"}],"resourceTypes":[{"resourceType":"components","locations":["East
+        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
+        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01","2014-04-01"]},{"resourceType":"queries","locations":["East
+        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"alertrules","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2016-03-01","2015-04-01","2014-04-01"]},{"resourceType":"autoscalesettings","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2015-04-01","2014-04-01"]},{"resourceType":"eventtypes","locations":[],"apiVersions":["2017-03-01-preview","2016-09-01-preview","2015-04-01","2014-11-01","2014-04-01"]},{"resourceType":"locations","locations":["East
+        US"],"apiVersions":["2015-04-01","2014-04-01"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2015-04-01","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-04-01","2014-06-01","2014-04-01"]},{"resourceType":"automatedExportSettings","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2015-04-01","2014-04-01"]},{"resourceType":"diagnosticSettings","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2017-05-01-preview","2016-09-01","2015-07-01"]},{"resourceType":"diagnosticSettingsCategories","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"extendedDiagnosticSettings","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2017-02-01"]},{"resourceType":"metricDefinitions","locations":["East
+        US","West US","West Europe","East Asia","Southeast Asia","Japan East","Japan
+        West","North Central US","South Central US","East US 2","Canada East","Canada
+        Central","Central US","Australia East","Australia Southeast","Brazil South","South
+        India","Central India","West India","North Europe","West US 2","West Central
+        US","Korea South","Korea Central","UK South","UK West","Global"],"apiVersions":["2017-05-01-preview","2016-03-01","2015-07-01"]},{"resourceType":"logDefinitions","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2015-07-01"]},{"resourceType":"eventCategories","locations":[],"apiVersions":["2015-04-01"]},{"resourceType":"metrics","locations":["East
+        US","West US","West Europe","East Asia","Southeast Asia","Japan East","Japan
+        West","North Central US","South Central US","East US 2","Canada East","Canada
+        Central","Central US","Australia East","Australia Southeast","Brazil South","South
+        India","Central India","West India","North Europe","West US 2","West Central
+        US","Korea South","Korea Central","UK South","UK West"],"apiVersions":["2017-05-01-preview","2016-09-01","2016-06-01"]},{"resourceType":"actiongroups","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]},{"resourceType":"activityLogAlerts","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.KeyVault","namespace":"Microsoft.KeyVault","resourceTypes":[{"resourceType":"vaults","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/accessPolicies","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-10-01","2015-06-01","2014-12-19-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"deletedVaults","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-10-01"]},{"resourceType":"locations/deletedVaults","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorization":{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"routeTables","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2017-04-26-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"]},{"resourceType":"workspaces/dataSources","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"storageInsightConfigs","locations":[],"apiVersions":["2014-10-10"]},{"resourceType":"workspaces/linkedServices","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"linkTargets","locations":["East
+        US"],"apiVersions":["2015-03-20"]},{"resourceType":"operations","locations":[],"apiVersions":["2014-11-10"]},{"resourceType":"devices","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationsManagement","namespace":"Microsoft.OperationsManagement","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"aa249101-6816-4966-aafa-08175d795f14"},"resourceTypes":[{"resourceType":"solutions","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Portal","namespace":"Microsoft.Portal","resourceTypes":[{"resourceType":"dashboards","locations":["Central
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
+        East","West India","South India","Central India","Canada Central","Canada
+        East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"operations","locations":["Central
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
+        East","West India","South India","Central India","Canada Central","Canada
+        East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"consoles","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/consoles","locations":["West
+        US","East US","Central India","North Europe","West Europe","South Central
+        US","Southeast Asia"],"apiVersions":["2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
+        US","East US","Central India","North Europe","West Europe","South Central
+        US","Southeast Asia"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","Canada Central","Canada East","West Central US","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-07-01","2016-12-01","2016-08-10","2016-06-01","2016-05-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"operations","locations":["Southeast
+        Asia"],"apiVersions":["2016-08-10","2016-06-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01"]},{"resourceType":"locations/backupStatus","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]},{"resourceType":"locations/allocatedStamp","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]},{"resourceType":"locations/allocateStamp","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ResourceHealth","namespace":"Microsoft.ResourceHealth","authorization":{"applicationId":"8bdebf23-c0fe-4187-a378-717ad86f6a53","roleDefinitionId":"cc026344-c8b1-4561-83ba-59eba84b27cc"},"resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2017-07-01","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"notifications","locations":["Australia
+        Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Security","namespace":"Microsoft.Security","authorization":{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatuses","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/virtualMachines","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/endpoints","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/subnets","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"tasks","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"alerts","locations":["Central
+        US","East US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"monitoring","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"monitoring/patch","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"monitoring/baseline","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"monitoring/antimalware","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"dataCollectionAgents","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"dataCollectionResults","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"pricings","locations":["Central
+        US","East US"],"apiVersions":["2017-08-01-preview"]},{"resourceType":"complianceResults","locations":["Central
+        US","East US"],"apiVersions":["2017-08-01"]},{"resourceType":"policies","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"appliances","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"webApplicationFirewalls","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/webApplicationFirewalls","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securitySolutions","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/securitySolutions","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securitySolutionsReferenceData","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/securitySolutionsReferenceData","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"jitNetworkAccessPolicies","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/jitNetworkAccessPolicies","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatusesSummaries","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/alerts","locations":["Central
+        US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/tasks","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.SiteRecovery","namespace":"Microsoft.SiteRecovery","authorization":{"applicationId":"b8340c3b-9267-498f-b21a-15d5547fd85e","roleDefinitionId":"8A00C8EA-8F1B-45A7-8F64-F4CC61EEE9B6"},"resourceTypes":[{"resourceType":"SiteRecoveryVault","locations":["East
+        US","West US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","Australia East","Australia Southeast","Brazil South","North
+        Central US","South Central US","Central US","East US 2","Central India","South
+        India"],"apiVersions":["2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Sql","namespace":"Microsoft.Sql","authorizations":[{"applicationId":"e4ab13ed-33cb-41b4-9140-6e264582cf85","roleDefinitionId":"ec3ddc95-44dc-47a2-9926-5e9f5ffd44ec"},{"applicationId":"0130cc9f-7ac5-4026-bd5f-80a08a54e6d9","roleDefinitionId":"45e8abf8-0ec4-44f3-9c37-cff4f7779302"},{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},{"applicationId":"76c7f279-7959-468f-8943-3954880e0d8c","roleDefinitionId":"7f7513a8-73f9-4c5f-97a2-c41f0ea783ef"}],"resourceTypes":[{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/capabilities","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverKeyOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/keys","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/encryptionProtector","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/communicationLinks","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recoverableDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/importExportOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/operationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/firewallrules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/elasticpools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-09-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/dnsAliases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/failoverGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/virtualNetworkRules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/virtualNetworkRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/virtualNetworkRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/databaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/extensions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditRecords","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/VulnerabilityAssessmentScans","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentScans","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups/syncMembers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/syncAgents","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncMemberOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncAgentOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncDatabaseIds","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorization":{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
+        US","West US","West Europe","North Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":["East
+        US","West US","West Europe","North Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Web","namespace":"Microsoft.Web","authorization":{"applicationId":"abfa0a7c-a6b6-4736-8310-5855508787cd","roleDefinitionId":"f47ed98b-b063-4a5b-9e10-4b9b44fa7735"},"resourceTypes":[{"resourceType":"sites/extensions","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots/extensions","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/instances","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots/instances","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/instances/extensions","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots/instances/extensions","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/publicCertificates","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots/publicCertificates","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"publishingUsers","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"ishostnameavailable","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"validate","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"isusernameavailable","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sourceControls","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"availableStacks","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"listSitesAssignedToHostName","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"sites/hostNameBindings","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"sites/domainOwnershipIdentifiers","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"sites/slots/hostNameBindings","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"operations","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"certificates","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms/workers","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"runtimes","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"sites/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"sites/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"sites/slots/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"sites/slots/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"serverFarms/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"serverFarms/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"sites/recommendations","locations":[],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"georegions","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/premieraddons","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01"]},{"resourceType":"hostingEnvironments","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/instances","locations":[],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/instances/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/instances/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/instances","locations":[],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/instances/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/instances/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"deploymentLocations","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"functions","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"deletedSites","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"ishostingenvironmentnameavailable","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"classicMobileServices","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"connections","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/managedApis","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/apiOperations","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"connectionGateways","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/connectionGatewayInstallations","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"checkNameAvailability","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"billingMeters","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/84codes.CloudAMQP","namespace":"84codes.CloudAMQP","resourceTypes":[{"resourceType":"servers","locations":["East
+        US 2","Central US","East US","North Central US","South Central US","West US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast"],"apiVersions":["2016-08-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/AppDynamics.APM","namespace":"AppDynamics.APM","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2016-05-26"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-05-26"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-05-26"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-05-26"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-05-26"]},{"resourceType":"locations/operationResults","locations":["West
+        US"],"apiVersions":["2016-05-26"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Aspera.Transfers","namespace":"Aspera.Transfers","resourceTypes":[{"resourceType":"services","locations":["West
+        US","North Europe","Central US","East US","West Europe","East Asia","Southeast
+        Asia","Japan East","East US 2","Japan West"],"apiVersions":["2016-03-25"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-03-25"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-03-25"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-03-25"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Auth0.Cloud","namespace":"Auth0.Cloud","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-11-23"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Citrix.Cloud","namespace":"Citrix.Cloud","resourceTypes":[{"resourceType":"accounts","locations":["West
+        US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Cloudyn.Analytics","namespace":"Cloudyn.Analytics","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US"],"apiVersions":["2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Conexlink.MyCloudIT","namespace":"Conexlink.MyCloudIT","resourceTypes":[{"resourceType":"accounts","locations":["Central
+        US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Crypteron.DataSecurity","namespace":"Crypteron.DataSecurity","resourceTypes":[{"resourceType":"apps","locations":["West
+        US"],"apiVersions":["2016-08-12"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-12"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-12"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-12"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Dynatrace.DynatraceSaaS","namespace":"Dynatrace.DynatraceSaaS","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-09-27"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Dynatrace.Ruxit","namespace":"Dynatrace.Ruxit","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US"],"apiVersions":["2016-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-09-07","2016-04-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-04-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/LiveArena.Broadcast","namespace":"LiveArena.Broadcast","resourceTypes":[{"resourceType":"services","locations":["West
+        US","North Europe","Japan West","Japan East","East Asia","West Europe","East
+        US","Southeast Asia","Central US"],"apiVersions":["2016-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Lombiq.DotNest","namespace":"Lombiq.DotNest","resourceTypes":[{"resourceType":"sites","locations":["East
+        US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Mailjet.Email","namespace":"Mailjet.Email","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]},{"resourceType":"diagnosticSettings","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"addsservices","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"configuration","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"agents","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"aadsupportcases","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"reports","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"servicehealthmetrics","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"logs","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"anonymousapiusers","locations":["West
+        US"],"apiVersions":["2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AnalysisServices","namespace":"Microsoft.AnalysisServices","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"servers","locations":["West
+        US","North Europe","South Central US","West Europe","West Central US","Southeast
+        Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
+        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/checkNameAvailability","locations":["West
+        US","North Europe","South Central US","West Europe","West Central US","Southeast
+        Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
+        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationresults","locations":["West
+        US","North Europe","South Central US","West Europe","West Central US","Southeast
+        Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
+        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationstatuses","locations":["West
+        US","North Europe","South Central US","West Europe","West Central US","Southeast
+        Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
+        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"operations","locations":["East
+        US 2","West Central US"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AppService","namespace":"Microsoft.AppService","authorization":{"applicationId":"dee7ba80-6a55-4f3b-a86c-746a9231ae49","roleDefinitionId":"6715d172-49c4-46f6-bb21-60512a8689dc"},"resourceTypes":[{"resourceType":"apiapps","locations":["East
+        US","West US","South Central US","North Europe","East Asia","Japan East","West
+        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
+        South","East US 2","Australia Southeast","Australia East","West India","South
+        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"appIdentities","locations":["East
+        US","West US","South Central US","North Europe","East Asia","Japan East","West
+        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
+        South","East US 2","Australia Southeast","Australia East","West India","South
+        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"gateways","locations":["East
+        US","West US","South Central US","North Europe","East Asia","Japan East","West
+        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
+        South","East US 2","Australia Southeast","Australia East","West India","South
+        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"deploymenttemplates","locations":[],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Authorization","namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"roleDefinitions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"classicAdministrators","locations":[],"apiVersions":["2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"permissions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"locks","locations":[],"apiVersions":["2017-04-01","2016-09-01","2015-06-01","2015-05-01-preview","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-01-01","2014-10-01-preview","2014-06-01"]},{"resourceType":"policyDefinitions","locations":[],"apiVersions":["2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"policySetDefinitions","locations":[],"apiVersions":["2017-06-01-preview"]},{"resourceType":"policyAssignments","locations":[],"apiVersions":["2017-06-01-preview","2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"providerOperations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01-preview","2015-07-01"]},{"resourceType":"elevateAccess","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureActiveDirectory","namespace":"Microsoft.AzureActiveDirectory","resourceTypes":[{"resourceType":"b2cDirectories","locations":["Global","United
+        States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureStack","namespace":"Microsoft.AzureStack","resourceTypes":[{"resourceType":"operations","locations":["Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations","locations":["West
+        Central US","Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations/products","locations":["West
+        Central US","Global"],"apiVersions":["2017-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Billing","namespace":"Microsoft.Billing","resourceTypes":[{"resourceType":"BillingPeriods","locations":["Central
+        US"],"apiVersions":["2017-04-24-preview"]},{"resourceType":"Invoices","locations":["Central
+        US"],"apiVersions":["2017-04-24-preview","2017-02-27-preview"]},{"resourceType":"operations","locations":["Central
+        US"],"apiVersions":["2017-04-24-preview","2017-02-27-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BingMaps","namespace":"Microsoft.BingMaps","resourceTypes":[{"resourceType":"mapApis","locations":["West
+        US"],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-18","2015-07-02"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BizTalkServices","namespace":"Microsoft.BizTalkServices","resourceTypes":[{"resourceType":"BizTalk","locations":["East
+        US","West US","North Europe","West Europe","Southeast Asia","East Asia","North
+        Central US","Japan West","Japan East","South Central US"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Cache","namespace":"Microsoft.Cache","authorization":{"applicationId":"96231a05-34ce-4eb4-aa6a-70759cbb5e83","roleDefinitionId":"4f731528-ba85-45c7-acfb-cd0a9b3cf31b"},"resourceTypes":[{"resourceType":"Redis","locations":["North
+        Central US","South Central US","Central US","West Europe","North Europe","West
+        US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
+        Asia","East Asia","Australia East","Australia Southeast","Central India","West
+        India","Canada Central","Canada East","UK South","UK West","West US 2","West
+        Central US","South India","Korea Central","Korea South"],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","South Central US","Central US","West Europe","North Europe","West
+        US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
+        Asia","East Asia","Australia East","Australia Southeast","Central India","West
+        India","South India","Canada Central","Canada East","UK South","UK West","West
+        US 2","West Central US","Korea Central","Korea South"],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01"]},{"resourceType":"Redis/metricDefinitions","locations":["North
+        Central US","South Central US","East US","East US 2","West US","Central US","East
+        Asia","Southeast Asia","North Europe","West Europe","Japan East","Japan West","Brazil
+        South","Australia Southeast","Australia East","Central India","West India","South
+        India","Canada Central","Canada East","UK West","UK South","West US 2","West
+        Central US","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"Redis/diagnosticSettings","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","West
+        US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
+        Asia","Australia East","Australia Southeast","Central India","West India","South
+        India","Canada Central","Canada East","UK West","UK South","West US 2","West
+        Central US","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Cdn","namespace":"Microsoft.Cdn","resourceTypes":[{"resourceType":"profiles","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/origins","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/customdomains","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/originresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/customdomainresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkResourceUsage","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02"]},{"resourceType":"validateProbe","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"edgenodes","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CertificateRegistration","namespace":"Microsoft.CertificateRegistration","authorization":{"applicationId":"f3c21649-0979-4721-ac85-b0216b2cf413","roleDefinitionId":"933fba7e-2ed3-4da8-973d-8bd8298a9b40"},"resourceTypes":[{"resourceType":"certificateOrders","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"certificateOrders/certificates","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"validateCertificateRegistrationInformation","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicSubscription","namespace":"Microsoft.ClassicSubscription","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicInfrastructureMigrate","namespace":"Microsoft.ClassicInfrastructureMigrate","authorization":{"applicationId":"5e5abe2b-83cd-4786-826a-a05653ebb103","roleDefinitionId":"766c4d9b-ef83-4f73-8352-1450a506a69b"},"resourceTypes":[{"resourceType":"classicInfrastructureResources","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","West
+        India","South India"],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CognitiveServices","namespace":"Microsoft.CognitiveServices","authorizations":[{"applicationId":"7d312290-28c8-473c-a0ed-8e53749b6d6d","roleDefinitionId":"5cb87f79-a7c3-4a95-9414-45b65974b51b"}],"resourceTypes":[{"resourceType":"accounts","locations":["Global","West
+        US","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"operations","locations":["Global","West
+        US","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations","locations":["Global","West
+        US","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/checkSkuAvailability","locations":["West
+        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/updateAccountsCreationSettings","locations":["West
+        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/accountsCreationSettings","locations":["West
+        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2016-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Commerce","namespace":"Microsoft.Commerce","resourceTypes":[{"resourceType":"UsageAggregates","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]},{"resourceType":"RateCard","locations":[],"apiVersions":["2016-08-31-preview","2015-06-01-preview","2015-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Consumption","namespace":"Microsoft.Consumption","resourceTypes":[{"resourceType":"reservationsummaries","locations":[],"apiVersions":["2017-01-30"]},{"resourceType":"reservationdetails","locations":[],"apiVersions":["2017-01-30"]},{"resourceType":"UsageDetails","locations":[],"apiVersions":["2017-06-30-preview","2017-04-24-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-30-preview","2017-04-24-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","resourceTypes":[{"resourceType":"containerGroups","locations":["West
+        US","East US","West Europe"],"apiVersions":["2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
+        US"],"apiVersions":["2016-04-08"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CustomerInsights","namespace":"Microsoft.CustomerInsights","authorization":{"applicationId":"38c77d00-5fcb-4cce-9d93-af4738258e3c","roleDefinitionId":"E006F9C7-F333-477C-8AD6-1F3A9FE87F55"},"resourceTypes":[{"resourceType":"hubs","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/profiles","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/interactions","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/authorizationPolicies","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/connectors","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/connectors/mappings","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/kpi","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/views","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/links","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/roleAssignments","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/roles","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/widgetTypes","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/suggestTypeSchema","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"operations","locations":["East
+        US 2"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataCatalog","namespace":"Microsoft.DataCatalog","resourceTypes":[{"resourceType":"catalogs","locations":["East
+        US","West US","Australia East","West Europe","North Europe","Southeast Asia","West
+        Central US"],"apiVersions":["2016-03-30","2015-07-01-preview"]},{"resourceType":"checkNameAvailability","locations":["West
+        Europe"],"apiVersions":["2016-03-30","2015-07-01-preview"]},{"resourceType":"operations","locations":["West
+        Europe"],"apiVersions":["2016-03-30","2015-07-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-03-30","2015-07-01-preview"]},{"resourceType":"locations/jobs","locations":["East
+        US","West US","Australia East","West Europe","North Europe","Southeast Asia","West
+        Central US"],"apiVersions":["2016-03-30","2015-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataFactory","namespace":"Microsoft.DataFactory","resourceTypes":[{"resourceType":"dataFactories","locations":["West
+        US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview","2014-04-01"]},{"resourceType":"factories","locations":["East
+        US"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
+        US"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
+        Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"dataFactories/metricDefinitions","locations":["North
+        Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"checkDataFactoryNameAvailability","locations":[],"apiVersions":["2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"checkAzureDataFactoryNameAvailability","locations":["West
+        US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"dataFactorySchema","locations":["West
+        US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"operations","locations":["West
+        US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeAnalytics","namespace":"Microsoft.DataLakeAnalytics","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/dataLakeStoreAccounts","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers/listSasTokens","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeStore","namespace":"Microsoft.DataLakeStore","authorization":{"applicationId":"e9f49c6b-5ce5-44c8-925d-015017e9f7ad","roleDefinitionId":"17eb9cca-f08a-4499-b2d3-852d175f614f"},"resourceTypes":[{"resourceType":"accounts","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/firewallRules","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","resourceTypes":[{"resourceType":"operations","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforPostgreSQL","namespace":"Microsoft.DBforPostgreSQL","resourceTypes":[{"resourceType":"operations","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
+        US","North Europe","East Asia","East US","West Europe","Southeast Asia","Japan
+        East","Japan West","Australia East","Australia Southeast","West US 2","West
+        Central US","East US 2","Central US","UK South","UK West","South India","Central
+        India"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"databaseAccountNames","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DomainRegistration","namespace":"Microsoft.DomainRegistration","authorization":{"applicationId":"ea2f600a-4980-45b7-89bf-d34da487bda1","roleDefinitionId":"54d7f2e3-5040-48a7-ae90-eebf629cfa0b"},"resourceTypes":[{"resourceType":"domains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"domains/domainOwnershipIdentifiers","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"topLevelDomains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"checkDomainAvailability","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"listDomainRecommendations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"validateDomainRegistrationInformation","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"generateSsoRequest","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DynamicsLcs","namespace":"Microsoft.DynamicsLcs","resourceTypes":[{"resourceType":"lcsprojects","locations":["Brazil
+        South","East Asia","East US","Japan East","Japan West","North Central US","North
+        Europe","South Central US","West Europe","West US","Southeast Asia","Central
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"lcsprojects/connectors","locations":["Brazil
+        South","East Asia","East US","Japan East","Japan West","North Central US","North
+        Europe","South Central US","West Europe","West US","Southeast Asia","Central
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"lcsprojects/clouddeployments","locations":["Brazil
+        South","East Asia","East US","Japan East","Japan West","North Central US","North
+        Europe","South Central US","West Europe","West US","Southeast Asia","Central
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"operations","locations":["Brazil
+        South","East Asia","East US","Japan East","Japan West","North Central US","North
+        Europe","South Central US","West Europe","West US","Southeast Asia","Central
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"topics","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operations","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"clusters/applications","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"clusters/operationresults","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations/capabilities","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations/operationresults","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations/azureasyncoperations","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations/validateCreateRequest","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"operations","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India"],"apiVersions":["2015-03-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ImportExport","namespace":"Microsoft.ImportExport","authorization":{"applicationId":"7de4d5c5-5b32-4235-b8a9-33b34d6bcd2a","roleDefinitionId":"9f7aa6bb-9454-46b6-8c01-a4b0f33ca151"},"resourceTypes":[{"resourceType":"jobs","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","North Central US","North Europe","South Central US","Southeast
+        Asia","South India","UK South","West Central US","West Europe","West India","West
+        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","North Central US","North Europe","South Central US","Southeast
+        Asia","South India","UK South","West Central US","West Europe","West India","West
+        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations/operationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","North Central US","North Europe","South Central US","Southeast
+        Asia","South India","UK South","West Central US","West Europe","West India","West
+        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","North Central US","North Europe","South Central US","Southeast
+        Asia","South India","UK South","West Central US","West Europe","West India","West
+        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Logic","namespace":"Microsoft.Logic","authorization":{"applicationId":"7cd684f4-8a78-49b0-91ec-6a35d38739ba","roleDefinitionId":"cb3ef1fb-6e31-49e2-9d87-ed821053fe58"},"resourceTypes":[{"resourceType":"workflows","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West"],"apiVersions":["2017-07-01","2016-10-01","2016-06-01","2015-08-01-preview","2015-02-01-preview"]},{"resourceType":"locations/workflows","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West"],"apiVersions":["2017-07-01","2016-10-01","2016-06-01","2015-08-01-preview","2015-02-01-preview"]},{"resourceType":"locations","locations":["North
+        Central US"],"apiVersions":["2017-07-01","2016-10-01","2016-06-01","2015-08-01-preview","2015-02-01-preview"]},{"resourceType":"operations","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West"],"apiVersions":["2017-07-01","2016-10-01","2016-06-01","2015-08-01-preview","2015-02-01-preview"]},{"resourceType":"integrationAccounts","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","West Central US"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"operations","locations":["South
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations","locations":["South
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operations","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"commitmentPlans","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
+        Central US","West US"],"apiVersions":["2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Media","namespace":"Microsoft.Media","authorization":{"applicationId":"374b2a64-3b6b-436b-934c-b820eacca870","roleDefinitionId":"aab70789-0cec-44b5-95d7-84b64c9487af"},"resourceTypes":[{"resourceType":"mediaservices","locations":["Japan
+        West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
+        US","West US","Australia East","Australia Southeast","Central US","Brazil
+        South","Central India","West India","South India","South Central US","Canada
+        Central","Canada East","West Central US"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
+        Central US","North Central US","East US 2","West US","West Europe","North
+        Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
+        East","UK South","West India"],"apiVersions":["2016-01-29"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-01-29"]},{"resourceType":"locations/checkNameAvailability","locations":["South
+        Central US","North Central US","East US 2","West US","West Europe","North
+        Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
+        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"operations","locations":["East
+        US 2"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Relay","namespace":"Microsoft.Relay","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US 2","West
+        US","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
+        East","West India","South India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
+        East","West India","South India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
+        Central US","South Central US","North Europe","West Europe","East Asia","Southeast
+        Asia","West US","East US","Japan West","Japan East","Brazil South","Central
+        US","East US 2","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-03-01","2016-01-01","2014-08-01-preview"]},{"resourceType":"operations","locations":["North
+        Central US","South Central US","North Europe","West Europe","East Asia","Southeast
+        Asia","West US","East US","Japan West","Japan East","Brazil South","Central
+        US","East US 2","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-03-01","2016-01-01","2014-08-01-preview"]},{"resourceType":"operationResults","locations":["North
+        Central US","South Central US","North Europe","West Europe","East Asia","Southeast
+        Asia","West US","East US","Japan West","Japan East","Brazil South","Central
+        US","East US 2","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-03-01","2016-01-01","2014-08-01-preview"]},{"resourceType":"flows","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast"],"apiVersions":["2015-08-01-preview","2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Search","namespace":"Microsoft.Search","resourceTypes":[{"resourceType":"searchServices","locations":["West
+        US","East US","North Europe","West Europe","Southeast Asia","East Asia","North
+        Central US","South Central US","Japan West","Australia East","Brazil South","Central
+        India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19","2015-02-28"]},{"resourceType":"checkServiceNameAvailability","locations":[],"apiVersions":["2015-02-28","2014-07-31-Preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2015-08-19"]},{"resourceType":"resourceHealthMetadata","locations":["West
+        US","East US","North Europe","West Europe","Southeast Asia","East Asia","North
+        Central US","South Central US","Japan West","Australia East","Brazil South","Central
+        India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US 2","West
+        US","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"premiumMessagingRegions","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceFabric","namespace":"Microsoft.ServiceFabric","authorization":{"applicationId":"74cb6831-0dbb-4be1-8206-fd4df301cdc2","roleDefinitionId":"e55cc65f-6903-4917-b4ef-f8d4640b57f5"},"resourceTypes":[{"resourceType":"clusters","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/clusterVersions","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operations","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Canada
+        Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","West Central US","Japan East","Japan West","Australia East","Australia
+        Southeast"],"apiVersions":["2017-06-01","2017-05-15","2017-01-01","2016-10-01","2016-06-01","2015-03-15","2014-09-01"]},{"resourceType":"operations","locations":["West
+        Central US","Southeast Asia"],"apiVersions":["2016-10-01","2016-06-01","2015-03-15","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StreamAnalytics","namespace":"Microsoft.StreamAnalytics","resourceTypes":[{"resourceType":"streamingjobs","locations":["Central
+        US","West Europe","East US 2","North Europe","Japan East","West US","Southeast
+        Asia","South Central US","East Asia","Japan West","North Central US","East
+        US","Australia East","Australia Southeast","Brazil South","Central India","West
+        Central US","UK South","UK West","Canada Central","Canada East","West US 2"],"apiVersions":["2017-04-01-preview","2016-03-01","2015-11-01","2015-10-01","2015-09-01","2015-08-01-preview","2015-06-01","2015-05-01","2015-04-01","2015-03-01-preview"]},{"resourceType":"locations","locations":["West
+        Europe","Central US","East US 2","North Europe","Japan East","West US","Southeast
+        Asia","South Central US","East Asia","Japan West","North Central US","East
+        US","Australia East","Australia Southeast","Brazil South","Central India","West
+        Central US","UK South","West US 2","UK West","Canada Central","Canada East"],"apiVersions":["2017-04-01-preview","2016-03-01","2015-11-01","2015-10-01","2015-09-01","2015-08-01-preview","2015-06-01","2015-05-01","2015-04-01","2015-03-01-preview"]},{"resourceType":"locations/quotas","locations":[],"apiVersions":["2017-04-01-preview","2016-03-01","2015-11-01","2015-10-01","2015-09-01","2015-08-01-preview","2015-06-01","2015-05-01","2015-04-01","2015-03-01-preview"]},{"resourceType":"streamingjobs/diagnosticSettings","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","Central
+        India","West Central US","UK South","UK West","Canada Central","Canada East","West
+        US 2","West US","Central US","South Central US","Japan East","Japan West","East
+        Asia","Southeast Asia","Australia East","Australia Southeast"],"apiVersions":["2014-04-01"]},{"resourceType":"streamingjobs/metricDefinitions","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","Central
+        India","West Central US","UK South","UK West","Canada Central","Canada East","West
+        US 2","West US","Central US","South Central US","Japan East","Japan West","East
+        Asia","Southeast Asia","Australia East","Australia Southeast"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":["West
+        Europe","West US","Central US","East US 2","North Europe","Japan East","Southeast
+        Asia","South Central US","East Asia","Japan West","North Central US","East
+        US","Australia East","Australia Southeast","Brazil South","Central India","West
+        Central US","UK South","UK West","Canada Central","Canada East","West US 2"],"apiVersions":["2017-04-01-preview","2016-03-01","2015-11-01","2015-10-01","2015-09-01","2015-08-01-preview","2015-06-01","2015-05-01","2015-04-01","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.support","namespace":"microsoft.support","resourceTypes":[{"resourceType":"operations","locations":["North
+        Central US","South Central US","Central US","West Europe","North Europe","West
+        US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
+        Asia","East Asia","Australia East","Australia Southeast"],"apiVersions":["2015-07-01-Preview","2015-03-01"]},{"resourceType":"supporttickets","locations":["North
+        Central US","South Central US","Central US","West Europe","North Europe","West
+        US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
+        Asia","East Asia","Australia East","Australia Southeast"],"apiVersions":["2015-07-01-Preview","2015-03-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.TimeSeriesInsights","namespace":"Microsoft.TimeSeriesInsights","authorizations":[{"applicationId":"120d688d-1518-4cf7-bd38-182f158850b6","roleDefinitionId":"5a43abdf-bb87-42c4-9e56-1c24bf364150"}],"resourceTypes":[{"resourceType":"environments","locations":["East
+        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/eventsources","locations":["East
+        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/referenceDataSets","locations":["East
+        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/accessPolicies","locations":["East
+        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"operations","locations":["East
+        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/project","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/extension","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"checkNameAvailability","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Myget.PackageManagement","namespace":"Myget.PackageManagement","resourceTypes":[{"resourceType":"services","locations":["West
+        Europe"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/NewRelic.APM","namespace":"NewRelic.APM","authorization":{"allowedThirdPartyExtensions":[{"name":"NewRelic_AzurePortal_APM"}]},"resourceTypes":[{"resourceType":"accounts","locations":["North
+        Central US","South Central US","West US","East US","North Europe","West Europe","Southeast
+        Asia","East Asia","Japan East","Japan West"],"apiVersions":["2014-10-01","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/nuubit.nextgencdn","namespace":"nuubit.nextgencdn","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US","East US 2","North Central US","South Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","West US","Central US"],"apiVersions":["2017-05-05"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-05"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-05-05"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-05-05"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Paraleap.CloudMonix","namespace":"Paraleap.CloudMonix","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2016-08-10"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-10"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-10"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Pokitdok.Platform","namespace":"Pokitdok.Platform","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2016-05-17"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-05-17"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-05-17"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-05-17"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RavenHq.Db","namespace":"RavenHq.Db","resourceTypes":[{"resourceType":"databases","locations":["East
+        US"],"apiVersions":["2016-07-18","2016-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-07-18","2016-06-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-07-18","2016-06-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-07-18","2016-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Raygun.CrashReporting","namespace":"Raygun.CrashReporting","resourceTypes":[{"resourceType":"apps","locations":["East
+        US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RedisLabs.Memcached","namespace":"RedisLabs.Memcached","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-07-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RedisLabs.Redis","namespace":"RedisLabs.Redis","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-07-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RevAPM.MobileCDN","namespace":"RevAPM.MobileCDN","resourceTypes":[{"resourceType":"accounts","locations":["Central
+        US","East US","East US 2","North Central US","South Central US","West US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast"],"apiVersions":["2016-08-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-24","2016-08-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sendgrid.Email","namespace":"Sendgrid.Email","resourceTypes":[{"resourceType":"accounts","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Canada Central","Canada
+        East","West Central US","West US 2","UK South","UK West"],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Signiant.Flight","namespace":"Signiant.Flight","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US","Central US","North Central US","South Central US","West US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast"],"apiVersions":["2015-06-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sparkpost.Basic","namespace":"Sparkpost.Basic","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2016-08-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/stackify.retrace","namespace":"stackify.retrace","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2016-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/SuccessBricks.ClearDB","namespace":"SuccessBricks.ClearDB","resourceTypes":[{"resourceType":"databases","locations":["Brazil
+        South","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","Southeast Asia","West Europe","West
+        US","South Central US","Australia East","Australia Southeast","Canada Central","Canada
+        East","Central India","South India","West India"],"apiVersions":["2014-04-01"]},{"resourceType":"clusters","locations":["Brazil
+        South","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","Southeast Asia","West Europe","West
+        US","Australia Southeast","Australia East","South Central US","Canada Central","Canada
+        East","Central India","South India","West India"],"apiVersions":["2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/TrendMicro.DeepSecurity","namespace":"TrendMicro.DeepSecurity","resourceTypes":[{"resourceType":"accounts","locations":["Central
+        US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
+        Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:32:39 GMT
+- request:
+    method: post
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
+    body:
+      encoding: UTF-8
+      string: '{"access":"read","durationInSeconds":3600}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NTksIm5iZiI6MTUwNDEwNjg1OSwiZXhwIjoxNTA0MTEwNzU5LCJhaW8iOiJZMkZnWVBqLzRYTjFuNkFMejlKNUVwZHI1UEt2QVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ0E5Z3hTX0ROVWlheDNCNTVOa1JBQSIsInZlciI6IjEuMCJ9.oxGm4SO5Jl4w7HzwE_SxjzfoYBBKTotYxIzCbvtK6jXAeT9MeHmuFSySpw_artOtHxhbcNphere9DcgGPF97B0t9cNHl0Tb-w3EPpYGiKRT4YeOKNlmQuaFdchlydmbBnqFlc9fzExSyLM-pzh1rOblVV1UC64gS8NprmI36wCQAOmXisBUnFB6qceFzN5EU9jpFiCXR9JlSZOxyo6AR5ms7-zfTKmDDahDCVryCyyyQV9z-q9YgrYyX-xj5hLDot7tHtbGi77l2ViCxoc67BUYjFay9Ff-oJlu3km94vHPcnhRD9W_dkcurtQwDjNM2Lblgkj7nDOS-S0SkW4-2ow
+      Content-Length:
+      - '42'
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '0'
+      Expires:
+      - "-1"
+      Location:
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/42ece62c-3dd9-4062-a6cd-6a2b5163d004?monitor=true&api-version=2017-03-30
+      Azure-Asyncoperation:
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/42ece62c-3dd9-4062-a6cd-6a2b5163d004?api-version=2017-03-30
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      X-Ms-Request-Id:
+      - 42ece62c-3dd9-4062-a6cd-6a2b5163d004
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Writes:
+      - '1196'
+      X-Ms-Correlation-Request-Id:
+      - 0b844184-1e82-4f1d-b321-43953d41b99f
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153241Z:0b844184-1e82-4f1d-b321-43953d41b99f
+      Date:
+      - Wed, 30 Aug 2017 15:32:40 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:32:40 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/42ece62c-3dd9-4062-a6cd-6a2b5163d004?api-version=2017-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NTksIm5iZiI6MTUwNDEwNjg1OSwiZXhwIjoxNTA0MTEwNzU5LCJhaW8iOiJZMkZnWVBqLzRYTjFuNkFMejlKNUVwZHI1UEt2QVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ0E5Z3hTX0ROVWlheDNCNTVOa1JBQSIsInZlciI6IjEuMCJ9.oxGm4SO5Jl4w7HzwE_SxjzfoYBBKTotYxIzCbvtK6jXAeT9MeHmuFSySpw_artOtHxhbcNphere9DcgGPF97B0t9cNHl0Tb-w3EPpYGiKRT4YeOKNlmQuaFdchlydmbBnqFlc9fzExSyLM-pzh1rOblVV1UC64gS8NprmI36wCQAOmXisBUnFB6qceFzN5EU9jpFiCXR9JlSZOxyo6AR5ms7-zfTKmDDahDCVryCyyyQV9z-q9YgrYyX-xj5hLDot7tHtbGi77l2ViCxoc67BUYjFay9Ff-oJlu3km94vHPcnhRD9W_dkcurtQwDjNM2Lblgkj7nDOS-S0SkW4-2ow
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      X-Ms-Request-Id:
+      - fcc88164-1140-4c50-9c6e-893d0b854e59
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14926'
+      X-Ms-Correlation-Request-Id:
+      - 639f98ca-d269-4a49-8760-ced518382bfa
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153241Z:639f98ca-d269-4a49-8760-ced518382bfa
+      Date:
+      - Wed, 30 Aug 2017 15:32:41 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"startTime\": \"2017-08-30T15:32:41.0739435+00:00\",\r\n  \"endTime\":
+        \"2017-08-30T15:32:41.3239499+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=ea500bb9-a986-4b69-8ad6-964c6f73558c&sig=w%2BsRRQbGgLMc6FhOaGM1ccfC0PFPI3OJNFCAIqxSiUA%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"42ece62c-3dd9-4062-a6cd-6a2b5163d004\"\r\n}"
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:32:40 GMT
+- request:
+    method: get
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=ea500bb9-a986-4b69-8ad6-964c6f73558c&sig=w%2BsRRQbGgLMc6FhOaGM1ccfC0PFPI3OJNFCAIqxSiUA=&sr=b&sv=2016-05-31
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      X-Ms-Range:
+      - bytes=0-0
+      Host:
+      - md-t4jdgqqlgszp.blob.core.windows.net
+  response:
+    status:
+      code: 206
+      message: Partial Content
+    headers:
+      Content-Length:
+      - '1'
+      Content-Type:
+      - application/octet-stream
+      Content-Range:
+      - bytes 0-0/34359738880
+      Last-Modified:
+      - Sat, 15 Jul 2017 14:23:07 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D4CB8D039FC699"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 79c1d103-0001-0107-23a5-2111fd000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Meta-Pirtag:
+      - '1'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '20'
+      X-Ms-Copy-Id:
+      - 30cedd78-548a-4fd8-967e-f8344f587e3c
+      X-Ms-Copy-Source:
+      - http://md-t4jdgqqlgszp.blob.core.windows.net:8080/fg25xxtqx0gc/abcd?sv=2016-02-19&sr=b&st=2017-05-04T21%3a06%3a57Z&se=9999-12-31T23%3a59%3a59Z&sp=r&api-version=2016-02-19
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 34359738880/34359738880
+      X-Ms-Copy-Completion-Time:
+      - Thu, 04 May 2017 21:21:56 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Wed, 30 Aug 2017 15:32:41 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        6w==
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:32:40 GMT
+- request:
+    method: post
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
+    body:
+      encoding: UTF-8
+      string: '{"access":"read","durationInSeconds":3600}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NTksIm5iZiI6MTUwNDEwNjg1OSwiZXhwIjoxNTA0MTEwNzU5LCJhaW8iOiJZMkZnWVBqLzRYTjFuNkFMejlKNUVwZHI1UEt2QVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ0E5Z3hTX0ROVWlheDNCNTVOa1JBQSIsInZlciI6IjEuMCJ9.oxGm4SO5Jl4w7HzwE_SxjzfoYBBKTotYxIzCbvtK6jXAeT9MeHmuFSySpw_artOtHxhbcNphere9DcgGPF97B0t9cNHl0Tb-w3EPpYGiKRT4YeOKNlmQuaFdchlydmbBnqFlc9fzExSyLM-pzh1rOblVV1UC64gS8NprmI36wCQAOmXisBUnFB6qceFzN5EU9jpFiCXR9JlSZOxyo6AR5ms7-zfTKmDDahDCVryCyyyQV9z-q9YgrYyX-xj5hLDot7tHtbGi77l2ViCxoc67BUYjFay9Ff-oJlu3km94vHPcnhRD9W_dkcurtQwDjNM2Lblgkj7nDOS-S0SkW4-2ow
+      Content-Length:
+      - '42'
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '0'
+      Expires:
+      - "-1"
+      Location:
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/30e982ec-4770-42c1-a8fd-79a18da6ba1a?monitor=true&api-version=2017-03-30
+      Azure-Asyncoperation:
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/30e982ec-4770-42c1-a8fd-79a18da6ba1a?api-version=2017-03-30
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      X-Ms-Request-Id:
+      - 30e982ec-4770-42c1-a8fd-79a18da6ba1a
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Writes:
+      - '1199'
+      X-Ms-Correlation-Request-Id:
+      - d0b89b46-b98e-487b-a862-d6bc809f4bb3
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153242Z:d0b89b46-b98e-487b-a862-d6bc809f4bb3
+      Date:
+      - Wed, 30 Aug 2017 15:32:42 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:32:41 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/30e982ec-4770-42c1-a8fd-79a18da6ba1a?api-version=2017-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NTksIm5iZiI6MTUwNDEwNjg1OSwiZXhwIjoxNTA0MTEwNzU5LCJhaW8iOiJZMkZnWVBqLzRYTjFuNkFMejlKNUVwZHI1UEt2QVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ0E5Z3hTX0ROVWlheDNCNTVOa1JBQSIsInZlciI6IjEuMCJ9.oxGm4SO5Jl4w7HzwE_SxjzfoYBBKTotYxIzCbvtK6jXAeT9MeHmuFSySpw_artOtHxhbcNphere9DcgGPF97B0t9cNHl0Tb-w3EPpYGiKRT4YeOKNlmQuaFdchlydmbBnqFlc9fzExSyLM-pzh1rOblVV1UC64gS8NprmI36wCQAOmXisBUnFB6qceFzN5EU9jpFiCXR9JlSZOxyo6AR5ms7-zfTKmDDahDCVryCyyyQV9z-q9YgrYyX-xj5hLDot7tHtbGi77l2ViCxoc67BUYjFay9Ff-oJlu3km94vHPcnhRD9W_dkcurtQwDjNM2Lblgkj7nDOS-S0SkW4-2ow
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      X-Ms-Request-Id:
+      - dfdde9f3-052e-45be-ab6a-19ea6d5906c8
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14938'
+      X-Ms-Correlation-Request-Id:
+      - 97ef3b79-4fab-4733-884e-ed0f1629170e
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153242Z:97ef3b79-4fab-4733-884e-ed0f1629170e
+      Date:
+      - Wed, 30 Aug 2017 15:32:42 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"startTime\": \"2017-08-30T15:32:41.9489642+00:00\",\r\n  \"endTime\":
+        \"2017-08-30T15:32:42.1520758+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=b702eff1-6c53-4aa7-8bf2-9d443e0abc68&sig=eK5qtSkbDWmcDe1MyIaGsDuCyECmiKjuSwFEjNx0vNY%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"30e982ec-4770-42c1-a8fd-79a18da6ba1a\"\r\n}"
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:32:41 GMT
+- request:
+    method: get
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=b702eff1-6c53-4aa7-8bf2-9d443e0abc68&sig=eK5qtSkbDWmcDe1MyIaGsDuCyECmiKjuSwFEjNx0vNY=&sr=b&sv=2016-05-31
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      X-Ms-Range:
+      - bytes=440-443
+      Host:
+      - md-t4jdgqqlgszp.blob.core.windows.net
+  response:
+    status:
+      code: 206
+      message: Partial Content
+    headers:
+      Content-Length:
+      - '4'
+      Content-Type:
+      - application/octet-stream
+      Content-Range:
+      - bytes 440-443/34359738880
+      Last-Modified:
+      - Sat, 15 Jul 2017 14:23:07 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D4CB8D039FC699"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - e342e249-0001-0116-13a5-2126e6000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Meta-Pirtag:
+      - '1'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '20'
+      X-Ms-Copy-Id:
+      - 30cedd78-548a-4fd8-967e-f8344f587e3c
+      X-Ms-Copy-Source:
+      - http://md-t4jdgqqlgszp.blob.core.windows.net:8080/fg25xxtqx0gc/abcd?sv=2016-02-19&sr=b&st=2017-05-04T21%3a06%3a57Z&se=9999-12-31T23%3a59%3a59Z&sp=r&api-version=2016-02-19
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 34359738880/34359738880
+      X-Ms-Copy-Completion-Time:
+      - Thu, 04 May 2017 21:21:56 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Wed, 30 Aug 2017 15:32:42 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        U5MJAA==
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:32:41 GMT
+recorded_with: VCR 3.0.3

--- a/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_new-2.yml
+++ b/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_new-2.yml
@@ -39,25 +39,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - c5600f08-c32f-4835-9ac7-7079e4d91100
+      - d2609c46-22b5-480b-b2d2-02e2a0fe1300
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAAA9kTklhVy7SJTGAzR-p1BcWJTxYspgz5B3Q-YOrxxdU5gWqWPNGm_oCvTsHY0RGrIjDPf8ovopVFHUZ4T1XQQtAH6ddxDX4ZvPtNYbAMbwwBoBZ3BIRENZl9ogYUOeK636KtLxD2I5_OiiLd-AD2UARVR6bmdQkt_qOct57FQA3Yie1TiVFIoEKA2grNKiBiEgAA;
+      - esctx=AQABAAAAAAA9kTklhVy7SJTGAzR-p1BctHQdXXD-Lvb1DK7rpchdgkkZqZQZD8WGoQLtYBSYXBDdYpXvEz0XR5fbm1tDu88ZeUfGzx0CdQ0qBnF_zAeGlMGbPx3Rwam3fZwoBIIyV3Xl0YhQ5dNcQ5lqmimrPAzub_-OHQxX5NfQduyA7dKjK-NT4pEp1lSfgxYJnWDwJRYgAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=005; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=004; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Wed, 30 Aug 2017 15:32:37 GMT
+      - Wed, 30 Aug 2017 17:05:10 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1504110759","not_before":"1504106859","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NTksIm5iZiI6MTUwNDEwNjg1OSwiZXhwIjoxNTA0MTEwNzU5LCJhaW8iOiJZMkZnWVBqLzRYTjFuNkFMejlKNUVwZHI1UEt2QVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ0E5Z3hTX0ROVWlheDNCNTVOa1JBQSIsInZlciI6IjEuMCJ9.oxGm4SO5Jl4w7HzwE_SxjzfoYBBKTotYxIzCbvtK6jXAeT9MeHmuFSySpw_artOtHxhbcNphere9DcgGPF97B0t9cNHl0Tb-w3EPpYGiKRT4YeOKNlmQuaFdchlydmbBnqFlc9fzExSyLM-pzh1rOblVV1UC64gS8NprmI36wCQAOmXisBUnFB6qceFzN5EU9jpFiCXR9JlSZOxyo6AR5ms7-zfTKmDDahDCVryCyyyQV9z-q9YgrYyX-xj5hLDot7tHtbGi77l2ViCxoc67BUYjFay9Ff-oJlu3km94vHPcnhRD9W_dkcurtQwDjNM2Lblgkj7nDOS-S0SkW4-2ow"}'
+      string: '{"token_type":"Bearer","expires_in":"3600","ext_expires_in":"0","expires_on":"1504116310","not_before":"1504112410","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MTAsIm5iZiI6MTUwNDExMjQxMCwiZXhwIjoxNTA0MTE2MzEwLCJhaW8iOiJZMkZnWVBqLzRYTjFuNkFMejlKNUVwZHI1UEt2QVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUnB4ZzByVWlDMGl5MGdMaW9QNFRBQSIsInZlciI6IjEuMCJ9.aV-5JccO9eCammf3bFDoERjH2iO_PJt9iEFaZZ96BAcnGlMCWEsA0RRuRM1E8_fUZXAxg7wvXF2IvSX2R5Cj-vfe4GAQGN85bERuA8YBBbrpGfPXcBdhhkrnA_HNEfYuk4KQEtE1laMZEawSzJDWgoxQCUxDcelgA-Zlh_m9QBvLlt1xZ9Owq8mNZHN2JE0exQ2DYpbq-P6_Dcu34H_-BB0chTbNYRykmwB9oUWN16Vjsz9p_FRik_BfC2AZ0Jjq0CMUmD3nOQcoXSYELEQQdLSlP3b_h_oQ5iSagb5zNwVKjZM5OAuVeOiXwPREeiO-8mylvy8j39VmyKfWEwjp3Q"}'
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:32:38 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:10 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -74,7 +74,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NTksIm5iZiI6MTUwNDEwNjg1OSwiZXhwIjoxNTA0MTEwNzU5LCJhaW8iOiJZMkZnWVBqLzRYTjFuNkFMejlKNUVwZHI1UEt2QVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ0E5Z3hTX0ROVWlheDNCNTVOa1JBQSIsInZlciI6IjEuMCJ9.oxGm4SO5Jl4w7HzwE_SxjzfoYBBKTotYxIzCbvtK6jXAeT9MeHmuFSySpw_artOtHxhbcNphere9DcgGPF97B0t9cNHl0Tb-w3EPpYGiKRT4YeOKNlmQuaFdchlydmbBnqFlc9fzExSyLM-pzh1rOblVV1UC64gS8NprmI36wCQAOmXisBUnFB6qceFzN5EU9jpFiCXR9JlSZOxyo6AR5ms7-zfTKmDDahDCVryCyyyQV9z-q9YgrYyX-xj5hLDot7tHtbGi77l2ViCxoc67BUYjFay9Ff-oJlu3km94vHPcnhRD9W_dkcurtQwDjNM2Lblgkj7nDOS-S0SkW4-2ow
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MTAsIm5iZiI6MTUwNDExMjQxMCwiZXhwIjoxNTA0MTE2MzEwLCJhaW8iOiJZMkZnWVBqLzRYTjFuNkFMejlKNUVwZHI1UEt2QVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUnB4ZzByVWlDMGl5MGdMaW9QNFRBQSIsInZlciI6IjEuMCJ9.aV-5JccO9eCammf3bFDoERjH2iO_PJt9iEFaZZ96BAcnGlMCWEsA0RRuRM1E8_fUZXAxg7wvXF2IvSX2R5Cj-vfe4GAQGN85bERuA8YBBbrpGfPXcBdhhkrnA_HNEfYuk4KQEtE1laMZEawSzJDWgoxQCUxDcelgA-Zlh_m9QBvLlt1xZ9Owq8mNZHN2JE0exQ2DYpbq-P6_Dcu34H_-BB0chTbNYRykmwB9oUWN16Vjsz9p_FRik_BfC2AZ0Jjq0CMUmD3nOQcoXSYELEQQdLSlP3b_h_oQ5iSagb5zNwVKjZM5OAuVeOiXwPREeiO-8mylvy8j39VmyKfWEwjp3Q
       Host:
       - management.azure.com
   response:
@@ -95,23 +95,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14999'
+      - '14997'
       X-Ms-Request-Id:
-      - 8b63cdb1-5407-4814-81f9-c34d5df3ca94
+      - c9617f96-1cca-4142-b87c-9701aa472da1
       X-Ms-Correlation-Request-Id:
-      - 8b63cdb1-5407-4814-81f9-c34d5df3ca94
+      - c9617f96-1cca-4142-b87c-9701aa472da1
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153239Z:8b63cdb1-5407-4814-81f9-c34d5df3ca94
+      - EASTUS:20170830T170510Z:c9617f96-1cca-4142-b87c-9701aa472da1
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 30 Aug 2017 15:32:39 GMT
+      - Wed, 30 Aug 2017 17:05:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:32:38 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:10 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/azure_subscription_id/providers?api-version=2015-01-01
@@ -128,7 +128,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NTksIm5iZiI6MTUwNDEwNjg1OSwiZXhwIjoxNTA0MTEwNzU5LCJhaW8iOiJZMkZnWVBqLzRYTjFuNkFMejlKNUVwZHI1UEt2QVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ0E5Z3hTX0ROVWlheDNCNTVOa1JBQSIsInZlciI6IjEuMCJ9.oxGm4SO5Jl4w7HzwE_SxjzfoYBBKTotYxIzCbvtK6jXAeT9MeHmuFSySpw_artOtHxhbcNphere9DcgGPF97B0t9cNHl0Tb-w3EPpYGiKRT4YeOKNlmQuaFdchlydmbBnqFlc9fzExSyLM-pzh1rOblVV1UC64gS8NprmI36wCQAOmXisBUnFB6qceFzN5EU9jpFiCXR9JlSZOxyo6AR5ms7-zfTKmDDahDCVryCyyyQV9z-q9YgrYyX-xj5hLDot7tHtbGi77l2ViCxoc67BUYjFay9Ff-oJlu3km94vHPcnhRD9W_dkcurtQwDjNM2Lblgkj7nDOS-S0SkW4-2ow
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MTAsIm5iZiI6MTUwNDExMjQxMCwiZXhwIjoxNTA0MTE2MzEwLCJhaW8iOiJZMkZnWVBqLzRYTjFuNkFMejlKNUVwZHI1UEt2QVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUnB4ZzByVWlDMGl5MGdMaW9QNFRBQSIsInZlciI6IjEuMCJ9.aV-5JccO9eCammf3bFDoERjH2iO_PJt9iEFaZZ96BAcnGlMCWEsA0RRuRM1E8_fUZXAxg7wvXF2IvSX2R5Cj-vfe4GAQGN85bERuA8YBBbrpGfPXcBdhhkrnA_HNEfYuk4KQEtE1laMZEawSzJDWgoxQCUxDcelgA-Zlh_m9QBvLlt1xZ9Owq8mNZHN2JE0exQ2DYpbq-P6_Dcu34H_-BB0chTbNYRykmwB9oUWN16Vjsz9p_FRik_BfC2AZ0Jjq0CMUmD3nOQcoXSYELEQQdLSlP3b_h_oQ5iSagb5zNwVKjZM5OAuVeOiXwPREeiO-8mylvy8j39VmyKfWEwjp3Q
       Host:
       - management.azure.com
   response:
@@ -147,17 +147,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14951'
+      - '14944'
       X-Ms-Request-Id:
-      - 6cd48d21-c1e7-422f-8570-4cfd744cd271
+      - ca349e11-9d4e-44d9-80da-a3889c812e01
       X-Ms-Correlation-Request-Id:
-      - 6cd48d21-c1e7-422f-8570-4cfd744cd271
+      - ca349e11-9d4e-44d9-80da-a3889c812e01
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153240Z:6cd48d21-c1e7-422f-8570-4cfd744cd271
+      - EASTUS:20170830T170511Z:ca349e11-9d4e-44d9-80da-a3889c812e01
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 30 Aug 2017 15:32:40 GMT
+      - Wed, 30 Aug 2017 17:05:11 GMT
       Content-Length:
       - '241615'
     body:
@@ -1891,7 +1891,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:32:39 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:11 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
@@ -1908,7 +1908,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NTksIm5iZiI6MTUwNDEwNjg1OSwiZXhwIjoxNTA0MTEwNzU5LCJhaW8iOiJZMkZnWVBqLzRYTjFuNkFMejlKNUVwZHI1UEt2QVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ0E5Z3hTX0ROVWlheDNCNTVOa1JBQSIsInZlciI6IjEuMCJ9.oxGm4SO5Jl4w7HzwE_SxjzfoYBBKTotYxIzCbvtK6jXAeT9MeHmuFSySpw_artOtHxhbcNphere9DcgGPF97B0t9cNHl0Tb-w3EPpYGiKRT4YeOKNlmQuaFdchlydmbBnqFlc9fzExSyLM-pzh1rOblVV1UC64gS8NprmI36wCQAOmXisBUnFB6qceFzN5EU9jpFiCXR9JlSZOxyo6AR5ms7-zfTKmDDahDCVryCyyyQV9z-q9YgrYyX-xj5hLDot7tHtbGi77l2ViCxoc67BUYjFay9Ff-oJlu3km94vHPcnhRD9W_dkcurtQwDjNM2Lblgkj7nDOS-S0SkW4-2ow
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MTAsIm5iZiI6MTUwNDExMjQxMCwiZXhwIjoxNTA0MTE2MzEwLCJhaW8iOiJZMkZnWVBqLzRYTjFuNkFMejlKNUVwZHI1UEt2QVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUnB4ZzByVWlDMGl5MGdMaW9QNFRBQSIsInZlciI6IjEuMCJ9.aV-5JccO9eCammf3bFDoERjH2iO_PJt9iEFaZZ96BAcnGlMCWEsA0RRuRM1E8_fUZXAxg7wvXF2IvSX2R5Cj-vfe4GAQGN85bERuA8YBBbrpGfPXcBdhhkrnA_HNEfYuk4KQEtE1laMZEawSzJDWgoxQCUxDcelgA-Zlh_m9QBvLlt1xZ9Owq8mNZHN2JE0exQ2DYpbq-P6_Dcu34H_-BB0chTbNYRykmwB9oUWN16Vjsz9p_FRik_BfC2AZ0Jjq0CMUmD3nOQcoXSYELEQQdLSlP3b_h_oQ5iSagb5zNwVKjZM5OAuVeOiXwPREeiO-8mylvy8j39VmyKfWEwjp3Q
       Content-Length:
       - '42'
       Host:
@@ -1927,34 +1927,34 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/42ece62c-3dd9-4062-a6cd-6a2b5163d004?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/1d45cfca-15c3-4995-97a4-94dbfcf8c5b3?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/42ece62c-3dd9-4062-a6cd-6a2b5163d004?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/1d45cfca-15c3-4995-97a4-94dbfcf8c5b3?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
       - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
       X-Ms-Request-Id:
-      - 42ece62c-3dd9-4062-a6cd-6a2b5163d004
+      - 1d45cfca-15c3-4995-97a4-94dbfcf8c5b3
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1196'
+      - '1195'
       X-Ms-Correlation-Request-Id:
-      - 0b844184-1e82-4f1d-b321-43953d41b99f
+      - 6f3831b0-5ba4-4a16-b7a9-e6065f818174
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153241Z:0b844184-1e82-4f1d-b321-43953d41b99f
+      - EASTUS:20170830T170512Z:6f3831b0-5ba4-4a16-b7a9-e6065f818174
       Date:
-      - Wed, 30 Aug 2017 15:32:40 GMT
+      - Wed, 30 Aug 2017 17:05:12 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:32:40 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:12 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/42ece62c-3dd9-4062-a6cd-6a2b5163d004?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/1d45cfca-15c3-4995-97a4-94dbfcf8c5b3?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -1968,7 +1968,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NTksIm5iZiI6MTUwNDEwNjg1OSwiZXhwIjoxNTA0MTEwNzU5LCJhaW8iOiJZMkZnWVBqLzRYTjFuNkFMejlKNUVwZHI1UEt2QVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ0E5Z3hTX0ROVWlheDNCNTVOa1JBQSIsInZlciI6IjEuMCJ9.oxGm4SO5Jl4w7HzwE_SxjzfoYBBKTotYxIzCbvtK6jXAeT9MeHmuFSySpw_artOtHxhbcNphere9DcgGPF97B0t9cNHl0Tb-w3EPpYGiKRT4YeOKNlmQuaFdchlydmbBnqFlc9fzExSyLM-pzh1rOblVV1UC64gS8NprmI36wCQAOmXisBUnFB6qceFzN5EU9jpFiCXR9JlSZOxyo6AR5ms7-zfTKmDDahDCVryCyyyQV9z-q9YgrYyX-xj5hLDot7tHtbGi77l2ViCxoc67BUYjFay9Ff-oJlu3km94vHPcnhRD9W_dkcurtQwDjNM2Lblgkj7nDOS-S0SkW4-2ow
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MTAsIm5iZiI6MTUwNDExMjQxMCwiZXhwIjoxNTA0MTE2MzEwLCJhaW8iOiJZMkZnWVBqLzRYTjFuNkFMejlKNUVwZHI1UEt2QVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUnB4ZzByVWlDMGl5MGdMaW9QNFRBQSIsInZlciI6IjEuMCJ9.aV-5JccO9eCammf3bFDoERjH2iO_PJt9iEFaZZ96BAcnGlMCWEsA0RRuRM1E8_fUZXAxg7wvXF2IvSX2R5Cj-vfe4GAQGN85bERuA8YBBbrpGfPXcBdhhkrnA_HNEfYuk4KQEtE1laMZEawSzJDWgoxQCUxDcelgA-Zlh_m9QBvLlt1xZ9Owq8mNZHN2JE0exQ2DYpbq-P6_Dcu34H_-BB0chTbNYRykmwB9oUWN16Vjsz9p_FRik_BfC2AZ0Jjq0CMUmD3nOQcoXSYELEQQdLSlP3b_h_oQ5iSagb5zNwVKjZM5OAuVeOiXwPREeiO-8mylvy8j39VmyKfWEwjp3Q
       Host:
       - management.azure.com
   response:
@@ -1993,29 +1993,29 @@ http_interactions:
       X-Ms-Served-By:
       - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
       X-Ms-Request-Id:
-      - fcc88164-1140-4c50-9c6e-893d0b854e59
+      - df9303b0-0c51-4c88-8fa4-ff6451710ab4
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14926'
+      - '14951'
       X-Ms-Correlation-Request-Id:
-      - 639f98ca-d269-4a49-8760-ced518382bfa
+      - c9b35bae-6996-4087-9881-0832bea9ced7
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153241Z:639f98ca-d269-4a49-8760-ced518382bfa
+      - EASTUS:20170830T170512Z:c9b35bae-6996-4087-9881-0832bea9ced7
       Date:
-      - Wed, 30 Aug 2017 15:32:41 GMT
+      - Wed, 30 Aug 2017 17:05:12 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-08-30T15:32:41.0739435+00:00\",\r\n  \"endTime\":
-        \"2017-08-30T15:32:41.3239499+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=ea500bb9-a986-4b69-8ad6-964c6f73558c&sig=w%2BsRRQbGgLMc6FhOaGM1ccfC0PFPI3OJNFCAIqxSiUA%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"42ece62c-3dd9-4062-a6cd-6a2b5163d004\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2017-08-30T17:05:11.920648+00:00\",\r\n  \"endTime\":
+        \"2017-08-30T17:05:12.0612747+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=cec49f3f-1af2-4737-932a-33e7851253f2&sig=sKG%2BHcT1N%2BQzNPeucnT%2B1ASb%2B8Zi1Um6mZLTmvmYSgQ%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"1d45cfca-15c3-4995-97a4-94dbfcf8c5b3\"\r\n}"
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:32:40 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:12 GMT
 - request:
     method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=ea500bb9-a986-4b69-8ad6-964c6f73558c&sig=w%2BsRRQbGgLMc6FhOaGM1ccfC0PFPI3OJNFCAIqxSiUA=&sr=b&sv=2016-05-31
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=cec49f3f-1af2-4737-932a-33e7851253f2&sig=sKG%2BHcT1N%2BQzNPeucnT%2B1ASb%2B8Zi1Um6mZLTmvmYSgQ=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2050,7 +2050,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 79c1d103-0001-0107-23a5-2111fd000000
+      - 2898ce2c-0001-0090-34b2-213461000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2076,13 +2076,13 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 30 Aug 2017 15:32:41 GMT
+      - Wed, 30 Aug 2017 17:05:11 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         6w==
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:32:40 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:12 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
@@ -2099,7 +2099,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NTksIm5iZiI6MTUwNDEwNjg1OSwiZXhwIjoxNTA0MTEwNzU5LCJhaW8iOiJZMkZnWVBqLzRYTjFuNkFMejlKNUVwZHI1UEt2QVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ0E5Z3hTX0ROVWlheDNCNTVOa1JBQSIsInZlciI6IjEuMCJ9.oxGm4SO5Jl4w7HzwE_SxjzfoYBBKTotYxIzCbvtK6jXAeT9MeHmuFSySpw_artOtHxhbcNphere9DcgGPF97B0t9cNHl0Tb-w3EPpYGiKRT4YeOKNlmQuaFdchlydmbBnqFlc9fzExSyLM-pzh1rOblVV1UC64gS8NprmI36wCQAOmXisBUnFB6qceFzN5EU9jpFiCXR9JlSZOxyo6AR5ms7-zfTKmDDahDCVryCyyyQV9z-q9YgrYyX-xj5hLDot7tHtbGi77l2ViCxoc67BUYjFay9Ff-oJlu3km94vHPcnhRD9W_dkcurtQwDjNM2Lblgkj7nDOS-S0SkW4-2ow
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MTAsIm5iZiI6MTUwNDExMjQxMCwiZXhwIjoxNTA0MTE2MzEwLCJhaW8iOiJZMkZnWVBqLzRYTjFuNkFMejlKNUVwZHI1UEt2QVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUnB4ZzByVWlDMGl5MGdMaW9QNFRBQSIsInZlciI6IjEuMCJ9.aV-5JccO9eCammf3bFDoERjH2iO_PJt9iEFaZZ96BAcnGlMCWEsA0RRuRM1E8_fUZXAxg7wvXF2IvSX2R5Cj-vfe4GAQGN85bERuA8YBBbrpGfPXcBdhhkrnA_HNEfYuk4KQEtE1laMZEawSzJDWgoxQCUxDcelgA-Zlh_m9QBvLlt1xZ9Owq8mNZHN2JE0exQ2DYpbq-P6_Dcu34H_-BB0chTbNYRykmwB9oUWN16Vjsz9p_FRik_BfC2AZ0Jjq0CMUmD3nOQcoXSYELEQQdLSlP3b_h_oQ5iSagb5zNwVKjZM5OAuVeOiXwPREeiO-8mylvy8j39VmyKfWEwjp3Q
       Content-Length:
       - '42'
       Host:
@@ -2118,34 +2118,34 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/30e982ec-4770-42c1-a8fd-79a18da6ba1a?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/f97cdc50-0bf4-4290-9f9f-389c6bbefeab?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/30e982ec-4770-42c1-a8fd-79a18da6ba1a?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/f97cdc50-0bf4-4290-9f9f-389c6bbefeab?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
       - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
       X-Ms-Request-Id:
-      - 30e982ec-4770-42c1-a8fd-79a18da6ba1a
+      - f97cdc50-0bf4-4290-9f9f-389c6bbefeab
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1199'
+      - '1194'
       X-Ms-Correlation-Request-Id:
-      - d0b89b46-b98e-487b-a862-d6bc809f4bb3
+      - f5b7a085-5bac-4cad-b091-eb6fa0d266d8
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153242Z:d0b89b46-b98e-487b-a862-d6bc809f4bb3
+      - EASTUS:20170830T170513Z:f5b7a085-5bac-4cad-b091-eb6fa0d266d8
       Date:
-      - Wed, 30 Aug 2017 15:32:42 GMT
+      - Wed, 30 Aug 2017 17:05:13 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:32:41 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:13 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/30e982ec-4770-42c1-a8fd-79a18da6ba1a?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/f97cdc50-0bf4-4290-9f9f-389c6bbefeab?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -2159,7 +2159,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NTksIm5iZiI6MTUwNDEwNjg1OSwiZXhwIjoxNTA0MTEwNzU5LCJhaW8iOiJZMkZnWVBqLzRYTjFuNkFMejlKNUVwZHI1UEt2QVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ0E5Z3hTX0ROVWlheDNCNTVOa1JBQSIsInZlciI6IjEuMCJ9.oxGm4SO5Jl4w7HzwE_SxjzfoYBBKTotYxIzCbvtK6jXAeT9MeHmuFSySpw_artOtHxhbcNphere9DcgGPF97B0t9cNHl0Tb-w3EPpYGiKRT4YeOKNlmQuaFdchlydmbBnqFlc9fzExSyLM-pzh1rOblVV1UC64gS8NprmI36wCQAOmXisBUnFB6qceFzN5EU9jpFiCXR9JlSZOxyo6AR5ms7-zfTKmDDahDCVryCyyyQV9z-q9YgrYyX-xj5hLDot7tHtbGi77l2ViCxoc67BUYjFay9Ff-oJlu3km94vHPcnhRD9W_dkcurtQwDjNM2Lblgkj7nDOS-S0SkW4-2ow
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MTAsIm5iZiI6MTUwNDExMjQxMCwiZXhwIjoxNTA0MTE2MzEwLCJhaW8iOiJZMkZnWVBqLzRYTjFuNkFMejlKNUVwZHI1UEt2QVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUnB4ZzByVWlDMGl5MGdMaW9QNFRBQSIsInZlciI6IjEuMCJ9.aV-5JccO9eCammf3bFDoERjH2iO_PJt9iEFaZZ96BAcnGlMCWEsA0RRuRM1E8_fUZXAxg7wvXF2IvSX2R5Cj-vfe4GAQGN85bERuA8YBBbrpGfPXcBdhhkrnA_HNEfYuk4KQEtE1laMZEawSzJDWgoxQCUxDcelgA-Zlh_m9QBvLlt1xZ9Owq8mNZHN2JE0exQ2DYpbq-P6_Dcu34H_-BB0chTbNYRykmwB9oUWN16Vjsz9p_FRik_BfC2AZ0Jjq0CMUmD3nOQcoXSYELEQQdLSlP3b_h_oQ5iSagb5zNwVKjZM5OAuVeOiXwPREeiO-8mylvy8j39VmyKfWEwjp3Q
       Host:
       - management.azure.com
   response:
@@ -2184,29 +2184,29 @@ http_interactions:
       X-Ms-Served-By:
       - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
       X-Ms-Request-Id:
-      - dfdde9f3-052e-45be-ab6a-19ea6d5906c8
+      - 8f51a28a-9fe7-417e-b14c-31e4ebef7370
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14938'
+      - '14943'
       X-Ms-Correlation-Request-Id:
-      - 97ef3b79-4fab-4733-884e-ed0f1629170e
+      - 06ed180f-69c6-4efc-abfa-fac544aaa6fd
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153242Z:97ef3b79-4fab-4733-884e-ed0f1629170e
+      - EASTUS:20170830T170513Z:06ed180f-69c6-4efc-abfa-fac544aaa6fd
       Date:
-      - Wed, 30 Aug 2017 15:32:42 GMT
+      - Wed, 30 Aug 2017 17:05:13 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-08-30T15:32:41.9489642+00:00\",\r\n  \"endTime\":
-        \"2017-08-30T15:32:42.1520758+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=b702eff1-6c53-4aa7-8bf2-9d443e0abc68&sig=eK5qtSkbDWmcDe1MyIaGsDuCyECmiKjuSwFEjNx0vNY%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"30e982ec-4770-42c1-a8fd-79a18da6ba1a\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2017-08-30T17:05:12.8424995+00:00\",\r\n  \"endTime\":
+        \"2017-08-30T17:05:13.0612862+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=02c73638-8120-4397-b515-2f65492ebfd7&sig=noijiHedqoZfPab1dZTFznwZYj2bYeeqkP47Mb93bzw%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"f97cdc50-0bf4-4290-9f9f-389c6bbefeab\"\r\n}"
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:32:41 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:13 GMT
 - request:
     method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=b702eff1-6c53-4aa7-8bf2-9d443e0abc68&sig=eK5qtSkbDWmcDe1MyIaGsDuCyECmiKjuSwFEjNx0vNY=&sr=b&sv=2016-05-31
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=02c73638-8120-4397-b515-2f65492ebfd7&sig=noijiHedqoZfPab1dZTFznwZYj2bYeeqkP47Mb93bzw=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2241,7 +2241,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - e342e249-0001-0116-13a5-2126e6000000
+      - 04dc96db-0001-007b-34b2-21ca9d000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2267,11 +2267,11 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 30 Aug 2017 15:32:42 GMT
+      - Wed, 30 Aug 2017 17:05:13 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         U5MJAA==
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:32:41 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:13 GMT
 recorded_with: VCR 3.0.3

--- a/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_partNum-1.yml
+++ b/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_partNum-1.yml
@@ -1,0 +1,2277 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://login.microsoftonline.com/azure_tenant_id/oauth2/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_key&resource=https%3A%2F%2Fmanagement.azure.com%2F
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - login.microsoftonline.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Server:
+      - Microsoft-IIS/8.5
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Request-Id:
+      - 0a00f6fa-5096-42af-b93e-2dc7a5b11200
+      P3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Set-Cookie:
+      - esctx=AQABAAAAAAA9kTklhVy7SJTGAzR-p1BcqfT1LTG_eWtrsyW0DS2PaDfc4SonrPLHNr2HTVRhlp8z3EgQFBTxZMxsTScniGNytWbu6Clc9UM_S6BDkiBDuQG3dhMV-JogHPiMAyKoPsTANQE-6PgQdmf-crOw9XF3IIWBMtAczQt2zsbgqSQ-fIv6jaa7n6cpi31LraF7YXYgAA;
+        domain=.login.microsoftonline.com; path=/; secure; HttpOnly
+      - stsservicecookie=ests; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=005; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Wed, 30 Aug 2017 15:32:50 GMT
+      Content-Length:
+      - '1505'
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1504110769","not_before":"1504106869","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NjksIm5iZiI6MTUwNDEwNjg2OSwiZXhwIjoxNTA0MTEwNzY5LCJhaW8iOiJZMkZnWUxpdk10WHh4TkdHaGxVMi9VN2YvWFNqQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiLXZZQUNwWlFyMEs1UGkzSHBiRVNBQSIsInZlciI6IjEuMCJ9.UFICVGWtPeBRB--F5ZnJjqxE3tQRMBDwjPodNIg7fSsZr-R_g6YVrTD4faj2t-lRkkhLiao2LYKryUxWwuOA9Fk_p-8WBSgsVt3243Pf-JBaoPJx8ePHnn3F9iECzt6vBoUM75vv7eiR7cAwD4DGUae8iamjvcFkfxr6DMNQuYQKG5UrJN6a0sC_PUDKvzzqfskcpMggg8kquSzJnXAmCgKIUZeep8XNw2vffKjI-PcIlfVLc1GRrny8ewiMJdPeSg2fsh4ImSyRy9C2XGRFlewcG_cdZwrLeYKCIJyL_ncQm3zoNorPN0LB_PctCwXe2gpIGMxkS1-_TLF5HitpRw"}'
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:32:47 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions?api-version=2016-06-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NjksIm5iZiI6MTUwNDEwNjg2OSwiZXhwIjoxNTA0MTEwNzY5LCJhaW8iOiJZMkZnWUxpdk10WHh4TkdHaGxVMi9VN2YvWFNqQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiLXZZQUNwWlFyMEs1UGkzSHBiRVNBQSIsInZlciI6IjEuMCJ9.UFICVGWtPeBRB--F5ZnJjqxE3tQRMBDwjPodNIg7fSsZr-R_g6YVrTD4faj2t-lRkkhLiao2LYKryUxWwuOA9Fk_p-8WBSgsVt3243Pf-JBaoPJx8ePHnn3F9iECzt6vBoUM75vv7eiR7cAwD4DGUae8iamjvcFkfxr6DMNQuYQKG5UrJN6a0sC_PUDKvzzqfskcpMggg8kquSzJnXAmCgKIUZeep8XNw2vffKjI-PcIlfVLc1GRrny8ewiMJdPeSg2fsh4ImSyRy9C2XGRFlewcG_cdZwrLeYKCIJyL_ncQm3zoNorPN0LB_PctCwXe2gpIGMxkS1-_TLF5HitpRw
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Tenant-Reads:
+      - '14997'
+      X-Ms-Request-Id:
+      - 9a557223-5228-4909-a9dc-d32f4a342ed6
+      X-Ms-Correlation-Request-Id:
+      - 9a557223-5228-4909-a9dc-d32f4a342ed6
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153249Z:9a557223-5228-4909-a9dc-d32f4a342ed6
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 30 Aug 2017 15:32:48 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
+        Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:32:47 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers?api-version=2015-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NjksIm5iZiI6MTUwNDEwNjg2OSwiZXhwIjoxNTA0MTEwNzY5LCJhaW8iOiJZMkZnWUxpdk10WHh4TkdHaGxVMi9VN2YvWFNqQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiLXZZQUNwWlFyMEs1UGkzSHBiRVNBQSIsInZlciI6IjEuMCJ9.UFICVGWtPeBRB--F5ZnJjqxE3tQRMBDwjPodNIg7fSsZr-R_g6YVrTD4faj2t-lRkkhLiao2LYKryUxWwuOA9Fk_p-8WBSgsVt3243Pf-JBaoPJx8ePHnn3F9iECzt6vBoUM75vv7eiR7cAwD4DGUae8iamjvcFkfxr6DMNQuYQKG5UrJN6a0sC_PUDKvzzqfskcpMggg8kquSzJnXAmCgKIUZeep8XNw2vffKjI-PcIlfVLc1GRrny8ewiMJdPeSg2fsh4ImSyRy9C2XGRFlewcG_cdZwrLeYKCIJyL_ncQm3zoNorPN0LB_PctCwXe2gpIGMxkS1-_TLF5HitpRw
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14932'
+      X-Ms-Request-Id:
+      - 19cb100a-681d-4a5b-8d12-6d805306a926
+      X-Ms-Correlation-Request-Id:
+      - 19cb100a-681d-4a5b-8d12-6d805306a926
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153255Z:19cb100a-681d-4a5b-8d12-6d805306a926
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 30 Aug 2017 15:32:55 GMT
+      Content-Length:
+      - '241615'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","North Central
+        US","South Central US","West Central US","West US","West US 2","Canada Central","Canada
+        East","North Europe","West Europe","UK South","UK West","East Asia","Southeast
+        Asia","Japan East","Japan West","Korea Central","Korea South","Brazil South","Central
+        India","South India","West India"],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"validateServiceName","locations":[],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"checkServiceNameAvailability","locations":[],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"reportFeedback","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"checkFeedbackRequired","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Automation","namespace":"Microsoft.Automation","authorizations":[{"applicationId":"fc75330b-179d-49af-87dd-3b1acf6827fa","roleDefinitionId":"95fd5de3-d071-4362-92bf-cf341c1de832"}],"resourceTypes":[{"resourceType":"automationAccounts","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
+        South","UK South","West Central US","North Europe","Canada Central","Australia
+        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/runbooks","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
+        South","UK South","West Central US","North Europe","Canada Central","Australia
+        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/configurations","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","North
+        Central US","Brazil South","UK South","West Central US","Central India","Australia
+        Southeast","Canada Central","North Europe"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/webhooks","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
+        South","UK South","West Central US","North Europe","Canada Central","Australia
+        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"operations","locations":["South
+        Central US"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/softwareUpdateConfigurations","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
+        South","UK South","West Central US","North Europe","Canada Central","Australia
+        Southeast","Central India"],"apiVersions":["2017-05-15-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Backup","namespace":"Microsoft.Backup","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"BackupVault","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India"],"apiVersions":["2015-03-15","2014-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Batch","namespace":"Microsoft.Batch","authorization":{"applicationId":"ddbf3205-c6bd-46ae-8127-60eb93363864","roleDefinitionId":"b7f84953-1d03-4eab-9ea4-45f065258ff8"},"resourceTypes":[{"resourceType":"batchAccounts","locations":["West
+        Europe","East US","East US 2","West US","North Central US","Brazil South","North
+        Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
+        West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
+        East","South India","Central India","Canada Central","Canada East","UK South","UK
+        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01","2015-07-01","2014-05-01-privatepreview"]},{"resourceType":"operations","locations":["West
+        Europe","East US","East US 2","West US","North Central US","Brazil South","North
+        Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
+        West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
+        East","South India","Central India","Canada Central","Canada East","UK South","UK
+        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations/quotas","locations":["West
+        Europe","East US","East US 2","West US","North Central US","Brazil South","North
+        Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
+        West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
+        East","South India","Central India","Canada Central","Canada East","UK South","UK
+        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]}],"registrationState":"Unregistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicCompute","namespace":"Microsoft.ClassicCompute","resourceTypes":[{"resourceType":"domainNames","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
+        Central","Canada East","UK South","UK West","West US","Central US","South
+        Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
+        East","Australia Southeast","West US 2","West Central US","South India","Central
+        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
+        Central","Canada East","UK South","UK West","West US","Central US","South
+        Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
+        East","Australia Southeast","West US 2","West Central US","South India","Central
+        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
+        Central US","South Central US","East US","East US 2","Canada Central","Canada
+        East","West US","West US 2","West Central US","Central US","East Asia","Southeast
+        Asia","North Europe","West Europe","UK South","UK West","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operatingSystems","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"operatingSystemFamilies","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicNetwork","namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"virtualNetworks/remoteVirtualNetworkPeeringProxies","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"reservedIps","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicStorage","namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
+        US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
+        Asia","Australia East","Australia Southeast","South India","Central India","West
+        India","West US 2","West Central US","East US","East US 2","North Central
+        US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
+        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
+        US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
+        Asia","Australia East","Australia Southeast","South India","Central India","West
+        India","West US 2","West Central US","East US","East US 2","North Central
+        US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
+        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"vmImages","locations":[],"apiVersions":["2016-11-01"]},{"resourceType":"publicImages","locations":[],"apiVersions":["2016-11-01","2016-04-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"osPlatformImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Compute","namespace":"Microsoft.Compute","authorization":{"applicationId":"60e6cd67-9c8c-4951-9b3c-23c25a2169af","roleDefinitionId":"e4770acb-272e-4dc8-87f3-12f44a612224"},"resourceTypes":[{"resourceType":"availabilitySets","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30"]},{"resourceType":"locations/usages","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"disks","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"snapshots","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"locations/diskoperations","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"images","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
+        US","East US","South Central US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","East Asia","Japan
+        East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/webhooks","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/ping","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/getCallbackConfig","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/listEvents","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"locations","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"locations/operationResults","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/GetCredentials","locations":["West
+        US","East US","South Central US","West Europe"],"apiVersions":["2016-06-27-preview"]},{"resourceType":"registries/listCredentials","locations":["South
+        Central US","East US","West US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","East Asia","Japan
+        East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/regenerateCredential","locations":["South
+        Central US","West US","East US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","East Asia","Japan
+        East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/listUsages","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/regenerateCredentials","locations":["West
+        US","East US","South Central US","West Europe"],"apiVersions":["2016-06-27-preview"]},{"resourceType":"checkNameAvailability","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview","2017-03-01","2016-06-27-preview"]},{"resourceType":"operations","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview","2017-03-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerService","namespace":"Microsoft.ContainerService","authorization":{"applicationId":"7319c514-987d-4e9b-ac3d-d38c4f427f4c","roleDefinitionId":"1b4a0c7f-2217-416f-acfa-cf73452fdc1c"},"resourceTypes":[{"resourceType":"containerServices","locations":["Japan
+        East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
+        East","Australia Southeast","Brazil South","Southeast Asia","West US","North
+        Central US","West Europe","North Europe","East US","UK West","UK South","West
+        Central US","West US 2","South India","Central India","West India","Canada
+        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
+        East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
+        East","Australia Southeast","Brazil South","Southeast Asia","West US","North
+        Central US","West Europe","North Europe","East US","UK West","UK South","West
+        Central US","West US 2","South India","Central India","West India","Canada
+        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DevTestLab","namespace":"Microsoft.DevTestLab","authorization":{"applicationId":"1a14be2a-e903-4cec-99cf-b2e209259a0f","roleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525"},"resourceTypes":[{"resourceType":"labs","locations":["West
+        Central US","Japan East","West US","Australia Southeast","Canada Central","Central
+        India","Central US","East Asia","Korea Central","North Europe","South Central
+        US","UK West","Australia East","Brazil South","Canada East","East US","East
+        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"schedules","locations":["West
+        Central US","Japan East","West US","Australia Southeast","Canada Central","Central
+        India","Central US","East Asia","Korea Central","North Europe","South Central
+        US","UK West","Australia East","Brazil South","Canada East","East US","East
+        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"labs/virtualMachines","locations":["West
+        Central US","Japan East","West US","Australia Southeast","Canada Central","Central
+        India","Central US","East Asia","Korea Central","North Europe","South Central
+        US","UK West","Australia East","Brazil South","Canada East","East US","East
+        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"labs/serviceRunners","locations":["Central
+        US","East US 2","South Central US"],"apiVersions":["2017-04-26-preview","2016-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"locations/operations","locations":["West
+        Central US","Japan East","West US","Australia Southeast","Canada Central","Central
+        India","Central US","East Asia","Korea Central","North Europe","South Central
+        US","UK West","Australia East","Brazil South","Canada East","East US","East
+        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"}],"resourceTypes":[{"resourceType":"components","locations":["East
+        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
+        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01","2014-04-01"]},{"resourceType":"queries","locations":["East
+        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"alertrules","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2016-03-01","2015-04-01","2014-04-01"]},{"resourceType":"autoscalesettings","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2015-04-01","2014-04-01"]},{"resourceType":"eventtypes","locations":[],"apiVersions":["2017-03-01-preview","2016-09-01-preview","2015-04-01","2014-11-01","2014-04-01"]},{"resourceType":"locations","locations":["East
+        US"],"apiVersions":["2015-04-01","2014-04-01"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2015-04-01","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-04-01","2014-06-01","2014-04-01"]},{"resourceType":"automatedExportSettings","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2015-04-01","2014-04-01"]},{"resourceType":"diagnosticSettings","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2017-05-01-preview","2016-09-01","2015-07-01"]},{"resourceType":"diagnosticSettingsCategories","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"extendedDiagnosticSettings","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2017-02-01"]},{"resourceType":"metricDefinitions","locations":["East
+        US","West US","West Europe","East Asia","Southeast Asia","Japan East","Japan
+        West","North Central US","South Central US","East US 2","Canada East","Canada
+        Central","Central US","Australia East","Australia Southeast","Brazil South","South
+        India","Central India","West India","North Europe","West US 2","West Central
+        US","Korea South","Korea Central","UK South","UK West","Global"],"apiVersions":["2017-05-01-preview","2016-03-01","2015-07-01"]},{"resourceType":"logDefinitions","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2015-07-01"]},{"resourceType":"eventCategories","locations":[],"apiVersions":["2015-04-01"]},{"resourceType":"metrics","locations":["East
+        US","West US","West Europe","East Asia","Southeast Asia","Japan East","Japan
+        West","North Central US","South Central US","East US 2","Canada East","Canada
+        Central","Central US","Australia East","Australia Southeast","Brazil South","South
+        India","Central India","West India","North Europe","West US 2","West Central
+        US","Korea South","Korea Central","UK South","UK West"],"apiVersions":["2017-05-01-preview","2016-09-01","2016-06-01"]},{"resourceType":"actiongroups","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]},{"resourceType":"activityLogAlerts","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.KeyVault","namespace":"Microsoft.KeyVault","resourceTypes":[{"resourceType":"vaults","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/accessPolicies","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-10-01","2015-06-01","2014-12-19-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"deletedVaults","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-10-01"]},{"resourceType":"locations/deletedVaults","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorization":{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"routeTables","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2017-04-26-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"]},{"resourceType":"workspaces/dataSources","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"storageInsightConfigs","locations":[],"apiVersions":["2014-10-10"]},{"resourceType":"workspaces/linkedServices","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"linkTargets","locations":["East
+        US"],"apiVersions":["2015-03-20"]},{"resourceType":"operations","locations":[],"apiVersions":["2014-11-10"]},{"resourceType":"devices","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationsManagement","namespace":"Microsoft.OperationsManagement","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"aa249101-6816-4966-aafa-08175d795f14"},"resourceTypes":[{"resourceType":"solutions","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Portal","namespace":"Microsoft.Portal","resourceTypes":[{"resourceType":"dashboards","locations":["Central
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
+        East","West India","South India","Central India","Canada Central","Canada
+        East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"operations","locations":["Central
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
+        East","West India","South India","Central India","Canada Central","Canada
+        East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"consoles","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/consoles","locations":["West
+        US","East US","Central India","North Europe","West Europe","South Central
+        US","Southeast Asia"],"apiVersions":["2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
+        US","East US","Central India","North Europe","West Europe","South Central
+        US","Southeast Asia"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","Canada Central","Canada East","West Central US","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-07-01","2016-12-01","2016-08-10","2016-06-01","2016-05-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"operations","locations":["Southeast
+        Asia"],"apiVersions":["2016-08-10","2016-06-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01"]},{"resourceType":"locations/backupStatus","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]},{"resourceType":"locations/allocatedStamp","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]},{"resourceType":"locations/allocateStamp","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ResourceHealth","namespace":"Microsoft.ResourceHealth","authorization":{"applicationId":"8bdebf23-c0fe-4187-a378-717ad86f6a53","roleDefinitionId":"cc026344-c8b1-4561-83ba-59eba84b27cc"},"resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2017-07-01","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"notifications","locations":["Australia
+        Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Security","namespace":"Microsoft.Security","authorization":{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatuses","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/virtualMachines","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/endpoints","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/subnets","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"tasks","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"alerts","locations":["Central
+        US","East US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"monitoring","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"monitoring/patch","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"monitoring/baseline","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"monitoring/antimalware","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"dataCollectionAgents","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"dataCollectionResults","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"pricings","locations":["Central
+        US","East US"],"apiVersions":["2017-08-01-preview"]},{"resourceType":"complianceResults","locations":["Central
+        US","East US"],"apiVersions":["2017-08-01"]},{"resourceType":"policies","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"appliances","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"webApplicationFirewalls","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/webApplicationFirewalls","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securitySolutions","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/securitySolutions","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securitySolutionsReferenceData","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/securitySolutionsReferenceData","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"jitNetworkAccessPolicies","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/jitNetworkAccessPolicies","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatusesSummaries","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/alerts","locations":["Central
+        US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/tasks","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.SiteRecovery","namespace":"Microsoft.SiteRecovery","authorization":{"applicationId":"b8340c3b-9267-498f-b21a-15d5547fd85e","roleDefinitionId":"8A00C8EA-8F1B-45A7-8F64-F4CC61EEE9B6"},"resourceTypes":[{"resourceType":"SiteRecoveryVault","locations":["East
+        US","West US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","Australia East","Australia Southeast","Brazil South","North
+        Central US","South Central US","Central US","East US 2","Central India","South
+        India"],"apiVersions":["2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Sql","namespace":"Microsoft.Sql","authorizations":[{"applicationId":"e4ab13ed-33cb-41b4-9140-6e264582cf85","roleDefinitionId":"ec3ddc95-44dc-47a2-9926-5e9f5ffd44ec"},{"applicationId":"0130cc9f-7ac5-4026-bd5f-80a08a54e6d9","roleDefinitionId":"45e8abf8-0ec4-44f3-9c37-cff4f7779302"},{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},{"applicationId":"76c7f279-7959-468f-8943-3954880e0d8c","roleDefinitionId":"7f7513a8-73f9-4c5f-97a2-c41f0ea783ef"}],"resourceTypes":[{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/capabilities","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverKeyOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/keys","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/encryptionProtector","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/communicationLinks","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recoverableDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/importExportOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/operationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/firewallrules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/elasticpools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-09-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/dnsAliases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/failoverGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/virtualNetworkRules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/virtualNetworkRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/virtualNetworkRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/databaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/extensions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditRecords","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/VulnerabilityAssessmentScans","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentScans","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups/syncMembers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/syncAgents","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncMemberOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncAgentOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncDatabaseIds","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorization":{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
+        US","West US","West Europe","North Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":["East
+        US","West US","West Europe","North Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Web","namespace":"Microsoft.Web","authorization":{"applicationId":"abfa0a7c-a6b6-4736-8310-5855508787cd","roleDefinitionId":"f47ed98b-b063-4a5b-9e10-4b9b44fa7735"},"resourceTypes":[{"resourceType":"sites/extensions","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots/extensions","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/instances","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots/instances","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/instances/extensions","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots/instances/extensions","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/publicCertificates","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots/publicCertificates","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"publishingUsers","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"ishostnameavailable","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"validate","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"isusernameavailable","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sourceControls","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"availableStacks","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"listSitesAssignedToHostName","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"sites/hostNameBindings","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"sites/domainOwnershipIdentifiers","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"sites/slots/hostNameBindings","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"operations","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"certificates","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms/workers","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"runtimes","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"sites/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"sites/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"sites/slots/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"sites/slots/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"serverFarms/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"serverFarms/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"sites/recommendations","locations":[],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"georegions","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/premieraddons","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01"]},{"resourceType":"hostingEnvironments","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/instances","locations":[],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/instances/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/instances/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/instances","locations":[],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/instances/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/instances/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"deploymentLocations","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"functions","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"deletedSites","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"ishostingenvironmentnameavailable","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"classicMobileServices","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"connections","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/managedApis","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/apiOperations","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"connectionGateways","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/connectionGatewayInstallations","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"checkNameAvailability","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"billingMeters","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/84codes.CloudAMQP","namespace":"84codes.CloudAMQP","resourceTypes":[{"resourceType":"servers","locations":["East
+        US 2","Central US","East US","North Central US","South Central US","West US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast"],"apiVersions":["2016-08-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/AppDynamics.APM","namespace":"AppDynamics.APM","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2016-05-26"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-05-26"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-05-26"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-05-26"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-05-26"]},{"resourceType":"locations/operationResults","locations":["West
+        US"],"apiVersions":["2016-05-26"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Aspera.Transfers","namespace":"Aspera.Transfers","resourceTypes":[{"resourceType":"services","locations":["West
+        US","North Europe","Central US","East US","West Europe","East Asia","Southeast
+        Asia","Japan East","East US 2","Japan West"],"apiVersions":["2016-03-25"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-03-25"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-03-25"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-03-25"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Auth0.Cloud","namespace":"Auth0.Cloud","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-11-23"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Citrix.Cloud","namespace":"Citrix.Cloud","resourceTypes":[{"resourceType":"accounts","locations":["West
+        US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Cloudyn.Analytics","namespace":"Cloudyn.Analytics","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US"],"apiVersions":["2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Conexlink.MyCloudIT","namespace":"Conexlink.MyCloudIT","resourceTypes":[{"resourceType":"accounts","locations":["Central
+        US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Crypteron.DataSecurity","namespace":"Crypteron.DataSecurity","resourceTypes":[{"resourceType":"apps","locations":["West
+        US"],"apiVersions":["2016-08-12"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-12"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-12"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-12"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Dynatrace.DynatraceSaaS","namespace":"Dynatrace.DynatraceSaaS","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-09-27"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Dynatrace.Ruxit","namespace":"Dynatrace.Ruxit","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US"],"apiVersions":["2016-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-09-07","2016-04-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-04-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/LiveArena.Broadcast","namespace":"LiveArena.Broadcast","resourceTypes":[{"resourceType":"services","locations":["West
+        US","North Europe","Japan West","Japan East","East Asia","West Europe","East
+        US","Southeast Asia","Central US"],"apiVersions":["2016-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Lombiq.DotNest","namespace":"Lombiq.DotNest","resourceTypes":[{"resourceType":"sites","locations":["East
+        US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Mailjet.Email","namespace":"Mailjet.Email","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]},{"resourceType":"diagnosticSettings","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"addsservices","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"configuration","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"agents","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"aadsupportcases","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"reports","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"servicehealthmetrics","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"logs","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"anonymousapiusers","locations":["West
+        US"],"apiVersions":["2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AnalysisServices","namespace":"Microsoft.AnalysisServices","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"servers","locations":["West
+        US","North Europe","South Central US","West Europe","West Central US","Southeast
+        Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
+        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/checkNameAvailability","locations":["West
+        US","North Europe","South Central US","West Europe","West Central US","Southeast
+        Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
+        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationresults","locations":["West
+        US","North Europe","South Central US","West Europe","West Central US","Southeast
+        Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
+        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationstatuses","locations":["West
+        US","North Europe","South Central US","West Europe","West Central US","Southeast
+        Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
+        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"operations","locations":["East
+        US 2","West Central US"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AppService","namespace":"Microsoft.AppService","authorization":{"applicationId":"dee7ba80-6a55-4f3b-a86c-746a9231ae49","roleDefinitionId":"6715d172-49c4-46f6-bb21-60512a8689dc"},"resourceTypes":[{"resourceType":"apiapps","locations":["East
+        US","West US","South Central US","North Europe","East Asia","Japan East","West
+        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
+        South","East US 2","Australia Southeast","Australia East","West India","South
+        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"appIdentities","locations":["East
+        US","West US","South Central US","North Europe","East Asia","Japan East","West
+        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
+        South","East US 2","Australia Southeast","Australia East","West India","South
+        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"gateways","locations":["East
+        US","West US","South Central US","North Europe","East Asia","Japan East","West
+        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
+        South","East US 2","Australia Southeast","Australia East","West India","South
+        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"deploymenttemplates","locations":[],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Authorization","namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"roleDefinitions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"classicAdministrators","locations":[],"apiVersions":["2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"permissions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"locks","locations":[],"apiVersions":["2017-04-01","2016-09-01","2015-06-01","2015-05-01-preview","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-01-01","2014-10-01-preview","2014-06-01"]},{"resourceType":"policyDefinitions","locations":[],"apiVersions":["2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"policySetDefinitions","locations":[],"apiVersions":["2017-06-01-preview"]},{"resourceType":"policyAssignments","locations":[],"apiVersions":["2017-06-01-preview","2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"providerOperations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01-preview","2015-07-01"]},{"resourceType":"elevateAccess","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureActiveDirectory","namespace":"Microsoft.AzureActiveDirectory","resourceTypes":[{"resourceType":"b2cDirectories","locations":["Global","United
+        States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureStack","namespace":"Microsoft.AzureStack","resourceTypes":[{"resourceType":"operations","locations":["Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations","locations":["West
+        Central US","Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations/products","locations":["West
+        Central US","Global"],"apiVersions":["2017-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Billing","namespace":"Microsoft.Billing","resourceTypes":[{"resourceType":"BillingPeriods","locations":["Central
+        US"],"apiVersions":["2017-04-24-preview"]},{"resourceType":"Invoices","locations":["Central
+        US"],"apiVersions":["2017-04-24-preview","2017-02-27-preview"]},{"resourceType":"operations","locations":["Central
+        US"],"apiVersions":["2017-04-24-preview","2017-02-27-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BingMaps","namespace":"Microsoft.BingMaps","resourceTypes":[{"resourceType":"mapApis","locations":["West
+        US"],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-18","2015-07-02"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BizTalkServices","namespace":"Microsoft.BizTalkServices","resourceTypes":[{"resourceType":"BizTalk","locations":["East
+        US","West US","North Europe","West Europe","Southeast Asia","East Asia","North
+        Central US","Japan West","Japan East","South Central US"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Cache","namespace":"Microsoft.Cache","authorization":{"applicationId":"96231a05-34ce-4eb4-aa6a-70759cbb5e83","roleDefinitionId":"4f731528-ba85-45c7-acfb-cd0a9b3cf31b"},"resourceTypes":[{"resourceType":"Redis","locations":["North
+        Central US","South Central US","Central US","West Europe","North Europe","West
+        US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
+        Asia","East Asia","Australia East","Australia Southeast","Central India","West
+        India","Canada Central","Canada East","UK South","UK West","West US 2","West
+        Central US","South India","Korea Central","Korea South"],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","South Central US","Central US","West Europe","North Europe","West
+        US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
+        Asia","East Asia","Australia East","Australia Southeast","Central India","West
+        India","South India","Canada Central","Canada East","UK South","UK West","West
+        US 2","West Central US","Korea Central","Korea South"],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01"]},{"resourceType":"Redis/metricDefinitions","locations":["North
+        Central US","South Central US","East US","East US 2","West US","Central US","East
+        Asia","Southeast Asia","North Europe","West Europe","Japan East","Japan West","Brazil
+        South","Australia Southeast","Australia East","Central India","West India","South
+        India","Canada Central","Canada East","UK West","UK South","West US 2","West
+        Central US","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"Redis/diagnosticSettings","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","West
+        US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
+        Asia","Australia East","Australia Southeast","Central India","West India","South
+        India","Canada Central","Canada East","UK West","UK South","West US 2","West
+        Central US","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Cdn","namespace":"Microsoft.Cdn","resourceTypes":[{"resourceType":"profiles","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/origins","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/customdomains","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/originresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/customdomainresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkResourceUsage","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02"]},{"resourceType":"validateProbe","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"edgenodes","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CertificateRegistration","namespace":"Microsoft.CertificateRegistration","authorization":{"applicationId":"f3c21649-0979-4721-ac85-b0216b2cf413","roleDefinitionId":"933fba7e-2ed3-4da8-973d-8bd8298a9b40"},"resourceTypes":[{"resourceType":"certificateOrders","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"certificateOrders/certificates","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"validateCertificateRegistrationInformation","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicSubscription","namespace":"Microsoft.ClassicSubscription","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicInfrastructureMigrate","namespace":"Microsoft.ClassicInfrastructureMigrate","authorization":{"applicationId":"5e5abe2b-83cd-4786-826a-a05653ebb103","roleDefinitionId":"766c4d9b-ef83-4f73-8352-1450a506a69b"},"resourceTypes":[{"resourceType":"classicInfrastructureResources","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","West
+        India","South India"],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CognitiveServices","namespace":"Microsoft.CognitiveServices","authorizations":[{"applicationId":"7d312290-28c8-473c-a0ed-8e53749b6d6d","roleDefinitionId":"5cb87f79-a7c3-4a95-9414-45b65974b51b"}],"resourceTypes":[{"resourceType":"accounts","locations":["Global","West
+        US","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"operations","locations":["Global","West
+        US","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations","locations":["Global","West
+        US","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/checkSkuAvailability","locations":["West
+        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/updateAccountsCreationSettings","locations":["West
+        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/accountsCreationSettings","locations":["West
+        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2016-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Commerce","namespace":"Microsoft.Commerce","resourceTypes":[{"resourceType":"UsageAggregates","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]},{"resourceType":"RateCard","locations":[],"apiVersions":["2016-08-31-preview","2015-06-01-preview","2015-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Consumption","namespace":"Microsoft.Consumption","resourceTypes":[{"resourceType":"reservationsummaries","locations":[],"apiVersions":["2017-01-30"]},{"resourceType":"reservationdetails","locations":[],"apiVersions":["2017-01-30"]},{"resourceType":"UsageDetails","locations":[],"apiVersions":["2017-06-30-preview","2017-04-24-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-30-preview","2017-04-24-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","resourceTypes":[{"resourceType":"containerGroups","locations":["West
+        US","East US","West Europe"],"apiVersions":["2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
+        US"],"apiVersions":["2016-04-08"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CustomerInsights","namespace":"Microsoft.CustomerInsights","authorization":{"applicationId":"38c77d00-5fcb-4cce-9d93-af4738258e3c","roleDefinitionId":"E006F9C7-F333-477C-8AD6-1F3A9FE87F55"},"resourceTypes":[{"resourceType":"hubs","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/profiles","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/interactions","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/authorizationPolicies","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/connectors","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/connectors/mappings","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/kpi","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/views","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/links","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/roleAssignments","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/roles","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/widgetTypes","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/suggestTypeSchema","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"operations","locations":["East
+        US 2"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataCatalog","namespace":"Microsoft.DataCatalog","resourceTypes":[{"resourceType":"catalogs","locations":["East
+        US","West US","Australia East","West Europe","North Europe","Southeast Asia","West
+        Central US"],"apiVersions":["2016-03-30","2015-07-01-preview"]},{"resourceType":"checkNameAvailability","locations":["West
+        Europe"],"apiVersions":["2016-03-30","2015-07-01-preview"]},{"resourceType":"operations","locations":["West
+        Europe"],"apiVersions":["2016-03-30","2015-07-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-03-30","2015-07-01-preview"]},{"resourceType":"locations/jobs","locations":["East
+        US","West US","Australia East","West Europe","North Europe","Southeast Asia","West
+        Central US"],"apiVersions":["2016-03-30","2015-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataFactory","namespace":"Microsoft.DataFactory","resourceTypes":[{"resourceType":"dataFactories","locations":["West
+        US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview","2014-04-01"]},{"resourceType":"factories","locations":["East
+        US"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
+        US"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
+        Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"dataFactories/metricDefinitions","locations":["North
+        Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"checkDataFactoryNameAvailability","locations":[],"apiVersions":["2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"checkAzureDataFactoryNameAvailability","locations":["West
+        US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"dataFactorySchema","locations":["West
+        US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"operations","locations":["West
+        US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeAnalytics","namespace":"Microsoft.DataLakeAnalytics","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/dataLakeStoreAccounts","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers/listSasTokens","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeStore","namespace":"Microsoft.DataLakeStore","authorization":{"applicationId":"e9f49c6b-5ce5-44c8-925d-015017e9f7ad","roleDefinitionId":"17eb9cca-f08a-4499-b2d3-852d175f614f"},"resourceTypes":[{"resourceType":"accounts","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/firewallRules","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","resourceTypes":[{"resourceType":"operations","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforPostgreSQL","namespace":"Microsoft.DBforPostgreSQL","resourceTypes":[{"resourceType":"operations","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
+        US","North Europe","East Asia","East US","West Europe","Southeast Asia","Japan
+        East","Japan West","Australia East","Australia Southeast","West US 2","West
+        Central US","East US 2","Central US","UK South","UK West","South India","Central
+        India"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"databaseAccountNames","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DomainRegistration","namespace":"Microsoft.DomainRegistration","authorization":{"applicationId":"ea2f600a-4980-45b7-89bf-d34da487bda1","roleDefinitionId":"54d7f2e3-5040-48a7-ae90-eebf629cfa0b"},"resourceTypes":[{"resourceType":"domains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"domains/domainOwnershipIdentifiers","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"topLevelDomains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"checkDomainAvailability","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"listDomainRecommendations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"validateDomainRegistrationInformation","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"generateSsoRequest","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DynamicsLcs","namespace":"Microsoft.DynamicsLcs","resourceTypes":[{"resourceType":"lcsprojects","locations":["Brazil
+        South","East Asia","East US","Japan East","Japan West","North Central US","North
+        Europe","South Central US","West Europe","West US","Southeast Asia","Central
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"lcsprojects/connectors","locations":["Brazil
+        South","East Asia","East US","Japan East","Japan West","North Central US","North
+        Europe","South Central US","West Europe","West US","Southeast Asia","Central
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"lcsprojects/clouddeployments","locations":["Brazil
+        South","East Asia","East US","Japan East","Japan West","North Central US","North
+        Europe","South Central US","West Europe","West US","Southeast Asia","Central
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"operations","locations":["Brazil
+        South","East Asia","East US","Japan East","Japan West","North Central US","North
+        Europe","South Central US","West Europe","West US","Southeast Asia","Central
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"topics","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operations","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"clusters/applications","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"clusters/operationresults","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations/capabilities","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations/operationresults","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations/azureasyncoperations","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations/validateCreateRequest","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"operations","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India"],"apiVersions":["2015-03-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ImportExport","namespace":"Microsoft.ImportExport","authorization":{"applicationId":"7de4d5c5-5b32-4235-b8a9-33b34d6bcd2a","roleDefinitionId":"9f7aa6bb-9454-46b6-8c01-a4b0f33ca151"},"resourceTypes":[{"resourceType":"jobs","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","North Central US","North Europe","South Central US","Southeast
+        Asia","South India","UK South","West Central US","West Europe","West India","West
+        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","North Central US","North Europe","South Central US","Southeast
+        Asia","South India","UK South","West Central US","West Europe","West India","West
+        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations/operationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","North Central US","North Europe","South Central US","Southeast
+        Asia","South India","UK South","West Central US","West Europe","West India","West
+        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","North Central US","North Europe","South Central US","Southeast
+        Asia","South India","UK South","West Central US","West Europe","West India","West
+        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Logic","namespace":"Microsoft.Logic","authorization":{"applicationId":"7cd684f4-8a78-49b0-91ec-6a35d38739ba","roleDefinitionId":"cb3ef1fb-6e31-49e2-9d87-ed821053fe58"},"resourceTypes":[{"resourceType":"workflows","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West"],"apiVersions":["2017-07-01","2016-10-01","2016-06-01","2015-08-01-preview","2015-02-01-preview"]},{"resourceType":"locations/workflows","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West"],"apiVersions":["2017-07-01","2016-10-01","2016-06-01","2015-08-01-preview","2015-02-01-preview"]},{"resourceType":"locations","locations":["North
+        Central US"],"apiVersions":["2017-07-01","2016-10-01","2016-06-01","2015-08-01-preview","2015-02-01-preview"]},{"resourceType":"operations","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West"],"apiVersions":["2017-07-01","2016-10-01","2016-06-01","2015-08-01-preview","2015-02-01-preview"]},{"resourceType":"integrationAccounts","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","West Central US"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"operations","locations":["South
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations","locations":["South
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operations","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"commitmentPlans","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
+        Central US","West US"],"apiVersions":["2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Media","namespace":"Microsoft.Media","authorization":{"applicationId":"374b2a64-3b6b-436b-934c-b820eacca870","roleDefinitionId":"aab70789-0cec-44b5-95d7-84b64c9487af"},"resourceTypes":[{"resourceType":"mediaservices","locations":["Japan
+        West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
+        US","West US","Australia East","Australia Southeast","Central US","Brazil
+        South","Central India","West India","South India","South Central US","Canada
+        Central","Canada East","West Central US"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
+        Central US","North Central US","East US 2","West US","West Europe","North
+        Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
+        East","UK South","West India"],"apiVersions":["2016-01-29"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-01-29"]},{"resourceType":"locations/checkNameAvailability","locations":["South
+        Central US","North Central US","East US 2","West US","West Europe","North
+        Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
+        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"operations","locations":["East
+        US 2"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Relay","namespace":"Microsoft.Relay","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US 2","West
+        US","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
+        East","West India","South India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
+        East","West India","South India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
+        Central US","South Central US","North Europe","West Europe","East Asia","Southeast
+        Asia","West US","East US","Japan West","Japan East","Brazil South","Central
+        US","East US 2","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-03-01","2016-01-01","2014-08-01-preview"]},{"resourceType":"operations","locations":["North
+        Central US","South Central US","North Europe","West Europe","East Asia","Southeast
+        Asia","West US","East US","Japan West","Japan East","Brazil South","Central
+        US","East US 2","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-03-01","2016-01-01","2014-08-01-preview"]},{"resourceType":"operationResults","locations":["North
+        Central US","South Central US","North Europe","West Europe","East Asia","Southeast
+        Asia","West US","East US","Japan West","Japan East","Brazil South","Central
+        US","East US 2","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-03-01","2016-01-01","2014-08-01-preview"]},{"resourceType":"flows","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast"],"apiVersions":["2015-08-01-preview","2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Search","namespace":"Microsoft.Search","resourceTypes":[{"resourceType":"searchServices","locations":["West
+        US","East US","North Europe","West Europe","Southeast Asia","East Asia","North
+        Central US","South Central US","Japan West","Australia East","Brazil South","Central
+        India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19","2015-02-28"]},{"resourceType":"checkServiceNameAvailability","locations":[],"apiVersions":["2015-02-28","2014-07-31-Preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2015-08-19"]},{"resourceType":"resourceHealthMetadata","locations":["West
+        US","East US","North Europe","West Europe","Southeast Asia","East Asia","North
+        Central US","South Central US","Japan West","Australia East","Brazil South","Central
+        India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US 2","West
+        US","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"premiumMessagingRegions","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceFabric","namespace":"Microsoft.ServiceFabric","authorization":{"applicationId":"74cb6831-0dbb-4be1-8206-fd4df301cdc2","roleDefinitionId":"e55cc65f-6903-4917-b4ef-f8d4640b57f5"},"resourceTypes":[{"resourceType":"clusters","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/clusterVersions","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operations","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Canada
+        Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","West Central US","Japan East","Japan West","Australia East","Australia
+        Southeast"],"apiVersions":["2017-06-01","2017-05-15","2017-01-01","2016-10-01","2016-06-01","2015-03-15","2014-09-01"]},{"resourceType":"operations","locations":["West
+        Central US","Southeast Asia"],"apiVersions":["2016-10-01","2016-06-01","2015-03-15","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StreamAnalytics","namespace":"Microsoft.StreamAnalytics","resourceTypes":[{"resourceType":"streamingjobs","locations":["Central
+        US","West Europe","East US 2","North Europe","Japan East","West US","Southeast
+        Asia","South Central US","East Asia","Japan West","North Central US","East
+        US","Australia East","Australia Southeast","Brazil South","Central India","West
+        Central US","UK South","UK West","Canada Central","Canada East","West US 2"],"apiVersions":["2017-04-01-preview","2016-03-01","2015-11-01","2015-10-01","2015-09-01","2015-08-01-preview","2015-06-01","2015-05-01","2015-04-01","2015-03-01-preview"]},{"resourceType":"locations","locations":["West
+        Europe","Central US","East US 2","North Europe","Japan East","West US","Southeast
+        Asia","South Central US","East Asia","Japan West","North Central US","East
+        US","Australia East","Australia Southeast","Brazil South","Central India","West
+        Central US","UK South","West US 2","UK West","Canada Central","Canada East"],"apiVersions":["2017-04-01-preview","2016-03-01","2015-11-01","2015-10-01","2015-09-01","2015-08-01-preview","2015-06-01","2015-05-01","2015-04-01","2015-03-01-preview"]},{"resourceType":"locations/quotas","locations":[],"apiVersions":["2017-04-01-preview","2016-03-01","2015-11-01","2015-10-01","2015-09-01","2015-08-01-preview","2015-06-01","2015-05-01","2015-04-01","2015-03-01-preview"]},{"resourceType":"streamingjobs/diagnosticSettings","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","Central
+        India","West Central US","UK South","UK West","Canada Central","Canada East","West
+        US 2","West US","Central US","South Central US","Japan East","Japan West","East
+        Asia","Southeast Asia","Australia East","Australia Southeast"],"apiVersions":["2014-04-01"]},{"resourceType":"streamingjobs/metricDefinitions","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","Central
+        India","West Central US","UK South","UK West","Canada Central","Canada East","West
+        US 2","West US","Central US","South Central US","Japan East","Japan West","East
+        Asia","Southeast Asia","Australia East","Australia Southeast"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":["West
+        Europe","West US","Central US","East US 2","North Europe","Japan East","Southeast
+        Asia","South Central US","East Asia","Japan West","North Central US","East
+        US","Australia East","Australia Southeast","Brazil South","Central India","West
+        Central US","UK South","UK West","Canada Central","Canada East","West US 2"],"apiVersions":["2017-04-01-preview","2016-03-01","2015-11-01","2015-10-01","2015-09-01","2015-08-01-preview","2015-06-01","2015-05-01","2015-04-01","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.support","namespace":"microsoft.support","resourceTypes":[{"resourceType":"operations","locations":["North
+        Central US","South Central US","Central US","West Europe","North Europe","West
+        US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
+        Asia","East Asia","Australia East","Australia Southeast"],"apiVersions":["2015-07-01-Preview","2015-03-01"]},{"resourceType":"supporttickets","locations":["North
+        Central US","South Central US","Central US","West Europe","North Europe","West
+        US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
+        Asia","East Asia","Australia East","Australia Southeast"],"apiVersions":["2015-07-01-Preview","2015-03-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.TimeSeriesInsights","namespace":"Microsoft.TimeSeriesInsights","authorizations":[{"applicationId":"120d688d-1518-4cf7-bd38-182f158850b6","roleDefinitionId":"5a43abdf-bb87-42c4-9e56-1c24bf364150"}],"resourceTypes":[{"resourceType":"environments","locations":["East
+        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/eventsources","locations":["East
+        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/referenceDataSets","locations":["East
+        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/accessPolicies","locations":["East
+        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"operations","locations":["East
+        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/project","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/extension","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"checkNameAvailability","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Myget.PackageManagement","namespace":"Myget.PackageManagement","resourceTypes":[{"resourceType":"services","locations":["West
+        Europe"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/NewRelic.APM","namespace":"NewRelic.APM","authorization":{"allowedThirdPartyExtensions":[{"name":"NewRelic_AzurePortal_APM"}]},"resourceTypes":[{"resourceType":"accounts","locations":["North
+        Central US","South Central US","West US","East US","North Europe","West Europe","Southeast
+        Asia","East Asia","Japan East","Japan West"],"apiVersions":["2014-10-01","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/nuubit.nextgencdn","namespace":"nuubit.nextgencdn","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US","East US 2","North Central US","South Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","West US","Central US"],"apiVersions":["2017-05-05"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-05"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-05-05"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-05-05"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Paraleap.CloudMonix","namespace":"Paraleap.CloudMonix","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2016-08-10"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-10"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-10"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Pokitdok.Platform","namespace":"Pokitdok.Platform","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2016-05-17"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-05-17"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-05-17"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-05-17"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RavenHq.Db","namespace":"RavenHq.Db","resourceTypes":[{"resourceType":"databases","locations":["East
+        US"],"apiVersions":["2016-07-18","2016-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-07-18","2016-06-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-07-18","2016-06-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-07-18","2016-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Raygun.CrashReporting","namespace":"Raygun.CrashReporting","resourceTypes":[{"resourceType":"apps","locations":["East
+        US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RedisLabs.Memcached","namespace":"RedisLabs.Memcached","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-07-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RedisLabs.Redis","namespace":"RedisLabs.Redis","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-07-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RevAPM.MobileCDN","namespace":"RevAPM.MobileCDN","resourceTypes":[{"resourceType":"accounts","locations":["Central
+        US","East US","East US 2","North Central US","South Central US","West US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast"],"apiVersions":["2016-08-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-24","2016-08-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sendgrid.Email","namespace":"Sendgrid.Email","resourceTypes":[{"resourceType":"accounts","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Canada Central","Canada
+        East","West Central US","West US 2","UK South","UK West"],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Signiant.Flight","namespace":"Signiant.Flight","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US","Central US","North Central US","South Central US","West US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast"],"apiVersions":["2015-06-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sparkpost.Basic","namespace":"Sparkpost.Basic","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2016-08-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/stackify.retrace","namespace":"stackify.retrace","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2016-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/SuccessBricks.ClearDB","namespace":"SuccessBricks.ClearDB","resourceTypes":[{"resourceType":"databases","locations":["Brazil
+        South","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","Southeast Asia","West Europe","West
+        US","South Central US","Australia East","Australia Southeast","Canada Central","Canada
+        East","Central India","South India","West India"],"apiVersions":["2014-04-01"]},{"resourceType":"clusters","locations":["Brazil
+        South","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","Southeast Asia","West Europe","West
+        US","Australia Southeast","Australia East","South Central US","Canada Central","Canada
+        East","Central India","South India","West India"],"apiVersions":["2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/TrendMicro.DeepSecurity","namespace":"TrendMicro.DeepSecurity","resourceTypes":[{"resourceType":"accounts","locations":["Central
+        US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
+        Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:32:53 GMT
+- request:
+    method: post
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
+    body:
+      encoding: UTF-8
+      string: '{"access":"read","durationInSeconds":3600}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NjksIm5iZiI6MTUwNDEwNjg2OSwiZXhwIjoxNTA0MTEwNzY5LCJhaW8iOiJZMkZnWUxpdk10WHh4TkdHaGxVMi9VN2YvWFNqQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiLXZZQUNwWlFyMEs1UGkzSHBiRVNBQSIsInZlciI6IjEuMCJ9.UFICVGWtPeBRB--F5ZnJjqxE3tQRMBDwjPodNIg7fSsZr-R_g6YVrTD4faj2t-lRkkhLiao2LYKryUxWwuOA9Fk_p-8WBSgsVt3243Pf-JBaoPJx8ePHnn3F9iECzt6vBoUM75vv7eiR7cAwD4DGUae8iamjvcFkfxr6DMNQuYQKG5UrJN6a0sC_PUDKvzzqfskcpMggg8kquSzJnXAmCgKIUZeep8XNw2vffKjI-PcIlfVLc1GRrny8ewiMJdPeSg2fsh4ImSyRy9C2XGRFlewcG_cdZwrLeYKCIJyL_ncQm3zoNorPN0LB_PctCwXe2gpIGMxkS1-_TLF5HitpRw
+      Content-Length:
+      - '42'
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '0'
+      Expires:
+      - "-1"
+      Location:
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/8ccee5d1-6447-42ca-9d3f-cb52d7e3ada6?monitor=true&api-version=2017-03-30
+      Azure-Asyncoperation:
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/8ccee5d1-6447-42ca-9d3f-cb52d7e3ada6?api-version=2017-03-30
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      X-Ms-Request-Id:
+      - 8ccee5d1-6447-42ca-9d3f-cb52d7e3ada6
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Writes:
+      - '1193'
+      X-Ms-Correlation-Request-Id:
+      - 2df832ef-d951-4fc1-b137-e203ac13e816
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153256Z:2df832ef-d951-4fc1-b137-e203ac13e816
+      Date:
+      - Wed, 30 Aug 2017 15:32:56 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:32:54 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/8ccee5d1-6447-42ca-9d3f-cb52d7e3ada6?api-version=2017-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NjksIm5iZiI6MTUwNDEwNjg2OSwiZXhwIjoxNTA0MTEwNzY5LCJhaW8iOiJZMkZnWUxpdk10WHh4TkdHaGxVMi9VN2YvWFNqQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiLXZZQUNwWlFyMEs1UGkzSHBiRVNBQSIsInZlciI6IjEuMCJ9.UFICVGWtPeBRB--F5ZnJjqxE3tQRMBDwjPodNIg7fSsZr-R_g6YVrTD4faj2t-lRkkhLiao2LYKryUxWwuOA9Fk_p-8WBSgsVt3243Pf-JBaoPJx8ePHnn3F9iECzt6vBoUM75vv7eiR7cAwD4DGUae8iamjvcFkfxr6DMNQuYQKG5UrJN6a0sC_PUDKvzzqfskcpMggg8kquSzJnXAmCgKIUZeep8XNw2vffKjI-PcIlfVLc1GRrny8ewiMJdPeSg2fsh4ImSyRy9C2XGRFlewcG_cdZwrLeYKCIJyL_ncQm3zoNorPN0LB_PctCwXe2gpIGMxkS1-_TLF5HitpRw
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      X-Ms-Request-Id:
+      - f2090e30-b511-464d-a147-70f4d44f61a3
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14939'
+      X-Ms-Correlation-Request-Id:
+      - 86f38f9b-4117-4535-aab3-fdc126fd293b
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153256Z:86f38f9b-4117-4535-aab3-fdc126fd293b
+      Date:
+      - Wed, 30 Aug 2017 15:32:56 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"startTime\": \"2017-08-30T15:32:55.8678193+00:00\",\r\n  \"endTime\":
+        \"2017-08-30T15:32:56.1178215+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=17f82286-b80e-487a-a847-7981879ff674&sig=Ul70ar70l2TUc4aGDcTi%2FCY42odydLmS6PsX23O%2BlvI%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"8ccee5d1-6447-42ca-9d3f-cb52d7e3ada6\"\r\n}"
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:32:54 GMT
+- request:
+    method: get
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=17f82286-b80e-487a-a847-7981879ff674&sig=Ul70ar70l2TUc4aGDcTi/CY42odydLmS6PsX23O%2BlvI=&sr=b&sv=2016-05-31
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      X-Ms-Range:
+      - bytes=0-0
+      Host:
+      - md-t4jdgqqlgszp.blob.core.windows.net
+  response:
+    status:
+      code: 206
+      message: Partial Content
+    headers:
+      Content-Length:
+      - '1'
+      Content-Type:
+      - application/octet-stream
+      Content-Range:
+      - bytes 0-0/34359738880
+      Last-Modified:
+      - Sat, 15 Jul 2017 14:23:07 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D4CB8D039FC699"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - a9815476-0001-0029-75a5-21d76f000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Meta-Pirtag:
+      - '1'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '20'
+      X-Ms-Copy-Id:
+      - 30cedd78-548a-4fd8-967e-f8344f587e3c
+      X-Ms-Copy-Source:
+      - http://md-t4jdgqqlgszp.blob.core.windows.net:8080/fg25xxtqx0gc/abcd?sv=2016-02-19&sr=b&st=2017-05-04T21%3a06%3a57Z&se=9999-12-31T23%3a59%3a59Z&sp=r&api-version=2016-02-19
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 34359738880/34359738880
+      X-Ms-Copy-Completion-Time:
+      - Thu, 04 May 2017 21:21:56 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Wed, 30 Aug 2017 15:32:56 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        6w==
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:32:55 GMT
+- request:
+    method: post
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
+    body:
+      encoding: UTF-8
+      string: '{"access":"read","durationInSeconds":3600}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NjksIm5iZiI6MTUwNDEwNjg2OSwiZXhwIjoxNTA0MTEwNzY5LCJhaW8iOiJZMkZnWUxpdk10WHh4TkdHaGxVMi9VN2YvWFNqQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiLXZZQUNwWlFyMEs1UGkzSHBiRVNBQSIsInZlciI6IjEuMCJ9.UFICVGWtPeBRB--F5ZnJjqxE3tQRMBDwjPodNIg7fSsZr-R_g6YVrTD4faj2t-lRkkhLiao2LYKryUxWwuOA9Fk_p-8WBSgsVt3243Pf-JBaoPJx8ePHnn3F9iECzt6vBoUM75vv7eiR7cAwD4DGUae8iamjvcFkfxr6DMNQuYQKG5UrJN6a0sC_PUDKvzzqfskcpMggg8kquSzJnXAmCgKIUZeep8XNw2vffKjI-PcIlfVLc1GRrny8ewiMJdPeSg2fsh4ImSyRy9C2XGRFlewcG_cdZwrLeYKCIJyL_ncQm3zoNorPN0LB_PctCwXe2gpIGMxkS1-_TLF5HitpRw
+      Content-Length:
+      - '42'
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '0'
+      Expires:
+      - "-1"
+      Location:
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/d106f534-ac3b-41ea-a336-576aafed1110?monitor=true&api-version=2017-03-30
+      Azure-Asyncoperation:
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/d106f534-ac3b-41ea-a336-576aafed1110?api-version=2017-03-30
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      X-Ms-Request-Id:
+      - d106f534-ac3b-41ea-a336-576aafed1110
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Writes:
+      - '1198'
+      X-Ms-Correlation-Request-Id:
+      - 9f29a8c4-698e-48e3-805d-d2e9151c4419
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153257Z:9f29a8c4-698e-48e3-805d-d2e9151c4419
+      Date:
+      - Wed, 30 Aug 2017 15:32:57 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:32:55 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/d106f534-ac3b-41ea-a336-576aafed1110?api-version=2017-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NjksIm5iZiI6MTUwNDEwNjg2OSwiZXhwIjoxNTA0MTEwNzY5LCJhaW8iOiJZMkZnWUxpdk10WHh4TkdHaGxVMi9VN2YvWFNqQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiLXZZQUNwWlFyMEs1UGkzSHBiRVNBQSIsInZlciI6IjEuMCJ9.UFICVGWtPeBRB--F5ZnJjqxE3tQRMBDwjPodNIg7fSsZr-R_g6YVrTD4faj2t-lRkkhLiao2LYKryUxWwuOA9Fk_p-8WBSgsVt3243Pf-JBaoPJx8ePHnn3F9iECzt6vBoUM75vv7eiR7cAwD4DGUae8iamjvcFkfxr6DMNQuYQKG5UrJN6a0sC_PUDKvzzqfskcpMggg8kquSzJnXAmCgKIUZeep8XNw2vffKjI-PcIlfVLc1GRrny8ewiMJdPeSg2fsh4ImSyRy9C2XGRFlewcG_cdZwrLeYKCIJyL_ncQm3zoNorPN0LB_PctCwXe2gpIGMxkS1-_TLF5HitpRw
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      X-Ms-Request-Id:
+      - bd9f24a6-98cc-4e0e-91d8-1062df1ec375
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14943'
+      X-Ms-Correlation-Request-Id:
+      - 4ff43e7c-48c4-4c0e-baee-7b41941340b7
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153257Z:4ff43e7c-48c4-4c0e-baee-7b41941340b7
+      Date:
+      - Wed, 30 Aug 2017 15:32:56 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"startTime\": \"2017-08-30T15:32:56.7896888+00:00\",\r\n  \"endTime\":
+        \"2017-08-30T15:32:56.9928204+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=11f21342-5e16-4cff-b176-b22382452ed5&sig=MLaDj%2BzgfRbpIn%2FLggQpGfBW7cLZkjKifJIctgL4%2BbY%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"d106f534-ac3b-41ea-a336-576aafed1110\"\r\n}"
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:32:55 GMT
+- request:
+    method: get
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=11f21342-5e16-4cff-b176-b22382452ed5&sig=MLaDj%2BzgfRbpIn/LggQpGfBW7cLZkjKifJIctgL4%2BbY=&sr=b&sv=2016-05-31
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      X-Ms-Range:
+      - bytes=440-443
+      Host:
+      - md-t4jdgqqlgszp.blob.core.windows.net
+  response:
+    status:
+      code: 206
+      message: Partial Content
+    headers:
+      Content-Length:
+      - '4'
+      Content-Type:
+      - application/octet-stream
+      Content-Range:
+      - bytes 440-443/34359738880
+      Last-Modified:
+      - Sat, 15 Jul 2017 14:23:07 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D4CB8D039FC699"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 27ab2df4-0001-0102-4ca5-21e582000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Meta-Pirtag:
+      - '1'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '20'
+      X-Ms-Copy-Id:
+      - 30cedd78-548a-4fd8-967e-f8344f587e3c
+      X-Ms-Copy-Source:
+      - http://md-t4jdgqqlgszp.blob.core.windows.net:8080/fg25xxtqx0gc/abcd?sv=2016-02-19&sr=b&st=2017-05-04T21%3a06%3a57Z&se=9999-12-31T23%3a59%3a59Z&sp=r&api-version=2016-02-19
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 34359738880/34359738880
+      X-Ms-Copy-Completion-Time:
+      - Thu, 04 May 2017 21:21:56 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Wed, 30 Aug 2017 15:32:57 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        U5MJAA==
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:32:55 GMT
+recorded_with: VCR 3.0.3

--- a/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_partNum-1.yml
+++ b/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_partNum-1.yml
@@ -39,25 +39,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 0a00f6fa-5096-42af-b93e-2dc7a5b11200
+      - 5c1f802f-a2e1-45fa-a27c-b81d96e91300
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAAA9kTklhVy7SJTGAzR-p1BcqfT1LTG_eWtrsyW0DS2PaDfc4SonrPLHNr2HTVRhlp8z3EgQFBTxZMxsTScniGNytWbu6Clc9UM_S6BDkiBDuQG3dhMV-JogHPiMAyKoPsTANQE-6PgQdmf-crOw9XF3IIWBMtAczQt2zsbgqSQ-fIv6jaa7n6cpi31LraF7YXYgAA;
+      - esctx=AQABAAAAAAA9kTklhVy7SJTGAzR-p1BcbjITRMzjKVUvqGFdvXpjJSnx2pmdcDrK3tYDn5bWz2qiEZ2A4uwvBFbLq3aOheAsvdArn3t3Wj7ADKa3tXYK31HybKW9JraKwV6LAM_qvahlEraBPKmJkP_Njt_uSYUzcZKBlblWqLPRFDWwc2GrRUcFrcKU1bC4DdO3v46ae_cgAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=005; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=003; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Wed, 30 Aug 2017 15:32:50 GMT
+      - Wed, 30 Aug 2017 17:11:11 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1504110769","not_before":"1504106869","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NjksIm5iZiI6MTUwNDEwNjg2OSwiZXhwIjoxNTA0MTEwNzY5LCJhaW8iOiJZMkZnWUxpdk10WHh4TkdHaGxVMi9VN2YvWFNqQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiLXZZQUNwWlFyMEs1UGkzSHBiRVNBQSIsInZlciI6IjEuMCJ9.UFICVGWtPeBRB--F5ZnJjqxE3tQRMBDwjPodNIg7fSsZr-R_g6YVrTD4faj2t-lRkkhLiao2LYKryUxWwuOA9Fk_p-8WBSgsVt3243Pf-JBaoPJx8ePHnn3F9iECzt6vBoUM75vv7eiR7cAwD4DGUae8iamjvcFkfxr6DMNQuYQKG5UrJN6a0sC_PUDKvzzqfskcpMggg8kquSzJnXAmCgKIUZeep8XNw2vffKjI-PcIlfVLc1GRrny8ewiMJdPeSg2fsh4ImSyRy9C2XGRFlewcG_cdZwrLeYKCIJyL_ncQm3zoNorPN0LB_PctCwXe2gpIGMxkS1-_TLF5HitpRw"}'
+      string: '{"token_type":"Bearer","expires_in":"3600","ext_expires_in":"0","expires_on":"1504116672","not_before":"1504112772","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI3NzIsIm5iZiI6MTUwNDExMjc3MiwiZXhwIjoxNTA0MTE2NjcyLCJhaW8iOiJZMkZnWVBqYUdIeHZodVFxSnE0OUNSeE1OanVQQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTDRBZlhPR2kta1dpZkxnZGx1a1RBQSIsInZlciI6IjEuMCJ9.Hkw6JsuGLBnmp0eKigIP4wi457Dm1Re_-oRnNLjsdzEnrQhP40p7ovIoQ_YhUYMgRH2q1X-Z9D9qLrVvxnU1LfMqaooa_zaEMaBgl7RZAd8js8XRzNp8fe49YMtPXD_DV49bjjHPE5iv5ShTsR52k81mrLq3-MrPWB3obtD19KogauNtgeLUq9JlFyt8VxfKGSxskV0bQtq3RULxiWMn3dYVUT8G931kJIJo2fmRdghEhnlsizBB-1FYSn2x3QPKVNK-jks31hWuanl9rTJjih2SlGr0_ndL0aKkGVturrMPTh7RgRkMUlj65H-wRpTm2eSDuvTbZgRGwAO1NuQ6Gg"}'
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:32:47 GMT
+  recorded_at: Wed, 30 Aug 2017 17:11:10 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -74,7 +74,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NjksIm5iZiI6MTUwNDEwNjg2OSwiZXhwIjoxNTA0MTEwNzY5LCJhaW8iOiJZMkZnWUxpdk10WHh4TkdHaGxVMi9VN2YvWFNqQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiLXZZQUNwWlFyMEs1UGkzSHBiRVNBQSIsInZlciI6IjEuMCJ9.UFICVGWtPeBRB--F5ZnJjqxE3tQRMBDwjPodNIg7fSsZr-R_g6YVrTD4faj2t-lRkkhLiao2LYKryUxWwuOA9Fk_p-8WBSgsVt3243Pf-JBaoPJx8ePHnn3F9iECzt6vBoUM75vv7eiR7cAwD4DGUae8iamjvcFkfxr6DMNQuYQKG5UrJN6a0sC_PUDKvzzqfskcpMggg8kquSzJnXAmCgKIUZeep8XNw2vffKjI-PcIlfVLc1GRrny8ewiMJdPeSg2fsh4ImSyRy9C2XGRFlewcG_cdZwrLeYKCIJyL_ncQm3zoNorPN0LB_PctCwXe2gpIGMxkS1-_TLF5HitpRw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI3NzIsIm5iZiI6MTUwNDExMjc3MiwiZXhwIjoxNTA0MTE2NjcyLCJhaW8iOiJZMkZnWVBqYUdIeHZodVFxSnE0OUNSeE1OanVQQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTDRBZlhPR2kta1dpZkxnZGx1a1RBQSIsInZlciI6IjEuMCJ9.Hkw6JsuGLBnmp0eKigIP4wi457Dm1Re_-oRnNLjsdzEnrQhP40p7ovIoQ_YhUYMgRH2q1X-Z9D9qLrVvxnU1LfMqaooa_zaEMaBgl7RZAd8js8XRzNp8fe49YMtPXD_DV49bjjHPE5iv5ShTsR52k81mrLq3-MrPWB3obtD19KogauNtgeLUq9JlFyt8VxfKGSxskV0bQtq3RULxiWMn3dYVUT8G931kJIJo2fmRdghEhnlsizBB-1FYSn2x3QPKVNK-jks31hWuanl9rTJjih2SlGr0_ndL0aKkGVturrMPTh7RgRkMUlj65H-wRpTm2eSDuvTbZgRGwAO1NuQ6Gg
       Host:
       - management.azure.com
   response:
@@ -95,23 +95,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14997'
+      - '14999'
       X-Ms-Request-Id:
-      - 9a557223-5228-4909-a9dc-d32f4a342ed6
+      - 4fc94df3-1523-4224-9f0f-a9e827d6de19
       X-Ms-Correlation-Request-Id:
-      - 9a557223-5228-4909-a9dc-d32f4a342ed6
+      - 4fc94df3-1523-4224-9f0f-a9e827d6de19
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153249Z:9a557223-5228-4909-a9dc-d32f4a342ed6
+      - EASTUS:20170830T171111Z:4fc94df3-1523-4224-9f0f-a9e827d6de19
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 30 Aug 2017 15:32:48 GMT
+      - Wed, 30 Aug 2017 17:11:10 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:32:47 GMT
+  recorded_at: Wed, 30 Aug 2017 17:11:10 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/azure_subscription_id/providers?api-version=2015-01-01
@@ -128,7 +128,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NjksIm5iZiI6MTUwNDEwNjg2OSwiZXhwIjoxNTA0MTEwNzY5LCJhaW8iOiJZMkZnWUxpdk10WHh4TkdHaGxVMi9VN2YvWFNqQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiLXZZQUNwWlFyMEs1UGkzSHBiRVNBQSIsInZlciI6IjEuMCJ9.UFICVGWtPeBRB--F5ZnJjqxE3tQRMBDwjPodNIg7fSsZr-R_g6YVrTD4faj2t-lRkkhLiao2LYKryUxWwuOA9Fk_p-8WBSgsVt3243Pf-JBaoPJx8ePHnn3F9iECzt6vBoUM75vv7eiR7cAwD4DGUae8iamjvcFkfxr6DMNQuYQKG5UrJN6a0sC_PUDKvzzqfskcpMggg8kquSzJnXAmCgKIUZeep8XNw2vffKjI-PcIlfVLc1GRrny8ewiMJdPeSg2fsh4ImSyRy9C2XGRFlewcG_cdZwrLeYKCIJyL_ncQm3zoNorPN0LB_PctCwXe2gpIGMxkS1-_TLF5HitpRw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI3NzIsIm5iZiI6MTUwNDExMjc3MiwiZXhwIjoxNTA0MTE2NjcyLCJhaW8iOiJZMkZnWVBqYUdIeHZodVFxSnE0OUNSeE1OanVQQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTDRBZlhPR2kta1dpZkxnZGx1a1RBQSIsInZlciI6IjEuMCJ9.Hkw6JsuGLBnmp0eKigIP4wi457Dm1Re_-oRnNLjsdzEnrQhP40p7ovIoQ_YhUYMgRH2q1X-Z9D9qLrVvxnU1LfMqaooa_zaEMaBgl7RZAd8js8XRzNp8fe49YMtPXD_DV49bjjHPE5iv5ShTsR52k81mrLq3-MrPWB3obtD19KogauNtgeLUq9JlFyt8VxfKGSxskV0bQtq3RULxiWMn3dYVUT8G931kJIJo2fmRdghEhnlsizBB-1FYSn2x3QPKVNK-jks31hWuanl9rTJjih2SlGr0_ndL0aKkGVturrMPTh7RgRkMUlj65H-wRpTm2eSDuvTbZgRGwAO1NuQ6Gg
       Host:
       - management.azure.com
   response:
@@ -147,17 +147,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14932'
+      - '14934'
       X-Ms-Request-Id:
-      - 19cb100a-681d-4a5b-8d12-6d805306a926
+      - 6e8cd21f-6121-48af-97e9-ac7d681c615c
       X-Ms-Correlation-Request-Id:
-      - 19cb100a-681d-4a5b-8d12-6d805306a926
+      - 6e8cd21f-6121-48af-97e9-ac7d681c615c
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153255Z:19cb100a-681d-4a5b-8d12-6d805306a926
+      - EASTUS:20170830T171112Z:6e8cd21f-6121-48af-97e9-ac7d681c615c
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 30 Aug 2017 15:32:55 GMT
+      - Wed, 30 Aug 2017 17:11:11 GMT
       Content-Length:
       - '241615'
     body:
@@ -1891,7 +1891,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:32:53 GMT
+  recorded_at: Wed, 30 Aug 2017 17:11:11 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
@@ -1908,7 +1908,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NjksIm5iZiI6MTUwNDEwNjg2OSwiZXhwIjoxNTA0MTEwNzY5LCJhaW8iOiJZMkZnWUxpdk10WHh4TkdHaGxVMi9VN2YvWFNqQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiLXZZQUNwWlFyMEs1UGkzSHBiRVNBQSIsInZlciI6IjEuMCJ9.UFICVGWtPeBRB--F5ZnJjqxE3tQRMBDwjPodNIg7fSsZr-R_g6YVrTD4faj2t-lRkkhLiao2LYKryUxWwuOA9Fk_p-8WBSgsVt3243Pf-JBaoPJx8ePHnn3F9iECzt6vBoUM75vv7eiR7cAwD4DGUae8iamjvcFkfxr6DMNQuYQKG5UrJN6a0sC_PUDKvzzqfskcpMggg8kquSzJnXAmCgKIUZeep8XNw2vffKjI-PcIlfVLc1GRrny8ewiMJdPeSg2fsh4ImSyRy9C2XGRFlewcG_cdZwrLeYKCIJyL_ncQm3zoNorPN0LB_PctCwXe2gpIGMxkS1-_TLF5HitpRw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI3NzIsIm5iZiI6MTUwNDExMjc3MiwiZXhwIjoxNTA0MTE2NjcyLCJhaW8iOiJZMkZnWVBqYUdIeHZodVFxSnE0OUNSeE1OanVQQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTDRBZlhPR2kta1dpZkxnZGx1a1RBQSIsInZlciI6IjEuMCJ9.Hkw6JsuGLBnmp0eKigIP4wi457Dm1Re_-oRnNLjsdzEnrQhP40p7ovIoQ_YhUYMgRH2q1X-Z9D9qLrVvxnU1LfMqaooa_zaEMaBgl7RZAd8js8XRzNp8fe49YMtPXD_DV49bjjHPE5iv5ShTsR52k81mrLq3-MrPWB3obtD19KogauNtgeLUq9JlFyt8VxfKGSxskV0bQtq3RULxiWMn3dYVUT8G931kJIJo2fmRdghEhnlsizBB-1FYSn2x3QPKVNK-jks31hWuanl9rTJjih2SlGr0_ndL0aKkGVturrMPTh7RgRkMUlj65H-wRpTm2eSDuvTbZgRGwAO1NuQ6Gg
       Content-Length:
       - '42'
       Host:
@@ -1927,34 +1927,34 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/8ccee5d1-6447-42ca-9d3f-cb52d7e3ada6?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/79829e98-8efc-432e-a9f8-33de752f37ab?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/8ccee5d1-6447-42ca-9d3f-cb52d7e3ada6?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/79829e98-8efc-432e-a9f8-33de752f37ab?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
       - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
       X-Ms-Request-Id:
-      - 8ccee5d1-6447-42ca-9d3f-cb52d7e3ada6
+      - 79829e98-8efc-432e-a9f8-33de752f37ab
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1193'
+      - '1188'
       X-Ms-Correlation-Request-Id:
-      - 2df832ef-d951-4fc1-b137-e203ac13e816
+      - 3a93dd98-5f8e-4bab-917f-9226b2eebcae
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153256Z:2df832ef-d951-4fc1-b137-e203ac13e816
+      - EASTUS:20170830T171113Z:3a93dd98-5f8e-4bab-917f-9226b2eebcae
       Date:
-      - Wed, 30 Aug 2017 15:32:56 GMT
+      - Wed, 30 Aug 2017 17:11:12 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:32:54 GMT
+  recorded_at: Wed, 30 Aug 2017 17:11:12 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/8ccee5d1-6447-42ca-9d3f-cb52d7e3ada6?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/79829e98-8efc-432e-a9f8-33de752f37ab?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -1968,7 +1968,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NjksIm5iZiI6MTUwNDEwNjg2OSwiZXhwIjoxNTA0MTEwNzY5LCJhaW8iOiJZMkZnWUxpdk10WHh4TkdHaGxVMi9VN2YvWFNqQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiLXZZQUNwWlFyMEs1UGkzSHBiRVNBQSIsInZlciI6IjEuMCJ9.UFICVGWtPeBRB--F5ZnJjqxE3tQRMBDwjPodNIg7fSsZr-R_g6YVrTD4faj2t-lRkkhLiao2LYKryUxWwuOA9Fk_p-8WBSgsVt3243Pf-JBaoPJx8ePHnn3F9iECzt6vBoUM75vv7eiR7cAwD4DGUae8iamjvcFkfxr6DMNQuYQKG5UrJN6a0sC_PUDKvzzqfskcpMggg8kquSzJnXAmCgKIUZeep8XNw2vffKjI-PcIlfVLc1GRrny8ewiMJdPeSg2fsh4ImSyRy9C2XGRFlewcG_cdZwrLeYKCIJyL_ncQm3zoNorPN0LB_PctCwXe2gpIGMxkS1-_TLF5HitpRw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI3NzIsIm5iZiI6MTUwNDExMjc3MiwiZXhwIjoxNTA0MTE2NjcyLCJhaW8iOiJZMkZnWVBqYUdIeHZodVFxSnE0OUNSeE1OanVQQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTDRBZlhPR2kta1dpZkxnZGx1a1RBQSIsInZlciI6IjEuMCJ9.Hkw6JsuGLBnmp0eKigIP4wi457Dm1Re_-oRnNLjsdzEnrQhP40p7ovIoQ_YhUYMgRH2q1X-Z9D9qLrVvxnU1LfMqaooa_zaEMaBgl7RZAd8js8XRzNp8fe49YMtPXD_DV49bjjHPE5iv5ShTsR52k81mrLq3-MrPWB3obtD19KogauNtgeLUq9JlFyt8VxfKGSxskV0bQtq3RULxiWMn3dYVUT8G931kJIJo2fmRdghEhnlsizBB-1FYSn2x3QPKVNK-jks31hWuanl9rTJjih2SlGr0_ndL0aKkGVturrMPTh7RgRkMUlj65H-wRpTm2eSDuvTbZgRGwAO1NuQ6Gg
       Host:
       - management.azure.com
   response:
@@ -1993,29 +1993,29 @@ http_interactions:
       X-Ms-Served-By:
       - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
       X-Ms-Request-Id:
-      - f2090e30-b511-464d-a147-70f4d44f61a3
+      - 4114174d-70de-4f38-a821-ba31f81721f2
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14939'
+      - '14930'
       X-Ms-Correlation-Request-Id:
-      - 86f38f9b-4117-4535-aab3-fdc126fd293b
+      - 7f1ca9df-fb64-4a36-a8df-a8ea122f173d
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153256Z:86f38f9b-4117-4535-aab3-fdc126fd293b
+      - EASTUS:20170830T171113Z:7f1ca9df-fb64-4a36-a8df-a8ea122f173d
       Date:
-      - Wed, 30 Aug 2017 15:32:56 GMT
+      - Wed, 30 Aug 2017 17:11:12 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-08-30T15:32:55.8678193+00:00\",\r\n  \"endTime\":
-        \"2017-08-30T15:32:56.1178215+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=17f82286-b80e-487a-a847-7981879ff674&sig=Ul70ar70l2TUc4aGDcTi%2FCY42odydLmS6PsX23O%2BlvI%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"8ccee5d1-6447-42ca-9d3f-cb52d7e3ada6\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2017-08-30T17:11:12.3956027+00:00\",\r\n  \"endTime\":
+        \"2017-08-30T17:11:12.6770484+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=6dc2a1bc-b036-4bf0-ab8a-80317f4c9a47&sig=S6tVss%2Ba4kF%2FArDckyeB%2FRapuWKrPAfPcnmU4%2FQiFTM%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"79829e98-8efc-432e-a9f8-33de752f37ab\"\r\n}"
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:32:54 GMT
+  recorded_at: Wed, 30 Aug 2017 17:11:12 GMT
 - request:
     method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=17f82286-b80e-487a-a847-7981879ff674&sig=Ul70ar70l2TUc4aGDcTi/CY42odydLmS6PsX23O%2BlvI=&sr=b&sv=2016-05-31
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=6dc2a1bc-b036-4bf0-ab8a-80317f4c9a47&sig=S6tVss%2Ba4kF/ArDckyeB/RapuWKrPAfPcnmU4/QiFTM=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2050,7 +2050,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - a9815476-0001-0029-75a5-21d76f000000
+      - 12d554af-0001-00c9-41b2-2131e7000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2076,13 +2076,13 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 30 Aug 2017 15:32:56 GMT
+      - Wed, 30 Aug 2017 17:11:12 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         6w==
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:32:55 GMT
+  recorded_at: Wed, 30 Aug 2017 17:11:12 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
@@ -2099,7 +2099,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NjksIm5iZiI6MTUwNDEwNjg2OSwiZXhwIjoxNTA0MTEwNzY5LCJhaW8iOiJZMkZnWUxpdk10WHh4TkdHaGxVMi9VN2YvWFNqQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiLXZZQUNwWlFyMEs1UGkzSHBiRVNBQSIsInZlciI6IjEuMCJ9.UFICVGWtPeBRB--F5ZnJjqxE3tQRMBDwjPodNIg7fSsZr-R_g6YVrTD4faj2t-lRkkhLiao2LYKryUxWwuOA9Fk_p-8WBSgsVt3243Pf-JBaoPJx8ePHnn3F9iECzt6vBoUM75vv7eiR7cAwD4DGUae8iamjvcFkfxr6DMNQuYQKG5UrJN6a0sC_PUDKvzzqfskcpMggg8kquSzJnXAmCgKIUZeep8XNw2vffKjI-PcIlfVLc1GRrny8ewiMJdPeSg2fsh4ImSyRy9C2XGRFlewcG_cdZwrLeYKCIJyL_ncQm3zoNorPN0LB_PctCwXe2gpIGMxkS1-_TLF5HitpRw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI3NzIsIm5iZiI6MTUwNDExMjc3MiwiZXhwIjoxNTA0MTE2NjcyLCJhaW8iOiJZMkZnWVBqYUdIeHZodVFxSnE0OUNSeE1OanVQQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTDRBZlhPR2kta1dpZkxnZGx1a1RBQSIsInZlciI6IjEuMCJ9.Hkw6JsuGLBnmp0eKigIP4wi457Dm1Re_-oRnNLjsdzEnrQhP40p7ovIoQ_YhUYMgRH2q1X-Z9D9qLrVvxnU1LfMqaooa_zaEMaBgl7RZAd8js8XRzNp8fe49YMtPXD_DV49bjjHPE5iv5ShTsR52k81mrLq3-MrPWB3obtD19KogauNtgeLUq9JlFyt8VxfKGSxskV0bQtq3RULxiWMn3dYVUT8G931kJIJo2fmRdghEhnlsizBB-1FYSn2x3QPKVNK-jks31hWuanl9rTJjih2SlGr0_ndL0aKkGVturrMPTh7RgRkMUlj65H-wRpTm2eSDuvTbZgRGwAO1NuQ6Gg
       Content-Length:
       - '42'
       Host:
@@ -2118,34 +2118,34 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/d106f534-ac3b-41ea-a336-576aafed1110?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/ec2805ba-c840-42c5-aa53-53277094c30a?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/d106f534-ac3b-41ea-a336-576aafed1110?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/ec2805ba-c840-42c5-aa53-53277094c30a?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
       - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
       X-Ms-Request-Id:
-      - d106f534-ac3b-41ea-a336-576aafed1110
+      - ec2805ba-c840-42c5-aa53-53277094c30a
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1198'
+      - '1192'
       X-Ms-Correlation-Request-Id:
-      - 9f29a8c4-698e-48e3-805d-d2e9151c4419
+      - b1a6f432-c2c2-49a7-a9ac-1b0c9852e907
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153257Z:9f29a8c4-698e-48e3-805d-d2e9151c4419
+      - EASTUS:20170830T171113Z:b1a6f432-c2c2-49a7-a9ac-1b0c9852e907
       Date:
-      - Wed, 30 Aug 2017 15:32:57 GMT
+      - Wed, 30 Aug 2017 17:11:13 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:32:55 GMT
+  recorded_at: Wed, 30 Aug 2017 17:11:13 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/d106f534-ac3b-41ea-a336-576aafed1110?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/ec2805ba-c840-42c5-aa53-53277094c30a?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -2159,7 +2159,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4NjksIm5iZiI6MTUwNDEwNjg2OSwiZXhwIjoxNTA0MTEwNzY5LCJhaW8iOiJZMkZnWUxpdk10WHh4TkdHaGxVMi9VN2YvWFNqQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiLXZZQUNwWlFyMEs1UGkzSHBiRVNBQSIsInZlciI6IjEuMCJ9.UFICVGWtPeBRB--F5ZnJjqxE3tQRMBDwjPodNIg7fSsZr-R_g6YVrTD4faj2t-lRkkhLiao2LYKryUxWwuOA9Fk_p-8WBSgsVt3243Pf-JBaoPJx8ePHnn3F9iECzt6vBoUM75vv7eiR7cAwD4DGUae8iamjvcFkfxr6DMNQuYQKG5UrJN6a0sC_PUDKvzzqfskcpMggg8kquSzJnXAmCgKIUZeep8XNw2vffKjI-PcIlfVLc1GRrny8ewiMJdPeSg2fsh4ImSyRy9C2XGRFlewcG_cdZwrLeYKCIJyL_ncQm3zoNorPN0LB_PctCwXe2gpIGMxkS1-_TLF5HitpRw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI3NzIsIm5iZiI6MTUwNDExMjc3MiwiZXhwIjoxNTA0MTE2NjcyLCJhaW8iOiJZMkZnWVBqYUdIeHZodVFxSnE0OUNSeE1OanVQQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTDRBZlhPR2kta1dpZkxnZGx1a1RBQSIsInZlciI6IjEuMCJ9.Hkw6JsuGLBnmp0eKigIP4wi457Dm1Re_-oRnNLjsdzEnrQhP40p7ovIoQ_YhUYMgRH2q1X-Z9D9qLrVvxnU1LfMqaooa_zaEMaBgl7RZAd8js8XRzNp8fe49YMtPXD_DV49bjjHPE5iv5ShTsR52k81mrLq3-MrPWB3obtD19KogauNtgeLUq9JlFyt8VxfKGSxskV0bQtq3RULxiWMn3dYVUT8G931kJIJo2fmRdghEhnlsizBB-1FYSn2x3QPKVNK-jks31hWuanl9rTJjih2SlGr0_ndL0aKkGVturrMPTh7RgRkMUlj65H-wRpTm2eSDuvTbZgRGwAO1NuQ6Gg
       Host:
       - management.azure.com
   response:
@@ -2184,29 +2184,29 @@ http_interactions:
       X-Ms-Served-By:
       - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
       X-Ms-Request-Id:
-      - bd9f24a6-98cc-4e0e-91d8-1062df1ec375
+      - 894e6f9a-8cf5-4ecc-acd3-3c09c575cd87
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14943'
+      - '14924'
       X-Ms-Correlation-Request-Id:
-      - 4ff43e7c-48c4-4c0e-baee-7b41941340b7
+      - 2c1d92fd-3665-432a-aba0-e76798ecef9a
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153257Z:4ff43e7c-48c4-4c0e-baee-7b41941340b7
+      - EASTUS:20170830T171114Z:2c1d92fd-3665-432a-aba0-e76798ecef9a
       Date:
-      - Wed, 30 Aug 2017 15:32:56 GMT
+      - Wed, 30 Aug 2017 17:11:14 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-08-30T15:32:56.7896888+00:00\",\r\n  \"endTime\":
-        \"2017-08-30T15:32:56.9928204+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=11f21342-5e16-4cff-b176-b22382452ed5&sig=MLaDj%2BzgfRbpIn%2FLggQpGfBW7cLZkjKifJIctgL4%2BbY%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"d106f534-ac3b-41ea-a336-576aafed1110\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2017-08-30T17:11:13.3868619+00:00\",\r\n  \"endTime\":
+        \"2017-08-30T17:11:13.556906+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=da804c19-fb28-4932-af4d-3fe527fda693&sig=qX6hOVUOGG0MxjrY9DsUgRHrPJTTq8gRzx7uCQIb6Bo%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"ec2805ba-c840-42c5-aa53-53277094c30a\"\r\n}"
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:32:55 GMT
+  recorded_at: Wed, 30 Aug 2017 17:11:13 GMT
 - request:
     method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=11f21342-5e16-4cff-b176-b22382452ed5&sig=MLaDj%2BzgfRbpIn/LggQpGfBW7cLZkjKifJIctgL4%2BbY=&sr=b&sv=2016-05-31
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=da804c19-fb28-4932-af4d-3fe527fda693&sig=qX6hOVUOGG0MxjrY9DsUgRHrPJTTq8gRzx7uCQIb6Bo=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2241,7 +2241,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 27ab2df4-0001-0102-4ca5-21e582000000
+      - ad8eec1e-0001-00f0-57b2-217143000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2267,11 +2267,11 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 30 Aug 2017 15:32:57 GMT
+      - Wed, 30 Aug 2017 17:11:13 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         U5MJAA==
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:32:55 GMT
+  recorded_at: Wed, 30 Aug 2017 17:11:13 GMT
 recorded_with: VCR 3.0.3

--- a/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_partType-1.yml
+++ b/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_partType-1.yml
@@ -1,0 +1,2277 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://login.microsoftonline.com/azure_tenant_id/oauth2/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_key&resource=https%3A%2F%2Fmanagement.azure.com%2F
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - login.microsoftonline.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Server:
+      - Microsoft-IIS/8.5
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Request-Id:
+      - b9e92bc7-9fb1-4968-987d-81edac751200
+      P3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Set-Cookie:
+      - esctx=AQABAAAAAAA9kTklhVy7SJTGAzR-p1BcyZ4OUZQ0nHc-YU98WAd7z8_zPKCL2HbWr_DSUafS6TQv3ra1IjdFjKciOuuSi7y7bys0on7hSMrJ5hpgWSLgLjv0gAeeLiLVNKa4NIi2K-bF-a-T_THFNvwZJPRqnW-DYlfOJfPfSjLBriifa4xbUVtrqDHtmcR1BwTgoC9qw5AgAA;
+        domain=.login.microsoftonline.com; path=/; secure; HttpOnly
+      - stsservicecookie=ests; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=005; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Wed, 30 Aug 2017 15:33:09 GMT
+      Content-Length:
+      - '1505'
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"Bearer","expires_in":"3600","ext_expires_in":"0","expires_on":"1504110788","not_before":"1504106888","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4ODgsIm5iZiI6MTUwNDEwNjg4OCwiZXhwIjoxNTA0MTEwNzg4LCJhaW8iOiJZMkZnWURpaU84L3Mzc21YUmR4TGc4N3pCUFJOQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieHl2cHViR2ZhRW1ZZllIdHJIVVNBQSIsInZlciI6IjEuMCJ9.KtY_qul3sPMRTk1G8dVaWBI9STS2XHIfnUHM8cHKj5Q56Ow3kJkGuAWs4fxBgnitN2kk4WSqg_i2geYoOThW0rl328fQnL22At7JhRCw7N-9LHT9ho2Ygm8MxgdJtRNg2zure-amphl4GnnLULXOeaXoPx93w6bA4D5wPGlI0OryVV79hivQgyHc2f91OjawotTjt5yEGQNAWf3MhXrQNJGbZ_1VzrV1p8wJkgUXiCgjsybXPSjZvKwf7hEG8yVuJxNykO7BLCrBtSIpW07gtRboHXujCwVOxx74lnQS8LrDM-_DZGqRA41NIDOZuZ6pruQIHp2EHEI0WfUsMqr9rw"}'
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:09 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions?api-version=2016-06-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4ODgsIm5iZiI6MTUwNDEwNjg4OCwiZXhwIjoxNTA0MTEwNzg4LCJhaW8iOiJZMkZnWURpaU84L3Mzc21YUmR4TGc4N3pCUFJOQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieHl2cHViR2ZhRW1ZZllIdHJIVVNBQSIsInZlciI6IjEuMCJ9.KtY_qul3sPMRTk1G8dVaWBI9STS2XHIfnUHM8cHKj5Q56Ow3kJkGuAWs4fxBgnitN2kk4WSqg_i2geYoOThW0rl328fQnL22At7JhRCw7N-9LHT9ho2Ygm8MxgdJtRNg2zure-amphl4GnnLULXOeaXoPx93w6bA4D5wPGlI0OryVV79hivQgyHc2f91OjawotTjt5yEGQNAWf3MhXrQNJGbZ_1VzrV1p8wJkgUXiCgjsybXPSjZvKwf7hEG8yVuJxNykO7BLCrBtSIpW07gtRboHXujCwVOxx74lnQS8LrDM-_DZGqRA41NIDOZuZ6pruQIHp2EHEI0WfUsMqr9rw
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Tenant-Reads:
+      - '14996'
+      X-Ms-Request-Id:
+      - 07146edb-f227-4173-a882-ca8e337f2a57
+      X-Ms-Correlation-Request-Id:
+      - 07146edb-f227-4173-a882-ca8e337f2a57
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153309Z:07146edb-f227-4173-a882-ca8e337f2a57
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 30 Aug 2017 15:33:08 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
+        Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:09 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers?api-version=2015-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4ODgsIm5iZiI6MTUwNDEwNjg4OCwiZXhwIjoxNTA0MTEwNzg4LCJhaW8iOiJZMkZnWURpaU84L3Mzc21YUmR4TGc4N3pCUFJOQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieHl2cHViR2ZhRW1ZZllIdHJIVVNBQSIsInZlciI6IjEuMCJ9.KtY_qul3sPMRTk1G8dVaWBI9STS2XHIfnUHM8cHKj5Q56Ow3kJkGuAWs4fxBgnitN2kk4WSqg_i2geYoOThW0rl328fQnL22At7JhRCw7N-9LHT9ho2Ygm8MxgdJtRNg2zure-amphl4GnnLULXOeaXoPx93w6bA4D5wPGlI0OryVV79hivQgyHc2f91OjawotTjt5yEGQNAWf3MhXrQNJGbZ_1VzrV1p8wJkgUXiCgjsybXPSjZvKwf7hEG8yVuJxNykO7BLCrBtSIpW07gtRboHXujCwVOxx74lnQS8LrDM-_DZGqRA41NIDOZuZ6pruQIHp2EHEI0WfUsMqr9rw
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14699'
+      X-Ms-Request-Id:
+      - 43932ff8-8519-4012-b995-e9266a44ebd4
+      X-Ms-Correlation-Request-Id:
+      - 43932ff8-8519-4012-b995-e9266a44ebd4
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153310Z:43932ff8-8519-4012-b995-e9266a44ebd4
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 30 Aug 2017 15:33:10 GMT
+      Content-Length:
+      - '241615'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","North Central
+        US","South Central US","West Central US","West US","West US 2","Canada Central","Canada
+        East","North Europe","West Europe","UK South","UK West","East Asia","Southeast
+        Asia","Japan East","Japan West","Korea Central","Korea South","Brazil South","Central
+        India","South India","West India"],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"validateServiceName","locations":[],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"checkServiceNameAvailability","locations":[],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"reportFeedback","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"checkFeedbackRequired","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Automation","namespace":"Microsoft.Automation","authorizations":[{"applicationId":"fc75330b-179d-49af-87dd-3b1acf6827fa","roleDefinitionId":"95fd5de3-d071-4362-92bf-cf341c1de832"}],"resourceTypes":[{"resourceType":"automationAccounts","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
+        South","UK South","West Central US","North Europe","Canada Central","Australia
+        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/runbooks","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
+        South","UK South","West Central US","North Europe","Canada Central","Australia
+        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/configurations","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","North
+        Central US","Brazil South","UK South","West Central US","Central India","Australia
+        Southeast","Canada Central","North Europe"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/webhooks","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
+        South","UK South","West Central US","North Europe","Canada Central","Australia
+        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"operations","locations":["South
+        Central US"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/softwareUpdateConfigurations","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
+        South","UK South","West Central US","North Europe","Canada Central","Australia
+        Southeast","Central India"],"apiVersions":["2017-05-15-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Backup","namespace":"Microsoft.Backup","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"BackupVault","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India"],"apiVersions":["2015-03-15","2014-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Batch","namespace":"Microsoft.Batch","authorization":{"applicationId":"ddbf3205-c6bd-46ae-8127-60eb93363864","roleDefinitionId":"b7f84953-1d03-4eab-9ea4-45f065258ff8"},"resourceTypes":[{"resourceType":"batchAccounts","locations":["West
+        Europe","East US","East US 2","West US","North Central US","Brazil South","North
+        Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
+        West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
+        East","South India","Central India","Canada Central","Canada East","UK South","UK
+        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01","2015-07-01","2014-05-01-privatepreview"]},{"resourceType":"operations","locations":["West
+        Europe","East US","East US 2","West US","North Central US","Brazil South","North
+        Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
+        West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
+        East","South India","Central India","Canada Central","Canada East","UK South","UK
+        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations/quotas","locations":["West
+        Europe","East US","East US 2","West US","North Central US","Brazil South","North
+        Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
+        West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
+        East","South India","Central India","Canada Central","Canada East","UK South","UK
+        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]}],"registrationState":"Unregistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicCompute","namespace":"Microsoft.ClassicCompute","resourceTypes":[{"resourceType":"domainNames","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
+        Central","Canada East","UK South","UK West","West US","Central US","South
+        Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
+        East","Australia Southeast","West US 2","West Central US","South India","Central
+        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
+        Central","Canada East","UK South","UK West","West US","Central US","South
+        Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
+        East","Australia Southeast","West US 2","West Central US","South India","Central
+        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
+        Central US","South Central US","East US","East US 2","Canada Central","Canada
+        East","West US","West US 2","West Central US","Central US","East Asia","Southeast
+        Asia","North Europe","West Europe","UK South","UK West","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operatingSystems","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"operatingSystemFamilies","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicNetwork","namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"virtualNetworks/remoteVirtualNetworkPeeringProxies","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"reservedIps","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicStorage","namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
+        US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
+        Asia","Australia East","Australia Southeast","South India","Central India","West
+        India","West US 2","West Central US","East US","East US 2","North Central
+        US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
+        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
+        US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
+        Asia","Australia East","Australia Southeast","South India","Central India","West
+        India","West US 2","West Central US","East US","East US 2","North Central
+        US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
+        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"vmImages","locations":[],"apiVersions":["2016-11-01"]},{"resourceType":"publicImages","locations":[],"apiVersions":["2016-11-01","2016-04-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"osPlatformImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Compute","namespace":"Microsoft.Compute","authorization":{"applicationId":"60e6cd67-9c8c-4951-9b3c-23c25a2169af","roleDefinitionId":"e4770acb-272e-4dc8-87f3-12f44a612224"},"resourceTypes":[{"resourceType":"availabilitySets","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30"]},{"resourceType":"locations/usages","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"disks","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"snapshots","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"locations/diskoperations","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"images","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
+        US","East US","South Central US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","East Asia","Japan
+        East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/webhooks","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/ping","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/getCallbackConfig","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/listEvents","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"locations","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"locations/operationResults","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/GetCredentials","locations":["West
+        US","East US","South Central US","West Europe"],"apiVersions":["2016-06-27-preview"]},{"resourceType":"registries/listCredentials","locations":["South
+        Central US","East US","West US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","East Asia","Japan
+        East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/regenerateCredential","locations":["South
+        Central US","West US","East US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","East Asia","Japan
+        East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/listUsages","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/regenerateCredentials","locations":["West
+        US","East US","South Central US","West Europe"],"apiVersions":["2016-06-27-preview"]},{"resourceType":"checkNameAvailability","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview","2017-03-01","2016-06-27-preview"]},{"resourceType":"operations","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview","2017-03-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerService","namespace":"Microsoft.ContainerService","authorization":{"applicationId":"7319c514-987d-4e9b-ac3d-d38c4f427f4c","roleDefinitionId":"1b4a0c7f-2217-416f-acfa-cf73452fdc1c"},"resourceTypes":[{"resourceType":"containerServices","locations":["Japan
+        East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
+        East","Australia Southeast","Brazil South","Southeast Asia","West US","North
+        Central US","West Europe","North Europe","East US","UK West","UK South","West
+        Central US","West US 2","South India","Central India","West India","Canada
+        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
+        East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
+        East","Australia Southeast","Brazil South","Southeast Asia","West US","North
+        Central US","West Europe","North Europe","East US","UK West","UK South","West
+        Central US","West US 2","South India","Central India","West India","Canada
+        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DevTestLab","namespace":"Microsoft.DevTestLab","authorization":{"applicationId":"1a14be2a-e903-4cec-99cf-b2e209259a0f","roleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525"},"resourceTypes":[{"resourceType":"labs","locations":["West
+        Central US","Japan East","West US","Australia Southeast","Canada Central","Central
+        India","Central US","East Asia","Korea Central","North Europe","South Central
+        US","UK West","Australia East","Brazil South","Canada East","East US","East
+        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"schedules","locations":["West
+        Central US","Japan East","West US","Australia Southeast","Canada Central","Central
+        India","Central US","East Asia","Korea Central","North Europe","South Central
+        US","UK West","Australia East","Brazil South","Canada East","East US","East
+        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"labs/virtualMachines","locations":["West
+        Central US","Japan East","West US","Australia Southeast","Canada Central","Central
+        India","Central US","East Asia","Korea Central","North Europe","South Central
+        US","UK West","Australia East","Brazil South","Canada East","East US","East
+        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"labs/serviceRunners","locations":["Central
+        US","East US 2","South Central US"],"apiVersions":["2017-04-26-preview","2016-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"locations/operations","locations":["West
+        Central US","Japan East","West US","Australia Southeast","Canada Central","Central
+        India","Central US","East Asia","Korea Central","North Europe","South Central
+        US","UK West","Australia East","Brazil South","Canada East","East US","East
+        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"}],"resourceTypes":[{"resourceType":"components","locations":["East
+        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
+        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01","2014-04-01"]},{"resourceType":"queries","locations":["East
+        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"alertrules","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2016-03-01","2015-04-01","2014-04-01"]},{"resourceType":"autoscalesettings","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2015-04-01","2014-04-01"]},{"resourceType":"eventtypes","locations":[],"apiVersions":["2017-03-01-preview","2016-09-01-preview","2015-04-01","2014-11-01","2014-04-01"]},{"resourceType":"locations","locations":["East
+        US"],"apiVersions":["2015-04-01","2014-04-01"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2015-04-01","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-04-01","2014-06-01","2014-04-01"]},{"resourceType":"automatedExportSettings","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2015-04-01","2014-04-01"]},{"resourceType":"diagnosticSettings","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2017-05-01-preview","2016-09-01","2015-07-01"]},{"resourceType":"diagnosticSettingsCategories","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"extendedDiagnosticSettings","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2017-02-01"]},{"resourceType":"metricDefinitions","locations":["East
+        US","West US","West Europe","East Asia","Southeast Asia","Japan East","Japan
+        West","North Central US","South Central US","East US 2","Canada East","Canada
+        Central","Central US","Australia East","Australia Southeast","Brazil South","South
+        India","Central India","West India","North Europe","West US 2","West Central
+        US","Korea South","Korea Central","UK South","UK West","Global"],"apiVersions":["2017-05-01-preview","2016-03-01","2015-07-01"]},{"resourceType":"logDefinitions","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2015-07-01"]},{"resourceType":"eventCategories","locations":[],"apiVersions":["2015-04-01"]},{"resourceType":"metrics","locations":["East
+        US","West US","West Europe","East Asia","Southeast Asia","Japan East","Japan
+        West","North Central US","South Central US","East US 2","Canada East","Canada
+        Central","Central US","Australia East","Australia Southeast","Brazil South","South
+        India","Central India","West India","North Europe","West US 2","West Central
+        US","Korea South","Korea Central","UK South","UK West"],"apiVersions":["2017-05-01-preview","2016-09-01","2016-06-01"]},{"resourceType":"actiongroups","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]},{"resourceType":"activityLogAlerts","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.KeyVault","namespace":"Microsoft.KeyVault","resourceTypes":[{"resourceType":"vaults","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/accessPolicies","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-10-01","2015-06-01","2014-12-19-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"deletedVaults","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-10-01"]},{"resourceType":"locations/deletedVaults","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorization":{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"routeTables","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2017-04-26-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"]},{"resourceType":"workspaces/dataSources","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"storageInsightConfigs","locations":[],"apiVersions":["2014-10-10"]},{"resourceType":"workspaces/linkedServices","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"linkTargets","locations":["East
+        US"],"apiVersions":["2015-03-20"]},{"resourceType":"operations","locations":[],"apiVersions":["2014-11-10"]},{"resourceType":"devices","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationsManagement","namespace":"Microsoft.OperationsManagement","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"aa249101-6816-4966-aafa-08175d795f14"},"resourceTypes":[{"resourceType":"solutions","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Portal","namespace":"Microsoft.Portal","resourceTypes":[{"resourceType":"dashboards","locations":["Central
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
+        East","West India","South India","Central India","Canada Central","Canada
+        East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"operations","locations":["Central
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
+        East","West India","South India","Central India","Canada Central","Canada
+        East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"consoles","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/consoles","locations":["West
+        US","East US","Central India","North Europe","West Europe","South Central
+        US","Southeast Asia"],"apiVersions":["2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
+        US","East US","Central India","North Europe","West Europe","South Central
+        US","Southeast Asia"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","Canada Central","Canada East","West Central US","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-07-01","2016-12-01","2016-08-10","2016-06-01","2016-05-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"operations","locations":["Southeast
+        Asia"],"apiVersions":["2016-08-10","2016-06-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01"]},{"resourceType":"locations/backupStatus","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]},{"resourceType":"locations/allocatedStamp","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]},{"resourceType":"locations/allocateStamp","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ResourceHealth","namespace":"Microsoft.ResourceHealth","authorization":{"applicationId":"8bdebf23-c0fe-4187-a378-717ad86f6a53","roleDefinitionId":"cc026344-c8b1-4561-83ba-59eba84b27cc"},"resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2017-07-01","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"notifications","locations":["Australia
+        Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Security","namespace":"Microsoft.Security","authorization":{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatuses","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/virtualMachines","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/endpoints","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/subnets","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"tasks","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"alerts","locations":["Central
+        US","East US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"monitoring","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"monitoring/patch","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"monitoring/baseline","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"monitoring/antimalware","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"dataCollectionAgents","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"dataCollectionResults","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"pricings","locations":["Central
+        US","East US"],"apiVersions":["2017-08-01-preview"]},{"resourceType":"complianceResults","locations":["Central
+        US","East US"],"apiVersions":["2017-08-01"]},{"resourceType":"policies","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"appliances","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"webApplicationFirewalls","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/webApplicationFirewalls","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securitySolutions","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/securitySolutions","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securitySolutionsReferenceData","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/securitySolutionsReferenceData","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"jitNetworkAccessPolicies","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/jitNetworkAccessPolicies","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatusesSummaries","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/alerts","locations":["Central
+        US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/tasks","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.SiteRecovery","namespace":"Microsoft.SiteRecovery","authorization":{"applicationId":"b8340c3b-9267-498f-b21a-15d5547fd85e","roleDefinitionId":"8A00C8EA-8F1B-45A7-8F64-F4CC61EEE9B6"},"resourceTypes":[{"resourceType":"SiteRecoveryVault","locations":["East
+        US","West US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","Australia East","Australia Southeast","Brazil South","North
+        Central US","South Central US","Central US","East US 2","Central India","South
+        India"],"apiVersions":["2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Sql","namespace":"Microsoft.Sql","authorizations":[{"applicationId":"e4ab13ed-33cb-41b4-9140-6e264582cf85","roleDefinitionId":"ec3ddc95-44dc-47a2-9926-5e9f5ffd44ec"},{"applicationId":"0130cc9f-7ac5-4026-bd5f-80a08a54e6d9","roleDefinitionId":"45e8abf8-0ec4-44f3-9c37-cff4f7779302"},{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},{"applicationId":"76c7f279-7959-468f-8943-3954880e0d8c","roleDefinitionId":"7f7513a8-73f9-4c5f-97a2-c41f0ea783ef"}],"resourceTypes":[{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/capabilities","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverKeyOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/keys","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/encryptionProtector","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/communicationLinks","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recoverableDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/importExportOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/operationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/firewallrules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/elasticpools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-09-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/dnsAliases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/failoverGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/virtualNetworkRules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/virtualNetworkRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/virtualNetworkRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/databaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/extensions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditRecords","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/VulnerabilityAssessmentScans","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentScans","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups/syncMembers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/syncAgents","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncMemberOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncAgentOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncDatabaseIds","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorization":{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
+        US","West US","West Europe","North Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":["East
+        US","West US","West Europe","North Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Web","namespace":"Microsoft.Web","authorization":{"applicationId":"abfa0a7c-a6b6-4736-8310-5855508787cd","roleDefinitionId":"f47ed98b-b063-4a5b-9e10-4b9b44fa7735"},"resourceTypes":[{"resourceType":"sites/extensions","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots/extensions","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/instances","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots/instances","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/instances/extensions","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots/instances/extensions","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/publicCertificates","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots/publicCertificates","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"publishingUsers","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"ishostnameavailable","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"validate","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"isusernameavailable","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sourceControls","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"availableStacks","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"listSitesAssignedToHostName","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"sites/hostNameBindings","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"sites/domainOwnershipIdentifiers","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"sites/slots/hostNameBindings","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"operations","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"certificates","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms/workers","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"runtimes","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"sites/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"sites/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"sites/slots/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"sites/slots/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"serverFarms/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"serverFarms/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"sites/recommendations","locations":[],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"georegions","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/premieraddons","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01"]},{"resourceType":"hostingEnvironments","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/instances","locations":[],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/instances/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/instances/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/instances","locations":[],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/instances/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/instances/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"deploymentLocations","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"functions","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"deletedSites","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"ishostingenvironmentnameavailable","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"classicMobileServices","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"connections","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/managedApis","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/apiOperations","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"connectionGateways","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/connectionGatewayInstallations","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"checkNameAvailability","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"billingMeters","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/84codes.CloudAMQP","namespace":"84codes.CloudAMQP","resourceTypes":[{"resourceType":"servers","locations":["East
+        US 2","Central US","East US","North Central US","South Central US","West US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast"],"apiVersions":["2016-08-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/AppDynamics.APM","namespace":"AppDynamics.APM","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2016-05-26"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-05-26"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-05-26"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-05-26"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-05-26"]},{"resourceType":"locations/operationResults","locations":["West
+        US"],"apiVersions":["2016-05-26"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Aspera.Transfers","namespace":"Aspera.Transfers","resourceTypes":[{"resourceType":"services","locations":["West
+        US","North Europe","Central US","East US","West Europe","East Asia","Southeast
+        Asia","Japan East","East US 2","Japan West"],"apiVersions":["2016-03-25"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-03-25"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-03-25"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-03-25"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Auth0.Cloud","namespace":"Auth0.Cloud","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-11-23"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Citrix.Cloud","namespace":"Citrix.Cloud","resourceTypes":[{"resourceType":"accounts","locations":["West
+        US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Cloudyn.Analytics","namespace":"Cloudyn.Analytics","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US"],"apiVersions":["2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Conexlink.MyCloudIT","namespace":"Conexlink.MyCloudIT","resourceTypes":[{"resourceType":"accounts","locations":["Central
+        US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Crypteron.DataSecurity","namespace":"Crypteron.DataSecurity","resourceTypes":[{"resourceType":"apps","locations":["West
+        US"],"apiVersions":["2016-08-12"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-12"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-12"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-12"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Dynatrace.DynatraceSaaS","namespace":"Dynatrace.DynatraceSaaS","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-09-27"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Dynatrace.Ruxit","namespace":"Dynatrace.Ruxit","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US"],"apiVersions":["2016-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-09-07","2016-04-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-04-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/LiveArena.Broadcast","namespace":"LiveArena.Broadcast","resourceTypes":[{"resourceType":"services","locations":["West
+        US","North Europe","Japan West","Japan East","East Asia","West Europe","East
+        US","Southeast Asia","Central US"],"apiVersions":["2016-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Lombiq.DotNest","namespace":"Lombiq.DotNest","resourceTypes":[{"resourceType":"sites","locations":["East
+        US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Mailjet.Email","namespace":"Mailjet.Email","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]},{"resourceType":"diagnosticSettings","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"addsservices","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"configuration","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"agents","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"aadsupportcases","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"reports","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"servicehealthmetrics","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"logs","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"anonymousapiusers","locations":["West
+        US"],"apiVersions":["2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AnalysisServices","namespace":"Microsoft.AnalysisServices","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"servers","locations":["West
+        US","North Europe","South Central US","West Europe","West Central US","Southeast
+        Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
+        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/checkNameAvailability","locations":["West
+        US","North Europe","South Central US","West Europe","West Central US","Southeast
+        Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
+        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationresults","locations":["West
+        US","North Europe","South Central US","West Europe","West Central US","Southeast
+        Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
+        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationstatuses","locations":["West
+        US","North Europe","South Central US","West Europe","West Central US","Southeast
+        Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
+        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"operations","locations":["East
+        US 2","West Central US"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AppService","namespace":"Microsoft.AppService","authorization":{"applicationId":"dee7ba80-6a55-4f3b-a86c-746a9231ae49","roleDefinitionId":"6715d172-49c4-46f6-bb21-60512a8689dc"},"resourceTypes":[{"resourceType":"apiapps","locations":["East
+        US","West US","South Central US","North Europe","East Asia","Japan East","West
+        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
+        South","East US 2","Australia Southeast","Australia East","West India","South
+        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"appIdentities","locations":["East
+        US","West US","South Central US","North Europe","East Asia","Japan East","West
+        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
+        South","East US 2","Australia Southeast","Australia East","West India","South
+        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"gateways","locations":["East
+        US","West US","South Central US","North Europe","East Asia","Japan East","West
+        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
+        South","East US 2","Australia Southeast","Australia East","West India","South
+        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"deploymenttemplates","locations":[],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Authorization","namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"roleDefinitions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"classicAdministrators","locations":[],"apiVersions":["2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"permissions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"locks","locations":[],"apiVersions":["2017-04-01","2016-09-01","2015-06-01","2015-05-01-preview","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-01-01","2014-10-01-preview","2014-06-01"]},{"resourceType":"policyDefinitions","locations":[],"apiVersions":["2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"policySetDefinitions","locations":[],"apiVersions":["2017-06-01-preview"]},{"resourceType":"policyAssignments","locations":[],"apiVersions":["2017-06-01-preview","2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"providerOperations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01-preview","2015-07-01"]},{"resourceType":"elevateAccess","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureActiveDirectory","namespace":"Microsoft.AzureActiveDirectory","resourceTypes":[{"resourceType":"b2cDirectories","locations":["Global","United
+        States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureStack","namespace":"Microsoft.AzureStack","resourceTypes":[{"resourceType":"operations","locations":["Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations","locations":["West
+        Central US","Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations/products","locations":["West
+        Central US","Global"],"apiVersions":["2017-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Billing","namespace":"Microsoft.Billing","resourceTypes":[{"resourceType":"BillingPeriods","locations":["Central
+        US"],"apiVersions":["2017-04-24-preview"]},{"resourceType":"Invoices","locations":["Central
+        US"],"apiVersions":["2017-04-24-preview","2017-02-27-preview"]},{"resourceType":"operations","locations":["Central
+        US"],"apiVersions":["2017-04-24-preview","2017-02-27-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BingMaps","namespace":"Microsoft.BingMaps","resourceTypes":[{"resourceType":"mapApis","locations":["West
+        US"],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-18","2015-07-02"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BizTalkServices","namespace":"Microsoft.BizTalkServices","resourceTypes":[{"resourceType":"BizTalk","locations":["East
+        US","West US","North Europe","West Europe","Southeast Asia","East Asia","North
+        Central US","Japan West","Japan East","South Central US"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Cache","namespace":"Microsoft.Cache","authorization":{"applicationId":"96231a05-34ce-4eb4-aa6a-70759cbb5e83","roleDefinitionId":"4f731528-ba85-45c7-acfb-cd0a9b3cf31b"},"resourceTypes":[{"resourceType":"Redis","locations":["North
+        Central US","South Central US","Central US","West Europe","North Europe","West
+        US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
+        Asia","East Asia","Australia East","Australia Southeast","Central India","West
+        India","Canada Central","Canada East","UK South","UK West","West US 2","West
+        Central US","South India","Korea Central","Korea South"],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","South Central US","Central US","West Europe","North Europe","West
+        US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
+        Asia","East Asia","Australia East","Australia Southeast","Central India","West
+        India","South India","Canada Central","Canada East","UK South","UK West","West
+        US 2","West Central US","Korea Central","Korea South"],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01"]},{"resourceType":"Redis/metricDefinitions","locations":["North
+        Central US","South Central US","East US","East US 2","West US","Central US","East
+        Asia","Southeast Asia","North Europe","West Europe","Japan East","Japan West","Brazil
+        South","Australia Southeast","Australia East","Central India","West India","South
+        India","Canada Central","Canada East","UK West","UK South","West US 2","West
+        Central US","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"Redis/diagnosticSettings","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","West
+        US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
+        Asia","Australia East","Australia Southeast","Central India","West India","South
+        India","Canada Central","Canada East","UK West","UK South","West US 2","West
+        Central US","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Cdn","namespace":"Microsoft.Cdn","resourceTypes":[{"resourceType":"profiles","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/origins","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/customdomains","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/originresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/customdomainresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkResourceUsage","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02"]},{"resourceType":"validateProbe","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"edgenodes","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CertificateRegistration","namespace":"Microsoft.CertificateRegistration","authorization":{"applicationId":"f3c21649-0979-4721-ac85-b0216b2cf413","roleDefinitionId":"933fba7e-2ed3-4da8-973d-8bd8298a9b40"},"resourceTypes":[{"resourceType":"certificateOrders","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"certificateOrders/certificates","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"validateCertificateRegistrationInformation","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicSubscription","namespace":"Microsoft.ClassicSubscription","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicInfrastructureMigrate","namespace":"Microsoft.ClassicInfrastructureMigrate","authorization":{"applicationId":"5e5abe2b-83cd-4786-826a-a05653ebb103","roleDefinitionId":"766c4d9b-ef83-4f73-8352-1450a506a69b"},"resourceTypes":[{"resourceType":"classicInfrastructureResources","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","West
+        India","South India"],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CognitiveServices","namespace":"Microsoft.CognitiveServices","authorizations":[{"applicationId":"7d312290-28c8-473c-a0ed-8e53749b6d6d","roleDefinitionId":"5cb87f79-a7c3-4a95-9414-45b65974b51b"}],"resourceTypes":[{"resourceType":"accounts","locations":["Global","West
+        US","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"operations","locations":["Global","West
+        US","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations","locations":["Global","West
+        US","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/checkSkuAvailability","locations":["West
+        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/updateAccountsCreationSettings","locations":["West
+        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/accountsCreationSettings","locations":["West
+        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2016-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Commerce","namespace":"Microsoft.Commerce","resourceTypes":[{"resourceType":"UsageAggregates","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]},{"resourceType":"RateCard","locations":[],"apiVersions":["2016-08-31-preview","2015-06-01-preview","2015-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Consumption","namespace":"Microsoft.Consumption","resourceTypes":[{"resourceType":"reservationsummaries","locations":[],"apiVersions":["2017-01-30"]},{"resourceType":"reservationdetails","locations":[],"apiVersions":["2017-01-30"]},{"resourceType":"UsageDetails","locations":[],"apiVersions":["2017-06-30-preview","2017-04-24-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-30-preview","2017-04-24-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","resourceTypes":[{"resourceType":"containerGroups","locations":["West
+        US","East US","West Europe"],"apiVersions":["2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
+        US"],"apiVersions":["2016-04-08"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CustomerInsights","namespace":"Microsoft.CustomerInsights","authorization":{"applicationId":"38c77d00-5fcb-4cce-9d93-af4738258e3c","roleDefinitionId":"E006F9C7-F333-477C-8AD6-1F3A9FE87F55"},"resourceTypes":[{"resourceType":"hubs","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/profiles","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/interactions","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/authorizationPolicies","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/connectors","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/connectors/mappings","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/kpi","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/views","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/links","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/roleAssignments","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/roles","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/widgetTypes","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/suggestTypeSchema","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"operations","locations":["East
+        US 2"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataCatalog","namespace":"Microsoft.DataCatalog","resourceTypes":[{"resourceType":"catalogs","locations":["East
+        US","West US","Australia East","West Europe","North Europe","Southeast Asia","West
+        Central US"],"apiVersions":["2016-03-30","2015-07-01-preview"]},{"resourceType":"checkNameAvailability","locations":["West
+        Europe"],"apiVersions":["2016-03-30","2015-07-01-preview"]},{"resourceType":"operations","locations":["West
+        Europe"],"apiVersions":["2016-03-30","2015-07-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-03-30","2015-07-01-preview"]},{"resourceType":"locations/jobs","locations":["East
+        US","West US","Australia East","West Europe","North Europe","Southeast Asia","West
+        Central US"],"apiVersions":["2016-03-30","2015-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataFactory","namespace":"Microsoft.DataFactory","resourceTypes":[{"resourceType":"dataFactories","locations":["West
+        US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview","2014-04-01"]},{"resourceType":"factories","locations":["East
+        US"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
+        US"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
+        Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"dataFactories/metricDefinitions","locations":["North
+        Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"checkDataFactoryNameAvailability","locations":[],"apiVersions":["2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"checkAzureDataFactoryNameAvailability","locations":["West
+        US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"dataFactorySchema","locations":["West
+        US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"operations","locations":["West
+        US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeAnalytics","namespace":"Microsoft.DataLakeAnalytics","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/dataLakeStoreAccounts","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers/listSasTokens","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeStore","namespace":"Microsoft.DataLakeStore","authorization":{"applicationId":"e9f49c6b-5ce5-44c8-925d-015017e9f7ad","roleDefinitionId":"17eb9cca-f08a-4499-b2d3-852d175f614f"},"resourceTypes":[{"resourceType":"accounts","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/firewallRules","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","resourceTypes":[{"resourceType":"operations","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforPostgreSQL","namespace":"Microsoft.DBforPostgreSQL","resourceTypes":[{"resourceType":"operations","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
+        US","North Europe","East Asia","East US","West Europe","Southeast Asia","Japan
+        East","Japan West","Australia East","Australia Southeast","West US 2","West
+        Central US","East US 2","Central US","UK South","UK West","South India","Central
+        India"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"databaseAccountNames","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DomainRegistration","namespace":"Microsoft.DomainRegistration","authorization":{"applicationId":"ea2f600a-4980-45b7-89bf-d34da487bda1","roleDefinitionId":"54d7f2e3-5040-48a7-ae90-eebf629cfa0b"},"resourceTypes":[{"resourceType":"domains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"domains/domainOwnershipIdentifiers","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"topLevelDomains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"checkDomainAvailability","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"listDomainRecommendations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"validateDomainRegistrationInformation","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"generateSsoRequest","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DynamicsLcs","namespace":"Microsoft.DynamicsLcs","resourceTypes":[{"resourceType":"lcsprojects","locations":["Brazil
+        South","East Asia","East US","Japan East","Japan West","North Central US","North
+        Europe","South Central US","West Europe","West US","Southeast Asia","Central
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"lcsprojects/connectors","locations":["Brazil
+        South","East Asia","East US","Japan East","Japan West","North Central US","North
+        Europe","South Central US","West Europe","West US","Southeast Asia","Central
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"lcsprojects/clouddeployments","locations":["Brazil
+        South","East Asia","East US","Japan East","Japan West","North Central US","North
+        Europe","South Central US","West Europe","West US","Southeast Asia","Central
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"operations","locations":["Brazil
+        South","East Asia","East US","Japan East","Japan West","North Central US","North
+        Europe","South Central US","West Europe","West US","Southeast Asia","Central
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"topics","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operations","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"clusters/applications","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"clusters/operationresults","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations/capabilities","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations/operationresults","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations/azureasyncoperations","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations/validateCreateRequest","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"operations","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India"],"apiVersions":["2015-03-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ImportExport","namespace":"Microsoft.ImportExport","authorization":{"applicationId":"7de4d5c5-5b32-4235-b8a9-33b34d6bcd2a","roleDefinitionId":"9f7aa6bb-9454-46b6-8c01-a4b0f33ca151"},"resourceTypes":[{"resourceType":"jobs","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","North Central US","North Europe","South Central US","Southeast
+        Asia","South India","UK South","West Central US","West Europe","West India","West
+        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","North Central US","North Europe","South Central US","Southeast
+        Asia","South India","UK South","West Central US","West Europe","West India","West
+        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations/operationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","North Central US","North Europe","South Central US","Southeast
+        Asia","South India","UK South","West Central US","West Europe","West India","West
+        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","North Central US","North Europe","South Central US","Southeast
+        Asia","South India","UK South","West Central US","West Europe","West India","West
+        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Logic","namespace":"Microsoft.Logic","authorization":{"applicationId":"7cd684f4-8a78-49b0-91ec-6a35d38739ba","roleDefinitionId":"cb3ef1fb-6e31-49e2-9d87-ed821053fe58"},"resourceTypes":[{"resourceType":"workflows","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West"],"apiVersions":["2017-07-01","2016-10-01","2016-06-01","2015-08-01-preview","2015-02-01-preview"]},{"resourceType":"locations/workflows","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West"],"apiVersions":["2017-07-01","2016-10-01","2016-06-01","2015-08-01-preview","2015-02-01-preview"]},{"resourceType":"locations","locations":["North
+        Central US"],"apiVersions":["2017-07-01","2016-10-01","2016-06-01","2015-08-01-preview","2015-02-01-preview"]},{"resourceType":"operations","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West"],"apiVersions":["2017-07-01","2016-10-01","2016-06-01","2015-08-01-preview","2015-02-01-preview"]},{"resourceType":"integrationAccounts","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","West Central US"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"operations","locations":["South
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations","locations":["South
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operations","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"commitmentPlans","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
+        Central US","West US"],"apiVersions":["2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Media","namespace":"Microsoft.Media","authorization":{"applicationId":"374b2a64-3b6b-436b-934c-b820eacca870","roleDefinitionId":"aab70789-0cec-44b5-95d7-84b64c9487af"},"resourceTypes":[{"resourceType":"mediaservices","locations":["Japan
+        West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
+        US","West US","Australia East","Australia Southeast","Central US","Brazil
+        South","Central India","West India","South India","South Central US","Canada
+        Central","Canada East","West Central US"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
+        Central US","North Central US","East US 2","West US","West Europe","North
+        Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
+        East","UK South","West India"],"apiVersions":["2016-01-29"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-01-29"]},{"resourceType":"locations/checkNameAvailability","locations":["South
+        Central US","North Central US","East US 2","West US","West Europe","North
+        Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
+        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"operations","locations":["East
+        US 2"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Relay","namespace":"Microsoft.Relay","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US 2","West
+        US","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
+        East","West India","South India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
+        East","West India","South India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
+        Central US","South Central US","North Europe","West Europe","East Asia","Southeast
+        Asia","West US","East US","Japan West","Japan East","Brazil South","Central
+        US","East US 2","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-03-01","2016-01-01","2014-08-01-preview"]},{"resourceType":"operations","locations":["North
+        Central US","South Central US","North Europe","West Europe","East Asia","Southeast
+        Asia","West US","East US","Japan West","Japan East","Brazil South","Central
+        US","East US 2","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-03-01","2016-01-01","2014-08-01-preview"]},{"resourceType":"operationResults","locations":["North
+        Central US","South Central US","North Europe","West Europe","East Asia","Southeast
+        Asia","West US","East US","Japan West","Japan East","Brazil South","Central
+        US","East US 2","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-03-01","2016-01-01","2014-08-01-preview"]},{"resourceType":"flows","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast"],"apiVersions":["2015-08-01-preview","2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Search","namespace":"Microsoft.Search","resourceTypes":[{"resourceType":"searchServices","locations":["West
+        US","East US","North Europe","West Europe","Southeast Asia","East Asia","North
+        Central US","South Central US","Japan West","Australia East","Brazil South","Central
+        India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19","2015-02-28"]},{"resourceType":"checkServiceNameAvailability","locations":[],"apiVersions":["2015-02-28","2014-07-31-Preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2015-08-19"]},{"resourceType":"resourceHealthMetadata","locations":["West
+        US","East US","North Europe","West Europe","Southeast Asia","East Asia","North
+        Central US","South Central US","Japan West","Australia East","Brazil South","Central
+        India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US 2","West
+        US","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"premiumMessagingRegions","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceFabric","namespace":"Microsoft.ServiceFabric","authorization":{"applicationId":"74cb6831-0dbb-4be1-8206-fd4df301cdc2","roleDefinitionId":"e55cc65f-6903-4917-b4ef-f8d4640b57f5"},"resourceTypes":[{"resourceType":"clusters","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/clusterVersions","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operations","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Canada
+        Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","West Central US","Japan East","Japan West","Australia East","Australia
+        Southeast"],"apiVersions":["2017-06-01","2017-05-15","2017-01-01","2016-10-01","2016-06-01","2015-03-15","2014-09-01"]},{"resourceType":"operations","locations":["West
+        Central US","Southeast Asia"],"apiVersions":["2016-10-01","2016-06-01","2015-03-15","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StreamAnalytics","namespace":"Microsoft.StreamAnalytics","resourceTypes":[{"resourceType":"streamingjobs","locations":["Central
+        US","West Europe","East US 2","North Europe","Japan East","West US","Southeast
+        Asia","South Central US","East Asia","Japan West","North Central US","East
+        US","Australia East","Australia Southeast","Brazil South","Central India","West
+        Central US","UK South","UK West","Canada Central","Canada East","West US 2"],"apiVersions":["2017-04-01-preview","2016-03-01","2015-11-01","2015-10-01","2015-09-01","2015-08-01-preview","2015-06-01","2015-05-01","2015-04-01","2015-03-01-preview"]},{"resourceType":"locations","locations":["West
+        Europe","Central US","East US 2","North Europe","Japan East","West US","Southeast
+        Asia","South Central US","East Asia","Japan West","North Central US","East
+        US","Australia East","Australia Southeast","Brazil South","Central India","West
+        Central US","UK South","West US 2","UK West","Canada Central","Canada East"],"apiVersions":["2017-04-01-preview","2016-03-01","2015-11-01","2015-10-01","2015-09-01","2015-08-01-preview","2015-06-01","2015-05-01","2015-04-01","2015-03-01-preview"]},{"resourceType":"locations/quotas","locations":[],"apiVersions":["2017-04-01-preview","2016-03-01","2015-11-01","2015-10-01","2015-09-01","2015-08-01-preview","2015-06-01","2015-05-01","2015-04-01","2015-03-01-preview"]},{"resourceType":"streamingjobs/diagnosticSettings","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","Central
+        India","West Central US","UK South","UK West","Canada Central","Canada East","West
+        US 2","West US","Central US","South Central US","Japan East","Japan West","East
+        Asia","Southeast Asia","Australia East","Australia Southeast"],"apiVersions":["2014-04-01"]},{"resourceType":"streamingjobs/metricDefinitions","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","Central
+        India","West Central US","UK South","UK West","Canada Central","Canada East","West
+        US 2","West US","Central US","South Central US","Japan East","Japan West","East
+        Asia","Southeast Asia","Australia East","Australia Southeast"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":["West
+        Europe","West US","Central US","East US 2","North Europe","Japan East","Southeast
+        Asia","South Central US","East Asia","Japan West","North Central US","East
+        US","Australia East","Australia Southeast","Brazil South","Central India","West
+        Central US","UK South","UK West","Canada Central","Canada East","West US 2"],"apiVersions":["2017-04-01-preview","2016-03-01","2015-11-01","2015-10-01","2015-09-01","2015-08-01-preview","2015-06-01","2015-05-01","2015-04-01","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.support","namespace":"microsoft.support","resourceTypes":[{"resourceType":"operations","locations":["North
+        Central US","South Central US","Central US","West Europe","North Europe","West
+        US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
+        Asia","East Asia","Australia East","Australia Southeast"],"apiVersions":["2015-07-01-Preview","2015-03-01"]},{"resourceType":"supporttickets","locations":["North
+        Central US","South Central US","Central US","West Europe","North Europe","West
+        US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
+        Asia","East Asia","Australia East","Australia Southeast"],"apiVersions":["2015-07-01-Preview","2015-03-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.TimeSeriesInsights","namespace":"Microsoft.TimeSeriesInsights","authorizations":[{"applicationId":"120d688d-1518-4cf7-bd38-182f158850b6","roleDefinitionId":"5a43abdf-bb87-42c4-9e56-1c24bf364150"}],"resourceTypes":[{"resourceType":"environments","locations":["East
+        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/eventsources","locations":["East
+        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/referenceDataSets","locations":["East
+        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/accessPolicies","locations":["East
+        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"operations","locations":["East
+        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/project","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/extension","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"checkNameAvailability","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Myget.PackageManagement","namespace":"Myget.PackageManagement","resourceTypes":[{"resourceType":"services","locations":["West
+        Europe"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/NewRelic.APM","namespace":"NewRelic.APM","authorization":{"allowedThirdPartyExtensions":[{"name":"NewRelic_AzurePortal_APM"}]},"resourceTypes":[{"resourceType":"accounts","locations":["North
+        Central US","South Central US","West US","East US","North Europe","West Europe","Southeast
+        Asia","East Asia","Japan East","Japan West"],"apiVersions":["2014-10-01","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/nuubit.nextgencdn","namespace":"nuubit.nextgencdn","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US","East US 2","North Central US","South Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","West US","Central US"],"apiVersions":["2017-05-05"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-05"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-05-05"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-05-05"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Paraleap.CloudMonix","namespace":"Paraleap.CloudMonix","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2016-08-10"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-10"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-10"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Pokitdok.Platform","namespace":"Pokitdok.Platform","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2016-05-17"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-05-17"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-05-17"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-05-17"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RavenHq.Db","namespace":"RavenHq.Db","resourceTypes":[{"resourceType":"databases","locations":["East
+        US"],"apiVersions":["2016-07-18","2016-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-07-18","2016-06-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-07-18","2016-06-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-07-18","2016-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Raygun.CrashReporting","namespace":"Raygun.CrashReporting","resourceTypes":[{"resourceType":"apps","locations":["East
+        US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RedisLabs.Memcached","namespace":"RedisLabs.Memcached","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-07-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RedisLabs.Redis","namespace":"RedisLabs.Redis","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-07-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RevAPM.MobileCDN","namespace":"RevAPM.MobileCDN","resourceTypes":[{"resourceType":"accounts","locations":["Central
+        US","East US","East US 2","North Central US","South Central US","West US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast"],"apiVersions":["2016-08-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-24","2016-08-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sendgrid.Email","namespace":"Sendgrid.Email","resourceTypes":[{"resourceType":"accounts","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Canada Central","Canada
+        East","West Central US","West US 2","UK South","UK West"],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Signiant.Flight","namespace":"Signiant.Flight","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US","Central US","North Central US","South Central US","West US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast"],"apiVersions":["2015-06-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sparkpost.Basic","namespace":"Sparkpost.Basic","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2016-08-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/stackify.retrace","namespace":"stackify.retrace","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2016-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/SuccessBricks.ClearDB","namespace":"SuccessBricks.ClearDB","resourceTypes":[{"resourceType":"databases","locations":["Brazil
+        South","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","Southeast Asia","West Europe","West
+        US","South Central US","Australia East","Australia Southeast","Canada Central","Canada
+        East","Central India","South India","West India"],"apiVersions":["2014-04-01"]},{"resourceType":"clusters","locations":["Brazil
+        South","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","Southeast Asia","West Europe","West
+        US","Australia Southeast","Australia East","South Central US","Canada Central","Canada
+        East","Central India","South India","West India"],"apiVersions":["2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/TrendMicro.DeepSecurity","namespace":"TrendMicro.DeepSecurity","resourceTypes":[{"resourceType":"accounts","locations":["Central
+        US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
+        Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:10 GMT
+- request:
+    method: post
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
+    body:
+      encoding: UTF-8
+      string: '{"access":"read","durationInSeconds":3600}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4ODgsIm5iZiI6MTUwNDEwNjg4OCwiZXhwIjoxNTA0MTEwNzg4LCJhaW8iOiJZMkZnWURpaU84L3Mzc21YUmR4TGc4N3pCUFJOQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieHl2cHViR2ZhRW1ZZllIdHJIVVNBQSIsInZlciI6IjEuMCJ9.KtY_qul3sPMRTk1G8dVaWBI9STS2XHIfnUHM8cHKj5Q56Ow3kJkGuAWs4fxBgnitN2kk4WSqg_i2geYoOThW0rl328fQnL22At7JhRCw7N-9LHT9ho2Ygm8MxgdJtRNg2zure-amphl4GnnLULXOeaXoPx93w6bA4D5wPGlI0OryVV79hivQgyHc2f91OjawotTjt5yEGQNAWf3MhXrQNJGbZ_1VzrV1p8wJkgUXiCgjsybXPSjZvKwf7hEG8yVuJxNykO7BLCrBtSIpW07gtRboHXujCwVOxx74lnQS8LrDM-_DZGqRA41NIDOZuZ6pruQIHp2EHEI0WfUsMqr9rw
+      Content-Length:
+      - '42'
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '0'
+      Expires:
+      - "-1"
+      Location:
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/899e0080-3d64-41ef-b644-2631ee4e88ac?monitor=true&api-version=2017-03-30
+      Azure-Asyncoperation:
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/899e0080-3d64-41ef-b644-2631ee4e88ac?api-version=2017-03-30
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      X-Ms-Request-Id:
+      - 899e0080-3d64-41ef-b644-2631ee4e88ac
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Writes:
+      - '1193'
+      X-Ms-Correlation-Request-Id:
+      - eda23609-8589-4366-b9c9-a8058a7d8bef
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153310Z:eda23609-8589-4366-b9c9-a8058a7d8bef
+      Date:
+      - Wed, 30 Aug 2017 15:33:09 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:10 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/899e0080-3d64-41ef-b644-2631ee4e88ac?api-version=2017-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4ODgsIm5iZiI6MTUwNDEwNjg4OCwiZXhwIjoxNTA0MTEwNzg4LCJhaW8iOiJZMkZnWURpaU84L3Mzc21YUmR4TGc4N3pCUFJOQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieHl2cHViR2ZhRW1ZZllIdHJIVVNBQSIsInZlciI6IjEuMCJ9.KtY_qul3sPMRTk1G8dVaWBI9STS2XHIfnUHM8cHKj5Q56Ow3kJkGuAWs4fxBgnitN2kk4WSqg_i2geYoOThW0rl328fQnL22At7JhRCw7N-9LHT9ho2Ygm8MxgdJtRNg2zure-amphl4GnnLULXOeaXoPx93w6bA4D5wPGlI0OryVV79hivQgyHc2f91OjawotTjt5yEGQNAWf3MhXrQNJGbZ_1VzrV1p8wJkgUXiCgjsybXPSjZvKwf7hEG8yVuJxNykO7BLCrBtSIpW07gtRboHXujCwVOxx74lnQS8LrDM-_DZGqRA41NIDOZuZ6pruQIHp2EHEI0WfUsMqr9rw
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      X-Ms-Request-Id:
+      - dcca7493-8c1b-4bd6-bbcc-838a0e10fbaa
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14939'
+      X-Ms-Correlation-Request-Id:
+      - 73f0c136-de00-4683-8999-4f37c4f21cf4
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153311Z:73f0c136-de00-4683-8999-4f37c4f21cf4
+      Date:
+      - Wed, 30 Aug 2017 15:33:11 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"startTime\": \"2017-08-30T15:33:10.3504011+00:00\",\r\n  \"endTime\":
+        \"2017-08-30T15:33:10.5693143+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=050bef5b-8c1d-4a46-b9e2-740991ae63d3&sig=NE1iKizxiEPgKh55TLxKPrN5AHu%2Bt%2BwkfE9HQNWgHKo%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"899e0080-3d64-41ef-b644-2631ee4e88ac\"\r\n}"
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:11 GMT
+- request:
+    method: get
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=050bef5b-8c1d-4a46-b9e2-740991ae63d3&sig=NE1iKizxiEPgKh55TLxKPrN5AHu%2Bt%2BwkfE9HQNWgHKo=&sr=b&sv=2016-05-31
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      X-Ms-Range:
+      - bytes=0-0
+      Host:
+      - md-t4jdgqqlgszp.blob.core.windows.net
+  response:
+    status:
+      code: 206
+      message: Partial Content
+    headers:
+      Content-Length:
+      - '1'
+      Content-Type:
+      - application/octet-stream
+      Content-Range:
+      - bytes 0-0/34359738880
+      Last-Modified:
+      - Sat, 15 Jul 2017 14:23:07 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D4CB8D039FC699"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - a138f85f-0001-009f-76a5-21d997000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Meta-Pirtag:
+      - '1'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '20'
+      X-Ms-Copy-Id:
+      - 30cedd78-548a-4fd8-967e-f8344f587e3c
+      X-Ms-Copy-Source:
+      - http://md-t4jdgqqlgszp.blob.core.windows.net:8080/fg25xxtqx0gc/abcd?sv=2016-02-19&sr=b&st=2017-05-04T21%3a06%3a57Z&se=9999-12-31T23%3a59%3a59Z&sp=r&api-version=2016-02-19
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 34359738880/34359738880
+      X-Ms-Copy-Completion-Time:
+      - Thu, 04 May 2017 21:21:56 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Wed, 30 Aug 2017 15:33:11 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        6w==
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:11 GMT
+- request:
+    method: post
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
+    body:
+      encoding: UTF-8
+      string: '{"access":"read","durationInSeconds":3600}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4ODgsIm5iZiI6MTUwNDEwNjg4OCwiZXhwIjoxNTA0MTEwNzg4LCJhaW8iOiJZMkZnWURpaU84L3Mzc21YUmR4TGc4N3pCUFJOQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieHl2cHViR2ZhRW1ZZllIdHJIVVNBQSIsInZlciI6IjEuMCJ9.KtY_qul3sPMRTk1G8dVaWBI9STS2XHIfnUHM8cHKj5Q56Ow3kJkGuAWs4fxBgnitN2kk4WSqg_i2geYoOThW0rl328fQnL22At7JhRCw7N-9LHT9ho2Ygm8MxgdJtRNg2zure-amphl4GnnLULXOeaXoPx93w6bA4D5wPGlI0OryVV79hivQgyHc2f91OjawotTjt5yEGQNAWf3MhXrQNJGbZ_1VzrV1p8wJkgUXiCgjsybXPSjZvKwf7hEG8yVuJxNykO7BLCrBtSIpW07gtRboHXujCwVOxx74lnQS8LrDM-_DZGqRA41NIDOZuZ6pruQIHp2EHEI0WfUsMqr9rw
+      Content-Length:
+      - '42'
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '0'
+      Expires:
+      - "-1"
+      Location:
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/e9014734-fffd-4545-891c-b3541448a4a8?monitor=true&api-version=2017-03-30
+      Azure-Asyncoperation:
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/e9014734-fffd-4545-891c-b3541448a4a8?api-version=2017-03-30
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      X-Ms-Request-Id:
+      - e9014734-fffd-4545-891c-b3541448a4a8
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Writes:
+      - '1197'
+      X-Ms-Correlation-Request-Id:
+      - f3859083-1aea-4f9e-b6a7-ffbb9d07d28c
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153311Z:f3859083-1aea-4f9e-b6a7-ffbb9d07d28c
+      Date:
+      - Wed, 30 Aug 2017 15:33:11 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:11 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/e9014734-fffd-4545-891c-b3541448a4a8?api-version=2017-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4ODgsIm5iZiI6MTUwNDEwNjg4OCwiZXhwIjoxNTA0MTEwNzg4LCJhaW8iOiJZMkZnWURpaU84L3Mzc21YUmR4TGc4N3pCUFJOQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieHl2cHViR2ZhRW1ZZllIdHJIVVNBQSIsInZlciI6IjEuMCJ9.KtY_qul3sPMRTk1G8dVaWBI9STS2XHIfnUHM8cHKj5Q56Ow3kJkGuAWs4fxBgnitN2kk4WSqg_i2geYoOThW0rl328fQnL22At7JhRCw7N-9LHT9ho2Ygm8MxgdJtRNg2zure-amphl4GnnLULXOeaXoPx93w6bA4D5wPGlI0OryVV79hivQgyHc2f91OjawotTjt5yEGQNAWf3MhXrQNJGbZ_1VzrV1p8wJkgUXiCgjsybXPSjZvKwf7hEG8yVuJxNykO7BLCrBtSIpW07gtRboHXujCwVOxx74lnQS8LrDM-_DZGqRA41NIDOZuZ6pruQIHp2EHEI0WfUsMqr9rw
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      X-Ms-Request-Id:
+      - cd08d2dc-584d-4def-9af2-5126c12d0f55
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14698'
+      X-Ms-Correlation-Request-Id:
+      - 9bfc802a-60d0-4f70-b9fe-63ecd19fd7c5
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153311Z:9bfc802a-60d0-4f70-b9fe-63ecd19fd7c5
+      Date:
+      - Wed, 30 Aug 2017 15:33:11 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"startTime\": \"2017-08-30T15:33:11.2269931+00:00\",\r\n  \"endTime\":
+        \"2017-08-30T15:33:11.4457485+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=4ab3aa41-f66c-4d6b-b8c6-17a45e4abc3a&sig=WFUkgWq35Ufv3%2B%2FAiS8b4uXQ9%2B%2FNmzKCc45FtXaEY0A%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"e9014734-fffd-4545-891c-b3541448a4a8\"\r\n}"
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:11 GMT
+- request:
+    method: get
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=4ab3aa41-f66c-4d6b-b8c6-17a45e4abc3a&sig=WFUkgWq35Ufv3%2B/AiS8b4uXQ9%2B/NmzKCc45FtXaEY0A=&sr=b&sv=2016-05-31
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      X-Ms-Range:
+      - bytes=440-443
+      Host:
+      - md-t4jdgqqlgszp.blob.core.windows.net
+  response:
+    status:
+      code: 206
+      message: Partial Content
+    headers:
+      Content-Length:
+      - '4'
+      Content-Type:
+      - application/octet-stream
+      Content-Range:
+      - bytes 440-443/34359738880
+      Last-Modified:
+      - Sat, 15 Jul 2017 14:23:07 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D4CB8D039FC699"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - e7e76fef-0001-0079-47a5-21c867000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Meta-Pirtag:
+      - '1'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '20'
+      X-Ms-Copy-Id:
+      - 30cedd78-548a-4fd8-967e-f8344f587e3c
+      X-Ms-Copy-Source:
+      - http://md-t4jdgqqlgszp.blob.core.windows.net:8080/fg25xxtqx0gc/abcd?sv=2016-02-19&sr=b&st=2017-05-04T21%3a06%3a57Z&se=9999-12-31T23%3a59%3a59Z&sp=r&api-version=2016-02-19
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 34359738880/34359738880
+      X-Ms-Copy-Completion-Time:
+      - Thu, 04 May 2017 21:21:56 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Wed, 30 Aug 2017 15:33:11 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        U5MJAA==
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:12 GMT
+recorded_with: VCR 3.0.3

--- a/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_partType-1.yml
+++ b/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_partType-1.yml
@@ -39,25 +39,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - b9e92bc7-9fb1-4968-987d-81edac751200
+      - 43f6363c-b69f-4f6f-8174-ecc450351400
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAAA9kTklhVy7SJTGAzR-p1BcyZ4OUZQ0nHc-YU98WAd7z8_zPKCL2HbWr_DSUafS6TQv3ra1IjdFjKciOuuSi7y7bys0on7hSMrJ5hpgWSLgLjv0gAeeLiLVNKa4NIi2K-bF-a-T_THFNvwZJPRqnW-DYlfOJfPfSjLBriifa4xbUVtrqDHtmcR1BwTgoC9qw5AgAA;
+      - esctx=AQABAAAAAAA9kTklhVy7SJTGAzR-p1Bc50iHipsCNkZPuZHmlHlN_lPAdkGBOutrV_PLahyTlo81LjMSWoUKG2L2uXqc09TCN0wQZru-uHZYksHCgcnqW2rpx21B9xpjgXExBGTuqdPVnkPMhO02msAddxBJwe9Jiyw0-YugHSPU76Py8pQRJV2S_zq82j0eaT_WWJrteYkgAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=005; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=004; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Wed, 30 Aug 2017 15:33:09 GMT
+      - Wed, 30 Aug 2017 17:05:41 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3600","ext_expires_in":"0","expires_on":"1504110788","not_before":"1504106888","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4ODgsIm5iZiI6MTUwNDEwNjg4OCwiZXhwIjoxNTA0MTEwNzg4LCJhaW8iOiJZMkZnWURpaU84L3Mzc21YUmR4TGc4N3pCUFJOQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieHl2cHViR2ZhRW1ZZllIdHJIVVNBQSIsInZlciI6IjEuMCJ9.KtY_qul3sPMRTk1G8dVaWBI9STS2XHIfnUHM8cHKj5Q56Ow3kJkGuAWs4fxBgnitN2kk4WSqg_i2geYoOThW0rl328fQnL22At7JhRCw7N-9LHT9ho2Ygm8MxgdJtRNg2zure-amphl4GnnLULXOeaXoPx93w6bA4D5wPGlI0OryVV79hivQgyHc2f91OjawotTjt5yEGQNAWf3MhXrQNJGbZ_1VzrV1p8wJkgUXiCgjsybXPSjZvKwf7hEG8yVuJxNykO7BLCrBtSIpW07gtRboHXujCwVOxx74lnQS8LrDM-_DZGqRA41NIDOZuZ6pruQIHp2EHEI0WfUsMqr9rw"}'
+      string: '{"token_type":"Bearer","expires_in":"3600","ext_expires_in":"0","expires_on":"1504116341","not_before":"1504112441","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0NDEsIm5iZiI6MTUwNDExMjQ0MSwiZXhwIjoxNTA0MTE2MzQxLCJhaW8iOiJZMkZnWUFqbS9Od1p0bjFuNm1ISEJhZERiTi9GQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUERiMlE1LTJiMC1CZE96RVVEVVVBQSIsInZlciI6IjEuMCJ9.P7qltdT57vynnvnukSfmh0nDfSK14eipWa82TqoPct0qms-cAv88unRZzRsim_67rTgEYcuxGzJ_y5B6syaRfxuMRlaAcfkgU4iymHA4YJz1SlNBXUGNP2TuhlAEepSqdd0x1QqST2jtqKrFVlMqyLonvBWjQpddfjjmn09EWiO8ii9bnbOdCtM2Amgk9yoCKADRPNZpmEexfxluvgeOmoKnUQJk9BgW2qQsI-VmStNLNYyIo71yPNFCA28mcMN_DRJHzTfrST4mh18UDbaKK5PdcO1KOGKangg2fkCij--CdH5KJYzm-XGuU8eygGwA2U86afhEAbfSA1rV4x7leg"}'
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:33:09 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:40 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -74,7 +74,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4ODgsIm5iZiI6MTUwNDEwNjg4OCwiZXhwIjoxNTA0MTEwNzg4LCJhaW8iOiJZMkZnWURpaU84L3Mzc21YUmR4TGc4N3pCUFJOQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieHl2cHViR2ZhRW1ZZllIdHJIVVNBQSIsInZlciI6IjEuMCJ9.KtY_qul3sPMRTk1G8dVaWBI9STS2XHIfnUHM8cHKj5Q56Ow3kJkGuAWs4fxBgnitN2kk4WSqg_i2geYoOThW0rl328fQnL22At7JhRCw7N-9LHT9ho2Ygm8MxgdJtRNg2zure-amphl4GnnLULXOeaXoPx93w6bA4D5wPGlI0OryVV79hivQgyHc2f91OjawotTjt5yEGQNAWf3MhXrQNJGbZ_1VzrV1p8wJkgUXiCgjsybXPSjZvKwf7hEG8yVuJxNykO7BLCrBtSIpW07gtRboHXujCwVOxx74lnQS8LrDM-_DZGqRA41NIDOZuZ6pruQIHp2EHEI0WfUsMqr9rw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0NDEsIm5iZiI6MTUwNDExMjQ0MSwiZXhwIjoxNTA0MTE2MzQxLCJhaW8iOiJZMkZnWUFqbS9Od1p0bjFuNm1ISEJhZERiTi9GQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUERiMlE1LTJiMC1CZE96RVVEVVVBQSIsInZlciI6IjEuMCJ9.P7qltdT57vynnvnukSfmh0nDfSK14eipWa82TqoPct0qms-cAv88unRZzRsim_67rTgEYcuxGzJ_y5B6syaRfxuMRlaAcfkgU4iymHA4YJz1SlNBXUGNP2TuhlAEepSqdd0x1QqST2jtqKrFVlMqyLonvBWjQpddfjjmn09EWiO8ii9bnbOdCtM2Amgk9yoCKADRPNZpmEexfxluvgeOmoKnUQJk9BgW2qQsI-VmStNLNYyIo71yPNFCA28mcMN_DRJHzTfrST4mh18UDbaKK5PdcO1KOGKangg2fkCij--CdH5KJYzm-XGuU8eygGwA2U86afhEAbfSA1rV4x7leg
       Host:
       - management.azure.com
   response:
@@ -95,23 +95,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14996'
+      - '14995'
       X-Ms-Request-Id:
-      - 07146edb-f227-4173-a882-ca8e337f2a57
+      - 2866416b-503a-4635-abc4-275b48d07c58
       X-Ms-Correlation-Request-Id:
-      - 07146edb-f227-4173-a882-ca8e337f2a57
+      - 2866416b-503a-4635-abc4-275b48d07c58
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153309Z:07146edb-f227-4173-a882-ca8e337f2a57
+      - EASTUS:20170830T170542Z:2866416b-503a-4635-abc4-275b48d07c58
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 30 Aug 2017 15:33:08 GMT
+      - Wed, 30 Aug 2017 17:05:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:33:09 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:40 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/azure_subscription_id/providers?api-version=2015-01-01
@@ -128,7 +128,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4ODgsIm5iZiI6MTUwNDEwNjg4OCwiZXhwIjoxNTA0MTEwNzg4LCJhaW8iOiJZMkZnWURpaU84L3Mzc21YUmR4TGc4N3pCUFJOQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieHl2cHViR2ZhRW1ZZllIdHJIVVNBQSIsInZlciI6IjEuMCJ9.KtY_qul3sPMRTk1G8dVaWBI9STS2XHIfnUHM8cHKj5Q56Ow3kJkGuAWs4fxBgnitN2kk4WSqg_i2geYoOThW0rl328fQnL22At7JhRCw7N-9LHT9ho2Ygm8MxgdJtRNg2zure-amphl4GnnLULXOeaXoPx93w6bA4D5wPGlI0OryVV79hivQgyHc2f91OjawotTjt5yEGQNAWf3MhXrQNJGbZ_1VzrV1p8wJkgUXiCgjsybXPSjZvKwf7hEG8yVuJxNykO7BLCrBtSIpW07gtRboHXujCwVOxx74lnQS8LrDM-_DZGqRA41NIDOZuZ6pruQIHp2EHEI0WfUsMqr9rw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0NDEsIm5iZiI6MTUwNDExMjQ0MSwiZXhwIjoxNTA0MTE2MzQxLCJhaW8iOiJZMkZnWUFqbS9Od1p0bjFuNm1ISEJhZERiTi9GQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUERiMlE1LTJiMC1CZE96RVVEVVVBQSIsInZlciI6IjEuMCJ9.P7qltdT57vynnvnukSfmh0nDfSK14eipWa82TqoPct0qms-cAv88unRZzRsim_67rTgEYcuxGzJ_y5B6syaRfxuMRlaAcfkgU4iymHA4YJz1SlNBXUGNP2TuhlAEepSqdd0x1QqST2jtqKrFVlMqyLonvBWjQpddfjjmn09EWiO8ii9bnbOdCtM2Amgk9yoCKADRPNZpmEexfxluvgeOmoKnUQJk9BgW2qQsI-VmStNLNYyIo71yPNFCA28mcMN_DRJHzTfrST4mh18UDbaKK5PdcO1KOGKangg2fkCij--CdH5KJYzm-XGuU8eygGwA2U86afhEAbfSA1rV4x7leg
       Host:
       - management.azure.com
   response:
@@ -147,17 +147,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14699'
+      - '14283'
       X-Ms-Request-Id:
-      - 43932ff8-8519-4012-b995-e9266a44ebd4
+      - 7645e982-dcd7-4bbc-977f-26dc300d8cff
       X-Ms-Correlation-Request-Id:
-      - 43932ff8-8519-4012-b995-e9266a44ebd4
+      - 7645e982-dcd7-4bbc-977f-26dc300d8cff
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153310Z:43932ff8-8519-4012-b995-e9266a44ebd4
+      - EASTUS:20170830T170542Z:7645e982-dcd7-4bbc-977f-26dc300d8cff
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 30 Aug 2017 15:33:10 GMT
+      - Wed, 30 Aug 2017 17:05:42 GMT
       Content-Length:
       - '241615'
     body:
@@ -1891,7 +1891,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:33:10 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:41 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
@@ -1908,7 +1908,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4ODgsIm5iZiI6MTUwNDEwNjg4OCwiZXhwIjoxNTA0MTEwNzg4LCJhaW8iOiJZMkZnWURpaU84L3Mzc21YUmR4TGc4N3pCUFJOQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieHl2cHViR2ZhRW1ZZllIdHJIVVNBQSIsInZlciI6IjEuMCJ9.KtY_qul3sPMRTk1G8dVaWBI9STS2XHIfnUHM8cHKj5Q56Ow3kJkGuAWs4fxBgnitN2kk4WSqg_i2geYoOThW0rl328fQnL22At7JhRCw7N-9LHT9ho2Ygm8MxgdJtRNg2zure-amphl4GnnLULXOeaXoPx93w6bA4D5wPGlI0OryVV79hivQgyHc2f91OjawotTjt5yEGQNAWf3MhXrQNJGbZ_1VzrV1p8wJkgUXiCgjsybXPSjZvKwf7hEG8yVuJxNykO7BLCrBtSIpW07gtRboHXujCwVOxx74lnQS8LrDM-_DZGqRA41NIDOZuZ6pruQIHp2EHEI0WfUsMqr9rw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0NDEsIm5iZiI6MTUwNDExMjQ0MSwiZXhwIjoxNTA0MTE2MzQxLCJhaW8iOiJZMkZnWUFqbS9Od1p0bjFuNm1ISEJhZERiTi9GQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUERiMlE1LTJiMC1CZE96RVVEVVVBQSIsInZlciI6IjEuMCJ9.P7qltdT57vynnvnukSfmh0nDfSK14eipWa82TqoPct0qms-cAv88unRZzRsim_67rTgEYcuxGzJ_y5B6syaRfxuMRlaAcfkgU4iymHA4YJz1SlNBXUGNP2TuhlAEepSqdd0x1QqST2jtqKrFVlMqyLonvBWjQpddfjjmn09EWiO8ii9bnbOdCtM2Amgk9yoCKADRPNZpmEexfxluvgeOmoKnUQJk9BgW2qQsI-VmStNLNYyIo71yPNFCA28mcMN_DRJHzTfrST4mh18UDbaKK5PdcO1KOGKangg2fkCij--CdH5KJYzm-XGuU8eygGwA2U86afhEAbfSA1rV4x7leg
       Content-Length:
       - '42'
       Host:
@@ -1927,34 +1927,34 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/899e0080-3d64-41ef-b644-2631ee4e88ac?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/b57daf9b-198a-4e20-8b88-869a0daf3e2f?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/899e0080-3d64-41ef-b644-2631ee4e88ac?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/b57daf9b-198a-4e20-8b88-869a0daf3e2f?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
       - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
       X-Ms-Request-Id:
-      - 899e0080-3d64-41ef-b644-2631ee4e88ac
+      - b57daf9b-198a-4e20-8b88-869a0daf3e2f
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
       - '1193'
       X-Ms-Correlation-Request-Id:
-      - eda23609-8589-4366-b9c9-a8058a7d8bef
+      - 7943b428-11c2-49a0-ac36-e69ab792d979
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153310Z:eda23609-8589-4366-b9c9-a8058a7d8bef
+      - EASTUS:20170830T170543Z:7943b428-11c2-49a0-ac36-e69ab792d979
       Date:
-      - Wed, 30 Aug 2017 15:33:09 GMT
+      - Wed, 30 Aug 2017 17:05:43 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:33:10 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:41 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/899e0080-3d64-41ef-b644-2631ee4e88ac?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/b57daf9b-198a-4e20-8b88-869a0daf3e2f?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -1968,7 +1968,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4ODgsIm5iZiI6MTUwNDEwNjg4OCwiZXhwIjoxNTA0MTEwNzg4LCJhaW8iOiJZMkZnWURpaU84L3Mzc21YUmR4TGc4N3pCUFJOQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieHl2cHViR2ZhRW1ZZllIdHJIVVNBQSIsInZlciI6IjEuMCJ9.KtY_qul3sPMRTk1G8dVaWBI9STS2XHIfnUHM8cHKj5Q56Ow3kJkGuAWs4fxBgnitN2kk4WSqg_i2geYoOThW0rl328fQnL22At7JhRCw7N-9LHT9ho2Ygm8MxgdJtRNg2zure-amphl4GnnLULXOeaXoPx93w6bA4D5wPGlI0OryVV79hivQgyHc2f91OjawotTjt5yEGQNAWf3MhXrQNJGbZ_1VzrV1p8wJkgUXiCgjsybXPSjZvKwf7hEG8yVuJxNykO7BLCrBtSIpW07gtRboHXujCwVOxx74lnQS8LrDM-_DZGqRA41NIDOZuZ6pruQIHp2EHEI0WfUsMqr9rw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0NDEsIm5iZiI6MTUwNDExMjQ0MSwiZXhwIjoxNTA0MTE2MzQxLCJhaW8iOiJZMkZnWUFqbS9Od1p0bjFuNm1ISEJhZERiTi9GQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUERiMlE1LTJiMC1CZE96RVVEVVVBQSIsInZlciI6IjEuMCJ9.P7qltdT57vynnvnukSfmh0nDfSK14eipWa82TqoPct0qms-cAv88unRZzRsim_67rTgEYcuxGzJ_y5B6syaRfxuMRlaAcfkgU4iymHA4YJz1SlNBXUGNP2TuhlAEepSqdd0x1QqST2jtqKrFVlMqyLonvBWjQpddfjjmn09EWiO8ii9bnbOdCtM2Amgk9yoCKADRPNZpmEexfxluvgeOmoKnUQJk9BgW2qQsI-VmStNLNYyIo71yPNFCA28mcMN_DRJHzTfrST4mh18UDbaKK5PdcO1KOGKangg2fkCij--CdH5KJYzm-XGuU8eygGwA2U86afhEAbfSA1rV4x7leg
       Host:
       - management.azure.com
   response:
@@ -1993,29 +1993,29 @@ http_interactions:
       X-Ms-Served-By:
       - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
       X-Ms-Request-Id:
-      - dcca7493-8c1b-4bd6-bbcc-838a0e10fbaa
+      - 1559c888-6735-466d-92bf-965ea6aa8fed
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14939'
+      - '14937'
       X-Ms-Correlation-Request-Id:
-      - 73f0c136-de00-4683-8999-4f37c4f21cf4
+      - d705bbc6-1e71-4582-a540-bcaafffb993c
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153311Z:73f0c136-de00-4683-8999-4f37c4f21cf4
+      - EASTUS:20170830T170543Z:d705bbc6-1e71-4582-a540-bcaafffb993c
       Date:
-      - Wed, 30 Aug 2017 15:33:11 GMT
+      - Wed, 30 Aug 2017 17:05:43 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-08-30T15:33:10.3504011+00:00\",\r\n  \"endTime\":
-        \"2017-08-30T15:33:10.5693143+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=050bef5b-8c1d-4a46-b9e2-740991ae63d3&sig=NE1iKizxiEPgKh55TLxKPrN5AHu%2Bt%2BwkfE9HQNWgHKo%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"899e0080-3d64-41ef-b644-2631ee4e88ac\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2017-08-30T17:05:42.8624806+00:00\",\r\n  \"endTime\":
+        \"2017-08-30T17:05:42.9874943+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=c79397b8-59cc-42ef-958e-940bdb0bf973&sig=t7L%2FmVN7SCscDF%2FLjOKBcQQEMezJ%2Be8vyaKJsFNTsGk%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"b57daf9b-198a-4e20-8b88-869a0daf3e2f\"\r\n}"
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:33:11 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:42 GMT
 - request:
     method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=050bef5b-8c1d-4a46-b9e2-740991ae63d3&sig=NE1iKizxiEPgKh55TLxKPrN5AHu%2Bt%2BwkfE9HQNWgHKo=&sr=b&sv=2016-05-31
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=c79397b8-59cc-42ef-958e-940bdb0bf973&sig=t7L/mVN7SCscDF/LjOKBcQQEMezJ%2Be8vyaKJsFNTsGk=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2050,7 +2050,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - a138f85f-0001-009f-76a5-21d997000000
+      - 016ad2bd-0001-00bd-06b2-21b7a1000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2076,13 +2076,13 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 30 Aug 2017 15:33:11 GMT
+      - Wed, 30 Aug 2017 17:05:43 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         6w==
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:33:11 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:42 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
@@ -2099,7 +2099,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4ODgsIm5iZiI6MTUwNDEwNjg4OCwiZXhwIjoxNTA0MTEwNzg4LCJhaW8iOiJZMkZnWURpaU84L3Mzc21YUmR4TGc4N3pCUFJOQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieHl2cHViR2ZhRW1ZZllIdHJIVVNBQSIsInZlciI6IjEuMCJ9.KtY_qul3sPMRTk1G8dVaWBI9STS2XHIfnUHM8cHKj5Q56Ow3kJkGuAWs4fxBgnitN2kk4WSqg_i2geYoOThW0rl328fQnL22At7JhRCw7N-9LHT9ho2Ygm8MxgdJtRNg2zure-amphl4GnnLULXOeaXoPx93w6bA4D5wPGlI0OryVV79hivQgyHc2f91OjawotTjt5yEGQNAWf3MhXrQNJGbZ_1VzrV1p8wJkgUXiCgjsybXPSjZvKwf7hEG8yVuJxNykO7BLCrBtSIpW07gtRboHXujCwVOxx74lnQS8LrDM-_DZGqRA41NIDOZuZ6pruQIHp2EHEI0WfUsMqr9rw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0NDEsIm5iZiI6MTUwNDExMjQ0MSwiZXhwIjoxNTA0MTE2MzQxLCJhaW8iOiJZMkZnWUFqbS9Od1p0bjFuNm1ISEJhZERiTi9GQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUERiMlE1LTJiMC1CZE96RVVEVVVBQSIsInZlciI6IjEuMCJ9.P7qltdT57vynnvnukSfmh0nDfSK14eipWa82TqoPct0qms-cAv88unRZzRsim_67rTgEYcuxGzJ_y5B6syaRfxuMRlaAcfkgU4iymHA4YJz1SlNBXUGNP2TuhlAEepSqdd0x1QqST2jtqKrFVlMqyLonvBWjQpddfjjmn09EWiO8ii9bnbOdCtM2Amgk9yoCKADRPNZpmEexfxluvgeOmoKnUQJk9BgW2qQsI-VmStNLNYyIo71yPNFCA28mcMN_DRJHzTfrST4mh18UDbaKK5PdcO1KOGKangg2fkCij--CdH5KJYzm-XGuU8eygGwA2U86afhEAbfSA1rV4x7leg
       Content-Length:
       - '42'
       Host:
@@ -2118,34 +2118,34 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/e9014734-fffd-4545-891c-b3541448a4a8?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/090561b7-03c4-4885-a9ea-33ff8fc06c1f?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/e9014734-fffd-4545-891c-b3541448a4a8?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/090561b7-03c4-4885-a9ea-33ff8fc06c1f?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
       - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
       X-Ms-Request-Id:
-      - e9014734-fffd-4545-891c-b3541448a4a8
+      - '090561b7-03c4-4885-a9ea-33ff8fc06c1f'
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1197'
+      - '1196'
       X-Ms-Correlation-Request-Id:
-      - f3859083-1aea-4f9e-b6a7-ffbb9d07d28c
+      - 6f4b7e67-d8ce-4518-b62d-1d3493e1d9f9
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153311Z:f3859083-1aea-4f9e-b6a7-ffbb9d07d28c
+      - EASTUS:20170830T170543Z:6f4b7e67-d8ce-4518-b62d-1d3493e1d9f9
       Date:
-      - Wed, 30 Aug 2017 15:33:11 GMT
+      - Wed, 30 Aug 2017 17:05:43 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:33:11 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:42 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/e9014734-fffd-4545-891c-b3541448a4a8?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/090561b7-03c4-4885-a9ea-33ff8fc06c1f?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -2159,7 +2159,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4ODgsIm5iZiI6MTUwNDEwNjg4OCwiZXhwIjoxNTA0MTEwNzg4LCJhaW8iOiJZMkZnWURpaU84L3Mzc21YUmR4TGc4N3pCUFJOQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieHl2cHViR2ZhRW1ZZllIdHJIVVNBQSIsInZlciI6IjEuMCJ9.KtY_qul3sPMRTk1G8dVaWBI9STS2XHIfnUHM8cHKj5Q56Ow3kJkGuAWs4fxBgnitN2kk4WSqg_i2geYoOThW0rl328fQnL22At7JhRCw7N-9LHT9ho2Ygm8MxgdJtRNg2zure-amphl4GnnLULXOeaXoPx93w6bA4D5wPGlI0OryVV79hivQgyHc2f91OjawotTjt5yEGQNAWf3MhXrQNJGbZ_1VzrV1p8wJkgUXiCgjsybXPSjZvKwf7hEG8yVuJxNykO7BLCrBtSIpW07gtRboHXujCwVOxx74lnQS8LrDM-_DZGqRA41NIDOZuZ6pruQIHp2EHEI0WfUsMqr9rw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0NDEsIm5iZiI6MTUwNDExMjQ0MSwiZXhwIjoxNTA0MTE2MzQxLCJhaW8iOiJZMkZnWUFqbS9Od1p0bjFuNm1ISEJhZERiTi9GQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUERiMlE1LTJiMC1CZE96RVVEVVVBQSIsInZlciI6IjEuMCJ9.P7qltdT57vynnvnukSfmh0nDfSK14eipWa82TqoPct0qms-cAv88unRZzRsim_67rTgEYcuxGzJ_y5B6syaRfxuMRlaAcfkgU4iymHA4YJz1SlNBXUGNP2TuhlAEepSqdd0x1QqST2jtqKrFVlMqyLonvBWjQpddfjjmn09EWiO8ii9bnbOdCtM2Amgk9yoCKADRPNZpmEexfxluvgeOmoKnUQJk9BgW2qQsI-VmStNLNYyIo71yPNFCA28mcMN_DRJHzTfrST4mh18UDbaKK5PdcO1KOGKangg2fkCij--CdH5KJYzm-XGuU8eygGwA2U86afhEAbfSA1rV4x7leg
       Host:
       - management.azure.com
   response:
@@ -2184,29 +2184,29 @@ http_interactions:
       X-Ms-Served-By:
       - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
       X-Ms-Request-Id:
-      - cd08d2dc-584d-4def-9af2-5126c12d0f55
+      - e611f288-a0eb-4a33-b5f8-507f876cbf5b
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14698'
+      - '14901'
       X-Ms-Correlation-Request-Id:
-      - 9bfc802a-60d0-4f70-b9fe-63ecd19fd7c5
+      - 53ca70b1-277e-4fae-bf17-c7855047dae2
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153311Z:9bfc802a-60d0-4f70-b9fe-63ecd19fd7c5
+      - EASTUS:20170830T170544Z:53ca70b1-277e-4fae-bf17-c7855047dae2
       Date:
-      - Wed, 30 Aug 2017 15:33:11 GMT
+      - Wed, 30 Aug 2017 17:05:43 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-08-30T15:33:11.2269931+00:00\",\r\n  \"endTime\":
-        \"2017-08-30T15:33:11.4457485+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=4ab3aa41-f66c-4d6b-b8c6-17a45e4abc3a&sig=WFUkgWq35Ufv3%2B%2FAiS8b4uXQ9%2B%2FNmzKCc45FtXaEY0A%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"e9014734-fffd-4545-891c-b3541448a4a8\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2017-08-30T17:05:43.487491+00:00\",\r\n  \"endTime\":
+        \"2017-08-30T17:05:43.6281055+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=56242576-a1d7-4a31-803f-eeaba3034b1e&sig=HqBub8gJzEcpNSr6RUZKnCRnRWgsw66jFB7zFnyCuHI%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"090561b7-03c4-4885-a9ea-33ff8fc06c1f\"\r\n}"
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:33:11 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:42 GMT
 - request:
     method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=4ab3aa41-f66c-4d6b-b8c6-17a45e4abc3a&sig=WFUkgWq35Ufv3%2B/AiS8b4uXQ9%2B/NmzKCc45FtXaEY0A=&sr=b&sv=2016-05-31
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=56242576-a1d7-4a31-803f-eeaba3034b1e&sig=HqBub8gJzEcpNSr6RUZKnCRnRWgsw66jFB7zFnyCuHI=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2241,7 +2241,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - e7e76fef-0001-0079-47a5-21c867000000
+      - 8873340e-0001-0126-1fb2-217ccc000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2267,11 +2267,11 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 30 Aug 2017 15:33:11 GMT
+      - Wed, 30 Aug 2017 17:05:43 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         U5MJAA==
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:33:12 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:42 GMT
 recorded_with: VCR 3.0.3

--- a/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_size-1.yml
+++ b/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_size-1.yml
@@ -39,25 +39,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 2c7325fa-d365-4b34-be01-04bf0eba1300
+      - 37e952ce-cc1d-47ce-96b1-1adaf91b1300
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAAA9kTklhVy7SJTGAzR-p1BcDGEUk_rhX0uOCyPaPvAOXiQcfRCLlGISoJ4EW3DDgH8LdHA0zfx-F6GAMpCjRXYKmwEox4ZZX8a2dxM9CZ3hsfaDJwFG3n78X33XvuSg-Q0Dsi-IalAtcbcjPR7dQwMl9lVvCYyx982iMa57b0SheP6HPvbn1A64mJyh6PzQSbogAA;
+      - esctx=AQABAAAAAAA9kTklhVy7SJTGAzR-p1Bczdi9I0q8LyHqwwe66zr7erjsl5y1qdODgJu-9ptmc9w0DYKGpnvqpeIUWBLfsQOtymHWRtd2_LZqTrQznl5-tOPGF45SCSn4wMpn9186xyJwklBk2KhYy0N6RMBBbeibNK_BTj-0jp1BiZ4YarQh1fwg3GxPpAl94OShUp3E94YgAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=006; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=005; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Wed, 30 Aug 2017 17:05:35 GMT
+      - Wed, 30 Aug 2017 17:05:48 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3600","ext_expires_in":"0","expires_on":"1504116339","not_before":"1504112439","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MzksIm5iZiI6MTUwNDExMjQzOSwiZXhwIjoxNTA0MTE2MzM5LCJhaW8iOiJZMkZnWUxCODVhdklVUEgxNTZMUWViOG5IdTI2Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiLWlWekxHWFRORXUtQVFTX0Ryb1RBQSIsInZlciI6IjEuMCJ9.YsIZ6WcG0zOMvZRUybffvxCinLyqT69L_acgM6-9JOtKLbQx1wNGuo2V3MXmv5i7LOVrIhzLEhfJ--jDHFa1J20jGQhWUZhYKqP2jTy4JytJwRi_4PBGL7NRJ_IqUuDrm1YIdeZRGH6kOZ1Ckx5_2ETcA2OYrSDa6zNgqBZGBYsoEMNL3n3ymVbKOw07qyJDqyJu-hZZ6BkceVCvPWeYov93yvu_272jQpGvvYow-fkwzNQknyLQKGZr45lPdbatsm1JhHARsPKJD4tV-0jhmfwf5nqz7MZxe5G597M98cpN7oOIalxLiLUmSNV7OeUxoSvHruBT1vh2oZZyVFq9AQ"}'
+      string: '{"token_type":"Bearer","expires_in":"3600","ext_expires_in":"0","expires_on":"1504116349","not_before":"1504112449","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0NDksIm5iZiI6MTUwNDExMjQ0OSwiZXhwIjoxNTA0MTE2MzQ5LCJhaW8iOiJZMkZnWVBBL2Nqa2hlRzF5Y2ZLVmdwZnJ6eVFmQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiemxMcE54M016a2VXc1JyYS1Sc1RBQSIsInZlciI6IjEuMCJ9.su8t54UWbgs4r3NoTbRZnQ4A0EBSlDpIgE-9phm9l9aP2iLEAxFgb_8SyUThFqSn_0FDJVCH6z9z7NmEmOmawyuBT_ViR5piV1LE5QybfynN9olGQzK-E8KucCBkbfPFw-pWXAHltakMqmga5tC-BZAVtjapxGveKEBtdbZZffng6wKkVaj2rwvraMRuTvle3XiL7rbx1dtUHcOjWc1COR7_Z5k5kqL83Zm66qrMnxmK5GRXaNBDODk6rfGNgPW-q1bfcQNwqHPJcpK_vVjJ50odE53ZtFw83grXAfZUPWGivCAkDyfEHkB6kR1jx5AHG2gZ2xwpgOGHFyIMQYiW5g"}'
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 17:05:37 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:46 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -74,7 +74,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MzksIm5iZiI6MTUwNDExMjQzOSwiZXhwIjoxNTA0MTE2MzM5LCJhaW8iOiJZMkZnWUxCODVhdklVUEgxNTZMUWViOG5IdTI2Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiLWlWekxHWFRORXUtQVFTX0Ryb1RBQSIsInZlciI6IjEuMCJ9.YsIZ6WcG0zOMvZRUybffvxCinLyqT69L_acgM6-9JOtKLbQx1wNGuo2V3MXmv5i7LOVrIhzLEhfJ--jDHFa1J20jGQhWUZhYKqP2jTy4JytJwRi_4PBGL7NRJ_IqUuDrm1YIdeZRGH6kOZ1Ckx5_2ETcA2OYrSDa6zNgqBZGBYsoEMNL3n3ymVbKOw07qyJDqyJu-hZZ6BkceVCvPWeYov93yvu_272jQpGvvYow-fkwzNQknyLQKGZr45lPdbatsm1JhHARsPKJD4tV-0jhmfwf5nqz7MZxe5G597M98cpN7oOIalxLiLUmSNV7OeUxoSvHruBT1vh2oZZyVFq9AQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0NDksIm5iZiI6MTUwNDExMjQ0OSwiZXhwIjoxNTA0MTE2MzQ5LCJhaW8iOiJZMkZnWVBBL2Nqa2hlRzF5Y2ZLVmdwZnJ6eVFmQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiemxMcE54M016a2VXc1JyYS1Sc1RBQSIsInZlciI6IjEuMCJ9.su8t54UWbgs4r3NoTbRZnQ4A0EBSlDpIgE-9phm9l9aP2iLEAxFgb_8SyUThFqSn_0FDJVCH6z9z7NmEmOmawyuBT_ViR5piV1LE5QybfynN9olGQzK-E8KucCBkbfPFw-pWXAHltakMqmga5tC-BZAVtjapxGveKEBtdbZZffng6wKkVaj2rwvraMRuTvle3XiL7rbx1dtUHcOjWc1COR7_Z5k5kqL83Zm66qrMnxmK5GRXaNBDODk6rfGNgPW-q1bfcQNwqHPJcpK_vVjJ50odE53ZtFw83grXAfZUPWGivCAkDyfEHkB6kR1jx5AHG2gZ2xwpgOGHFyIMQYiW5g
       Host:
       - management.azure.com
   response:
@@ -95,23 +95,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14997'
+      - '14996'
       X-Ms-Request-Id:
-      - 48bc0a15-5fac-477d-a801-3f592dd5cccc
+      - d321e7fb-b8dc-4ae8-b7d3-035dd047ea50
       X-Ms-Correlation-Request-Id:
-      - 48bc0a15-5fac-477d-a801-3f592dd5cccc
+      - d321e7fb-b8dc-4ae8-b7d3-035dd047ea50
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T170539Z:48bc0a15-5fac-477d-a801-3f592dd5cccc
+      - EASTUS:20170830T170548Z:d321e7fb-b8dc-4ae8-b7d3-035dd047ea50
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 30 Aug 2017 17:05:38 GMT
+      - Wed, 30 Aug 2017 17:05:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 17:05:37 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:46 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/azure_subscription_id/providers?api-version=2015-01-01
@@ -128,7 +128,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MzksIm5iZiI6MTUwNDExMjQzOSwiZXhwIjoxNTA0MTE2MzM5LCJhaW8iOiJZMkZnWUxCODVhdklVUEgxNTZMUWViOG5IdTI2Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiLWlWekxHWFRORXUtQVFTX0Ryb1RBQSIsInZlciI6IjEuMCJ9.YsIZ6WcG0zOMvZRUybffvxCinLyqT69L_acgM6-9JOtKLbQx1wNGuo2V3MXmv5i7LOVrIhzLEhfJ--jDHFa1J20jGQhWUZhYKqP2jTy4JytJwRi_4PBGL7NRJ_IqUuDrm1YIdeZRGH6kOZ1Ckx5_2ETcA2OYrSDa6zNgqBZGBYsoEMNL3n3ymVbKOw07qyJDqyJu-hZZ6BkceVCvPWeYov93yvu_272jQpGvvYow-fkwzNQknyLQKGZr45lPdbatsm1JhHARsPKJD4tV-0jhmfwf5nqz7MZxe5G597M98cpN7oOIalxLiLUmSNV7OeUxoSvHruBT1vh2oZZyVFq9AQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0NDksIm5iZiI6MTUwNDExMjQ0OSwiZXhwIjoxNTA0MTE2MzQ5LCJhaW8iOiJZMkZnWVBBL2Nqa2hlRzF5Y2ZLVmdwZnJ6eVFmQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiemxMcE54M016a2VXc1JyYS1Sc1RBQSIsInZlciI6IjEuMCJ9.su8t54UWbgs4r3NoTbRZnQ4A0EBSlDpIgE-9phm9l9aP2iLEAxFgb_8SyUThFqSn_0FDJVCH6z9z7NmEmOmawyuBT_ViR5piV1LE5QybfynN9olGQzK-E8KucCBkbfPFw-pWXAHltakMqmga5tC-BZAVtjapxGveKEBtdbZZffng6wKkVaj2rwvraMRuTvle3XiL7rbx1dtUHcOjWc1COR7_Z5k5kqL83Zm66qrMnxmK5GRXaNBDODk6rfGNgPW-q1bfcQNwqHPJcpK_vVjJ50odE53ZtFw83grXAfZUPWGivCAkDyfEHkB6kR1jx5AHG2gZ2xwpgOGHFyIMQYiW5g
       Host:
       - management.azure.com
   response:
@@ -147,17 +147,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14938'
+      - '14923'
       X-Ms-Request-Id:
-      - d8fa9775-288e-42d6-9e39-4182967013b0
+      - e7d9a908-6c3b-4436-84d0-31560674c946
       X-Ms-Correlation-Request-Id:
-      - d8fa9775-288e-42d6-9e39-4182967013b0
+      - e7d9a908-6c3b-4436-84d0-31560674c946
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T170539Z:d8fa9775-288e-42d6-9e39-4182967013b0
+      - EASTUS:20170830T170549Z:e7d9a908-6c3b-4436-84d0-31560674c946
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 30 Aug 2017 17:05:39 GMT
+      - Wed, 30 Aug 2017 17:05:48 GMT
       Content-Length:
       - '241615'
     body:
@@ -1891,7 +1891,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 17:05:38 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:47 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
@@ -1908,7 +1908,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MzksIm5iZiI6MTUwNDExMjQzOSwiZXhwIjoxNTA0MTE2MzM5LCJhaW8iOiJZMkZnWUxCODVhdklVUEgxNTZMUWViOG5IdTI2Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiLWlWekxHWFRORXUtQVFTX0Ryb1RBQSIsInZlciI6IjEuMCJ9.YsIZ6WcG0zOMvZRUybffvxCinLyqT69L_acgM6-9JOtKLbQx1wNGuo2V3MXmv5i7LOVrIhzLEhfJ--jDHFa1J20jGQhWUZhYKqP2jTy4JytJwRi_4PBGL7NRJ_IqUuDrm1YIdeZRGH6kOZ1Ckx5_2ETcA2OYrSDa6zNgqBZGBYsoEMNL3n3ymVbKOw07qyJDqyJu-hZZ6BkceVCvPWeYov93yvu_272jQpGvvYow-fkwzNQknyLQKGZr45lPdbatsm1JhHARsPKJD4tV-0jhmfwf5nqz7MZxe5G597M98cpN7oOIalxLiLUmSNV7OeUxoSvHruBT1vh2oZZyVFq9AQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0NDksIm5iZiI6MTUwNDExMjQ0OSwiZXhwIjoxNTA0MTE2MzQ5LCJhaW8iOiJZMkZnWVBBL2Nqa2hlRzF5Y2ZLVmdwZnJ6eVFmQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiemxMcE54M016a2VXc1JyYS1Sc1RBQSIsInZlciI6IjEuMCJ9.su8t54UWbgs4r3NoTbRZnQ4A0EBSlDpIgE-9phm9l9aP2iLEAxFgb_8SyUThFqSn_0FDJVCH6z9z7NmEmOmawyuBT_ViR5piV1LE5QybfynN9olGQzK-E8KucCBkbfPFw-pWXAHltakMqmga5tC-BZAVtjapxGveKEBtdbZZffng6wKkVaj2rwvraMRuTvle3XiL7rbx1dtUHcOjWc1COR7_Z5k5kqL83Zm66qrMnxmK5GRXaNBDODk6rfGNgPW-q1bfcQNwqHPJcpK_vVjJ50odE53ZtFw83grXAfZUPWGivCAkDyfEHkB6kR1jx5AHG2gZ2xwpgOGHFyIMQYiW5g
       Content-Length:
       - '42'
       Host:
@@ -1927,34 +1927,34 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/6a1bb9fb-39ff-48be-bd20-32462c373bce?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/6b756d68-6959-477a-b88e-cb207d34fc18?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/6a1bb9fb-39ff-48be-bd20-32462c373bce?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/6b756d68-6959-477a-b88e-cb207d34fc18?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
       - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
       X-Ms-Request-Id:
-      - 6a1bb9fb-39ff-48be-bd20-32462c373bce
+      - 6b756d68-6959-477a-b88e-cb207d34fc18
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1193'
+      - '1196'
       X-Ms-Correlation-Request-Id:
-      - d2c6ea3b-f174-4835-aa9e-d313e935592d
+      - 8a99a2bb-6263-48c9-92da-adc2c680b538
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T170540Z:d2c6ea3b-f174-4835-aa9e-d313e935592d
+      - EASTUS:20170830T170549Z:8a99a2bb-6263-48c9-92da-adc2c680b538
       Date:
-      - Wed, 30 Aug 2017 17:05:40 GMT
+      - Wed, 30 Aug 2017 17:05:49 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 17:05:39 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:48 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/6a1bb9fb-39ff-48be-bd20-32462c373bce?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/6b756d68-6959-477a-b88e-cb207d34fc18?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -1968,7 +1968,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MzksIm5iZiI6MTUwNDExMjQzOSwiZXhwIjoxNTA0MTE2MzM5LCJhaW8iOiJZMkZnWUxCODVhdklVUEgxNTZMUWViOG5IdTI2Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiLWlWekxHWFRORXUtQVFTX0Ryb1RBQSIsInZlciI6IjEuMCJ9.YsIZ6WcG0zOMvZRUybffvxCinLyqT69L_acgM6-9JOtKLbQx1wNGuo2V3MXmv5i7LOVrIhzLEhfJ--jDHFa1J20jGQhWUZhYKqP2jTy4JytJwRi_4PBGL7NRJ_IqUuDrm1YIdeZRGH6kOZ1Ckx5_2ETcA2OYrSDa6zNgqBZGBYsoEMNL3n3ymVbKOw07qyJDqyJu-hZZ6BkceVCvPWeYov93yvu_272jQpGvvYow-fkwzNQknyLQKGZr45lPdbatsm1JhHARsPKJD4tV-0jhmfwf5nqz7MZxe5G597M98cpN7oOIalxLiLUmSNV7OeUxoSvHruBT1vh2oZZyVFq9AQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0NDksIm5iZiI6MTUwNDExMjQ0OSwiZXhwIjoxNTA0MTE2MzQ5LCJhaW8iOiJZMkZnWVBBL2Nqa2hlRzF5Y2ZLVmdwZnJ6eVFmQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiemxMcE54M016a2VXc1JyYS1Sc1RBQSIsInZlciI6IjEuMCJ9.su8t54UWbgs4r3NoTbRZnQ4A0EBSlDpIgE-9phm9l9aP2iLEAxFgb_8SyUThFqSn_0FDJVCH6z9z7NmEmOmawyuBT_ViR5piV1LE5QybfynN9olGQzK-E8KucCBkbfPFw-pWXAHltakMqmga5tC-BZAVtjapxGveKEBtdbZZffng6wKkVaj2rwvraMRuTvle3XiL7rbx1dtUHcOjWc1COR7_Z5k5kqL83Zm66qrMnxmK5GRXaNBDODk6rfGNgPW-q1bfcQNwqHPJcpK_vVjJ50odE53ZtFw83grXAfZUPWGivCAkDyfEHkB6kR1jx5AHG2gZ2xwpgOGHFyIMQYiW5g
       Host:
       - management.azure.com
   response:
@@ -1993,29 +1993,29 @@ http_interactions:
       X-Ms-Served-By:
       - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
       X-Ms-Request-Id:
-      - 3a770b55-cc32-46d6-953a-90b0f91d02ee
+      - df2a1ab9-4926-4c40-b99b-d348a5b8d7ab
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14941'
+      - '14280'
       X-Ms-Correlation-Request-Id:
-      - '078b6930-83ec-4d6d-aff2-023cee5a278b'
+      - f1dd5a0c-74f1-496c-9296-f5a690ff6354
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T170540Z:078b6930-83ec-4d6d-aff2-023cee5a278b
+      - EASTUS:20170830T170550Z:f1dd5a0c-74f1-496c-9296-f5a690ff6354
       Date:
-      - Wed, 30 Aug 2017 17:05:40 GMT
+      - Wed, 30 Aug 2017 17:05:49 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-08-30T17:05:39.9249879+00:00\",\r\n  \"endTime\":
-        \"2017-08-30T17:05:40.0968824+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=bdda1e2c-2959-494f-931e-8c3cdbbc27dd&sig=43Gxlx%2B81oJS6um%2BEwZQehZlIlclD8DsVW2BZ%2FxxIn0%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"6a1bb9fb-39ff-48be-bd20-32462c373bce\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2017-08-30T17:05:49.4874998+00:00\",\r\n  \"endTime\":
+        \"2017-08-30T17:05:49.6286563+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=43b1671c-7c4f-4a87-9e15-74df4c62beea&sig=Mvhmd%2Bnm7h%2FAjw6TykEqwRy48Ce9PxG8IPlkZxCF2N0%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"6b756d68-6959-477a-b88e-cb207d34fc18\"\r\n}"
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 17:05:39 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:48 GMT
 - request:
     method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=bdda1e2c-2959-494f-931e-8c3cdbbc27dd&sig=43Gxlx%2B81oJS6um%2BEwZQehZlIlclD8DsVW2BZ/xxIn0=&sr=b&sv=2016-05-31
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=43b1671c-7c4f-4a87-9e15-74df4c62beea&sig=Mvhmd%2Bnm7h/Ajw6TykEqwRy48Ce9PxG8IPlkZxCF2N0=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2050,7 +2050,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - d4dc1651-0001-000a-71b2-21b8a4000000
+      - 81b4236a-0001-009c-63b2-21da90000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2076,13 +2076,13 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 30 Aug 2017 17:05:39 GMT
+      - Wed, 30 Aug 2017 17:05:50 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         6w==
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 17:05:39 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:50 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
@@ -2099,7 +2099,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MzksIm5iZiI6MTUwNDExMjQzOSwiZXhwIjoxNTA0MTE2MzM5LCJhaW8iOiJZMkZnWUxCODVhdklVUEgxNTZMUWViOG5IdTI2Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiLWlWekxHWFRORXUtQVFTX0Ryb1RBQSIsInZlciI6IjEuMCJ9.YsIZ6WcG0zOMvZRUybffvxCinLyqT69L_acgM6-9JOtKLbQx1wNGuo2V3MXmv5i7LOVrIhzLEhfJ--jDHFa1J20jGQhWUZhYKqP2jTy4JytJwRi_4PBGL7NRJ_IqUuDrm1YIdeZRGH6kOZ1Ckx5_2ETcA2OYrSDa6zNgqBZGBYsoEMNL3n3ymVbKOw07qyJDqyJu-hZZ6BkceVCvPWeYov93yvu_272jQpGvvYow-fkwzNQknyLQKGZr45lPdbatsm1JhHARsPKJD4tV-0jhmfwf5nqz7MZxe5G597M98cpN7oOIalxLiLUmSNV7OeUxoSvHruBT1vh2oZZyVFq9AQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0NDksIm5iZiI6MTUwNDExMjQ0OSwiZXhwIjoxNTA0MTE2MzQ5LCJhaW8iOiJZMkZnWVBBL2Nqa2hlRzF5Y2ZLVmdwZnJ6eVFmQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiemxMcE54M016a2VXc1JyYS1Sc1RBQSIsInZlciI6IjEuMCJ9.su8t54UWbgs4r3NoTbRZnQ4A0EBSlDpIgE-9phm9l9aP2iLEAxFgb_8SyUThFqSn_0FDJVCH6z9z7NmEmOmawyuBT_ViR5piV1LE5QybfynN9olGQzK-E8KucCBkbfPFw-pWXAHltakMqmga5tC-BZAVtjapxGveKEBtdbZZffng6wKkVaj2rwvraMRuTvle3XiL7rbx1dtUHcOjWc1COR7_Z5k5kqL83Zm66qrMnxmK5GRXaNBDODk6rfGNgPW-q1bfcQNwqHPJcpK_vVjJ50odE53ZtFw83grXAfZUPWGivCAkDyfEHkB6kR1jx5AHG2gZ2xwpgOGHFyIMQYiW5g
       Content-Length:
       - '42'
       Host:
@@ -2118,34 +2118,34 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/b87322f6-ae76-41eb-8e21-da78ee934736?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/4ea2621d-73aa-46fd-be08-11e81b4320e4?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/b87322f6-ae76-41eb-8e21-da78ee934736?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/4ea2621d-73aa-46fd-be08-11e81b4320e4?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
       - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
       X-Ms-Request-Id:
-      - b87322f6-ae76-41eb-8e21-da78ee934736
+      - 4ea2621d-73aa-46fd-be08-11e81b4320e4
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1195'
+      - '1192'
       X-Ms-Correlation-Request-Id:
-      - de8cb81f-3c7f-408e-b98e-0ae9de88da16
+      - 6ab62144-e235-460a-82c3-1e31620f6106
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T170541Z:de8cb81f-3c7f-408e-b98e-0ae9de88da16
+      - EASTUS:20170830T170550Z:6ab62144-e235-460a-82c3-1e31620f6106
       Date:
-      - Wed, 30 Aug 2017 17:05:40 GMT
+      - Wed, 30 Aug 2017 17:05:50 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 17:05:39 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:50 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/b87322f6-ae76-41eb-8e21-da78ee934736?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/4ea2621d-73aa-46fd-be08-11e81b4320e4?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -2159,7 +2159,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MzksIm5iZiI6MTUwNDExMjQzOSwiZXhwIjoxNTA0MTE2MzM5LCJhaW8iOiJZMkZnWUxCODVhdklVUEgxNTZMUWViOG5IdTI2Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiLWlWekxHWFRORXUtQVFTX0Ryb1RBQSIsInZlciI6IjEuMCJ9.YsIZ6WcG0zOMvZRUybffvxCinLyqT69L_acgM6-9JOtKLbQx1wNGuo2V3MXmv5i7LOVrIhzLEhfJ--jDHFa1J20jGQhWUZhYKqP2jTy4JytJwRi_4PBGL7NRJ_IqUuDrm1YIdeZRGH6kOZ1Ckx5_2ETcA2OYrSDa6zNgqBZGBYsoEMNL3n3ymVbKOw07qyJDqyJu-hZZ6BkceVCvPWeYov93yvu_272jQpGvvYow-fkwzNQknyLQKGZr45lPdbatsm1JhHARsPKJD4tV-0jhmfwf5nqz7MZxe5G597M98cpN7oOIalxLiLUmSNV7OeUxoSvHruBT1vh2oZZyVFq9AQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0NDksIm5iZiI6MTUwNDExMjQ0OSwiZXhwIjoxNTA0MTE2MzQ5LCJhaW8iOiJZMkZnWVBBL2Nqa2hlRzF5Y2ZLVmdwZnJ6eVFmQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiemxMcE54M016a2VXc1JyYS1Sc1RBQSIsInZlciI6IjEuMCJ9.su8t54UWbgs4r3NoTbRZnQ4A0EBSlDpIgE-9phm9l9aP2iLEAxFgb_8SyUThFqSn_0FDJVCH6z9z7NmEmOmawyuBT_ViR5piV1LE5QybfynN9olGQzK-E8KucCBkbfPFw-pWXAHltakMqmga5tC-BZAVtjapxGveKEBtdbZZffng6wKkVaj2rwvraMRuTvle3XiL7rbx1dtUHcOjWc1COR7_Z5k5kqL83Zm66qrMnxmK5GRXaNBDODk6rfGNgPW-q1bfcQNwqHPJcpK_vVjJ50odE53ZtFw83grXAfZUPWGivCAkDyfEHkB6kR1jx5AHG2gZ2xwpgOGHFyIMQYiW5g
       Host:
       - management.azure.com
   response:
@@ -2184,29 +2184,29 @@ http_interactions:
       X-Ms-Served-By:
       - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
       X-Ms-Request-Id:
-      - 047a4ed2-826c-4808-aab5-eaa2dc64d766
+      - 15b15c67-f28f-4653-b096-53d32839c239
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14938'
+      - '14943'
       X-Ms-Correlation-Request-Id:
-      - 5b62ec33-9302-4b24-9350-dabeb62ea21e
+      - fafa918a-356f-4e46-9a61-b926f0661e8b
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T170541Z:5b62ec33-9302-4b24-9350-dabeb62ea21e
+      - EASTUS:20170830T170551Z:fafa918a-356f-4e46-9a61-b926f0661e8b
       Date:
-      - Wed, 30 Aug 2017 17:05:40 GMT
+      - Wed, 30 Aug 2017 17:05:50 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-08-30T17:05:40.5500153+00:00\",\r\n  \"endTime\":
-        \"2017-08-30T17:05:40.7062434+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=38a3b196-1295-4dd8-9b7b-f9d7592dc9eb&sig=lxwowcsKkaoP13xO%2BrqmKYm0YcQSiuuz7dYCcx28ERU%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"b87322f6-ae76-41eb-8e21-da78ee934736\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2017-08-30T17:05:50.0817842+00:00\",\r\n  \"endTime\":
+        \"2017-08-30T17:05:50.2380095+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=ba484e41-825a-4503-9089-4903b863214a&sig=M9CP9kDm4yawlQ1wBYEn9uB%2FhTsHnV%2FYTvvWJZdiE%2Bg%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"4ea2621d-73aa-46fd-be08-11e81b4320e4\"\r\n}"
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 17:05:39 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:51 GMT
 - request:
     method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=38a3b196-1295-4dd8-9b7b-f9d7592dc9eb&sig=lxwowcsKkaoP13xO%2BrqmKYm0YcQSiuuz7dYCcx28ERU=&sr=b&sv=2016-05-31
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=ba484e41-825a-4503-9089-4903b863214a&sig=M9CP9kDm4yawlQ1wBYEn9uB/hTsHnV/YTvvWJZdiE%2Bg=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2241,7 +2241,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - b4a6b309-0001-00f9-2db2-216bcd000000
+      - 75e34170-0001-0006-4bb2-215655000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2267,11 +2267,11 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 30 Aug 2017 17:05:40 GMT
+      - Wed, 30 Aug 2017 17:05:50 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         U5MJAA==
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 17:05:39 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:51 GMT
 recorded_with: VCR 3.0.3

--- a/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_startByteAddr-1.yml
+++ b/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_startByteAddr-1.yml
@@ -39,25 +39,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 828f1081-ac7a-42f8-9b83-e1b194221200
+      - 559a516e-3e86-4496-8618-bb1be8931400
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAAA9kTklhVy7SJTGAzR-p1BcIGIMfitzdSO376Zv9yPyXmdMBYbyUndexmARzt1x9SBBg_USoP47e2gMUNI8zXj__DBCAdx-ClS6aI1Yb-yd2TtG8xUm94yheO8xRg4Mn5dCemrb6H6YR0yOf4cwR_fjff1Bpd8PzG__OsnTzbBxz7KZEfzpg4tWcdY73uxZBrggAA;
+      - esctx=AQABAAAAAAA9kTklhVy7SJTGAzR-p1BcngaoVpiH-_klLDz-AilMhO4JfnZ3siWR9ozCJB5PjgHGKVkNp1Rw6Lg0fZYe35ICjTuD5J9pWfPm2ts2voni9qDIQVU5nptnTAnK5yuLYEp8o3-cRqDzfAwESJl7-3BS7vW0ghgkNvysBKjcUq_Jly4yOmizXbYO6MdyVgpoJSEgAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=005; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=008; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Wed, 30 Aug 2017 15:33:15 GMT
+      - Wed, 30 Aug 2017 17:05:16 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3600","ext_expires_in":"0","expires_on":"1504110795","not_before":"1504106895","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4OTUsIm5iZiI6MTUwNDEwNjg5NSwiZXhwIjoxNTA0MTEwNzk1LCJhaW8iOiJZMkZnWVBqeGJmMVBCUnNOUmcwdkRzdnQwbnovQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZ1JDUGducXMtRUtiZy1HeGxDSVNBQSIsInZlciI6IjEuMCJ9.KSUCtfYUWBYpiRZ8Oe73YcjB0AVtFDYwfvV6kPGobrVZzVhauDn0q_hprykjN5-EWT07l_ZXgPKZZsiJ0-52T97sTkKTUlqOwMnP3exbb-aqVt0cSL7dnerJdF6SXw7vOif6OPUWkkg_bShX1ZHg6eYEZ_uGoxPa67r34OB-iwZV4kZdZSvP2sPVW75g3jhgEkSnsDBZZ9u5PuuecS5DTeMXnaR6uryG-Aoi8j0x773sApFV-_9G7WuYugGMp-QmB9aJUqOeYrkiZqQnJtR4Ot6s-EJlO7mjps-CqSWCWrspbRKGueJXDLSnBmCKZkqVWwvHDt1lxCUM5JfRWG6ODQ"}'
+      string: '{"token_type":"Bearer","expires_in":"3600","ext_expires_in":"0","expires_on":"1504116317","not_before":"1504112417","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MTcsIm5iZiI6MTUwNDExMjQxNywiZXhwIjoxNTA0MTE2MzE3LCJhaW8iOiJZMkZnWVBodlpwMmdma2I0Yy8veXZLaVVwUk0rQWdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYmxHYVZZWS1sa1NHR0xzYjZKTVVBQSIsInZlciI6IjEuMCJ9.qxk8VXz_2hqLNN144IW8Gr_TJLbaeu4YttqsP99mqfeFeWcTSdOrYMCgTOYeJiEIzY62qfYohHIeEJmT19Fi-ZwWPT7DjzRhCasMR55l3wKugRrn1TEWAEXi5wGcr1jXgBByDg7ldqAuh97aclaQDE-yTmNUgGUzlQ1Up0Mltgvh8CpzO3O5Go4reZui1E1L__0FQ7tHycxuf6MwZRhQfZS9LzQRoUmzxrEcHS5ChF0DF7LxMn5k9RIFwpvyO87Eh5wClg_IeuLSuxlwZQ03YnSXwfh6daFLkiwtnWW5ykJ7YgxtSmpYBwBp3XTz5XyWdK9-OHsq55XdpoKk5ZuTzA"}'
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:33:15 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:16 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -74,7 +74,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4OTUsIm5iZiI6MTUwNDEwNjg5NSwiZXhwIjoxNTA0MTEwNzk1LCJhaW8iOiJZMkZnWVBqeGJmMVBCUnNOUmcwdkRzdnQwbnovQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZ1JDUGducXMtRUtiZy1HeGxDSVNBQSIsInZlciI6IjEuMCJ9.KSUCtfYUWBYpiRZ8Oe73YcjB0AVtFDYwfvV6kPGobrVZzVhauDn0q_hprykjN5-EWT07l_ZXgPKZZsiJ0-52T97sTkKTUlqOwMnP3exbb-aqVt0cSL7dnerJdF6SXw7vOif6OPUWkkg_bShX1ZHg6eYEZ_uGoxPa67r34OB-iwZV4kZdZSvP2sPVW75g3jhgEkSnsDBZZ9u5PuuecS5DTeMXnaR6uryG-Aoi8j0x773sApFV-_9G7WuYugGMp-QmB9aJUqOeYrkiZqQnJtR4Ot6s-EJlO7mjps-CqSWCWrspbRKGueJXDLSnBmCKZkqVWwvHDt1lxCUM5JfRWG6ODQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MTcsIm5iZiI6MTUwNDExMjQxNywiZXhwIjoxNTA0MTE2MzE3LCJhaW8iOiJZMkZnWVBodlpwMmdma2I0Yy8veXZLaVVwUk0rQWdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYmxHYVZZWS1sa1NHR0xzYjZKTVVBQSIsInZlciI6IjEuMCJ9.qxk8VXz_2hqLNN144IW8Gr_TJLbaeu4YttqsP99mqfeFeWcTSdOrYMCgTOYeJiEIzY62qfYohHIeEJmT19Fi-ZwWPT7DjzRhCasMR55l3wKugRrn1TEWAEXi5wGcr1jXgBByDg7ldqAuh97aclaQDE-yTmNUgGUzlQ1Up0Mltgvh8CpzO3O5Go4reZui1E1L__0FQ7tHycxuf6MwZRhQfZS9LzQRoUmzxrEcHS5ChF0DF7LxMn5k9RIFwpvyO87Eh5wClg_IeuLSuxlwZQ03YnSXwfh6daFLkiwtnWW5ykJ7YgxtSmpYBwBp3XTz5XyWdK9-OHsq55XdpoKk5ZuTzA
       Host:
       - management.azure.com
   response:
@@ -95,23 +95,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14999'
+      - '14995'
       X-Ms-Request-Id:
-      - 2c06d66f-870f-4e89-bc03-627668e5e8d7
+      - '0907367a-132c-409b-ac76-e19d73a0a1a5'
       X-Ms-Correlation-Request-Id:
-      - 2c06d66f-870f-4e89-bc03-627668e5e8d7
+      - '0907367a-132c-409b-ac76-e19d73a0a1a5'
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153316Z:2c06d66f-870f-4e89-bc03-627668e5e8d7
+      - EASTUS:20170830T170517Z:0907367a-132c-409b-ac76-e19d73a0a1a5
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 30 Aug 2017 15:33:15 GMT
+      - Wed, 30 Aug 2017 17:05:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:33:16 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:16 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/azure_subscription_id/providers?api-version=2015-01-01
@@ -128,7 +128,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4OTUsIm5iZiI6MTUwNDEwNjg5NSwiZXhwIjoxNTA0MTEwNzk1LCJhaW8iOiJZMkZnWVBqeGJmMVBCUnNOUmcwdkRzdnQwbnovQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZ1JDUGducXMtRUtiZy1HeGxDSVNBQSIsInZlciI6IjEuMCJ9.KSUCtfYUWBYpiRZ8Oe73YcjB0AVtFDYwfvV6kPGobrVZzVhauDn0q_hprykjN5-EWT07l_ZXgPKZZsiJ0-52T97sTkKTUlqOwMnP3exbb-aqVt0cSL7dnerJdF6SXw7vOif6OPUWkkg_bShX1ZHg6eYEZ_uGoxPa67r34OB-iwZV4kZdZSvP2sPVW75g3jhgEkSnsDBZZ9u5PuuecS5DTeMXnaR6uryG-Aoi8j0x773sApFV-_9G7WuYugGMp-QmB9aJUqOeYrkiZqQnJtR4Ot6s-EJlO7mjps-CqSWCWrspbRKGueJXDLSnBmCKZkqVWwvHDt1lxCUM5JfRWG6ODQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MTcsIm5iZiI6MTUwNDExMjQxNywiZXhwIjoxNTA0MTE2MzE3LCJhaW8iOiJZMkZnWVBodlpwMmdma2I0Yy8veXZLaVVwUk0rQWdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYmxHYVZZWS1sa1NHR0xzYjZKTVVBQSIsInZlciI6IjEuMCJ9.qxk8VXz_2hqLNN144IW8Gr_TJLbaeu4YttqsP99mqfeFeWcTSdOrYMCgTOYeJiEIzY62qfYohHIeEJmT19Fi-ZwWPT7DjzRhCasMR55l3wKugRrn1TEWAEXi5wGcr1jXgBByDg7ldqAuh97aclaQDE-yTmNUgGUzlQ1Up0Mltgvh8CpzO3O5Go4reZui1E1L__0FQ7tHycxuf6MwZRhQfZS9LzQRoUmzxrEcHS5ChF0DF7LxMn5k9RIFwpvyO87Eh5wClg_IeuLSuxlwZQ03YnSXwfh6daFLkiwtnWW5ykJ7YgxtSmpYBwBp3XTz5XyWdK9-OHsq55XdpoKk5ZuTzA
       Host:
       - management.azure.com
   response:
@@ -147,17 +147,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14247'
+      - '14950'
       X-Ms-Request-Id:
-      - ee3bc4e9-2168-4f2e-8299-33afc229ee71
+      - 240f261f-5626-446b-b56e-140d7c702b0e
       X-Ms-Correlation-Request-Id:
-      - ee3bc4e9-2168-4f2e-8299-33afc229ee71
+      - 240f261f-5626-446b-b56e-140d7c702b0e
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153317Z:ee3bc4e9-2168-4f2e-8299-33afc229ee71
+      - EASTUS:20170830T170518Z:240f261f-5626-446b-b56e-140d7c702b0e
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 30 Aug 2017 15:33:16 GMT
+      - Wed, 30 Aug 2017 17:05:17 GMT
       Content-Length:
       - '241615'
     body:
@@ -1891,7 +1891,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:33:17 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:17 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
@@ -1908,7 +1908,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4OTUsIm5iZiI6MTUwNDEwNjg5NSwiZXhwIjoxNTA0MTEwNzk1LCJhaW8iOiJZMkZnWVBqeGJmMVBCUnNOUmcwdkRzdnQwbnovQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZ1JDUGducXMtRUtiZy1HeGxDSVNBQSIsInZlciI6IjEuMCJ9.KSUCtfYUWBYpiRZ8Oe73YcjB0AVtFDYwfvV6kPGobrVZzVhauDn0q_hprykjN5-EWT07l_ZXgPKZZsiJ0-52T97sTkKTUlqOwMnP3exbb-aqVt0cSL7dnerJdF6SXw7vOif6OPUWkkg_bShX1ZHg6eYEZ_uGoxPa67r34OB-iwZV4kZdZSvP2sPVW75g3jhgEkSnsDBZZ9u5PuuecS5DTeMXnaR6uryG-Aoi8j0x773sApFV-_9G7WuYugGMp-QmB9aJUqOeYrkiZqQnJtR4Ot6s-EJlO7mjps-CqSWCWrspbRKGueJXDLSnBmCKZkqVWwvHDt1lxCUM5JfRWG6ODQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MTcsIm5iZiI6MTUwNDExMjQxNywiZXhwIjoxNTA0MTE2MzE3LCJhaW8iOiJZMkZnWVBodlpwMmdma2I0Yy8veXZLaVVwUk0rQWdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYmxHYVZZWS1sa1NHR0xzYjZKTVVBQSIsInZlciI6IjEuMCJ9.qxk8VXz_2hqLNN144IW8Gr_TJLbaeu4YttqsP99mqfeFeWcTSdOrYMCgTOYeJiEIzY62qfYohHIeEJmT19Fi-ZwWPT7DjzRhCasMR55l3wKugRrn1TEWAEXi5wGcr1jXgBByDg7ldqAuh97aclaQDE-yTmNUgGUzlQ1Up0Mltgvh8CpzO3O5Go4reZui1E1L__0FQ7tHycxuf6MwZRhQfZS9LzQRoUmzxrEcHS5ChF0DF7LxMn5k9RIFwpvyO87Eh5wClg_IeuLSuxlwZQ03YnSXwfh6daFLkiwtnWW5ykJ7YgxtSmpYBwBp3XTz5XyWdK9-OHsq55XdpoKk5ZuTzA
       Content-Length:
       - '42'
       Host:
@@ -1927,34 +1927,34 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/c911d693-2699-4d33-9a77-cf67d5af9d01?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/237a0433-c339-4c81-a606-e91a5e31a465?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/c911d693-2699-4d33-9a77-cf67d5af9d01?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/237a0433-c339-4c81-a606-e91a5e31a465?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
       - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
       X-Ms-Request-Id:
-      - c911d693-2699-4d33-9a77-cf67d5af9d01
+      - 237a0433-c339-4c81-a606-e91a5e31a465
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1196'
+      - '1189'
       X-Ms-Correlation-Request-Id:
-      - 56885322-9c3a-4dd3-9d7f-01b9a4b87fb7
+      - e463e4c5-f752-4250-bf43-7ced7e2d4977
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153317Z:56885322-9c3a-4dd3-9d7f-01b9a4b87fb7
+      - EASTUS:20170830T170518Z:e463e4c5-f752-4250-bf43-7ced7e2d4977
       Date:
-      - Wed, 30 Aug 2017 15:33:16 GMT
+      - Wed, 30 Aug 2017 17:05:18 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:33:17 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:18 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/c911d693-2699-4d33-9a77-cf67d5af9d01?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/237a0433-c339-4c81-a606-e91a5e31a465?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -1968,7 +1968,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4OTUsIm5iZiI6MTUwNDEwNjg5NSwiZXhwIjoxNTA0MTEwNzk1LCJhaW8iOiJZMkZnWVBqeGJmMVBCUnNOUmcwdkRzdnQwbnovQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZ1JDUGducXMtRUtiZy1HeGxDSVNBQSIsInZlciI6IjEuMCJ9.KSUCtfYUWBYpiRZ8Oe73YcjB0AVtFDYwfvV6kPGobrVZzVhauDn0q_hprykjN5-EWT07l_ZXgPKZZsiJ0-52T97sTkKTUlqOwMnP3exbb-aqVt0cSL7dnerJdF6SXw7vOif6OPUWkkg_bShX1ZHg6eYEZ_uGoxPa67r34OB-iwZV4kZdZSvP2sPVW75g3jhgEkSnsDBZZ9u5PuuecS5DTeMXnaR6uryG-Aoi8j0x773sApFV-_9G7WuYugGMp-QmB9aJUqOeYrkiZqQnJtR4Ot6s-EJlO7mjps-CqSWCWrspbRKGueJXDLSnBmCKZkqVWwvHDt1lxCUM5JfRWG6ODQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MTcsIm5iZiI6MTUwNDExMjQxNywiZXhwIjoxNTA0MTE2MzE3LCJhaW8iOiJZMkZnWVBodlpwMmdma2I0Yy8veXZLaVVwUk0rQWdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYmxHYVZZWS1sa1NHR0xzYjZKTVVBQSIsInZlciI6IjEuMCJ9.qxk8VXz_2hqLNN144IW8Gr_TJLbaeu4YttqsP99mqfeFeWcTSdOrYMCgTOYeJiEIzY62qfYohHIeEJmT19Fi-ZwWPT7DjzRhCasMR55l3wKugRrn1TEWAEXi5wGcr1jXgBByDg7ldqAuh97aclaQDE-yTmNUgGUzlQ1Up0Mltgvh8CpzO3O5Go4reZui1E1L__0FQ7tHycxuf6MwZRhQfZS9LzQRoUmzxrEcHS5ChF0DF7LxMn5k9RIFwpvyO87Eh5wClg_IeuLSuxlwZQ03YnSXwfh6daFLkiwtnWW5ykJ7YgxtSmpYBwBp3XTz5XyWdK9-OHsq55XdpoKk5ZuTzA
       Host:
       - management.azure.com
   response:
@@ -1993,29 +1993,29 @@ http_interactions:
       X-Ms-Served-By:
       - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
       X-Ms-Request-Id:
-      - 5f58ae07-92fd-4ab8-975b-0ea408183880
+      - a04a6b1c-4400-4dce-a95d-312d760af279
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14953'
+      - '14277'
       X-Ms-Correlation-Request-Id:
-      - 3b554937-d6ce-4593-a576-fca77c5f00e3
+      - 0cc8c0da-2733-45c5-bc00-c9525e4c4979
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153317Z:3b554937-d6ce-4593-a576-fca77c5f00e3
+      - EASTUS:20170830T170519Z:0cc8c0da-2733-45c5-bc00-c9525e4c4979
       Date:
-      - Wed, 30 Aug 2017 15:33:17 GMT
+      - Wed, 30 Aug 2017 17:05:18 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-08-30T15:33:17.1189295+00:00\",\r\n  \"endTime\":
-        \"2017-08-30T15:33:17.3220439+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=cf92b8ab-a4eb-4074-882b-beabe371861c&sig=Hxb0jpPtk3iG3Qxkb4Nwf97GoNrNrfvR%2FFBVzKr8mOM%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"c911d693-2699-4d33-9a77-cf67d5af9d01\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2017-08-30T17:05:18.2488009+00:00\",\r\n  \"endTime\":
+        \"2017-08-30T17:05:18.4519321+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=0dd05d16-7e40-437a-941e-95fec29739db&sig=o9LytWsS43HAO29PXnWQYOXwCBlDXxwrZBbz11xl4L0%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"237a0433-c339-4c81-a606-e91a5e31a465\"\r\n}"
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:33:17 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:18 GMT
 - request:
     method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=cf92b8ab-a4eb-4074-882b-beabe371861c&sig=Hxb0jpPtk3iG3Qxkb4Nwf97GoNrNrfvR/FBVzKr8mOM=&sr=b&sv=2016-05-31
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=0dd05d16-7e40-437a-941e-95fec29739db&sig=o9LytWsS43HAO29PXnWQYOXwCBlDXxwrZBbz11xl4L0=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2050,7 +2050,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 9f854775-0001-00f6-64a5-21863b000000
+      - ea737820-0001-00fa-75b2-2168ca000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2076,13 +2076,13 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 30 Aug 2017 15:33:18 GMT
+      - Wed, 30 Aug 2017 17:05:18 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         6w==
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:33:18 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:18 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
@@ -2099,7 +2099,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4OTUsIm5iZiI6MTUwNDEwNjg5NSwiZXhwIjoxNTA0MTEwNzk1LCJhaW8iOiJZMkZnWVBqeGJmMVBCUnNOUmcwdkRzdnQwbnovQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZ1JDUGducXMtRUtiZy1HeGxDSVNBQSIsInZlciI6IjEuMCJ9.KSUCtfYUWBYpiRZ8Oe73YcjB0AVtFDYwfvV6kPGobrVZzVhauDn0q_hprykjN5-EWT07l_ZXgPKZZsiJ0-52T97sTkKTUlqOwMnP3exbb-aqVt0cSL7dnerJdF6SXw7vOif6OPUWkkg_bShX1ZHg6eYEZ_uGoxPa67r34OB-iwZV4kZdZSvP2sPVW75g3jhgEkSnsDBZZ9u5PuuecS5DTeMXnaR6uryG-Aoi8j0x773sApFV-_9G7WuYugGMp-QmB9aJUqOeYrkiZqQnJtR4Ot6s-EJlO7mjps-CqSWCWrspbRKGueJXDLSnBmCKZkqVWwvHDt1lxCUM5JfRWG6ODQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MTcsIm5iZiI6MTUwNDExMjQxNywiZXhwIjoxNTA0MTE2MzE3LCJhaW8iOiJZMkZnWVBodlpwMmdma2I0Yy8veXZLaVVwUk0rQWdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYmxHYVZZWS1sa1NHR0xzYjZKTVVBQSIsInZlciI6IjEuMCJ9.qxk8VXz_2hqLNN144IW8Gr_TJLbaeu4YttqsP99mqfeFeWcTSdOrYMCgTOYeJiEIzY62qfYohHIeEJmT19Fi-ZwWPT7DjzRhCasMR55l3wKugRrn1TEWAEXi5wGcr1jXgBByDg7ldqAuh97aclaQDE-yTmNUgGUzlQ1Up0Mltgvh8CpzO3O5Go4reZui1E1L__0FQ7tHycxuf6MwZRhQfZS9LzQRoUmzxrEcHS5ChF0DF7LxMn5k9RIFwpvyO87Eh5wClg_IeuLSuxlwZQ03YnSXwfh6daFLkiwtnWW5ykJ7YgxtSmpYBwBp3XTz5XyWdK9-OHsq55XdpoKk5ZuTzA
       Content-Length:
       - '42'
       Host:
@@ -2118,34 +2118,34 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/efeff584-4db2-4606-876f-d614a54bd704?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/62262e0b-bebc-45d9-ac40-6f0c03798226?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/efeff584-4db2-4606-876f-d614a54bd704?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/62262e0b-bebc-45d9-ac40-6f0c03798226?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
       - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
       X-Ms-Request-Id:
-      - efeff584-4db2-4606-876f-d614a54bd704
+      - 62262e0b-bebc-45d9-ac40-6f0c03798226
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1196'
+      - '1195'
       X-Ms-Correlation-Request-Id:
-      - e8008514-3484-4194-beec-20fdb5adbf1b
+      - b997db76-99db-450c-ab57-7e6f44a6206d
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153318Z:e8008514-3484-4194-beec-20fdb5adbf1b
+      - EASTUS:20170830T170519Z:b997db76-99db-450c-ab57-7e6f44a6206d
       Date:
-      - Wed, 30 Aug 2017 15:33:18 GMT
+      - Wed, 30 Aug 2017 17:05:18 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:33:18 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:18 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/efeff584-4db2-4606-876f-d614a54bd704?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/62262e0b-bebc-45d9-ac40-6f0c03798226?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -2159,7 +2159,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4OTUsIm5iZiI6MTUwNDEwNjg5NSwiZXhwIjoxNTA0MTEwNzk1LCJhaW8iOiJZMkZnWVBqeGJmMVBCUnNOUmcwdkRzdnQwbnovQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZ1JDUGducXMtRUtiZy1HeGxDSVNBQSIsInZlciI6IjEuMCJ9.KSUCtfYUWBYpiRZ8Oe73YcjB0AVtFDYwfvV6kPGobrVZzVhauDn0q_hprykjN5-EWT07l_ZXgPKZZsiJ0-52T97sTkKTUlqOwMnP3exbb-aqVt0cSL7dnerJdF6SXw7vOif6OPUWkkg_bShX1ZHg6eYEZ_uGoxPa67r34OB-iwZV4kZdZSvP2sPVW75g3jhgEkSnsDBZZ9u5PuuecS5DTeMXnaR6uryG-Aoi8j0x773sApFV-_9G7WuYugGMp-QmB9aJUqOeYrkiZqQnJtR4Ot6s-EJlO7mjps-CqSWCWrspbRKGueJXDLSnBmCKZkqVWwvHDt1lxCUM5JfRWG6ODQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMTI0MTcsIm5iZiI6MTUwNDExMjQxNywiZXhwIjoxNTA0MTE2MzE3LCJhaW8iOiJZMkZnWVBodlpwMmdma2I0Yy8veXZLaVVwUk0rQWdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYmxHYVZZWS1sa1NHR0xzYjZKTVVBQSIsInZlciI6IjEuMCJ9.qxk8VXz_2hqLNN144IW8Gr_TJLbaeu4YttqsP99mqfeFeWcTSdOrYMCgTOYeJiEIzY62qfYohHIeEJmT19Fi-ZwWPT7DjzRhCasMR55l3wKugRrn1TEWAEXi5wGcr1jXgBByDg7ldqAuh97aclaQDE-yTmNUgGUzlQ1Up0Mltgvh8CpzO3O5Go4reZui1E1L__0FQ7tHycxuf6MwZRhQfZS9LzQRoUmzxrEcHS5ChF0DF7LxMn5k9RIFwpvyO87Eh5wClg_IeuLSuxlwZQ03YnSXwfh6daFLkiwtnWW5ykJ7YgxtSmpYBwBp3XTz5XyWdK9-OHsq55XdpoKk5ZuTzA
       Host:
       - management.azure.com
   response:
@@ -2184,29 +2184,29 @@ http_interactions:
       X-Ms-Served-By:
       - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
       X-Ms-Request-Id:
-      - 8c683ab6-9282-415b-9807-4f1714be078c
+      - e7d5d28e-5f4f-4d6b-8133-c0493aee94b6
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14244'
+      - '14276'
       X-Ms-Correlation-Request-Id:
-      - 7b6b44e8-303e-44a4-acdf-32d5b0a2c24b
+      - 6634381b-070c-481c-9cc4-4d953cfef412
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170830T153323Z:7b6b44e8-303e-44a4-acdf-32d5b0a2c24b
+      - EASTUS:20170830T170519Z:6634381b-070c-481c-9cc4-4d953cfef412
       Date:
-      - Wed, 30 Aug 2017 15:33:22 GMT
+      - Wed, 30 Aug 2017 17:05:19 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-08-30T15:33:17.9157821+00:00\",\r\n  \"endTime\":
-        \"2017-08-30T15:33:18.0563995+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=783f6191-bbea-42d3-878d-740aba95d48d&sig=OtThUc15DR7RwVihDCGKskEmF16XxsbHzVZqLC53Nk0%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"efeff584-4db2-4606-876f-d614a54bd704\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2017-08-30T17:05:18.9519095+00:00\",\r\n  \"endTime\":
+        \"2017-08-30T17:05:19.1091403+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=539c1da9-bdb0-4fc6-abff-ad99aa757487&sig=k5ENDtjtYKVqJNeXcvuUTv2Xe50Z2xW3mlE8VkQqcxU%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"62262e0b-bebc-45d9-ac40-6f0c03798226\"\r\n}"
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:33:23 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:18 GMT
 - request:
     method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=783f6191-bbea-42d3-878d-740aba95d48d&sig=OtThUc15DR7RwVihDCGKskEmF16XxsbHzVZqLC53Nk0=&sr=b&sv=2016-05-31
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=539c1da9-bdb0-4fc6-abff-ad99aa757487&sig=k5ENDtjtYKVqJNeXcvuUTv2Xe50Z2xW3mlE8VkQqcxU=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2241,7 +2241,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 4250a130-0001-00a6-36a5-219933000000
+      - 67f22a10-0001-006e-21b2-210804000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2267,11 +2267,11 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 30 Aug 2017 15:33:28 GMT
+      - Wed, 30 Aug 2017 17:05:18 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         U5MJAA==
     http_version: 
-  recorded_at: Wed, 30 Aug 2017 15:33:28 GMT
+  recorded_at: Wed, 30 Aug 2017 17:05:19 GMT
 recorded_with: VCR 3.0.3

--- a/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_startByteAddr-1.yml
+++ b/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_startByteAddr-1.yml
@@ -1,0 +1,2277 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://login.microsoftonline.com/azure_tenant_id/oauth2/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_key&resource=https%3A%2F%2Fmanagement.azure.com%2F
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - login.microsoftonline.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Server:
+      - Microsoft-IIS/8.5
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Request-Id:
+      - 828f1081-ac7a-42f8-9b83-e1b194221200
+      P3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Set-Cookie:
+      - esctx=AQABAAAAAAA9kTklhVy7SJTGAzR-p1BcIGIMfitzdSO376Zv9yPyXmdMBYbyUndexmARzt1x9SBBg_USoP47e2gMUNI8zXj__DBCAdx-ClS6aI1Yb-yd2TtG8xUm94yheO8xRg4Mn5dCemrb6H6YR0yOf4cwR_fjff1Bpd8PzG__OsnTzbBxz7KZEfzpg4tWcdY73uxZBrggAA;
+        domain=.login.microsoftonline.com; path=/; secure; HttpOnly
+      - stsservicecookie=ests; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=005; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Wed, 30 Aug 2017 15:33:15 GMT
+      Content-Length:
+      - '1505'
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"Bearer","expires_in":"3600","ext_expires_in":"0","expires_on":"1504110795","not_before":"1504106895","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4OTUsIm5iZiI6MTUwNDEwNjg5NSwiZXhwIjoxNTA0MTEwNzk1LCJhaW8iOiJZMkZnWVBqeGJmMVBCUnNOUmcwdkRzdnQwbnovQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZ1JDUGducXMtRUtiZy1HeGxDSVNBQSIsInZlciI6IjEuMCJ9.KSUCtfYUWBYpiRZ8Oe73YcjB0AVtFDYwfvV6kPGobrVZzVhauDn0q_hprykjN5-EWT07l_ZXgPKZZsiJ0-52T97sTkKTUlqOwMnP3exbb-aqVt0cSL7dnerJdF6SXw7vOif6OPUWkkg_bShX1ZHg6eYEZ_uGoxPa67r34OB-iwZV4kZdZSvP2sPVW75g3jhgEkSnsDBZZ9u5PuuecS5DTeMXnaR6uryG-Aoi8j0x773sApFV-_9G7WuYugGMp-QmB9aJUqOeYrkiZqQnJtR4Ot6s-EJlO7mjps-CqSWCWrspbRKGueJXDLSnBmCKZkqVWwvHDt1lxCUM5JfRWG6ODQ"}'
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:15 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions?api-version=2016-06-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4OTUsIm5iZiI6MTUwNDEwNjg5NSwiZXhwIjoxNTA0MTEwNzk1LCJhaW8iOiJZMkZnWVBqeGJmMVBCUnNOUmcwdkRzdnQwbnovQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZ1JDUGducXMtRUtiZy1HeGxDSVNBQSIsInZlciI6IjEuMCJ9.KSUCtfYUWBYpiRZ8Oe73YcjB0AVtFDYwfvV6kPGobrVZzVhauDn0q_hprykjN5-EWT07l_ZXgPKZZsiJ0-52T97sTkKTUlqOwMnP3exbb-aqVt0cSL7dnerJdF6SXw7vOif6OPUWkkg_bShX1ZHg6eYEZ_uGoxPa67r34OB-iwZV4kZdZSvP2sPVW75g3jhgEkSnsDBZZ9u5PuuecS5DTeMXnaR6uryG-Aoi8j0x773sApFV-_9G7WuYugGMp-QmB9aJUqOeYrkiZqQnJtR4Ot6s-EJlO7mjps-CqSWCWrspbRKGueJXDLSnBmCKZkqVWwvHDt1lxCUM5JfRWG6ODQ
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Tenant-Reads:
+      - '14999'
+      X-Ms-Request-Id:
+      - 2c06d66f-870f-4e89-bc03-627668e5e8d7
+      X-Ms-Correlation-Request-Id:
+      - 2c06d66f-870f-4e89-bc03-627668e5e8d7
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153316Z:2c06d66f-870f-4e89-bc03-627668e5e8d7
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 30 Aug 2017 15:33:15 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
+        Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:16 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers?api-version=2015-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4OTUsIm5iZiI6MTUwNDEwNjg5NSwiZXhwIjoxNTA0MTEwNzk1LCJhaW8iOiJZMkZnWVBqeGJmMVBCUnNOUmcwdkRzdnQwbnovQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZ1JDUGducXMtRUtiZy1HeGxDSVNBQSIsInZlciI6IjEuMCJ9.KSUCtfYUWBYpiRZ8Oe73YcjB0AVtFDYwfvV6kPGobrVZzVhauDn0q_hprykjN5-EWT07l_ZXgPKZZsiJ0-52T97sTkKTUlqOwMnP3exbb-aqVt0cSL7dnerJdF6SXw7vOif6OPUWkkg_bShX1ZHg6eYEZ_uGoxPa67r34OB-iwZV4kZdZSvP2sPVW75g3jhgEkSnsDBZZ9u5PuuecS5DTeMXnaR6uryG-Aoi8j0x773sApFV-_9G7WuYugGMp-QmB9aJUqOeYrkiZqQnJtR4Ot6s-EJlO7mjps-CqSWCWrspbRKGueJXDLSnBmCKZkqVWwvHDt1lxCUM5JfRWG6ODQ
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14247'
+      X-Ms-Request-Id:
+      - ee3bc4e9-2168-4f2e-8299-33afc229ee71
+      X-Ms-Correlation-Request-Id:
+      - ee3bc4e9-2168-4f2e-8299-33afc229ee71
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153317Z:ee3bc4e9-2168-4f2e-8299-33afc229ee71
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 30 Aug 2017 15:33:16 GMT
+      Content-Length:
+      - '241615'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","North Central
+        US","South Central US","West Central US","West US","West US 2","Canada Central","Canada
+        East","North Europe","West Europe","UK South","UK West","East Asia","Southeast
+        Asia","Japan East","Japan West","Korea Central","Korea South","Brazil South","Central
+        India","South India","West India"],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"validateServiceName","locations":[],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"checkServiceNameAvailability","locations":[],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"reportFeedback","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"checkFeedbackRequired","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Automation","namespace":"Microsoft.Automation","authorizations":[{"applicationId":"fc75330b-179d-49af-87dd-3b1acf6827fa","roleDefinitionId":"95fd5de3-d071-4362-92bf-cf341c1de832"}],"resourceTypes":[{"resourceType":"automationAccounts","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
+        South","UK South","West Central US","North Europe","Canada Central","Australia
+        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/runbooks","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
+        South","UK South","West Central US","North Europe","Canada Central","Australia
+        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/configurations","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","North
+        Central US","Brazil South","UK South","West Central US","Central India","Australia
+        Southeast","Canada Central","North Europe"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/webhooks","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
+        South","UK South","West Central US","North Europe","Canada Central","Australia
+        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"operations","locations":["South
+        Central US"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/softwareUpdateConfigurations","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
+        South","UK South","West Central US","North Europe","Canada Central","Australia
+        Southeast","Central India"],"apiVersions":["2017-05-15-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Backup","namespace":"Microsoft.Backup","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"BackupVault","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India"],"apiVersions":["2015-03-15","2014-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Batch","namespace":"Microsoft.Batch","authorization":{"applicationId":"ddbf3205-c6bd-46ae-8127-60eb93363864","roleDefinitionId":"b7f84953-1d03-4eab-9ea4-45f065258ff8"},"resourceTypes":[{"resourceType":"batchAccounts","locations":["West
+        Europe","East US","East US 2","West US","North Central US","Brazil South","North
+        Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
+        West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
+        East","South India","Central India","Canada Central","Canada East","UK South","UK
+        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01","2015-07-01","2014-05-01-privatepreview"]},{"resourceType":"operations","locations":["West
+        Europe","East US","East US 2","West US","North Central US","Brazil South","North
+        Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
+        West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
+        East","South India","Central India","Canada Central","Canada East","UK South","UK
+        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations/quotas","locations":["West
+        Europe","East US","East US 2","West US","North Central US","Brazil South","North
+        Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
+        West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
+        East","South India","Central India","Canada Central","Canada East","UK South","UK
+        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]}],"registrationState":"Unregistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicCompute","namespace":"Microsoft.ClassicCompute","resourceTypes":[{"resourceType":"domainNames","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
+        Central","Canada East","UK South","UK West","West US","Central US","South
+        Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
+        East","Australia Southeast","West US 2","West Central US","South India","Central
+        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
+        Central","Canada East","UK South","UK West","West US","Central US","South
+        Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
+        East","Australia Southeast","West US 2","West Central US","South India","Central
+        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
+        Central US","South Central US","East US","East US 2","Canada Central","Canada
+        East","West US","West US 2","West Central US","Central US","East Asia","Southeast
+        Asia","North Europe","West Europe","UK South","UK West","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operatingSystems","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"operatingSystemFamilies","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicNetwork","namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"virtualNetworks/remoteVirtualNetworkPeeringProxies","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"reservedIps","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicStorage","namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
+        Central US","South Central US","West Central US","Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia East","Australia
+        Southeast","South India","Central India","West India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
+        US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
+        Asia","Australia East","Australia Southeast","South India","Central India","West
+        India","West US 2","West Central US","East US","East US 2","North Central
+        US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
+        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
+        US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
+        Asia","Australia East","Australia Southeast","South India","Central India","West
+        India","West US 2","West Central US","East US","East US 2","North Central
+        US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
+        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"vmImages","locations":[],"apiVersions":["2016-11-01"]},{"resourceType":"publicImages","locations":[],"apiVersions":["2016-11-01","2016-04-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"osPlatformImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Compute","namespace":"Microsoft.Compute","authorization":{"applicationId":"60e6cd67-9c8c-4951-9b3c-23c25a2169af","roleDefinitionId":"e4770acb-272e-4dc8-87f3-12f44a612224"},"resourceTypes":[{"resourceType":"availabilitySets","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30"]},{"resourceType":"locations/usages","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Brazil South","South India","Central India","West
+        India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"disks","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"snapshots","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"locations/diskoperations","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"images","locations":["Southeast
+        Asia","East US 2","Central US","West Europe","East US","North Central US","South
+        Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
+        Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
+        East","Central India","South India","Australia East","Australia Southeast","Korea
+        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
+        US","East US","South Central US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","East Asia","Japan
+        East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/webhooks","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/ping","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/getCallbackConfig","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/listEvents","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"locations","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"locations/operationResults","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/GetCredentials","locations":["West
+        US","East US","South Central US","West Europe"],"apiVersions":["2016-06-27-preview"]},{"resourceType":"registries/listCredentials","locations":["South
+        Central US","East US","West US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","East Asia","Japan
+        East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/regenerateCredential","locations":["South
+        Central US","West US","East US","West Europe","North Europe","UK South","UK
+        West","Australia East","Australia Southeast","Central India","East Asia","Japan
+        East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
+        Central","Central US","East US 2","North Central US","West Central US","West
+        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/listUsages","locations":["West
+        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/regenerateCredentials","locations":["West
+        US","East US","South Central US","West Europe"],"apiVersions":["2016-06-27-preview"]},{"resourceType":"checkNameAvailability","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview","2017-03-01","2016-06-27-preview"]},{"resourceType":"operations","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview","2017-03-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerService","namespace":"Microsoft.ContainerService","authorization":{"applicationId":"7319c514-987d-4e9b-ac3d-d38c4f427f4c","roleDefinitionId":"1b4a0c7f-2217-416f-acfa-cf73452fdc1c"},"resourceTypes":[{"resourceType":"containerServices","locations":["Japan
+        East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
+        East","Australia Southeast","Brazil South","Southeast Asia","West US","North
+        Central US","West Europe","North Europe","East US","UK West","UK South","West
+        Central US","West US 2","South India","Central India","West India","Canada
+        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
+        East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
+        East","Australia Southeast","Brazil South","Southeast Asia","West US","North
+        Central US","West Europe","North Europe","East US","UK West","UK South","West
+        Central US","West US 2","South India","Central India","West India","Canada
+        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DevTestLab","namespace":"Microsoft.DevTestLab","authorization":{"applicationId":"1a14be2a-e903-4cec-99cf-b2e209259a0f","roleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525"},"resourceTypes":[{"resourceType":"labs","locations":["West
+        Central US","Japan East","West US","Australia Southeast","Canada Central","Central
+        India","Central US","East Asia","Korea Central","North Europe","South Central
+        US","UK West","Australia East","Brazil South","Canada East","East US","East
+        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"schedules","locations":["West
+        Central US","Japan East","West US","Australia Southeast","Canada Central","Central
+        India","Central US","East Asia","Korea Central","North Europe","South Central
+        US","UK West","Australia East","Brazil South","Canada East","East US","East
+        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"labs/virtualMachines","locations":["West
+        Central US","Japan East","West US","Australia Southeast","Canada Central","Central
+        India","Central US","East Asia","Korea Central","North Europe","South Central
+        US","UK West","Australia East","Brazil South","Canada East","East US","East
+        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"labs/serviceRunners","locations":["Central
+        US","East US 2","South Central US"],"apiVersions":["2017-04-26-preview","2016-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"locations/operations","locations":["West
+        Central US","Japan East","West US","Australia Southeast","Canada Central","Central
+        India","Central US","East Asia","Korea Central","North Europe","South Central
+        US","UK West","Australia East","Brazil South","Canada East","East US","East
+        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"}],"resourceTypes":[{"resourceType":"components","locations":["East
+        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
+        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01","2014-04-01"]},{"resourceType":"queries","locations":["East
+        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"alertrules","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2016-03-01","2015-04-01","2014-04-01"]},{"resourceType":"autoscalesettings","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2015-04-01","2014-04-01"]},{"resourceType":"eventtypes","locations":[],"apiVersions":["2017-03-01-preview","2016-09-01-preview","2015-04-01","2014-11-01","2014-04-01"]},{"resourceType":"locations","locations":["East
+        US"],"apiVersions":["2015-04-01","2014-04-01"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2015-04-01","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-04-01","2014-06-01","2014-04-01"]},{"resourceType":"automatedExportSettings","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2015-04-01","2014-04-01"]},{"resourceType":"diagnosticSettings","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2017-05-01-preview","2016-09-01","2015-07-01"]},{"resourceType":"diagnosticSettingsCategories","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"extendedDiagnosticSettings","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2017-02-01"]},{"resourceType":"metricDefinitions","locations":["East
+        US","West US","West Europe","East Asia","Southeast Asia","Japan East","Japan
+        West","North Central US","South Central US","East US 2","Canada East","Canada
+        Central","Central US","Australia East","Australia Southeast","Brazil South","South
+        India","Central India","West India","North Europe","West US 2","West Central
+        US","Korea South","Korea Central","UK South","UK West","Global"],"apiVersions":["2017-05-01-preview","2016-03-01","2015-07-01"]},{"resourceType":"logDefinitions","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
+        India","Central India","West India","Canada East","Canada Central","West Central
+        US","West US 2","Korea South","Korea Central"],"apiVersions":["2015-07-01"]},{"resourceType":"eventCategories","locations":[],"apiVersions":["2015-04-01"]},{"resourceType":"metrics","locations":["East
+        US","West US","West Europe","East Asia","Southeast Asia","Japan East","Japan
+        West","North Central US","South Central US","East US 2","Canada East","Canada
+        Central","Central US","Australia East","Australia Southeast","Brazil South","South
+        India","Central India","West India","North Europe","West US 2","West Central
+        US","Korea South","Korea Central","UK South","UK West"],"apiVersions":["2017-05-01-preview","2016-09-01","2016-06-01"]},{"resourceType":"actiongroups","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]},{"resourceType":"activityLogAlerts","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.KeyVault","namespace":"Microsoft.KeyVault","resourceTypes":[{"resourceType":"vaults","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/accessPolicies","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-10-01","2015-06-01","2014-12-19-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"deletedVaults","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-10-01"]},{"resourceType":"locations/deletedVaults","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","East US","North Europe","West Europe","East Asia","Southeast
+        Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India","South
+        India","West India","Canada Central","Canada East","UK South","UK West","West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorization":{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"routeTables","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2017-04-26-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"]},{"resourceType":"workspaces/dataSources","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"storageInsightConfigs","locations":[],"apiVersions":["2014-10-10"]},{"resourceType":"workspaces/linkedServices","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"linkTargets","locations":["East
+        US"],"apiVersions":["2015-03-20"]},{"resourceType":"operations","locations":[],"apiVersions":["2014-11-10"]},{"resourceType":"devices","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationsManagement","namespace":"Microsoft.OperationsManagement","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"aa249101-6816-4966-aafa-08175d795f14"},"resourceTypes":[{"resourceType":"solutions","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Portal","namespace":"Microsoft.Portal","resourceTypes":[{"resourceType":"dashboards","locations":["Central
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
+        East","West India","South India","Central India","Canada Central","Canada
+        East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"operations","locations":["Central
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
+        East","West India","South India","Central India","Canada Central","Canada
+        East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"consoles","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/consoles","locations":["West
+        US","East US","Central India","North Europe","West Europe","South Central
+        US","Southeast Asia"],"apiVersions":["2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
+        US","East US","Central India","North Europe","West Europe","South Central
+        US","Southeast Asia"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","Canada Central","Canada East","West Central US","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-07-01","2016-12-01","2016-08-10","2016-06-01","2016-05-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"operations","locations":["Southeast
+        Asia"],"apiVersions":["2016-08-10","2016-06-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01"]},{"resourceType":"locations/backupStatus","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]},{"resourceType":"locations/allocatedStamp","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]},{"resourceType":"locations/allocateStamp","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ResourceHealth","namespace":"Microsoft.ResourceHealth","authorization":{"applicationId":"8bdebf23-c0fe-4187-a378-717ad86f6a53","roleDefinitionId":"cc026344-c8b1-4561-83ba-59eba84b27cc"},"resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2017-07-01","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"notifications","locations":["Australia
+        Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Security","namespace":"Microsoft.Security","authorization":{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatuses","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/virtualMachines","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/endpoints","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/subnets","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"tasks","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"alerts","locations":["Central
+        US","East US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"monitoring","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"monitoring/patch","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"monitoring/baseline","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"monitoring/antimalware","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"dataCollectionAgents","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"dataCollectionResults","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"pricings","locations":["Central
+        US","East US"],"apiVersions":["2017-08-01-preview"]},{"resourceType":"complianceResults","locations":["Central
+        US","East US"],"apiVersions":["2017-08-01"]},{"resourceType":"policies","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"appliances","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"webApplicationFirewalls","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/webApplicationFirewalls","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securitySolutions","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/securitySolutions","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securitySolutionsReferenceData","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/securitySolutionsReferenceData","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"jitNetworkAccessPolicies","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/jitNetworkAccessPolicies","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations","locations":["Central
+        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatusesSummaries","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/alerts","locations":["Central
+        US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/tasks","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.SiteRecovery","namespace":"Microsoft.SiteRecovery","authorization":{"applicationId":"b8340c3b-9267-498f-b21a-15d5547fd85e","roleDefinitionId":"8A00C8EA-8F1B-45A7-8F64-F4CC61EEE9B6"},"resourceTypes":[{"resourceType":"SiteRecoveryVault","locations":["East
+        US","West US","North Europe","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","Australia East","Australia Southeast","Brazil South","North
+        Central US","South Central US","Central US","East US 2","Central India","South
+        India"],"apiVersions":["2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Sql","namespace":"Microsoft.Sql","authorizations":[{"applicationId":"e4ab13ed-33cb-41b4-9140-6e264582cf85","roleDefinitionId":"ec3ddc95-44dc-47a2-9926-5e9f5ffd44ec"},{"applicationId":"0130cc9f-7ac5-4026-bd5f-80a08a54e6d9","roleDefinitionId":"45e8abf8-0ec4-44f3-9c37-cff4f7779302"},{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},{"applicationId":"76c7f279-7959-468f-8943-3954880e0d8c","roleDefinitionId":"7f7513a8-73f9-4c5f-97a2-c41f0ea783ef"}],"resourceTypes":[{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/capabilities","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverKeyOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/keys","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/encryptionProtector","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/communicationLinks","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recoverableDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/importExportOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/operationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/firewallrules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/elasticpools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-09-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/dnsAliases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/failoverGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/virtualNetworkRules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/virtualNetworkRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/virtualNetworkRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/databaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/extensions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditRecords","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/VulnerabilityAssessmentScans","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentScans","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups/syncMembers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/syncAgents","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncMemberOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncAgentOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncDatabaseIds","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorization":{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
+        US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","Central US","North
+        Europe","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
+        US","West US","West Europe","North Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":["East
+        US","West US","West Europe","North Europe","East Asia","Southeast Asia","Japan
+        East","Japan West","North Central US","South Central US","East US 2","Central
+        US","Australia East","Australia Southeast","Brazil South","South India","Central
+        India","West India","Canada East","Canada Central","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Web","namespace":"Microsoft.Web","authorization":{"applicationId":"abfa0a7c-a6b6-4736-8310-5855508787cd","roleDefinitionId":"f47ed98b-b063-4a5b-9e10-4b9b44fa7735"},"resourceTypes":[{"resourceType":"sites/extensions","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots/extensions","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/instances","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots/instances","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/instances/extensions","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots/instances/extensions","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/publicCertificates","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots/publicCertificates","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"publishingUsers","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"ishostnameavailable","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"validate","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"isusernameavailable","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sourceControls","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"availableStacks","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"listSitesAssignedToHostName","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"sites/hostNameBindings","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"sites/domainOwnershipIdentifiers","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"sites/slots/hostNameBindings","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01"]},{"resourceType":"operations","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"certificates","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms/workers","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/slots","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"runtimes","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"sites/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"sites/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"sites/slots/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"sites/slots/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"serverFarms/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"serverFarms/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"sites/recommendations","locations":[],"apiVersions":["2016-08-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"georegions","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"sites/premieraddons","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01"]},{"resourceType":"hostingEnvironments","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01"]},{"resourceType":"hostingEnvironments/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/instances","locations":[],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/instances/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/multiRolePools/instances/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/instances","locations":[],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/instances/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"hostingEnvironments/workerPools/instances/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"deploymentLocations","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"functions","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"deletedSites","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"ishostingenvironmentnameavailable","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"classicMobileServices","locations":[],"apiVersions":["2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"connections","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/managedApis","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/apiOperations","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"connectionGateways","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/connectionGatewayInstallations","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"checkNameAvailability","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"billingMeters","locations":["South
+        Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
+        South","West US","East US","Japan West","Japan East","East Asia","East US
+        2","North Central US","Central US","Brazil South","Australia East","Australia
+        Southeast","West India","Central India","South India","Canada Central","Canada
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-03-01","2015-08-01-preview","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/84codes.CloudAMQP","namespace":"84codes.CloudAMQP","resourceTypes":[{"resourceType":"servers","locations":["East
+        US 2","Central US","East US","North Central US","South Central US","West US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast"],"apiVersions":["2016-08-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/AppDynamics.APM","namespace":"AppDynamics.APM","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2016-05-26"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-05-26"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-05-26"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-05-26"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-05-26"]},{"resourceType":"locations/operationResults","locations":["West
+        US"],"apiVersions":["2016-05-26"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Aspera.Transfers","namespace":"Aspera.Transfers","resourceTypes":[{"resourceType":"services","locations":["West
+        US","North Europe","Central US","East US","West Europe","East Asia","Southeast
+        Asia","Japan East","East US 2","Japan West"],"apiVersions":["2016-03-25"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-03-25"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-03-25"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-03-25"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Auth0.Cloud","namespace":"Auth0.Cloud","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-11-23"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Citrix.Cloud","namespace":"Citrix.Cloud","resourceTypes":[{"resourceType":"accounts","locations":["West
+        US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Cloudyn.Analytics","namespace":"Cloudyn.Analytics","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US"],"apiVersions":["2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Conexlink.MyCloudIT","namespace":"Conexlink.MyCloudIT","resourceTypes":[{"resourceType":"accounts","locations":["Central
+        US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Crypteron.DataSecurity","namespace":"Crypteron.DataSecurity","resourceTypes":[{"resourceType":"apps","locations":["West
+        US"],"apiVersions":["2016-08-12"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-12"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-12"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-12"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Dynatrace.DynatraceSaaS","namespace":"Dynatrace.DynatraceSaaS","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-09-27"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Dynatrace.Ruxit","namespace":"Dynatrace.Ruxit","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US"],"apiVersions":["2016-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-09-07","2016-04-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-04-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/LiveArena.Broadcast","namespace":"LiveArena.Broadcast","resourceTypes":[{"resourceType":"services","locations":["West
+        US","North Europe","Japan West","Japan East","East Asia","West Europe","East
+        US","Southeast Asia","Central US"],"apiVersions":["2016-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Lombiq.DotNest","namespace":"Lombiq.DotNest","resourceTypes":[{"resourceType":"sites","locations":["East
+        US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Mailjet.Email","namespace":"Mailjet.Email","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]},{"resourceType":"diagnosticSettings","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"addsservices","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"configuration","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"agents","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"aadsupportcases","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"reports","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"servicehealthmetrics","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"logs","locations":["West
+        US"],"apiVersions":["2014-01-01"]},{"resourceType":"anonymousapiusers","locations":["West
+        US"],"apiVersions":["2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AnalysisServices","namespace":"Microsoft.AnalysisServices","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"servers","locations":["West
+        US","North Europe","South Central US","West Europe","West Central US","Southeast
+        Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
+        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/checkNameAvailability","locations":["West
+        US","North Europe","South Central US","West Europe","West Central US","Southeast
+        Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
+        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationresults","locations":["West
+        US","North Europe","South Central US","West Europe","West Central US","Southeast
+        Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
+        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationstatuses","locations":["West
+        US","North Europe","South Central US","West Europe","West Central US","Southeast
+        Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
+        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"operations","locations":["East
+        US 2","West Central US"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AppService","namespace":"Microsoft.AppService","authorization":{"applicationId":"dee7ba80-6a55-4f3b-a86c-746a9231ae49","roleDefinitionId":"6715d172-49c4-46f6-bb21-60512a8689dc"},"resourceTypes":[{"resourceType":"apiapps","locations":["East
+        US","West US","South Central US","North Europe","East Asia","Japan East","West
+        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
+        South","East US 2","Australia Southeast","Australia East","West India","South
+        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"appIdentities","locations":["East
+        US","West US","South Central US","North Europe","East Asia","Japan East","West
+        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
+        South","East US 2","Australia Southeast","Australia East","West India","South
+        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"gateways","locations":["East
+        US","West US","South Central US","North Europe","East Asia","Japan East","West
+        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
+        South","East US 2","Australia Southeast","Australia East","West India","South
+        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"deploymenttemplates","locations":[],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Authorization","namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"roleDefinitions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"classicAdministrators","locations":[],"apiVersions":["2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"permissions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"locks","locations":[],"apiVersions":["2017-04-01","2016-09-01","2015-06-01","2015-05-01-preview","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-01-01","2014-10-01-preview","2014-06-01"]},{"resourceType":"policyDefinitions","locations":[],"apiVersions":["2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"policySetDefinitions","locations":[],"apiVersions":["2017-06-01-preview"]},{"resourceType":"policyAssignments","locations":[],"apiVersions":["2017-06-01-preview","2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"providerOperations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01-preview","2015-07-01"]},{"resourceType":"elevateAccess","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureActiveDirectory","namespace":"Microsoft.AzureActiveDirectory","resourceTypes":[{"resourceType":"b2cDirectories","locations":["Global","United
+        States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureStack","namespace":"Microsoft.AzureStack","resourceTypes":[{"resourceType":"operations","locations":["Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations","locations":["West
+        Central US","Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations/products","locations":["West
+        Central US","Global"],"apiVersions":["2017-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Billing","namespace":"Microsoft.Billing","resourceTypes":[{"resourceType":"BillingPeriods","locations":["Central
+        US"],"apiVersions":["2017-04-24-preview"]},{"resourceType":"Invoices","locations":["Central
+        US"],"apiVersions":["2017-04-24-preview","2017-02-27-preview"]},{"resourceType":"operations","locations":["Central
+        US"],"apiVersions":["2017-04-24-preview","2017-02-27-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BingMaps","namespace":"Microsoft.BingMaps","resourceTypes":[{"resourceType":"mapApis","locations":["West
+        US"],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-18","2015-07-02"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BizTalkServices","namespace":"Microsoft.BizTalkServices","resourceTypes":[{"resourceType":"BizTalk","locations":["East
+        US","West US","North Europe","West Europe","Southeast Asia","East Asia","North
+        Central US","Japan West","Japan East","South Central US"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Cache","namespace":"Microsoft.Cache","authorization":{"applicationId":"96231a05-34ce-4eb4-aa6a-70759cbb5e83","roleDefinitionId":"4f731528-ba85-45c7-acfb-cd0a9b3cf31b"},"resourceTypes":[{"resourceType":"Redis","locations":["North
+        Central US","South Central US","Central US","West Europe","North Europe","West
+        US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
+        Asia","East Asia","Australia East","Australia Southeast","Central India","West
+        India","Canada Central","Canada East","UK South","UK West","West US 2","West
+        Central US","South India","Korea Central","Korea South"],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","South Central US","Central US","West Europe","North Europe","West
+        US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
+        Asia","East Asia","Australia East","Australia Southeast","Central India","West
+        India","South India","Canada Central","Canada East","UK South","UK West","West
+        US 2","West Central US","Korea Central","Korea South"],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01"]},{"resourceType":"Redis/metricDefinitions","locations":["North
+        Central US","South Central US","East US","East US 2","West US","Central US","East
+        Asia","Southeast Asia","North Europe","West Europe","Japan East","Japan West","Brazil
+        South","Australia Southeast","Australia East","Central India","West India","South
+        India","Canada Central","Canada East","UK West","UK South","West US 2","West
+        Central US","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"Redis/diagnosticSettings","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","West
+        US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
+        Asia","Australia East","Australia Southeast","Central India","West India","South
+        India","Canada Central","Canada East","UK West","UK South","West US 2","West
+        Central US","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Cdn","namespace":"Microsoft.Cdn","resourceTypes":[{"resourceType":"profiles","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/origins","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/customdomains","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/originresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/customdomainresults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkResourceUsage","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02"]},{"resourceType":"validateProbe","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"edgenodes","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","South Central US","South India","Southeast
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CertificateRegistration","namespace":"Microsoft.CertificateRegistration","authorization":{"applicationId":"f3c21649-0979-4721-ac85-b0216b2cf413","roleDefinitionId":"933fba7e-2ed3-4da8-973d-8bd8298a9b40"},"resourceTypes":[{"resourceType":"certificateOrders","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"certificateOrders/certificates","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"validateCertificateRegistrationInformation","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicSubscription","namespace":"Microsoft.ClassicSubscription","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicInfrastructureMigrate","namespace":"Microsoft.ClassicInfrastructureMigrate","authorization":{"applicationId":"5e5abe2b-83cd-4786-826a-a05653ebb103","roleDefinitionId":"766c4d9b-ef83-4f73-8352-1450a506a69b"},"resourceTypes":[{"resourceType":"classicInfrastructureResources","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","West
+        India","South India"],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CognitiveServices","namespace":"Microsoft.CognitiveServices","authorizations":[{"applicationId":"7d312290-28c8-473c-a0ed-8e53749b6d6d","roleDefinitionId":"5cb87f79-a7c3-4a95-9414-45b65974b51b"}],"resourceTypes":[{"resourceType":"accounts","locations":["Global","West
+        US","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"operations","locations":["Global","West
+        US","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations","locations":["Global","West
+        US","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/checkSkuAvailability","locations":["West
+        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/updateAccountsCreationSettings","locations":["West
+        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/accountsCreationSettings","locations":["West
+        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2016-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Commerce","namespace":"Microsoft.Commerce","resourceTypes":[{"resourceType":"UsageAggregates","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]},{"resourceType":"RateCard","locations":[],"apiVersions":["2016-08-31-preview","2015-06-01-preview","2015-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Consumption","namespace":"Microsoft.Consumption","resourceTypes":[{"resourceType":"reservationsummaries","locations":[],"apiVersions":["2017-01-30"]},{"resourceType":"reservationdetails","locations":[],"apiVersions":["2017-01-30"]},{"resourceType":"UsageDetails","locations":[],"apiVersions":["2017-06-30-preview","2017-04-24-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-30-preview","2017-04-24-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","resourceTypes":[{"resourceType":"containerGroups","locations":["West
+        US","East US","West Europe"],"apiVersions":["2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
+        US"],"apiVersions":["2016-04-08"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CustomerInsights","namespace":"Microsoft.CustomerInsights","authorization":{"applicationId":"38c77d00-5fcb-4cce-9d93-af4738258e3c","roleDefinitionId":"E006F9C7-F333-477C-8AD6-1F3A9FE87F55"},"resourceTypes":[{"resourceType":"hubs","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/profiles","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/interactions","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/authorizationPolicies","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/connectors","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/connectors/mappings","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/kpi","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/views","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/links","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/roleAssignments","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/roles","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/widgetTypes","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/suggestTypeSchema","locations":["East
+        US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"operations","locations":["East
+        US 2"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataCatalog","namespace":"Microsoft.DataCatalog","resourceTypes":[{"resourceType":"catalogs","locations":["East
+        US","West US","Australia East","West Europe","North Europe","Southeast Asia","West
+        Central US"],"apiVersions":["2016-03-30","2015-07-01-preview"]},{"resourceType":"checkNameAvailability","locations":["West
+        Europe"],"apiVersions":["2016-03-30","2015-07-01-preview"]},{"resourceType":"operations","locations":["West
+        Europe"],"apiVersions":["2016-03-30","2015-07-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-03-30","2015-07-01-preview"]},{"resourceType":"locations/jobs","locations":["East
+        US","West US","Australia East","West Europe","North Europe","Southeast Asia","West
+        Central US"],"apiVersions":["2016-03-30","2015-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataFactory","namespace":"Microsoft.DataFactory","resourceTypes":[{"resourceType":"dataFactories","locations":["West
+        US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview","2014-04-01"]},{"resourceType":"factories","locations":["East
+        US"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
+        US"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
+        Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"dataFactories/metricDefinitions","locations":["North
+        Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"checkDataFactoryNameAvailability","locations":[],"apiVersions":["2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"checkAzureDataFactoryNameAvailability","locations":["West
+        US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"dataFactorySchema","locations":["West
+        US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"operations","locations":["West
+        US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeAnalytics","namespace":"Microsoft.DataLakeAnalytics","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/dataLakeStoreAccounts","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers/listSasTokens","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeStore","namespace":"Microsoft.DataLakeStore","authorization":{"applicationId":"e9f49c6b-5ce5-44c8-925d-015017e9f7ad","roleDefinitionId":"17eb9cca-f08a-4499-b2d3-852d175f614f"},"resourceTypes":[{"resourceType":"accounts","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/firewallRules","locations":["East
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","resourceTypes":[{"resourceType":"operations","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforPostgreSQL","namespace":"Microsoft.DBforPostgreSQL","resourceTypes":[{"resourceType":"operations","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
+        India","East Asia","East US 2","East US","Japan East","Japan West","North
+        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
+        US","North Europe","East Asia","East US","West Europe","Southeast Asia","Japan
+        East","Japan West","Australia East","Australia Southeast","West US 2","West
+        Central US","East US 2","Central US","UK South","UK West","South India","Central
+        India"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"databaseAccountNames","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DomainRegistration","namespace":"Microsoft.DomainRegistration","authorization":{"applicationId":"ea2f600a-4980-45b7-89bf-d34da487bda1","roleDefinitionId":"54d7f2e3-5040-48a7-ae90-eebf629cfa0b"},"resourceTypes":[{"resourceType":"domains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"domains/domainOwnershipIdentifiers","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"topLevelDomains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"checkDomainAvailability","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"listDomainRecommendations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"validateDomainRegistrationInformation","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"generateSsoRequest","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DynamicsLcs","namespace":"Microsoft.DynamicsLcs","resourceTypes":[{"resourceType":"lcsprojects","locations":["Brazil
+        South","East Asia","East US","Japan East","Japan West","North Central US","North
+        Europe","South Central US","West Europe","West US","Southeast Asia","Central
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"lcsprojects/connectors","locations":["Brazil
+        South","East Asia","East US","Japan East","Japan West","North Central US","North
+        Europe","South Central US","West Europe","West US","Southeast Asia","Central
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"lcsprojects/clouddeployments","locations":["Brazil
+        South","East Asia","East US","Japan East","Japan West","North Central US","North
+        Europe","South Central US","West Europe","West US","Southeast Asia","Central
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"operations","locations":["Brazil
+        South","East Asia","East US","Japan East","Japan West","North Central US","North
+        Europe","South Central US","West Europe","West US","Southeast Asia","Central
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"topics","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operations","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"clusters/applications","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"clusters/operationresults","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Australia East","Australia Southeast","Brazil South","Central India"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations/capabilities","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations/operationresults","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations/azureasyncoperations","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"locations/validateCreateRequest","locations":["East
+        US","East US 2","West US","South Central US","Central US","Australia East","Australia
+        Southeast","Central India","West Central US","West US 2","Canada East","Canada
+        Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
+        West","North Europe","West Europe","North Central US","Southeast Asia","Korea
+        South","Korea Central"],"apiVersions":["2015-03-01-preview"]},{"resourceType":"operations","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India"],"apiVersions":["2015-03-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ImportExport","namespace":"Microsoft.ImportExport","authorization":{"applicationId":"7de4d5c5-5b32-4235-b8a9-33b34d6bcd2a","roleDefinitionId":"9f7aa6bb-9454-46b6-8c01-a4b0f33ca151"},"resourceTypes":[{"resourceType":"jobs","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","North Central US","North Europe","South Central US","Southeast
+        Asia","South India","UK South","West Central US","West Europe","West India","West
+        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","North Central US","North Europe","South Central US","Southeast
+        Asia","South India","UK South","West Central US","West Europe","West India","West
+        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations/operationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","North Central US","North Europe","South Central US","Southeast
+        Asia","South India","UK South","West Central US","West Europe","West India","West
+        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","North Central US","North Europe","South Central US","Southeast
+        Asia","South India","UK South","West Central US","West Europe","West India","West
+        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Logic","namespace":"Microsoft.Logic","authorization":{"applicationId":"7cd684f4-8a78-49b0-91ec-6a35d38739ba","roleDefinitionId":"cb3ef1fb-6e31-49e2-9d87-ed821053fe58"},"resourceTypes":[{"resourceType":"workflows","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West"],"apiVersions":["2017-07-01","2016-10-01","2016-06-01","2015-08-01-preview","2015-02-01-preview"]},{"resourceType":"locations/workflows","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West"],"apiVersions":["2017-07-01","2016-10-01","2016-06-01","2015-08-01-preview","2015-02-01-preview"]},{"resourceType":"locations","locations":["North
+        Central US"],"apiVersions":["2017-07-01","2016-10-01","2016-06-01","2015-08-01-preview","2015-02-01-preview"]},{"resourceType":"operations","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West"],"apiVersions":["2017-07-01","2016-10-01","2016-06-01","2015-08-01-preview","2015-02-01-preview"]},{"resourceType":"integrationAccounts","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","West Central US"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"operations","locations":["South
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations","locations":["South
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operations","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"commitmentPlans","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
+        Central US","West US"],"apiVersions":["2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Media","namespace":"Microsoft.Media","authorization":{"applicationId":"374b2a64-3b6b-436b-934c-b820eacca870","roleDefinitionId":"aab70789-0cec-44b5-95d7-84b64c9487af"},"resourceTypes":[{"resourceType":"mediaservices","locations":["Japan
+        West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
+        US","West US","Australia East","Australia Southeast","Central US","Brazil
+        South","Central India","West India","South India","South Central US","Canada
+        Central","Canada East","West Central US"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
+        Central US","North Central US","East US 2","West US","West Europe","North
+        Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
+        East","UK South","West India"],"apiVersions":["2016-01-29"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-01-29"]},{"resourceType":"locations/checkNameAvailability","locations":["South
+        Central US","North Central US","East US 2","West US","West Europe","North
+        Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
+        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"operations","locations":["East
+        US 2"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Relay","namespace":"Microsoft.Relay","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US 2","West
+        US","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
+        East","West India","South India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","North Europe","West
+        Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
+        East","West India","South India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
+        Central US","South Central US","North Europe","West Europe","East Asia","Southeast
+        Asia","West US","East US","Japan West","Japan East","Brazil South","Central
+        US","East US 2","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-03-01","2016-01-01","2014-08-01-preview"]},{"resourceType":"operations","locations":["North
+        Central US","South Central US","North Europe","West Europe","East Asia","Southeast
+        Asia","West US","East US","Japan West","Japan East","Brazil South","Central
+        US","East US 2","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-03-01","2016-01-01","2014-08-01-preview"]},{"resourceType":"operationResults","locations":["North
+        Central US","South Central US","North Europe","West Europe","East Asia","Southeast
+        Asia","West US","East US","Japan West","Japan East","Brazil South","Central
+        US","East US 2","Australia East","Australia Southeast","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-03-01","2016-01-01","2014-08-01-preview"]},{"resourceType":"flows","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast"],"apiVersions":["2015-08-01-preview","2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Search","namespace":"Microsoft.Search","resourceTypes":[{"resourceType":"searchServices","locations":["West
+        US","East US","North Europe","West Europe","Southeast Asia","East Asia","North
+        Central US","South Central US","Japan West","Australia East","Brazil South","Central
+        India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19","2015-02-28"]},{"resourceType":"checkServiceNameAvailability","locations":[],"apiVersions":["2015-02-28","2014-07-31-Preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2015-08-19"]},{"resourceType":"resourceHealthMetadata","locations":["West
+        US","East US","North Europe","West Europe","Southeast Asia","East Asia","North
+        Central US","South Central US","Japan West","Australia East","Brazil South","Central
+        India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US 2","West
+        US","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"premiumMessagingRegions","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceFabric","namespace":"Microsoft.ServiceFabric","authorization":{"applicationId":"74cb6831-0dbb-4be1-8206-fd4df301cdc2","roleDefinitionId":"e55cc65f-6903-4917-b4ef-f8d4640b57f5"},"resourceTypes":[{"resourceType":"clusters","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/clusterVersions","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operations","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Canada
+        Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","West Central US","Japan East","Japan West","Australia East","Australia
+        Southeast"],"apiVersions":["2017-06-01","2017-05-15","2017-01-01","2016-10-01","2016-06-01","2015-03-15","2014-09-01"]},{"resourceType":"operations","locations":["West
+        Central US","Southeast Asia"],"apiVersions":["2016-10-01","2016-06-01","2015-03-15","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StreamAnalytics","namespace":"Microsoft.StreamAnalytics","resourceTypes":[{"resourceType":"streamingjobs","locations":["Central
+        US","West Europe","East US 2","North Europe","Japan East","West US","Southeast
+        Asia","South Central US","East Asia","Japan West","North Central US","East
+        US","Australia East","Australia Southeast","Brazil South","Central India","West
+        Central US","UK South","UK West","Canada Central","Canada East","West US 2"],"apiVersions":["2017-04-01-preview","2016-03-01","2015-11-01","2015-10-01","2015-09-01","2015-08-01-preview","2015-06-01","2015-05-01","2015-04-01","2015-03-01-preview"]},{"resourceType":"locations","locations":["West
+        Europe","Central US","East US 2","North Europe","Japan East","West US","Southeast
+        Asia","South Central US","East Asia","Japan West","North Central US","East
+        US","Australia East","Australia Southeast","Brazil South","Central India","West
+        Central US","UK South","West US 2","UK West","Canada Central","Canada East"],"apiVersions":["2017-04-01-preview","2016-03-01","2015-11-01","2015-10-01","2015-09-01","2015-08-01-preview","2015-06-01","2015-05-01","2015-04-01","2015-03-01-preview"]},{"resourceType":"locations/quotas","locations":[],"apiVersions":["2017-04-01-preview","2016-03-01","2015-11-01","2015-10-01","2015-09-01","2015-08-01-preview","2015-06-01","2015-05-01","2015-04-01","2015-03-01-preview"]},{"resourceType":"streamingjobs/diagnosticSettings","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","Central
+        India","West Central US","UK South","UK West","Canada Central","Canada East","West
+        US 2","West US","Central US","South Central US","Japan East","Japan West","East
+        Asia","Southeast Asia","Australia East","Australia Southeast"],"apiVersions":["2014-04-01"]},{"resourceType":"streamingjobs/metricDefinitions","locations":["East
+        US","East US 2","North Central US","North Europe","West Europe","Brazil South","Central
+        India","West Central US","UK South","UK West","Canada Central","Canada East","West
+        US 2","West US","Central US","South Central US","Japan East","Japan West","East
+        Asia","Southeast Asia","Australia East","Australia Southeast"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":["West
+        Europe","West US","Central US","East US 2","North Europe","Japan East","Southeast
+        Asia","South Central US","East Asia","Japan West","North Central US","East
+        US","Australia East","Australia Southeast","Brazil South","Central India","West
+        Central US","UK South","UK West","Canada Central","Canada East","West US 2"],"apiVersions":["2017-04-01-preview","2016-03-01","2015-11-01","2015-10-01","2015-09-01","2015-08-01-preview","2015-06-01","2015-05-01","2015-04-01","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.support","namespace":"microsoft.support","resourceTypes":[{"resourceType":"operations","locations":["North
+        Central US","South Central US","Central US","West Europe","North Europe","West
+        US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
+        Asia","East Asia","Australia East","Australia Southeast"],"apiVersions":["2015-07-01-Preview","2015-03-01"]},{"resourceType":"supporttickets","locations":["North
+        Central US","South Central US","Central US","West Europe","North Europe","West
+        US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
+        Asia","East Asia","Australia East","Australia Southeast"],"apiVersions":["2015-07-01-Preview","2015-03-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.TimeSeriesInsights","namespace":"Microsoft.TimeSeriesInsights","authorizations":[{"applicationId":"120d688d-1518-4cf7-bd38-182f158850b6","roleDefinitionId":"5a43abdf-bb87-42c4-9e56-1c24bf364150"}],"resourceTypes":[{"resourceType":"environments","locations":["East
+        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/eventsources","locations":["East
+        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/referenceDataSets","locations":["East
+        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/accessPolicies","locations":["East
+        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"operations","locations":["East
+        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/project","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/extension","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"checkNameAvailability","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Myget.PackageManagement","namespace":"Myget.PackageManagement","resourceTypes":[{"resourceType":"services","locations":["West
+        Europe"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/NewRelic.APM","namespace":"NewRelic.APM","authorization":{"allowedThirdPartyExtensions":[{"name":"NewRelic_AzurePortal_APM"}]},"resourceTypes":[{"resourceType":"accounts","locations":["North
+        Central US","South Central US","West US","East US","North Europe","West Europe","Southeast
+        Asia","East Asia","Japan East","Japan West"],"apiVersions":["2014-10-01","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/nuubit.nextgencdn","namespace":"nuubit.nextgencdn","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US","East US 2","North Central US","South Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","West US","Central US"],"apiVersions":["2017-05-05"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-05"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-05-05"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-05-05"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Paraleap.CloudMonix","namespace":"Paraleap.CloudMonix","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2016-08-10"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-10"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-10"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Pokitdok.Platform","namespace":"Pokitdok.Platform","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2016-05-17"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-05-17"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-05-17"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-05-17"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RavenHq.Db","namespace":"RavenHq.Db","resourceTypes":[{"resourceType":"databases","locations":["East
+        US"],"apiVersions":["2016-07-18","2016-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-07-18","2016-06-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-07-18","2016-06-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-07-18","2016-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Raygun.CrashReporting","namespace":"Raygun.CrashReporting","resourceTypes":[{"resourceType":"apps","locations":["East
+        US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RedisLabs.Memcached","namespace":"RedisLabs.Memcached","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-07-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RedisLabs.Redis","namespace":"RedisLabs.Redis","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-07-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RevAPM.MobileCDN","namespace":"RevAPM.MobileCDN","resourceTypes":[{"resourceType":"accounts","locations":["Central
+        US","East US","East US 2","North Central US","South Central US","West US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast"],"apiVersions":["2016-08-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-24","2016-08-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sendgrid.Email","namespace":"Sendgrid.Email","resourceTypes":[{"resourceType":"accounts","locations":["East
+        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
+        Central US","Central US","North Europe","West Europe","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Canada Central","Canada
+        East","West Central US","West US 2","UK South","UK West"],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Signiant.Flight","namespace":"Signiant.Flight","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US","Central US","North Central US","South Central US","West US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast"],"apiVersions":["2015-06-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sparkpost.Basic","namespace":"Sparkpost.Basic","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2016-08-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/stackify.retrace","namespace":"stackify.retrace","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2016-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/SuccessBricks.ClearDB","namespace":"SuccessBricks.ClearDB","resourceTypes":[{"resourceType":"databases","locations":["Brazil
+        South","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","Southeast Asia","West Europe","West
+        US","South Central US","Australia East","Australia Southeast","Canada Central","Canada
+        East","Central India","South India","West India"],"apiVersions":["2014-04-01"]},{"resourceType":"clusters","locations":["Brazil
+        South","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","North Central US","North Europe","Southeast Asia","West Europe","West
+        US","Australia Southeast","Australia East","South Central US","Canada Central","Canada
+        East","Central India","South India","West India"],"apiVersions":["2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/TrendMicro.DeepSecurity","namespace":"TrendMicro.DeepSecurity","resourceTypes":[{"resourceType":"accounts","locations":["Central
+        US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
+        Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:17 GMT
+- request:
+    method: post
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
+    body:
+      encoding: UTF-8
+      string: '{"access":"read","durationInSeconds":3600}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4OTUsIm5iZiI6MTUwNDEwNjg5NSwiZXhwIjoxNTA0MTEwNzk1LCJhaW8iOiJZMkZnWVBqeGJmMVBCUnNOUmcwdkRzdnQwbnovQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZ1JDUGducXMtRUtiZy1HeGxDSVNBQSIsInZlciI6IjEuMCJ9.KSUCtfYUWBYpiRZ8Oe73YcjB0AVtFDYwfvV6kPGobrVZzVhauDn0q_hprykjN5-EWT07l_ZXgPKZZsiJ0-52T97sTkKTUlqOwMnP3exbb-aqVt0cSL7dnerJdF6SXw7vOif6OPUWkkg_bShX1ZHg6eYEZ_uGoxPa67r34OB-iwZV4kZdZSvP2sPVW75g3jhgEkSnsDBZZ9u5PuuecS5DTeMXnaR6uryG-Aoi8j0x773sApFV-_9G7WuYugGMp-QmB9aJUqOeYrkiZqQnJtR4Ot6s-EJlO7mjps-CqSWCWrspbRKGueJXDLSnBmCKZkqVWwvHDt1lxCUM5JfRWG6ODQ
+      Content-Length:
+      - '42'
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '0'
+      Expires:
+      - "-1"
+      Location:
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/c911d693-2699-4d33-9a77-cf67d5af9d01?monitor=true&api-version=2017-03-30
+      Azure-Asyncoperation:
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/c911d693-2699-4d33-9a77-cf67d5af9d01?api-version=2017-03-30
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      X-Ms-Request-Id:
+      - c911d693-2699-4d33-9a77-cf67d5af9d01
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Writes:
+      - '1196'
+      X-Ms-Correlation-Request-Id:
+      - 56885322-9c3a-4dd3-9d7f-01b9a4b87fb7
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153317Z:56885322-9c3a-4dd3-9d7f-01b9a4b87fb7
+      Date:
+      - Wed, 30 Aug 2017 15:33:16 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:17 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/c911d693-2699-4d33-9a77-cf67d5af9d01?api-version=2017-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4OTUsIm5iZiI6MTUwNDEwNjg5NSwiZXhwIjoxNTA0MTEwNzk1LCJhaW8iOiJZMkZnWVBqeGJmMVBCUnNOUmcwdkRzdnQwbnovQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZ1JDUGducXMtRUtiZy1HeGxDSVNBQSIsInZlciI6IjEuMCJ9.KSUCtfYUWBYpiRZ8Oe73YcjB0AVtFDYwfvV6kPGobrVZzVhauDn0q_hprykjN5-EWT07l_ZXgPKZZsiJ0-52T97sTkKTUlqOwMnP3exbb-aqVt0cSL7dnerJdF6SXw7vOif6OPUWkkg_bShX1ZHg6eYEZ_uGoxPa67r34OB-iwZV4kZdZSvP2sPVW75g3jhgEkSnsDBZZ9u5PuuecS5DTeMXnaR6uryG-Aoi8j0x773sApFV-_9G7WuYugGMp-QmB9aJUqOeYrkiZqQnJtR4Ot6s-EJlO7mjps-CqSWCWrspbRKGueJXDLSnBmCKZkqVWwvHDt1lxCUM5JfRWG6ODQ
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      X-Ms-Request-Id:
+      - 5f58ae07-92fd-4ab8-975b-0ea408183880
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14953'
+      X-Ms-Correlation-Request-Id:
+      - 3b554937-d6ce-4593-a576-fca77c5f00e3
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153317Z:3b554937-d6ce-4593-a576-fca77c5f00e3
+      Date:
+      - Wed, 30 Aug 2017 15:33:17 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"startTime\": \"2017-08-30T15:33:17.1189295+00:00\",\r\n  \"endTime\":
+        \"2017-08-30T15:33:17.3220439+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=cf92b8ab-a4eb-4074-882b-beabe371861c&sig=Hxb0jpPtk3iG3Qxkb4Nwf97GoNrNrfvR%2FFBVzKr8mOM%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"c911d693-2699-4d33-9a77-cf67d5af9d01\"\r\n}"
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:17 GMT
+- request:
+    method: get
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=cf92b8ab-a4eb-4074-882b-beabe371861c&sig=Hxb0jpPtk3iG3Qxkb4Nwf97GoNrNrfvR/FBVzKr8mOM=&sr=b&sv=2016-05-31
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      X-Ms-Range:
+      - bytes=0-0
+      Host:
+      - md-t4jdgqqlgszp.blob.core.windows.net
+  response:
+    status:
+      code: 206
+      message: Partial Content
+    headers:
+      Content-Length:
+      - '1'
+      Content-Type:
+      - application/octet-stream
+      Content-Range:
+      - bytes 0-0/34359738880
+      Last-Modified:
+      - Sat, 15 Jul 2017 14:23:07 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D4CB8D039FC699"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 9f854775-0001-00f6-64a5-21863b000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Meta-Pirtag:
+      - '1'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '20'
+      X-Ms-Copy-Id:
+      - 30cedd78-548a-4fd8-967e-f8344f587e3c
+      X-Ms-Copy-Source:
+      - http://md-t4jdgqqlgszp.blob.core.windows.net:8080/fg25xxtqx0gc/abcd?sv=2016-02-19&sr=b&st=2017-05-04T21%3a06%3a57Z&se=9999-12-31T23%3a59%3a59Z&sp=r&api-version=2016-02-19
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 34359738880/34359738880
+      X-Ms-Copy-Completion-Time:
+      - Thu, 04 May 2017 21:21:56 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Wed, 30 Aug 2017 15:33:18 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        6w==
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:18 GMT
+- request:
+    method: post
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
+    body:
+      encoding: UTF-8
+      string: '{"access":"read","durationInSeconds":3600}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4OTUsIm5iZiI6MTUwNDEwNjg5NSwiZXhwIjoxNTA0MTEwNzk1LCJhaW8iOiJZMkZnWVBqeGJmMVBCUnNOUmcwdkRzdnQwbnovQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZ1JDUGducXMtRUtiZy1HeGxDSVNBQSIsInZlciI6IjEuMCJ9.KSUCtfYUWBYpiRZ8Oe73YcjB0AVtFDYwfvV6kPGobrVZzVhauDn0q_hprykjN5-EWT07l_ZXgPKZZsiJ0-52T97sTkKTUlqOwMnP3exbb-aqVt0cSL7dnerJdF6SXw7vOif6OPUWkkg_bShX1ZHg6eYEZ_uGoxPa67r34OB-iwZV4kZdZSvP2sPVW75g3jhgEkSnsDBZZ9u5PuuecS5DTeMXnaR6uryG-Aoi8j0x773sApFV-_9G7WuYugGMp-QmB9aJUqOeYrkiZqQnJtR4Ot6s-EJlO7mjps-CqSWCWrspbRKGueJXDLSnBmCKZkqVWwvHDt1lxCUM5JfRWG6ODQ
+      Content-Length:
+      - '42'
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '0'
+      Expires:
+      - "-1"
+      Location:
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/efeff584-4db2-4606-876f-d614a54bd704?monitor=true&api-version=2017-03-30
+      Azure-Asyncoperation:
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/efeff584-4db2-4606-876f-d614a54bd704?api-version=2017-03-30
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      X-Ms-Request-Id:
+      - efeff584-4db2-4606-876f-d614a54bd704
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Writes:
+      - '1196'
+      X-Ms-Correlation-Request-Id:
+      - e8008514-3484-4194-beec-20fdb5adbf1b
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153318Z:e8008514-3484-4194-beec-20fdb5adbf1b
+      Date:
+      - Wed, 30 Aug 2017 15:33:18 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:18 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/efeff584-4db2-4606-876f-d614a54bd704?api-version=2017-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQxMDY4OTUsIm5iZiI6MTUwNDEwNjg5NSwiZXhwIjoxNTA0MTEwNzk1LCJhaW8iOiJZMkZnWVBqeGJmMVBCUnNOUmcwdkRzdnQwbnovQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZ1JDUGducXMtRUtiZy1HeGxDSVNBQSIsInZlciI6IjEuMCJ9.KSUCtfYUWBYpiRZ8Oe73YcjB0AVtFDYwfvV6kPGobrVZzVhauDn0q_hprykjN5-EWT07l_ZXgPKZZsiJ0-52T97sTkKTUlqOwMnP3exbb-aqVt0cSL7dnerJdF6SXw7vOif6OPUWkkg_bShX1ZHg6eYEZ_uGoxPa67r34OB-iwZV4kZdZSvP2sPVW75g3jhgEkSnsDBZZ9u5PuuecS5DTeMXnaR6uryG-Aoi8j0x773sApFV-_9G7WuYugGMp-QmB9aJUqOeYrkiZqQnJtR4Ot6s-EJlO7mjps-CqSWCWrspbRKGueJXDLSnBmCKZkqVWwvHDt1lxCUM5JfRWG6ODQ
+      Host:
+      - management.azure.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      X-Ms-Request-Id:
+      - 8c683ab6-9282-415b-9807-4f1714be078c
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14244'
+      X-Ms-Correlation-Request-Id:
+      - 7b6b44e8-303e-44a4-acdf-32d5b0a2c24b
+      X-Ms-Routing-Request-Id:
+      - EASTUS:20170830T153323Z:7b6b44e8-303e-44a4-acdf-32d5b0a2c24b
+      Date:
+      - Wed, 30 Aug 2017 15:33:22 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"startTime\": \"2017-08-30T15:33:17.9157821+00:00\",\r\n  \"endTime\":
+        \"2017-08-30T15:33:18.0563995+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=783f6191-bbea-42d3-878d-740aba95d48d&sig=OtThUc15DR7RwVihDCGKskEmF16XxsbHzVZqLC53Nk0%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"efeff584-4db2-4606-876f-d614a54bd704\"\r\n}"
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:23 GMT
+- request:
+    method: get
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=783f6191-bbea-42d3-878d-740aba95d48d&sig=OtThUc15DR7RwVihDCGKskEmF16XxsbHzVZqLC53Nk0=&sr=b&sv=2016-05-31
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      X-Ms-Range:
+      - bytes=440-443
+      Host:
+      - md-t4jdgqqlgszp.blob.core.windows.net
+  response:
+    status:
+      code: 206
+      message: Partial Content
+    headers:
+      Content-Length:
+      - '4'
+      Content-Type:
+      - application/octet-stream
+      Content-Range:
+      - bytes 440-443/34359738880
+      Last-Modified:
+      - Sat, 15 Jul 2017 14:23:07 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D4CB8D039FC699"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 4250a130-0001-00a6-36a5-219933000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Meta-Pirtag:
+      - '1'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '20'
+      X-Ms-Copy-Id:
+      - 30cedd78-548a-4fd8-967e-f8344f587e3c
+      X-Ms-Copy-Source:
+      - http://md-t4jdgqqlgszp.blob.core.windows.net:8080/fg25xxtqx0gc/abcd?sv=2016-02-19&sr=b&st=2017-05-04T21%3a06%3a57Z&se=9999-12-31T23%3a59%3a59Z&sp=r&api-version=2016-02-19
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 34359738880/34359738880
+      X-Ms-Copy-Completion-Time:
+      - Thu, 04 May 2017 21:21:56 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Wed, 30 Aug 2017 15:33:28 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        U5MJAA==
+    http_version: 
+  recorded_at: Wed, 30 Aug 2017 15:33:28 GMT
+recorded_with: VCR 3.0.3

--- a/spec/test_env/config/disk/modules/azure_managed_disk_spec.yml
+++ b/spec/test_env/config/disk/modules/azure_managed_disk_spec.yml
@@ -1,0 +1,6 @@
+---
+:values:
+:filter:
+:default:
+  :resource_group: my-azure-resource-group
+  :azure_disk_name: my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef


### PR DESCRIPTION
If the Azure VM has a Managed Disk then use the new Managed Disk
disk module to read its snapshot.

On this go-round the snapshot will only be required for Managed Disks.

This is one of several PRs required to add support for SSA for Managed Disks,
that is is response to the following BZs:
https://bugzilla.redhat.com/show_bug.cgi?id=1475540
and
https://bugzilla.redhat.com/show_bug.cgi?id=1459612

A PR for the azure-armrest gem has already been merged in advance of this:
https://github.com/ManageIQ/azure-armrest/pull/299

A PR for the ManageIQ repo has been added as well to work with this - 
https://github.com/ManageIQ/manageiq/pull/15865

A PR for the manageiq-providers-azure repo has also been added.
https://github.com/ManageIQ/manageiq-providers-azure/pull/117

Links
----------------

* https://bugzilla.redhat.com/show_bug.cgi?id=1475540
* https://bugzilla.redhat.com/show_bug.cgi?id=1459612
* https://github.com/ManageIQ/azure-armrest/pull/299
* https://github.com/ManageIQ/manageiq/pull/15865
* https://github.com/ManageIQ/manageiq-providers-azure/pull/117

Steps for Testing/QA
-------------------------------

Add an Azure VM with a Managed Disk.
Run SmartState Analysis against the VM.

@roliveri @hsong-rh please review.  