### PR TITLE
Snapshot Support for Non-Managed Disks

### DIFF
--- a/lib/MiqVm/miq_azure_vm.rb
+++ b/lib/MiqVm/miq_azure_vm.rb
@@ -15,7 +15,7 @@ class MiqAzureVm < MiqVm
     if args[:image_uri]
       @uri = args[:image_uri]
     elsif args[:resource_group] && args[:name]
-      vm_obj = vm_svc.get(@name, args[:resource_group])
+      vm_obj = vm_svc.get(@name, @resource_group.name)
       os_disk = vm_obj.properties.storage_profile.os_disk
       if vm_obj.managed_disk?
         #
@@ -24,9 +24,10 @@ class MiqAzureVm < MiqVm
         @snap_name = os_disk.name + "__EVM__SSA__SNAPSHOT"
       else
         #
-        # Non-Managed Disk Snapshot handling will be added here by a separate PR.
+        # Non-Managed Disk Snapshot handling
         #
         @uri = os_disk.vhd.uri
+        @uri << "?snapshot=" << args[:snapshot] if args[:snapshot]
       end
     else
       raise ArgumentError, "MiqAzureVm: missing required args: :image_uri or :resource_group"
@@ -101,7 +102,7 @@ class MiqAzureVm < MiqVm
     disk_format              = @vmConfig.getHash["#{disk_tag}.format"]
     disk_info.format         = disk_format unless disk_format.blank?
     disk_info.rawDisk        = true
-    disk_info.resource_group = @resource_group
+    disk_info.resource_group = @resource_group.name
     disk_info
   end
 

--- a/lib/MiqVm/miq_azure_vm.rb
+++ b/lib/MiqVm/miq_azure_vm.rb
@@ -27,7 +27,7 @@ class MiqAzureVm < MiqVm
         # Non-Managed Disk Snapshot handling
         #
         @uri = os_disk.vhd.uri
-        @uri << "?snapshot=" << args[:snapshot] if args[:snapshot]
+        @uri << "?snapshot=#{args[:snapshot]}" if args[:snapshot]
       end
     else
       raise ArgumentError, "MiqAzureVm: missing required args: :image_uri or :resource_group"

--- a/spec/miq_vm/miq_azure_vm_image_spec.rb
+++ b/spec/miq_vm/miq_azure_vm_image_spec.rb
@@ -9,12 +9,14 @@ describe MiqAzureVm do
     @test_env = TestEnvHelper.new(__FILE__)
     @test_env.vcr_filter
 
-    @client_id       = @test_env[:azure_client_id]
-    @client_key      = @test_env[:azure_client_key]
-    @tenant_id       = @test_env[:azure_tenant_id]
-    @subscription_id = @test_env[:azure_subscription_id]
-    @image_name      = @test_env[:image_name]
-    @image_uri       = @test_env[:image_uri]
+    @client_id            = @test_env[:azure_client_id]
+    @client_key           = @test_env[:azure_client_key]
+    @tenant_id            = @test_env[:azure_tenant_id]
+    @subscription_id      = @test_env[:azure_subscription_id]
+    @image_name           = @test_env[:image_name]
+    @image_uri            = @test_env[:image_uri]
+    resource_group_json   = '{"name": "#{@test_env[:image_resource_group]}"}'
+    @image_resource_group = Azure::Armrest::ResourceGroup.new(resource_group_json)
 
     @test_env.ensure_recording_dir_exists
   end
@@ -57,14 +59,14 @@ describe MiqAzureVm do
     end
 
     it "should return an MiqAzureVm object", :ex_tag => 4 do
-      azure_vm = MiqAzureVm.new(@azure_config, :name => @image_name, :image_uri => @image_uri)
+      azure_vm = MiqAzureVm.new(@azure_config, :name => @image_name, :image_uri => @image_uri, :resource_group => @image_resource_group)
       expect(azure_vm).to be_kind_of(MiqAzureVm)
     end
   end
 
   describe "Instance methods" do
     before(:each) do
-      @azure_vm = MiqAzureVm.new(@azure_config, :name => @image_name, :image_uri => @image_uri)
+      @azure_vm = MiqAzureVm.new(@azure_config, :name => @image_name, :image_uri => @image_uri, :resource_group => @image_resource_group)
     end
 
     after(:each) do

--- a/spec/miq_vm/miq_azure_vm_instance_spec.rb
+++ b/spec/miq_vm/miq_azure_vm_instance_spec.rb
@@ -14,7 +14,8 @@ describe MiqAzureVm do
     @tenant_id               = @test_env[:azure_tenant_id]
     @subscription_id         = @test_env[:azure_subscription_id]
     @instance_name           = @test_env[:instance_name]
-    @instance_resource_group = @test_env[:instance_resource_group]
+    resource_group_json      = "{\"name\": \"#{@test_env[:instance_resource_group]}\"}"
+    @instance_resource_group = Azure::Armrest::ResourceGroup.new(resource_group_json)
 
     @test_env.ensure_recording_dir_exists
   end

--- a/spec/test_env/config/miq_vm/miq_azure_vm_image_spec.yml
+++ b/spec/test_env/config/miq_vm/miq_azure_vm_image_spec.yml
@@ -3,4 +3,5 @@
 :filter:
 :default:
   :image_name: test-win2k12
+  :image_resource_group: my_resource_group
   :image_uri: https://my-azure-storage-account2.blob.core.windows.net/system/Microsoft.Compute/Images/miq-test-container/test-win2k12-img-osDisk.e17a95b0-f4fb-4196-93c5-0c8be7d5c536.vhd


### PR DESCRIPTION
In the case of non-Managed (Blob) disks, append the snapshot
name (which is in all actuality the date tag returned from
azure-armrest for the snapshot) to the URI to be used to read
the disk.

This is one of several PRs required to fix https://bugzilla.redhat.com/show_bug.cgi?id=1463780.
The PR against ManageIQ/manageiq is https://github.com/ManageIQ/manageiq/pull/15960, and one against ManageIQ/manageiq-providers-azure will be noted here when it is added.

This PR can be merged in any order since it checks for a tag to be passed in and only uses that snapshot tag if it is there.

@roliveri @hsong-rh please review.  I'm not sure if we need to back port this to Fine but it wouldn't be a bad idea.