### PR TITLE
Bump gem version to 0.1.4

### DIFF
--- a/lib/manageiq/smartstate/version.rb
+++ b/lib/manageiq/smartstate/version.rb
@@ -1,5 +1,5 @@
 module ManageIQ
   module Smartstate
-    VERSION = "0.1.3".freeze
+    VERSION = "0.1.4".freeze
   end
 end


### PR DESCRIPTION
As part of the fix for https://bugzilla.redhat.com/show_bug.cgi?id=1463780 this gem was updated but the version number was not yet bumped.  We need this bumped and then the new version noted in the manageiq main repo Gemfile.

@roliveri please review and do the magic to create the tag and push out the gem.  Thanks.