### PR TITLE
Increase Disk Caching for Azure Managed Disks

### DIFF
--- a/lib/MiqVm/miq_azure_vm.rb
+++ b/lib/MiqVm/miq_azure_vm.rb
@@ -67,7 +67,7 @@ class MiqAzureVm < MiqVm
         if @uri
           d = MiqDiskCache.new(AzureBlobDisk.new(sa_svc, @uri, d_info), 100, 128)
         else
-          d = MiqDiskCache.new(AzureManagedDisk.new(snap_svc, @snap_name, d_info), 100, 128)
+          d = MiqDiskCache.new(AzureManagedDisk.new(snap_svc, @snap_name, d_info), 200, 512)
         end
       rescue => err
         $log.error("#{err}: Couldn't open disk file: #{df}")


### PR DESCRIPTION
Azure Managed Disks need more hash entries and larger buffer sizes so that performance doesn't lag.

This is in support of high priority BZ https://bugzilla.redhat.com/show_bug.cgi?id=1488967
and will need to be back ported to FINE.

@roliveri please review and merge when possible.