### PR TITLE
Handle case where attempted LVM2 Thin device reads fail

### DIFF
--- a/lib/VolumeManager/LVM/lvm2disk.rb
+++ b/lib/VolumeManager/LVM/lvm2disk.rb
@@ -43,10 +43,14 @@ module Lvm2DiskIO
       device_id = logicalVolume.thin_segment.device_id
       thin_pool = logicalVolume.thin_pool_volume
       data_blks = thin_pool.metadata_volume.superblock.device_to_data(device_id, pos, len)
+
       data_blks.each do |offset, len|
         thin_pool.data_volume.disk.seek offset
         retStr << thin_pool.data_volume.disk.read(len)
       end
+
+      # add zeros to result if reading from unallocated memory
+      retStr << thin_pool.metadata_volume.superblock.device_fill_data(device_id, pos, len)
 
       return retStr
     end

--- a/lib/VolumeManager/LVM/lvm2disk.rb
+++ b/lib/VolumeManager/LVM/lvm2disk.rb
@@ -44,14 +44,13 @@ module Lvm2DiskIO
       thin_pool = logicalVolume.thin_pool_volume
       data_blks = thin_pool.metadata_volume.superblock.device_to_data(device_id, pos, len)
 
-      data_blks.each do |device_blk, data_blk, blk_offset, blk_len|
+      data_blks.each do |_device_blk, data_blk, blk_offset, blk_len|
         if data_blk.nil?
           # fill in unallactored data
-          puts blk_len
           retStr << Array.new(blk_len, 0).pack("C*")
 
         else
-          thin_pool.data_volume.disk.seek blk_offset
+          thin_pool.data_volume.disk.seek(blk_offset)
           retStr << thin_pool.data_volume.disk.read(blk_len)
         end
       end

--- a/lib/VolumeManager/LVM/thin/data_map.rb
+++ b/lib/VolumeManager/LVM/thin/data_map.rb
@@ -22,14 +22,13 @@ module Lvm2Thin
       @total_blocks ||= begin
         t = 0
         entries.each do |entry|
-          t += entry.kind_of?(DataMap) ?
-               entry.total_blocks : 1
+          t += entry.kind_of?(DataMap) ? entry.total_blocks : 1
         end
         t
       end
     end
 
-    def has_block?(blk)
+    def block?(blk)
       blk < total_blocks
     end
 

--- a/lib/VolumeManager/LVM/thin/data_map.rb
+++ b/lib/VolumeManager/LVM/thin/data_map.rb
@@ -18,6 +18,21 @@ module Lvm2Thin
       end
     end
 
+    def total_blocks
+      @total_blocks ||= begin
+        t = 0
+        entries.each do |entry|
+          t += entry.kind_of?(DataMap) ?
+               entry.total_blocks : 1
+        end
+        t
+      end
+    end
+
+    def has_block?(blk)
+      blk < total_blocks
+    end
+
     def data_block(device_block)
       device_blocks.reverse.each do |map_device_block|
         if map_device_block <= device_block

--- a/lib/VolumeManager/LVM/thin/superblock.rb
+++ b/lib/VolumeManager/LVM/thin/superblock.rb
@@ -103,7 +103,7 @@ module Lvm2Thin
           data_blk = data_map.data_block(current_blk)
           blk_start = data_blk * data_block_size
 
-          if i == 0
+          if i.zero?
             blk_start += dev_off
             blk_len    = data_block_size - dev_off - 1
 
@@ -111,7 +111,7 @@ module Lvm2Thin
             blk_len = len - total_len
 
           else
-            blk_len    = data_block_size
+            blk_len = data_block_size
           end
 
           data_blks << [current_blk, data_blk, blk_start, blk_len]


### PR DESCRIPTION
As it stands if a client invokes a disk read against a LVM2 Thin Provisioned
volume for which space has not yet been allocated for the address being read,
a rather confusing / ugly error will occur:

  LVM2Thin cannot find device block: N (closest: X)]

  Where N is the data block corresponding to the address being looked up
  and X is the last allocated data block

This patch catches this case and simply returns an empty string if the read
cannot be completed