### PR TITLE
Bump Gem Version for Azure Snapshots Code

### DIFF
--- a/lib/manageiq/smartstate/version.rb
+++ b/lib/manageiq/smartstate/version.rb
@@ -1,5 +1,5 @@
 module ManageIQ
   module Smartstate
-    VERSION = "0.1.2"
+    VERSION = "0.1.3"
   end
 end


### PR DESCRIPTION
The manageiq-smartstate gem version will be bumped to 0.1.3.  

This is in support of https://bugzilla.redhat.com/show_bug.cgi?id=1475540.

@roliveri please merge - thanks.