### PR TITLE
Bump Gem Version to 0.1.5

### DIFF
--- a/lib/manageiq/smartstate/version.rb
+++ b/lib/manageiq/smartstate/version.rb
@@ -1,5 +1,5 @@
 module ManageIQ
   module Smartstate
-    VERSION = "0.1.4".freeze
+    VERSION = "0.1.5".freeze
   end
 end

--- a/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_blockSize-1.yml
+++ b/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_blockSize-1.yml
@@ -17,8 +17,6 @@ http_interactions:
       - '186'
       Content-Type:
       - application/x-www-form-urlencoded
-      Host:
-      - login.microsoftonline.com
   response:
     status:
       code: 200
@@ -39,25 +37,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - c5961506-e26d-4c5e-be62-0feae8ad2000
+      - 76a57ce7-1d66-437f-84c4-918643290e00
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAAA9kTklhVy7SJTGAzR-p1Bc29rcA0Sl2T1N6tW0exzfblVuwRjje4gkNlavKPv_EDiVtQwzaeJS_7b30M7uZvoQAe3P3PvduRzbh6FMJLUyKlQSa5DwPZTV5sct-xQczh8hp7O8ATTBDyxngSBleUeYMcmcSEroGl6h1WnFpysfmWgL7rAGqL54A5_do41HxsogAA;
+      - esctx=AQABAAAAAAABlDrqfEFlSaui6xnRjX5Eg3WbAgOT4RyVyqPfg63eN3w3DA2o2E7ceIvUjXpkFdzthQ38xhbPqBe0sTXAIsPoaLA3WTtgARnZq6LBINLOYGOysineaBWH2jRcHKcJgBLjxnJcrG6stdos6xTRTWZS7BMXJpH56ILLXFTVwyX9Z4xHQ9TvSBhBLMeo82cwXFggAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=008; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=005; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Tue, 05 Sep 2017 20:04:35 GMT
+      - Fri, 22 Sep 2017 21:43:18 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3600","ext_expires_in":"0","expires_on":"1504645477","not_before":"1504641577","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NzcsIm5iZiI6MTUwNDY0MTU3NywiZXhwIjoxNTA0NjQ1NDc3LCJhaW8iOiJZMkZnWUppVHRtTnI3OWRtdzBpR2VkZTNURmxYRFFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQmhXV3hXM2lYa3ktWWdfcTZLMGdBQSIsInZlciI6IjEuMCJ9.wF1HOCTfdLuDzQXO7Z1CtjKG4uJoD6FnMGKkrpMT6wNwTYnQ_DzHIYG6jyxcf_XpQ03RhzSBpDC_O629iCO4p5Gdj5a7a_Sqw0C2Mryn_RIu8-TzyI9Tbad5shsPte0bt8bZgU4rg-dZyD-OZAczUfZte9kPY4sdPX0hcm9bKwtcFV0alVjMfCLXUbsMTTZxClSQ53sSELtmigdZ6r-j3Yu4ZweOO5tyD5ms09ChA9rxmGb1Q3iJmWo_krnfpvGo9V05OlKce6nf1LYdjpihz_R6r2kzg9KkS52aoGDf4CmRo_BIrctGk06x4_F_Nhlxh2s18FETiTTeqbXxQmNSLw"}'
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1506120198","not_before":"1506116298","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyOTgsIm5iZiI6MTUwNjExNjI5OCwiZXhwIjoxNTA2MTIwMTk4LCJhaW8iOiJZMlZnWVBpYkdpZTFMU0JhNkUvbm8rMWF5cWRXQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTN5bGRtWWRmME9FeEpHR1F5a09BQSIsInZlciI6IjEuMCJ9.GXfU7XOKtiFTBk1pmTywNCCfzOXXoOfOiww3yywW6Ukwzy3_nMl-h1y9gCia2FHM5GqUnV530zFq_glFJtlMzRFfDxRC_SCmdNrrUtI025PnBxiPBy43kvGugxRdlzDwtxuWeJc0MjZha9lM5I3tBjGQTKYGyCF4rrXnijh-pFPopigaPbUeB0k0joA30JSnYUWDV6LhKYzBtlUrn8rhz4xpuLlRL7sMvHOWbZpTT_XOLL_6Dd9lcdGPCW2TadXlUTvlQMQM3r4KX6dfARWt96SltdoAwjLxFGi6fk5VYIFPtdZihzYQO3IWKsFNiM3S5KSoJxGHl0_OKp11fkmHGw"}'
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:33 GMT
+  recorded_at: Fri, 22 Sep 2017 21:43:18 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -74,9 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NzcsIm5iZiI6MTUwNDY0MTU3NywiZXhwIjoxNTA0NjQ1NDc3LCJhaW8iOiJZMkZnWUppVHRtTnI3OWRtdzBpR2VkZTNURmxYRFFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQmhXV3hXM2lYa3ktWWdfcTZLMGdBQSIsInZlciI6IjEuMCJ9.wF1HOCTfdLuDzQXO7Z1CtjKG4uJoD6FnMGKkrpMT6wNwTYnQ_DzHIYG6jyxcf_XpQ03RhzSBpDC_O629iCO4p5Gdj5a7a_Sqw0C2Mryn_RIu8-TzyI9Tbad5shsPte0bt8bZgU4rg-dZyD-OZAczUfZte9kPY4sdPX0hcm9bKwtcFV0alVjMfCLXUbsMTTZxClSQ53sSELtmigdZ6r-j3Yu4ZweOO5tyD5ms09ChA9rxmGb1Q3iJmWo_krnfpvGo9V05OlKce6nf1LYdjpihz_R6r2kzg9KkS52aoGDf4CmRo_BIrctGk06x4_F_Nhlxh2s18FETiTTeqbXxQmNSLw
-      Host:
-      - management.azure.com
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyOTgsIm5iZiI6MTUwNjExNjI5OCwiZXhwIjoxNTA2MTIwMTk4LCJhaW8iOiJZMlZnWVBpYkdpZTFMU0JhNkUvbm8rMWF5cWRXQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTN5bGRtWWRmME9FeEpHR1F5a09BQSIsInZlciI6IjEuMCJ9.GXfU7XOKtiFTBk1pmTywNCCfzOXXoOfOiww3yywW6Ukwzy3_nMl-h1y9gCia2FHM5GqUnV530zFq_glFJtlMzRFfDxRC_SCmdNrrUtI025PnBxiPBy43kvGugxRdlzDwtxuWeJc0MjZha9lM5I3tBjGQTKYGyCF4rrXnijh-pFPopigaPbUeB0k0joA30JSnYUWDV6LhKYzBtlUrn8rhz4xpuLlRL7sMvHOWbZpTT_XOLL_6Dd9lcdGPCW2TadXlUTvlQMQM3r4KX6dfARWt96SltdoAwjLxFGi6fk5VYIFPtdZihzYQO3IWKsFNiM3S5KSoJxGHl0_OKp11fkmHGw
   response:
     status:
       code: 200
@@ -95,23 +91,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14995'
+      - '14999'
       X-Ms-Request-Id:
-      - c443c9d6-bce7-43c1-8245-35283ac414e6
+      - dbddeb53-848f-4a05-b877-188eeb28608c
       X-Ms-Correlation-Request-Id:
-      - c443c9d6-bce7-43c1-8245-35283ac414e6
+      - dbddeb53-848f-4a05-b877-188eeb28608c
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200437Z:c443c9d6-bce7-43c1-8245-35283ac414e6
+      - WESTUS:20170922T214318Z:dbddeb53-848f-4a05-b877-188eeb28608c
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 05 Sep 2017 20:04:36 GMT
+      - Fri, 22 Sep 2017 21:43:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:34 GMT
+  recorded_at: Fri, 22 Sep 2017 21:43:18 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/azure_subscription_id/providers?api-version=2015-01-01
@@ -128,9 +124,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NzcsIm5iZiI6MTUwNDY0MTU3NywiZXhwIjoxNTA0NjQ1NDc3LCJhaW8iOiJZMkZnWUppVHRtTnI3OWRtdzBpR2VkZTNURmxYRFFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQmhXV3hXM2lYa3ktWWdfcTZLMGdBQSIsInZlciI6IjEuMCJ9.wF1HOCTfdLuDzQXO7Z1CtjKG4uJoD6FnMGKkrpMT6wNwTYnQ_DzHIYG6jyxcf_XpQ03RhzSBpDC_O629iCO4p5Gdj5a7a_Sqw0C2Mryn_RIu8-TzyI9Tbad5shsPte0bt8bZgU4rg-dZyD-OZAczUfZte9kPY4sdPX0hcm9bKwtcFV0alVjMfCLXUbsMTTZxClSQ53sSELtmigdZ6r-j3Yu4ZweOO5tyD5ms09ChA9rxmGb1Q3iJmWo_krnfpvGo9V05OlKce6nf1LYdjpihz_R6r2kzg9KkS52aoGDf4CmRo_BIrctGk06x4_F_Nhlxh2s18FETiTTeqbXxQmNSLw
-      Host:
-      - management.azure.com
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyOTgsIm5iZiI6MTUwNjExNjI5OCwiZXhwIjoxNTA2MTIwMTk4LCJhaW8iOiJZMlZnWVBpYkdpZTFMU0JhNkUvbm8rMWF5cWRXQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTN5bGRtWWRmME9FeEpHR1F5a09BQSIsInZlciI6IjEuMCJ9.GXfU7XOKtiFTBk1pmTywNCCfzOXXoOfOiww3yywW6Ukwzy3_nMl-h1y9gCia2FHM5GqUnV530zFq_glFJtlMzRFfDxRC_SCmdNrrUtI025PnBxiPBy43kvGugxRdlzDwtxuWeJc0MjZha9lM5I3tBjGQTKYGyCF4rrXnijh-pFPopigaPbUeB0k0joA30JSnYUWDV6LhKYzBtlUrn8rhz4xpuLlRL7sMvHOWbZpTT_XOLL_6Dd9lcdGPCW2TadXlUTvlQMQM3r4KX6dfARWt96SltdoAwjLxFGi6fk5VYIFPtdZihzYQO3IWKsFNiM3S5KSoJxGHl0_OKp11fkmHGw
   response:
     status:
       code: 200
@@ -147,22 +141,42 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14903'
+      - '14924'
       X-Ms-Request-Id:
-      - d44f2100-dff2-467c-9a64-80c208529bc5
+      - 71e85ebf-c450-4f0d-863e-655d6920c4f1
       X-Ms-Correlation-Request-Id:
-      - d44f2100-dff2-467c-9a64-80c208529bc5
+      - 71e85ebf-c450-4f0d-863e-655d6920c4f1
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200438Z:d44f2100-dff2-467c-9a64-80c208529bc5
+      - WESTUS:20170922T214319Z:71e85ebf-c450-4f0d-863e-655d6920c4f1
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 05 Sep 2017 20:04:38 GMT
+      - Fri, 22 Sep 2017 21:43:19 GMT
       Content-Length:
-      - '243687'
+      - '254785'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
+      string: '{"value":[{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"operations","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","North Central
         US","South Central US","West Central US","West US","West US 2","Canada Central","Canada
         East","North Europe","West Europe","UK South","UK West","East Asia","Southeast
@@ -437,7 +451,7 @@ http_interactions:
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
         Central US","West US 2","South India","Central India","West India","Canada
-        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
+        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
         East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
@@ -466,7 +480,7 @@ http_interactions:
         Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"}],"resourceTypes":[{"resourceType":"components","locations":["East
         US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
         US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01","2014-04-01"]},{"resourceType":"queries","locations":["East
-        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"alertrules","locations":["West
+        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
@@ -542,7 +556,7 @@ http_interactions:
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorization":{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorizations":[{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},{"applicationId":"7c33bfcb-8d33-48d6-8e60-dc6404003489","roleDefinitionId":"ad6261e4-fa9a-4642-aa5f-104f1b67e9e3"},{"applicationId":"1e3e4475-288f-4018-a376-df66fd7fac5f","roleDefinitionId":"1d538b69-3d87-4e56-8ff8-25786fd48261"},{"applicationId":"a0be0c72-870e-46f0-9c49-c98333a996f7","roleDefinitionId":"7ce22727-ffce-45a9-930c-ddb2e56fa131"}],"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -552,7 +566,7 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -567,7 +581,8 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
+        Central US"],"apiVersions":["2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -577,7 +592,12 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -597,7 +617,7 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -612,7 +632,7 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -622,7 +642,31 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
         East","UK South","Central India","Canada Central"],"apiVersions":["2017-04-26-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"]},{"resourceType":"workspaces/dataSources","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
@@ -641,17 +685,17 @@ http_interactions:
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"consoles","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/consoles","locations":["West
+        East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"consoles","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/consoles","locations":["West
         US","East US","Central India","North Europe","West Europe","South Central
-        US","Southeast Asia"],"apiVersions":["2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
+        US","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
         US","East US","Central India","North Europe","West Europe","South Central
-        US","Southeast Asia"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
+        US","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","Canada Central","Canada East","West Central US","West US 2","UK South","UK
         West","Korea Central","Korea South"],"apiVersions":["2017-07-01","2016-12-01","2016-08-10","2016-06-01","2016-05-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"operations","locations":["Southeast
-        Asia"],"apiVersions":["2016-08-10","2016-06-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01"]},{"resourceType":"locations/backupStatus","locations":["West
+        Asia"],"apiVersions":["2016-08-10","2016-06-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01","2016-06-01"]},{"resourceType":"locations/backupStatus","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
@@ -687,6 +731,7 @@ http_interactions:
         Central US","Central US","North Europe","West Europe","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada Central","Canada East"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"pricings","locations":["Central
+        US","East US"],"apiVersions":["2017-08-01-preview"]},{"resourceType":"securityContacts","locations":["Central
         US","East US"],"apiVersions":["2017-08-01-preview"]},{"resourceType":"workspaceSettings","locations":["Central
         US","East US"],"apiVersions":["2017-08-01-preview"]},{"resourceType":"complianceResults","locations":["Central
         US","East US"],"apiVersions":["2017-08-01"]},{"resourceType":"policies","locations":["Central
@@ -703,6 +748,8 @@ http_interactions:
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatusesSummaries","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/alerts","locations":["Central
         US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/tasks","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"externalSecuritySolutions","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/externalSecuritySolutions","locations":["Central
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.SiteRecovery","namespace":"Microsoft.SiteRecovery","authorization":{"applicationId":"b8340c3b-9267-498f-b21a-15d5547fd85e","roleDefinitionId":"8A00C8EA-8F1B-45A7-8F64-F4CC61EEE9B6"},"resourceTypes":[{"resourceType":"SiteRecoveryVault","locations":["East
         US","West US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","Australia East","Australia Southeast","Brazil South","North
@@ -722,7 +769,7 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -842,7 +889,22 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/databases/transparentDataEncryption","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -1077,6 +1139,26 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
         US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
@@ -1307,6 +1389,11 @@ http_interactions:
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"customApis","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
         East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/managedApis","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
@@ -1358,23 +1445,8 @@ http_interactions:
         US","North Europe","Japan West","Japan East","East Asia","West Europe","East
         US","Southeast Asia","Central US"],"apiVersions":["2016-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Lombiq.DotNest","namespace":"Lombiq.DotNest","resourceTypes":[{"resourceType":"sites","locations":["East
         US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Mailjet.Email","namespace":"Mailjet.Email","resourceTypes":[{"resourceType":"services","locations":["West
-        US"],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
-        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]},{"resourceType":"diagnosticSettings","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"addsservices","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"configuration","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"operations","locations":["West
@@ -1498,8 +1570,10 @@ http_interactions:
         Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
         Central US","Central US","North Europe","West Europe","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","West
-        India","South India"],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CognitiveServices","namespace":"Microsoft.CognitiveServices","authorizations":[{"applicationId":"7d312290-28c8-473c-a0ed-8e53749b6d6d","roleDefinitionId":"5cb87f79-a7c3-4a95-9414-45b65974b51b"}],"resourceTypes":[{"resourceType":"accounts","locations":["Global","West
-        US","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"operations","locations":["Global","Australia
+        India","South India"],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CognitiveServices","namespace":"Microsoft.CognitiveServices","authorizations":[{"applicationId":"7d312290-28c8-473c-a0ed-8e53749b6d6d","roleDefinitionId":"5cb87f79-a7c3-4a95-9414-45b65974b51b"}],"resourceTypes":[{"resourceType":"accounts","locations":["Global","Australia
+        East","Brazil South","West US","West US 2","West Europe","North Europe","Southeast
+        Asia","East Asia","West Central US","South Central US","East US","East US
+        2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"operations","locations":["Global","Australia
         East","Brazil South","West US","West US 2","West Europe","North Europe","Southeast
         Asia","East Asia","West Central US","South Central US","East US","East US
         2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations","locations":["Global","Australia
@@ -1534,13 +1608,13 @@ http_interactions:
         US","West US","Australia East","West Europe","North Europe","Southeast Asia","West
         Central US"],"apiVersions":["2016-03-30","2015-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataFactory","namespace":"Microsoft.DataFactory","resourceTypes":[{"resourceType":"dataFactories","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview","2014-04-01"]},{"resourceType":"factories","locations":["East
-        US"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
-        US"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
+        US","East US 2"],"apiVersions":["2017-09-01-preview","2017-03-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
+        US","East US 2"],"apiVersions":["2017-09-01-preview","2017-03-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
         Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"dataFactories/metricDefinitions","locations":["North
         Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"checkDataFactoryNameAvailability","locations":[],"apiVersions":["2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"checkAzureDataFactoryNameAvailability","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"dataFactorySchema","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"operations","locations":["West
-        US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeAnalytics","namespace":"Microsoft.DataLakeAnalytics","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US","North Europe","East US","West Central US"],"apiVersions":["2017-09-01-preview","2017-03-01-preview","2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeAnalytics","namespace":"Microsoft.DataLakeAnalytics","resourceTypes":[{"resourceType":"accounts","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/dataLakeStoreAccounts","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers","locations":["East
@@ -1589,11 +1663,12 @@ http_interactions:
         India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
         India","East Asia","East US 2","East US","Japan East","Japan West","North
         Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"checkProvisioningServiceNameAvailability","locations":[],"apiVersions":["2017-08-21-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
         US","North Europe","East Asia","East US","West Europe","Southeast Asia","Japan
         East","Japan West","Australia East","Australia Southeast","West US 2","West
         Central US","East US 2","Central US","UK South","UK West","South India","Central
-        India"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
+        India","Canada Central","Canada East"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"ProvisioningServices","locations":["East
+        US","West Europe","Southeast Asia"],"apiVersions":["2017-08-21-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
         East","Australia Southeast","Canada Central","Canada East","Central India","Central
         US","East Asia","East US","East US 2","Japan East","Japan West","North Central
         US","North Europe","South Central US","South India","Southeast Asia","West
@@ -1620,16 +1695,16 @@ http_interactions:
         US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"operations","locations":["Brazil
         South","East Asia","East US","Japan East","Japan West","North Central US","North
         Europe","South Central US","West Europe","West US","Southeast Asia","Central
-        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"topics","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operations","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topics","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operations","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","West
         US 2","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
@@ -1727,48 +1802,39 @@ http_interactions:
         Central US","West Europe","Southeast Asia","Japan East","East US 2","West
         Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"commitmentPlans","locations":["South
         Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
-        Central US","West US"],"apiVersions":["2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Media","namespace":"Microsoft.Media","authorization":{"applicationId":"374b2a64-3b6b-436b-934c-b820eacca870","roleDefinitionId":"aab70789-0cec-44b5-95d7-84b64c9487af"},"resourceTypes":[{"resourceType":"mediaservices","locations":["Japan
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningExperimentation","namespace":"Microsoft.MachineLearningExperimentation","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"accounts","locations":["Australia
+        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces","locations":["Australia
+        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces/projects","locations":["Australia
+        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningCompute","namespace":"Microsoft.MachineLearningCompute","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"376aa7d7-51a9-463d-bd4d-7e1691345612","managedByRoleDefinitionId":"91d00862-cf55-46a5-9dce-260bbd92ce25"},"resourceTypes":[{"resourceType":"operationalizationClusters","locations":["East
+        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"operations","locations":["East
+        US 2"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations","locations":["East
+        US 2"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["East
+        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningModelManagement","namespace":"Microsoft.MachineLearningModelManagement","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US 2","West Central US","Australia East"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"operations","locations":["West
+        Central US"],"apiVersions":["2017-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
+        Central US","West US"],"apiVersions":["2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01"]},{"resourceType":"offertypes","locations":["South
+        Central US","West US"],"apiVersions":["2015-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Media","namespace":"Microsoft.Media","authorization":{"applicationId":"374b2a64-3b6b-436b-934c-b820eacca870","roleDefinitionId":"aab70789-0cec-44b5-95d7-84b64c9487af"},"resourceTypes":[{"resourceType":"mediaservices","locations":["Japan
         West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
         US","West US","Australia East","Australia Southeast","Central US","Brazil
         South","Central India","West India","South India","South Central US","Canada
-        Central","Canada East","West Central US"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
+        Central","Canada East","West Central US"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
         Central US","North Central US","East US 2","West US","West Europe","North
         Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
         East","UK South","West India"],"apiVersions":["2016-01-29"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-01-29"]},{"resourceType":"locations/checkNameAvailability","locations":["South
         Central US","North Central US","East US 2","West US","West Europe","North
         Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
-        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"operations","locations":["East
+        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"capacities","locations":["West
+        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
+        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationresults","locations":["West
+        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
+        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"operations","locations":["East
         US 2"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Relay","namespace":"Microsoft.Relay","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US 2","West
         US","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
         India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2017-08-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkPolicyCompliance","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
@@ -1827,8 +1893,11 @@ http_interactions:
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","resourceTypes":[{"resourceType":"operations","locations":["West
-        Central US"],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
+        Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applianceDefinitions","locations":["West
+        Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"locations","locations":["West
+        Central US"],"apiVersions":["2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
+        Central US"],"apiVersions":["2017-09-01","2016-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","West Central US","Japan East","Japan West","Australia East","Australia
         Southeast"],"apiVersions":["2017-06-01","2017-05-15","2017-01-01","2016-10-01","2016-06-01","2015-03-15","2014-09-01"]},{"resourceType":"operations","locations":["West
@@ -1888,11 +1957,17 @@ http_interactions:
         US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RedisLabs.Memcached","namespace":"RedisLabs.Memcached","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-07-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RedisLabs.Redis","namespace":"RedisLabs.Redis","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-07-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RevAPM.MobileCDN","namespace":"RevAPM.MobileCDN","resourceTypes":[{"resourceType":"accounts","locations":["Central
         US","East US","East US 2","North Central US","South Central US","West US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
-        East","Australia Southeast"],"apiVersions":["2016-08-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-24","2016-08-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sendgrid.Email","namespace":"Sendgrid.Email","resourceTypes":[{"resourceType":"accounts","locations":["East
-        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
-        Central US","Central US","North Europe","West Europe","Japan East","Japan
-        West","Brazil South","Australia East","Australia Southeast","Canada Central","Canada
-        East","West Central US","West US 2","UK South","UK West"],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Signiant.Flight","namespace":"Signiant.Flight","resourceTypes":[{"resourceType":"accounts","locations":["East
+        East","Australia Southeast"],"apiVersions":["2016-08-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-24","2016-08-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sendgrid.Email","namespace":"Sendgrid.Email","resourceTypes":[{"resourceType":"accounts","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Signiant.Flight","namespace":"Signiant.Flight","resourceTypes":[{"resourceType":"accounts","locations":["East
         US","Central US","North Central US","South Central US","West US","North Europe","West
         Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast"],"apiVersions":["2015-06-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sparkpost.Basic","namespace":"Sparkpost.Basic","resourceTypes":[{"resourceType":"services","locations":["West
@@ -1909,7 +1984,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:35 GMT
+  recorded_at: Fri, 22 Sep 2017 21:43:20 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
@@ -1926,11 +2001,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NzcsIm5iZiI6MTUwNDY0MTU3NywiZXhwIjoxNTA0NjQ1NDc3LCJhaW8iOiJZMkZnWUppVHRtTnI3OWRtdzBpR2VkZTNURmxYRFFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQmhXV3hXM2lYa3ktWWdfcTZLMGdBQSIsInZlciI6IjEuMCJ9.wF1HOCTfdLuDzQXO7Z1CtjKG4uJoD6FnMGKkrpMT6wNwTYnQ_DzHIYG6jyxcf_XpQ03RhzSBpDC_O629iCO4p5Gdj5a7a_Sqw0C2Mryn_RIu8-TzyI9Tbad5shsPte0bt8bZgU4rg-dZyD-OZAczUfZte9kPY4sdPX0hcm9bKwtcFV0alVjMfCLXUbsMTTZxClSQ53sSELtmigdZ6r-j3Yu4ZweOO5tyD5ms09ChA9rxmGb1Q3iJmWo_krnfpvGo9V05OlKce6nf1LYdjpihz_R6r2kzg9KkS52aoGDf4CmRo_BIrctGk06x4_F_Nhlxh2s18FETiTTeqbXxQmNSLw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyOTgsIm5iZiI6MTUwNjExNjI5OCwiZXhwIjoxNTA2MTIwMTk4LCJhaW8iOiJZMlZnWVBpYkdpZTFMU0JhNkUvbm8rMWF5cWRXQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTN5bGRtWWRmME9FeEpHR1F5a09BQSIsInZlciI6IjEuMCJ9.GXfU7XOKtiFTBk1pmTywNCCfzOXXoOfOiww3yywW6Ukwzy3_nMl-h1y9gCia2FHM5GqUnV530zFq_glFJtlMzRFfDxRC_SCmdNrrUtI025PnBxiPBy43kvGugxRdlzDwtxuWeJc0MjZha9lM5I3tBjGQTKYGyCF4rrXnijh-pFPopigaPbUeB0k0joA30JSnYUWDV6LhKYzBtlUrn8rhz4xpuLlRL7sMvHOWbZpTT_XOLL_6Dd9lcdGPCW2TadXlUTvlQMQM3r4KX6dfARWt96SltdoAwjLxFGi6fk5VYIFPtdZihzYQO3IWKsFNiM3S5KSoJxGHl0_OKp11fkmHGw
       Content-Length:
       - '42'
-      Host:
-      - management.azure.com
   response:
     status:
       code: 202
@@ -1945,34 +2018,34 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/13acc700-ec8f-4658-b06e-889904b3f96f?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/ecf32a2f-c18d-4b1c-bc42-fc0f00cac50a?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/13acc700-ec8f-4658-b06e-889904b3f96f?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/ecf32a2f-c18d-4b1c-bc42-fc0f00cac50a?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - 13acc700-ec8f-4658-b06e-889904b3f96f
+      - ecf32a2f-c18d-4b1c-bc42-fc0f00cac50a
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1180'
+      - '1181'
       X-Ms-Correlation-Request-Id:
-      - f45c75f1-b330-44bc-9ca6-bdadc0c72b59
+      - 44f31156-1555-4f42-8657-7bc65ba7e375
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200439Z:f45c75f1-b330-44bc-9ca6-bdadc0c72b59
+      - WESTUS:20170922T214321Z:44f31156-1555-4f42-8657-7bc65ba7e375
       Date:
-      - Tue, 05 Sep 2017 20:04:38 GMT
+      - Fri, 22 Sep 2017 21:43:21 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:35 GMT
+  recorded_at: Fri, 22 Sep 2017 21:43:21 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/13acc700-ec8f-4658-b06e-889904b3f96f?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/ecf32a2f-c18d-4b1c-bc42-fc0f00cac50a?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -1986,9 +2059,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NzcsIm5iZiI6MTUwNDY0MTU3NywiZXhwIjoxNTA0NjQ1NDc3LCJhaW8iOiJZMkZnWUppVHRtTnI3OWRtdzBpR2VkZTNURmxYRFFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQmhXV3hXM2lYa3ktWWdfcTZLMGdBQSIsInZlciI6IjEuMCJ9.wF1HOCTfdLuDzQXO7Z1CtjKG4uJoD6FnMGKkrpMT6wNwTYnQ_DzHIYG6jyxcf_XpQ03RhzSBpDC_O629iCO4p5Gdj5a7a_Sqw0C2Mryn_RIu8-TzyI9Tbad5shsPte0bt8bZgU4rg-dZyD-OZAczUfZte9kPY4sdPX0hcm9bKwtcFV0alVjMfCLXUbsMTTZxClSQ53sSELtmigdZ6r-j3Yu4ZweOO5tyD5ms09ChA9rxmGb1Q3iJmWo_krnfpvGo9V05OlKce6nf1LYdjpihz_R6r2kzg9KkS52aoGDf4CmRo_BIrctGk06x4_F_Nhlxh2s18FETiTTeqbXxQmNSLw
-      Host:
-      - management.azure.com
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyOTgsIm5iZiI6MTUwNjExNjI5OCwiZXhwIjoxNTA2MTIwMTk4LCJhaW8iOiJZMlZnWVBpYkdpZTFMU0JhNkUvbm8rMWF5cWRXQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTN5bGRtWWRmME9FeEpHR1F5a09BQSIsInZlciI6IjEuMCJ9.GXfU7XOKtiFTBk1pmTywNCCfzOXXoOfOiww3yywW6Ukwzy3_nMl-h1y9gCia2FHM5GqUnV530zFq_glFJtlMzRFfDxRC_SCmdNrrUtI025PnBxiPBy43kvGugxRdlzDwtxuWeJc0MjZha9lM5I3tBjGQTKYGyCF4rrXnijh-pFPopigaPbUeB0k0joA30JSnYUWDV6LhKYzBtlUrn8rhz4xpuLlRL7sMvHOWbZpTT_XOLL_6Dd9lcdGPCW2TadXlUTvlQMQM3r4KX6dfARWt96SltdoAwjLxFGi6fk5VYIFPtdZihzYQO3IWKsFNiM3S5KSoJxGHl0_OKp11fkmHGw
   response:
     status:
       code: 200
@@ -2009,31 +2080,90 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - b76dca58-490d-4e4e-9374-a769935e0fe6
+      - 71a3c669-edcb-4d21-b9b6-d077cf5e2a4e
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14943'
+      - '14936'
       X-Ms-Correlation-Request-Id:
-      - 1ac5b06b-544f-4044-9f97-f7c5cba3243c
+      - bc66b0ee-bb61-4629-9835-40b8d70a7b3b
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200439Z:1ac5b06b-544f-4044-9f97-f7c5cba3243c
+      - WESTUS:20170922T214322Z:bc66b0ee-bb61-4629-9835-40b8d70a7b3b
       Date:
-      - Tue, 05 Sep 2017 20:04:39 GMT
+      - Fri, 22 Sep 2017 21:43:21 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-05T20:04:38.4727909+00:00\",\r\n  \"endTime\":
-        \"2017-09-05T20:04:38.660357+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=1897ddb8-dcef-4b11-a5be-8820991c1528&sig=pAJBB6TK8qVSs2cCj5sLQcszXTUdfKYo8NsoNH8AOR8%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"13acc700-ec8f-4658-b06e-889904b3f96f\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2017-09-22T21:43:22.6790953+00:00\",\r\n  \"endTime\":
+        \"2017-09-22T21:43:22.8510167+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=0e6847e5-43a4-4a22-9baf-6cbd6b92bcf9&sig=ZYWDMMESZruGP%2Bb82bh%2FtQUuwqM%2BKubYfgw6kUANajQ%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"ecf32a2f-c18d-4b1c-bc42-fc0f00cac50a\"\r\n}"
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:36 GMT
+  recorded_at: Fri, 22 Sep 2017 21:43:21 GMT
 - request:
     method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=1897ddb8-dcef-4b11-a5be-8820991c1528&sig=pAJBB6TK8qVSs2cCj5sLQcszXTUdfKYo8NsoNH8AOR8=&sr=b&sv=2016-05-31
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/ecf32a2f-c18d-4b1c-bc42-fc0f00cac50a?api-version=2017-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyOTgsIm5iZiI6MTUwNjExNjI5OCwiZXhwIjoxNTA2MTIwMTk4LCJhaW8iOiJZMlZnWVBpYkdpZTFMU0JhNkUvbm8rMWF5cWRXQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTN5bGRtWWRmME9FeEpHR1F5a09BQSIsInZlciI6IjEuMCJ9.GXfU7XOKtiFTBk1pmTywNCCfzOXXoOfOiww3yywW6Ukwzy3_nMl-h1y9gCia2FHM5GqUnV530zFq_glFJtlMzRFfDxRC_SCmdNrrUtI025PnBxiPBy43kvGugxRdlzDwtxuWeJc0MjZha9lM5I3tBjGQTKYGyCF4rrXnijh-pFPopigaPbUeB0k0joA30JSnYUWDV6LhKYzBtlUrn8rhz4xpuLlRL7sMvHOWbZpTT_XOLL_6Dd9lcdGPCW2TadXlUTvlQMQM3r4KX6dfARWt96SltdoAwjLxFGi6fk5VYIFPtdZihzYQO3IWKsFNiM3S5KSoJxGHl0_OKp11fkmHGw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
+      X-Ms-Request-Id:
+      - ec07f302-9c84-4e4a-8e1d-b5a023584dc8
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14917'
+      X-Ms-Correlation-Request-Id:
+      - 1367ff81-60cd-4a08-aaaf-8c6041d15413
+      X-Ms-Routing-Request-Id:
+      - WESTUS:20170922T214322Z:1367ff81-60cd-4a08-aaaf-8c6041d15413
+      Date:
+      - Fri, 22 Sep 2017 21:43:21 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"startTime\": \"2017-09-22T21:43:22.6790953+00:00\",\r\n  \"endTime\":
+        \"2017-09-22T21:43:22.8510167+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=0e6847e5-43a4-4a22-9baf-6cbd6b92bcf9&sig=ZYWDMMESZruGP%2Bb82bh%2FtQUuwqM%2BKubYfgw6kUANajQ%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"ecf32a2f-c18d-4b1c-bc42-fc0f00cac50a\"\r\n}"
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 21:43:22 GMT
+- request:
+    method: get
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=0e6847e5-43a4-4a22-9baf-6cbd6b92bcf9&sig=ZYWDMMESZruGP%2Bb82bh/tQUuwqM%2BKubYfgw6kUANajQ=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2046,8 +2176,6 @@ http_interactions:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
       X-Ms-Range:
       - bytes=0-0
-      Host:
-      - md-t4jdgqqlgszp.blob.core.windows.net
   response:
     status:
       code: 206
@@ -2068,7 +2196,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 4e164c54-001e-00be-2982-26b4a6000000
+      - ac592393-001e-0118-07eb-33caed000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2094,13 +2222,13 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Tue, 05 Sep 2017 20:04:39 GMT
+      - Fri, 22 Sep 2017 21:43:22 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         6w==
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:36 GMT
+  recorded_at: Fri, 22 Sep 2017 21:43:22 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/EndGetAccess?api-version=2017-03-30
@@ -2117,11 +2245,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NzcsIm5iZiI6MTUwNDY0MTU3NywiZXhwIjoxNTA0NjQ1NDc3LCJhaW8iOiJZMkZnWUppVHRtTnI3OWRtdzBpR2VkZTNURmxYRFFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQmhXV3hXM2lYa3ktWWdfcTZLMGdBQSIsInZlciI6IjEuMCJ9.wF1HOCTfdLuDzQXO7Z1CtjKG4uJoD6FnMGKkrpMT6wNwTYnQ_DzHIYG6jyxcf_XpQ03RhzSBpDC_O629iCO4p5Gdj5a7a_Sqw0C2Mryn_RIu8-TzyI9Tbad5shsPte0bt8bZgU4rg-dZyD-OZAczUfZte9kPY4sdPX0hcm9bKwtcFV0alVjMfCLXUbsMTTZxClSQ53sSELtmigdZ6r-j3Yu4ZweOO5tyD5ms09ChA9rxmGb1Q3iJmWo_krnfpvGo9V05OlKce6nf1LYdjpihz_R6r2kzg9KkS52aoGDf4CmRo_BIrctGk06x4_F_Nhlxh2s18FETiTTeqbXxQmNSLw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyOTgsIm5iZiI6MTUwNjExNjI5OCwiZXhwIjoxNTA2MTIwMTk4LCJhaW8iOiJZMlZnWVBpYkdpZTFMU0JhNkUvbm8rMWF5cWRXQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTN5bGRtWWRmME9FeEpHR1F5a09BQSIsInZlciI6IjEuMCJ9.GXfU7XOKtiFTBk1pmTywNCCfzOXXoOfOiww3yywW6Ukwzy3_nMl-h1y9gCia2FHM5GqUnV530zFq_glFJtlMzRFfDxRC_SCmdNrrUtI025PnBxiPBy43kvGugxRdlzDwtxuWeJc0MjZha9lM5I3tBjGQTKYGyCF4rrXnijh-pFPopigaPbUeB0k0joA30JSnYUWDV6LhKYzBtlUrn8rhz4xpuLlRL7sMvHOWbZpTT_XOLL_6Dd9lcdGPCW2TadXlUTvlQMQM3r4KX6dfARWt96SltdoAwjLxFGi6fk5VYIFPtdZihzYQO3IWKsFNiM3S5KSoJxGHl0_OKp11fkmHGw
       Content-Length:
       - '0'
-      Host:
-      - management.azure.com
   response:
     status:
       code: 202
@@ -2136,31 +2262,31 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/90e6ec86-3e77-4ab5-b0fa-494d2f558f2c?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/a7f4008f-d5ca-4c73-9934-f74338f5cea9?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/90e6ec86-3e77-4ab5-b0fa-494d2f558f2c?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/a7f4008f-d5ca-4c73-9934-f74338f5cea9?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - 90e6ec86-3e77-4ab5-b0fa-494d2f558f2c
+      - a7f4008f-d5ca-4c73-9934-f74338f5cea9
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1179'
+      - '1184'
       X-Ms-Correlation-Request-Id:
-      - 20502bc5-6feb-41ff-835e-e7c10bae6973
+      - cdf877f8-2f68-46de-8bf6-7b1f603136a6
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200440Z:20502bc5-6feb-41ff-835e-e7c10bae6973
+      - WESTUS:20170922T214323Z:cdf877f8-2f68-46de-8bf6-7b1f603136a6
       Date:
-      - Tue, 05 Sep 2017 20:04:39 GMT
+      - Fri, 22 Sep 2017 21:43:23 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:36 GMT
+  recorded_at: Fri, 22 Sep 2017 21:43:23 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
@@ -2177,11 +2303,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NzcsIm5iZiI6MTUwNDY0MTU3NywiZXhwIjoxNTA0NjQ1NDc3LCJhaW8iOiJZMkZnWUppVHRtTnI3OWRtdzBpR2VkZTNURmxYRFFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQmhXV3hXM2lYa3ktWWdfcTZLMGdBQSIsInZlciI6IjEuMCJ9.wF1HOCTfdLuDzQXO7Z1CtjKG4uJoD6FnMGKkrpMT6wNwTYnQ_DzHIYG6jyxcf_XpQ03RhzSBpDC_O629iCO4p5Gdj5a7a_Sqw0C2Mryn_RIu8-TzyI9Tbad5shsPte0bt8bZgU4rg-dZyD-OZAczUfZte9kPY4sdPX0hcm9bKwtcFV0alVjMfCLXUbsMTTZxClSQ53sSELtmigdZ6r-j3Yu4ZweOO5tyD5ms09ChA9rxmGb1Q3iJmWo_krnfpvGo9V05OlKce6nf1LYdjpihz_R6r2kzg9KkS52aoGDf4CmRo_BIrctGk06x4_F_Nhlxh2s18FETiTTeqbXxQmNSLw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyOTgsIm5iZiI6MTUwNjExNjI5OCwiZXhwIjoxNTA2MTIwMTk4LCJhaW8iOiJZMlZnWVBpYkdpZTFMU0JhNkUvbm8rMWF5cWRXQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTN5bGRtWWRmME9FeEpHR1F5a09BQSIsInZlciI6IjEuMCJ9.GXfU7XOKtiFTBk1pmTywNCCfzOXXoOfOiww3yywW6Ukwzy3_nMl-h1y9gCia2FHM5GqUnV530zFq_glFJtlMzRFfDxRC_SCmdNrrUtI025PnBxiPBy43kvGugxRdlzDwtxuWeJc0MjZha9lM5I3tBjGQTKYGyCF4rrXnijh-pFPopigaPbUeB0k0joA30JSnYUWDV6LhKYzBtlUrn8rhz4xpuLlRL7sMvHOWbZpTT_XOLL_6Dd9lcdGPCW2TadXlUTvlQMQM3r4KX6dfARWt96SltdoAwjLxFGi6fk5VYIFPtdZihzYQO3IWKsFNiM3S5KSoJxGHl0_OKp11fkmHGw
       Content-Length:
       - '42'
-      Host:
-      - management.azure.com
   response:
     status:
       code: 202
@@ -2196,34 +2320,34 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/423981d5-bdc8-4d73-bfda-7a82f5537c91?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/d5303e2e-9f0c-42c0-8e92-41f1b947ce98?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/423981d5-bdc8-4d73-bfda-7a82f5537c91?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/d5303e2e-9f0c-42c0-8e92-41f1b947ce98?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - 423981d5-bdc8-4d73-bfda-7a82f5537c91
+      - d5303e2e-9f0c-42c0-8e92-41f1b947ce98
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1197'
+      - '1181'
       X-Ms-Correlation-Request-Id:
-      - 35fdbf14-9080-444d-b41e-a1815621ae2b
+      - d59d8d37-4f2b-41d1-9c39-09ad1b190e93
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200440Z:35fdbf14-9080-444d-b41e-a1815621ae2b
+      - WESTUS:20170922T214325Z:d59d8d37-4f2b-41d1-9c39-09ad1b190e93
       Date:
-      - Tue, 05 Sep 2017 20:04:40 GMT
+      - Fri, 22 Sep 2017 21:43:24 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:36 GMT
+  recorded_at: Fri, 22 Sep 2017 21:43:25 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/423981d5-bdc8-4d73-bfda-7a82f5537c91?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/d5303e2e-9f0c-42c0-8e92-41f1b947ce98?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -2237,9 +2361,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NzcsIm5iZiI6MTUwNDY0MTU3NywiZXhwIjoxNTA0NjQ1NDc3LCJhaW8iOiJZMkZnWUppVHRtTnI3OWRtdzBpR2VkZTNURmxYRFFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQmhXV3hXM2lYa3ktWWdfcTZLMGdBQSIsInZlciI6IjEuMCJ9.wF1HOCTfdLuDzQXO7Z1CtjKG4uJoD6FnMGKkrpMT6wNwTYnQ_DzHIYG6jyxcf_XpQ03RhzSBpDC_O629iCO4p5Gdj5a7a_Sqw0C2Mryn_RIu8-TzyI9Tbad5shsPte0bt8bZgU4rg-dZyD-OZAczUfZte9kPY4sdPX0hcm9bKwtcFV0alVjMfCLXUbsMTTZxClSQ53sSELtmigdZ6r-j3Yu4ZweOO5tyD5ms09ChA9rxmGb1Q3iJmWo_krnfpvGo9V05OlKce6nf1LYdjpihz_R6r2kzg9KkS52aoGDf4CmRo_BIrctGk06x4_F_Nhlxh2s18FETiTTeqbXxQmNSLw
-      Host:
-      - management.azure.com
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyOTgsIm5iZiI6MTUwNjExNjI5OCwiZXhwIjoxNTA2MTIwMTk4LCJhaW8iOiJZMlZnWVBpYkdpZTFMU0JhNkUvbm8rMWF5cWRXQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTN5bGRtWWRmME9FeEpHR1F5a09BQSIsInZlciI6IjEuMCJ9.GXfU7XOKtiFTBk1pmTywNCCfzOXXoOfOiww3yywW6Ukwzy3_nMl-h1y9gCia2FHM5GqUnV530zFq_glFJtlMzRFfDxRC_SCmdNrrUtI025PnBxiPBy43kvGugxRdlzDwtxuWeJc0MjZha9lM5I3tBjGQTKYGyCF4rrXnijh-pFPopigaPbUeB0k0joA30JSnYUWDV6LhKYzBtlUrn8rhz4xpuLlRL7sMvHOWbZpTT_XOLL_6Dd9lcdGPCW2TadXlUTvlQMQM3r4KX6dfARWt96SltdoAwjLxFGi6fk5VYIFPtdZihzYQO3IWKsFNiM3S5KSoJxGHl0_OKp11fkmHGw
   response:
     status:
       code: 200
@@ -2260,31 +2382,90 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - 200c91c3-2fe5-4eee-81b1-4a32deb1cb81
+      - 18fe3312-d435-48d6-95cf-1ea961fddb62
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14921'
+      - '14917'
       X-Ms-Correlation-Request-Id:
-      - e673b62f-1281-4bda-acf2-8dce5658d31d
+      - 1aa08855-cb1c-4d99-bb52-b43e362aa6e0
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200440Z:e673b62f-1281-4bda-acf2-8dce5658d31d
+      - WESTUS:20170922T214326Z:1aa08855-cb1c-4d99-bb52-b43e362aa6e0
       Date:
-      - Tue, 05 Sep 2017 20:04:40 GMT
+      - Fri, 22 Sep 2017 21:43:26 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-05T20:04:39.4884765+00:00\",\r\n  \"endTime\":
-        \"2017-09-05T20:04:39.6603614+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=3f54d911-95b0-4a4f-8f36-56b6a46e223a&sig=isf7jRmr6ax8n7Kju3qtGLe%2FqfMl8VLCj5hGRRVFmFA%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"423981d5-bdc8-4d73-bfda-7a82f5537c91\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2017-09-22T21:43:26.8087261+00:00\",\r\n  \"endTime\":
+        \"2017-09-22T21:43:26.9650264+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=dd9f1548-c7a2-4a92-b9a4-bdb1ba19c1f9&sig=3siCGhj9NYpe%2BKYdwiF%2Bh7Rce%2BnvAeHxpc4jITj9AvA%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"d5303e2e-9f0c-42c0-8e92-41f1b947ce98\"\r\n}"
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:37 GMT
+  recorded_at: Fri, 22 Sep 2017 21:43:26 GMT
 - request:
     method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=3f54d911-95b0-4a4f-8f36-56b6a46e223a&sig=isf7jRmr6ax8n7Kju3qtGLe/qfMl8VLCj5hGRRVFmFA=&sr=b&sv=2016-05-31
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/d5303e2e-9f0c-42c0-8e92-41f1b947ce98?api-version=2017-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyOTgsIm5iZiI6MTUwNjExNjI5OCwiZXhwIjoxNTA2MTIwMTk4LCJhaW8iOiJZMlZnWVBpYkdpZTFMU0JhNkUvbm8rMWF5cWRXQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTN5bGRtWWRmME9FeEpHR1F5a09BQSIsInZlciI6IjEuMCJ9.GXfU7XOKtiFTBk1pmTywNCCfzOXXoOfOiww3yywW6Ukwzy3_nMl-h1y9gCia2FHM5GqUnV530zFq_glFJtlMzRFfDxRC_SCmdNrrUtI025PnBxiPBy43kvGugxRdlzDwtxuWeJc0MjZha9lM5I3tBjGQTKYGyCF4rrXnijh-pFPopigaPbUeB0k0joA30JSnYUWDV6LhKYzBtlUrn8rhz4xpuLlRL7sMvHOWbZpTT_XOLL_6Dd9lcdGPCW2TadXlUTvlQMQM3r4KX6dfARWt96SltdoAwjLxFGi6fk5VYIFPtdZihzYQO3IWKsFNiM3S5KSoJxGHl0_OKp11fkmHGw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
+      X-Ms-Request-Id:
+      - e860cfaa-43d8-4544-90e9-a660b25c9e68
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14986'
+      X-Ms-Correlation-Request-Id:
+      - 8194b7ae-d2af-45e6-b0e2-e09a8849e072
+      X-Ms-Routing-Request-Id:
+      - WESTUS:20170922T214327Z:8194b7ae-d2af-45e6-b0e2-e09a8849e072
+      Date:
+      - Fri, 22 Sep 2017 21:43:26 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"startTime\": \"2017-09-22T21:43:26.8087261+00:00\",\r\n  \"endTime\":
+        \"2017-09-22T21:43:26.9650264+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=dd9f1548-c7a2-4a92-b9a4-bdb1ba19c1f9&sig=3siCGhj9NYpe%2BKYdwiF%2Bh7Rce%2BnvAeHxpc4jITj9AvA%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"d5303e2e-9f0c-42c0-8e92-41f1b947ce98\"\r\n}"
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 21:43:26 GMT
+- request:
+    method: get
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=dd9f1548-c7a2-4a92-b9a4-bdb1ba19c1f9&sig=3siCGhj9NYpe%2BKYdwiF%2Bh7Rce%2BnvAeHxpc4jITj9AvA=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2297,8 +2478,6 @@ http_interactions:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
       X-Ms-Range:
       - bytes=440-443
-      Host:
-      - md-t4jdgqqlgszp.blob.core.windows.net
   response:
     status:
       code: 206
@@ -2319,7 +2498,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 543ca14c-001e-009f-2c82-26d997000000
+      - 19df09c1-001e-00d0-08eb-331d8f000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2345,13 +2524,13 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Tue, 05 Sep 2017 20:04:40 GMT
+      - Fri, 22 Sep 2017 21:43:27 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         U5MJAA==
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:37 GMT
+  recorded_at: Fri, 22 Sep 2017 21:43:27 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/EndGetAccess?api-version=2017-03-30
@@ -2368,11 +2547,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NzcsIm5iZiI6MTUwNDY0MTU3NywiZXhwIjoxNTA0NjQ1NDc3LCJhaW8iOiJZMkZnWUppVHRtTnI3OWRtdzBpR2VkZTNURmxYRFFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQmhXV3hXM2lYa3ktWWdfcTZLMGdBQSIsInZlciI6IjEuMCJ9.wF1HOCTfdLuDzQXO7Z1CtjKG4uJoD6FnMGKkrpMT6wNwTYnQ_DzHIYG6jyxcf_XpQ03RhzSBpDC_O629iCO4p5Gdj5a7a_Sqw0C2Mryn_RIu8-TzyI9Tbad5shsPte0bt8bZgU4rg-dZyD-OZAczUfZte9kPY4sdPX0hcm9bKwtcFV0alVjMfCLXUbsMTTZxClSQ53sSELtmigdZ6r-j3Yu4ZweOO5tyD5ms09ChA9rxmGb1Q3iJmWo_krnfpvGo9V05OlKce6nf1LYdjpihz_R6r2kzg9KkS52aoGDf4CmRo_BIrctGk06x4_F_Nhlxh2s18FETiTTeqbXxQmNSLw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyOTgsIm5iZiI6MTUwNjExNjI5OCwiZXhwIjoxNTA2MTIwMTk4LCJhaW8iOiJZMlZnWVBpYkdpZTFMU0JhNkUvbm8rMWF5cWRXQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTN5bGRtWWRmME9FeEpHR1F5a09BQSIsInZlciI6IjEuMCJ9.GXfU7XOKtiFTBk1pmTywNCCfzOXXoOfOiww3yywW6Ukwzy3_nMl-h1y9gCia2FHM5GqUnV530zFq_glFJtlMzRFfDxRC_SCmdNrrUtI025PnBxiPBy43kvGugxRdlzDwtxuWeJc0MjZha9lM5I3tBjGQTKYGyCF4rrXnijh-pFPopigaPbUeB0k0joA30JSnYUWDV6LhKYzBtlUrn8rhz4xpuLlRL7sMvHOWbZpTT_XOLL_6Dd9lcdGPCW2TadXlUTvlQMQM3r4KX6dfARWt96SltdoAwjLxFGi6fk5VYIFPtdZihzYQO3IWKsFNiM3S5KSoJxGHl0_OKp11fkmHGw
       Content-Length:
       - '0'
-      Host:
-      - management.azure.com
   response:
     status:
       code: 202
@@ -2387,29 +2564,29 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/c11667f4-d3ba-408d-a0ad-87e6329101d0?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/a8bc71ec-235f-4e1c-a974-93e139af1347?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/c11667f4-d3ba-408d-a0ad-87e6329101d0?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/a8bc71ec-235f-4e1c-a974-93e139af1347?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - c11667f4-d3ba-408d-a0ad-87e6329101d0
+      - a8bc71ec-235f-4e1c-a974-93e139af1347
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1199'
+      - '1184'
       X-Ms-Correlation-Request-Id:
-      - b582ff2a-b42d-4b18-8de7-d2dc34ca183c
+      - 4ec9d408-0207-4f2e-bf2e-fb57fcd4b32c
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200441Z:b582ff2a-b42d-4b18-8de7-d2dc34ca183c
+      - WESTUS:20170922T214328Z:4ec9d408-0207-4f2e-bf2e-fb57fcd4b32c
       Date:
-      - Tue, 05 Sep 2017 20:04:40 GMT
+      - Fri, 22 Sep 2017 21:43:27 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:37 GMT
+  recorded_at: Fri, 22 Sep 2017 21:43:27 GMT
 recorded_with: VCR 3.0.3

--- a/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_diskType-1.yml
+++ b/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_diskType-1.yml
@@ -17,8 +17,6 @@ http_interactions:
       - '186'
       Content-Type:
       - application/x-www-form-urlencoded
-      Host:
-      - login.microsoftonline.com
   response:
     status:
       code: 200
@@ -39,25 +37,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - cf04dec5-2a9b-4abd-9696-4e90ffa71e00
+      - c73edbde-235e-45f9-8f62-7b7798a40a00
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAAA9kTklhVy7SJTGAzR-p1BccbBqFu1gVK8AWCPMK_J0S5RWJmYtZYLgmKqBL4ZmDzVE0rOzkPylxiIEknKDjp1hGjqtmH1ujBH6fcsHdkxy9yahDK58FI9dtmkrGq9bo5CGA6GZVy4lPaiTomXYAXU3YVl9PLbuW74daM8cpr_OQuQpKvAl2yead9ZDDJIbauIgAA;
+      - esctx=AQABAAAAAAABlDrqfEFlSaui6xnRjX5EZPGl2GfjW0Go6xkXR5q1iJrJh-w1VkWLg7up53muVZJCu0TimEdEV_4hlzxfKSKhemvES3r4S-_apBmdAAW5IHbj5lE5UB2-fyIdLoFrkBEdjwUaIQRW7b_0iiO-gHQh6dZA6Fs1cVZxwwckFaEWh-9r0oUCzh3vrbkZOnFwbukgAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=005; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=006; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Tue, 05 Sep 2017 20:04:41 GMT
+      - Fri, 22 Sep 2017 21:41:53 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1504645482","not_before":"1504641582","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1ODIsIm5iZiI6MTUwNDY0MTU4MiwiZXhwIjoxNTA0NjQ1NDgyLCJhaW8iOiJZMkZnWUFnKzFtRFcvRzdCcDNnV0llOFZ6UUw3QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieGQ0RXo1c3F2VXFXbGs2UV82Y2VBQSIsInZlciI6IjEuMCJ9.xt3WR3R1Pll8AY23wUz4BppEYoPLrBZArSr5NrSrApIHJm4_H50MP_dS2HjIig8UkJPQN9WyPNObk9qUbrDPQFN-Oc_7-xSkK-Qd_AjS92GJzzWLq7aPtrxKTTQ_RT2lC4H3cc9rlb3rk9Vl8M1wWY_26ll8Ryd1JUGAnhjbXZoqbTx7IyrfAtOTxP1d6LBk3ErAs84eSMmMXvjomFORUrt6AQdAcmMLvzUCUPc8Fj_dWK0YFGk9Un48OTdbGdqBrRaTHfIgsRRm0QQAofVCluS5GaSocMPRvVM9I7-pRYNT5zVmw8IsYRTcdj6U_AweuwvtpH377bsuqctgVB4MdQ"}'
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1506120114","not_before":"1506116214","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMTQsIm5iZiI6MTUwNjExNjIxNCwiZXhwIjoxNTA2MTIwMTE0LCJhaW8iOiJZMlZnWURoNkxlTFlueWZjdXhLM1AwbGxXakZ0Q3dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiM3RzLXgxNGotVVdQWW50M21LUUtBQSIsInZlciI6IjEuMCJ9.tNfZxYjnzlN9LDikmqxEQ9ZcfV9Yn8I3V3YgPPMCQLu3VgrgqT1_rVmxUL5elZ7234OpvauDuw7T2xQ1ea_cnqFrbD2iIEH3LeIndrF0vmL16m8SaE9Adbufc2txA0w0nKguQnS51reRhW196Cv_p_w7_KFjhOba6m9Xg6w2eAmeRZGVccg0Esjne3ymo09Hvq4cdUq-RfDoTuZk9Sm9QglJEcC9IIargAWz2A37cemo9amSIV1VQrz-UyCgbvXygTJXgMoix96kQ8FvsLtiNTjhsdoFC0jdytz3igNPoUEIJnflKEYUP9nYddgNqO95tJ4jns580aLjg_Yn_mnuTw"}'
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:37 GMT
+  recorded_at: Fri, 22 Sep 2017 21:41:53 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -74,9 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1ODIsIm5iZiI6MTUwNDY0MTU4MiwiZXhwIjoxNTA0NjQ1NDgyLCJhaW8iOiJZMkZnWUFnKzFtRFcvRzdCcDNnV0llOFZ6UUw3QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieGQ0RXo1c3F2VXFXbGs2UV82Y2VBQSIsInZlciI6IjEuMCJ9.xt3WR3R1Pll8AY23wUz4BppEYoPLrBZArSr5NrSrApIHJm4_H50MP_dS2HjIig8UkJPQN9WyPNObk9qUbrDPQFN-Oc_7-xSkK-Qd_AjS92GJzzWLq7aPtrxKTTQ_RT2lC4H3cc9rlb3rk9Vl8M1wWY_26ll8Ryd1JUGAnhjbXZoqbTx7IyrfAtOTxP1d6LBk3ErAs84eSMmMXvjomFORUrt6AQdAcmMLvzUCUPc8Fj_dWK0YFGk9Un48OTdbGdqBrRaTHfIgsRRm0QQAofVCluS5GaSocMPRvVM9I7-pRYNT5zVmw8IsYRTcdj6U_AweuwvtpH377bsuqctgVB4MdQ
-      Host:
-      - management.azure.com
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMTQsIm5iZiI6MTUwNjExNjIxNCwiZXhwIjoxNTA2MTIwMTE0LCJhaW8iOiJZMlZnWURoNkxlTFlueWZjdXhLM1AwbGxXakZ0Q3dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiM3RzLXgxNGotVVdQWW50M21LUUtBQSIsInZlciI6IjEuMCJ9.tNfZxYjnzlN9LDikmqxEQ9ZcfV9Yn8I3V3YgPPMCQLu3VgrgqT1_rVmxUL5elZ7234OpvauDuw7T2xQ1ea_cnqFrbD2iIEH3LeIndrF0vmL16m8SaE9Adbufc2txA0w0nKguQnS51reRhW196Cv_p_w7_KFjhOba6m9Xg6w2eAmeRZGVccg0Esjne3ymo09Hvq4cdUq-RfDoTuZk9Sm9QglJEcC9IIargAWz2A37cemo9amSIV1VQrz-UyCgbvXygTJXgMoix96kQ8FvsLtiNTjhsdoFC0jdytz3igNPoUEIJnflKEYUP9nYddgNqO95tJ4jns580aLjg_Yn_mnuTw
   response:
     status:
       code: 200
@@ -95,23 +91,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14996'
+      - '14999'
       X-Ms-Request-Id:
-      - c0c84bfc-d653-424b-8612-f6c04dda7bc9
+      - 872a2570-4e2d-4fac-93dc-824b0ae3cc0c
       X-Ms-Correlation-Request-Id:
-      - c0c84bfc-d653-424b-8612-f6c04dda7bc9
+      - 872a2570-4e2d-4fac-93dc-824b0ae3cc0c
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200442Z:c0c84bfc-d653-424b-8612-f6c04dda7bc9
+      - WESTUS:20170922T214154Z:872a2570-4e2d-4fac-93dc-824b0ae3cc0c
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 05 Sep 2017 20:04:41 GMT
+      - Fri, 22 Sep 2017 21:41:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:38 GMT
+  recorded_at: Fri, 22 Sep 2017 21:41:54 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/azure_subscription_id/providers?api-version=2015-01-01
@@ -128,9 +124,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1ODIsIm5iZiI6MTUwNDY0MTU4MiwiZXhwIjoxNTA0NjQ1NDgyLCJhaW8iOiJZMkZnWUFnKzFtRFcvRzdCcDNnV0llOFZ6UUw3QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieGQ0RXo1c3F2VXFXbGs2UV82Y2VBQSIsInZlciI6IjEuMCJ9.xt3WR3R1Pll8AY23wUz4BppEYoPLrBZArSr5NrSrApIHJm4_H50MP_dS2HjIig8UkJPQN9WyPNObk9qUbrDPQFN-Oc_7-xSkK-Qd_AjS92GJzzWLq7aPtrxKTTQ_RT2lC4H3cc9rlb3rk9Vl8M1wWY_26ll8Ryd1JUGAnhjbXZoqbTx7IyrfAtOTxP1d6LBk3ErAs84eSMmMXvjomFORUrt6AQdAcmMLvzUCUPc8Fj_dWK0YFGk9Un48OTdbGdqBrRaTHfIgsRRm0QQAofVCluS5GaSocMPRvVM9I7-pRYNT5zVmw8IsYRTcdj6U_AweuwvtpH377bsuqctgVB4MdQ
-      Host:
-      - management.azure.com
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMTQsIm5iZiI6MTUwNjExNjIxNCwiZXhwIjoxNTA2MTIwMTE0LCJhaW8iOiJZMlZnWURoNkxlTFlueWZjdXhLM1AwbGxXakZ0Q3dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiM3RzLXgxNGotVVdQWW50M21LUUtBQSIsInZlciI6IjEuMCJ9.tNfZxYjnzlN9LDikmqxEQ9ZcfV9Yn8I3V3YgPPMCQLu3VgrgqT1_rVmxUL5elZ7234OpvauDuw7T2xQ1ea_cnqFrbD2iIEH3LeIndrF0vmL16m8SaE9Adbufc2txA0w0nKguQnS51reRhW196Cv_p_w7_KFjhOba6m9Xg6w2eAmeRZGVccg0Esjne3ymo09Hvq4cdUq-RfDoTuZk9Sm9QglJEcC9IIargAWz2A37cemo9amSIV1VQrz-UyCgbvXygTJXgMoix96kQ8FvsLtiNTjhsdoFC0jdytz3igNPoUEIJnflKEYUP9nYddgNqO95tJ4jns580aLjg_Yn_mnuTw
   response:
     status:
       code: 200
@@ -147,22 +141,42 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
+      - '14930'
       X-Ms-Request-Id:
-      - bc98e6bc-03e1-442f-b53e-51ffd659d1e2
+      - 53685ca2-e45b-40ee-96ea-6a1c7d43abf0
       X-Ms-Correlation-Request-Id:
-      - bc98e6bc-03e1-442f-b53e-51ffd659d1e2
+      - 53685ca2-e45b-40ee-96ea-6a1c7d43abf0
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200442Z:bc98e6bc-03e1-442f-b53e-51ffd659d1e2
+      - WESTUS:20170922T214156Z:53685ca2-e45b-40ee-96ea-6a1c7d43abf0
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 05 Sep 2017 20:04:41 GMT
+      - Fri, 22 Sep 2017 21:41:55 GMT
       Content-Length:
-      - '243687'
+      - '254785'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
+      string: '{"value":[{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"operations","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","North Central
         US","South Central US","West Central US","West US","West US 2","Canada Central","Canada
         East","North Europe","West Europe","UK South","UK West","East Asia","Southeast
@@ -437,7 +451,7 @@ http_interactions:
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
         Central US","West US 2","South India","Central India","West India","Canada
-        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
+        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
         East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
@@ -466,7 +480,7 @@ http_interactions:
         Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"}],"resourceTypes":[{"resourceType":"components","locations":["East
         US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
         US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01","2014-04-01"]},{"resourceType":"queries","locations":["East
-        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"alertrules","locations":["West
+        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
@@ -542,7 +556,7 @@ http_interactions:
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorization":{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorizations":[{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},{"applicationId":"7c33bfcb-8d33-48d6-8e60-dc6404003489","roleDefinitionId":"ad6261e4-fa9a-4642-aa5f-104f1b67e9e3"},{"applicationId":"1e3e4475-288f-4018-a376-df66fd7fac5f","roleDefinitionId":"1d538b69-3d87-4e56-8ff8-25786fd48261"},{"applicationId":"a0be0c72-870e-46f0-9c49-c98333a996f7","roleDefinitionId":"7ce22727-ffce-45a9-930c-ddb2e56fa131"}],"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -552,7 +566,7 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -567,7 +581,8 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
+        Central US"],"apiVersions":["2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -577,7 +592,12 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -597,7 +617,7 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -612,7 +632,7 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -622,7 +642,31 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
         East","UK South","Central India","Canada Central"],"apiVersions":["2017-04-26-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"]},{"resourceType":"workspaces/dataSources","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
@@ -641,17 +685,17 @@ http_interactions:
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"consoles","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/consoles","locations":["West
+        East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"consoles","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/consoles","locations":["West
         US","East US","Central India","North Europe","West Europe","South Central
-        US","Southeast Asia"],"apiVersions":["2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
+        US","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
         US","East US","Central India","North Europe","West Europe","South Central
-        US","Southeast Asia"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
+        US","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","Canada Central","Canada East","West Central US","West US 2","UK South","UK
         West","Korea Central","Korea South"],"apiVersions":["2017-07-01","2016-12-01","2016-08-10","2016-06-01","2016-05-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"operations","locations":["Southeast
-        Asia"],"apiVersions":["2016-08-10","2016-06-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01"]},{"resourceType":"locations/backupStatus","locations":["West
+        Asia"],"apiVersions":["2016-08-10","2016-06-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01","2016-06-01"]},{"resourceType":"locations/backupStatus","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
@@ -687,6 +731,7 @@ http_interactions:
         Central US","Central US","North Europe","West Europe","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada Central","Canada East"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"pricings","locations":["Central
+        US","East US"],"apiVersions":["2017-08-01-preview"]},{"resourceType":"securityContacts","locations":["Central
         US","East US"],"apiVersions":["2017-08-01-preview"]},{"resourceType":"workspaceSettings","locations":["Central
         US","East US"],"apiVersions":["2017-08-01-preview"]},{"resourceType":"complianceResults","locations":["Central
         US","East US"],"apiVersions":["2017-08-01"]},{"resourceType":"policies","locations":["Central
@@ -703,6 +748,8 @@ http_interactions:
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatusesSummaries","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/alerts","locations":["Central
         US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/tasks","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"externalSecuritySolutions","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/externalSecuritySolutions","locations":["Central
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.SiteRecovery","namespace":"Microsoft.SiteRecovery","authorization":{"applicationId":"b8340c3b-9267-498f-b21a-15d5547fd85e","roleDefinitionId":"8A00C8EA-8F1B-45A7-8F64-F4CC61EEE9B6"},"resourceTypes":[{"resourceType":"SiteRecoveryVault","locations":["East
         US","West US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","Australia East","Australia Southeast","Brazil South","North
@@ -722,7 +769,7 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -842,7 +889,22 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/databases/transparentDataEncryption","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -1077,6 +1139,26 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
         US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
@@ -1307,6 +1389,11 @@ http_interactions:
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"customApis","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
         East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/managedApis","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
@@ -1358,23 +1445,8 @@ http_interactions:
         US","North Europe","Japan West","Japan East","East Asia","West Europe","East
         US","Southeast Asia","Central US"],"apiVersions":["2016-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Lombiq.DotNest","namespace":"Lombiq.DotNest","resourceTypes":[{"resourceType":"sites","locations":["East
         US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Mailjet.Email","namespace":"Mailjet.Email","resourceTypes":[{"resourceType":"services","locations":["West
-        US"],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
-        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]},{"resourceType":"diagnosticSettings","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"addsservices","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"configuration","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"operations","locations":["West
@@ -1498,8 +1570,10 @@ http_interactions:
         Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
         Central US","Central US","North Europe","West Europe","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","West
-        India","South India"],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CognitiveServices","namespace":"Microsoft.CognitiveServices","authorizations":[{"applicationId":"7d312290-28c8-473c-a0ed-8e53749b6d6d","roleDefinitionId":"5cb87f79-a7c3-4a95-9414-45b65974b51b"}],"resourceTypes":[{"resourceType":"accounts","locations":["Global","West
-        US","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"operations","locations":["Global","Australia
+        India","South India"],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CognitiveServices","namespace":"Microsoft.CognitiveServices","authorizations":[{"applicationId":"7d312290-28c8-473c-a0ed-8e53749b6d6d","roleDefinitionId":"5cb87f79-a7c3-4a95-9414-45b65974b51b"}],"resourceTypes":[{"resourceType":"accounts","locations":["Global","Australia
+        East","Brazil South","West US","West US 2","West Europe","North Europe","Southeast
+        Asia","East Asia","West Central US","South Central US","East US","East US
+        2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"operations","locations":["Global","Australia
         East","Brazil South","West US","West US 2","West Europe","North Europe","Southeast
         Asia","East Asia","West Central US","South Central US","East US","East US
         2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations","locations":["Global","Australia
@@ -1534,13 +1608,13 @@ http_interactions:
         US","West US","Australia East","West Europe","North Europe","Southeast Asia","West
         Central US"],"apiVersions":["2016-03-30","2015-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataFactory","namespace":"Microsoft.DataFactory","resourceTypes":[{"resourceType":"dataFactories","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview","2014-04-01"]},{"resourceType":"factories","locations":["East
-        US"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
-        US"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
+        US","East US 2"],"apiVersions":["2017-09-01-preview","2017-03-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
+        US","East US 2"],"apiVersions":["2017-09-01-preview","2017-03-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
         Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"dataFactories/metricDefinitions","locations":["North
         Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"checkDataFactoryNameAvailability","locations":[],"apiVersions":["2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"checkAzureDataFactoryNameAvailability","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"dataFactorySchema","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"operations","locations":["West
-        US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeAnalytics","namespace":"Microsoft.DataLakeAnalytics","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US","North Europe","East US","West Central US"],"apiVersions":["2017-09-01-preview","2017-03-01-preview","2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeAnalytics","namespace":"Microsoft.DataLakeAnalytics","resourceTypes":[{"resourceType":"accounts","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/dataLakeStoreAccounts","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers","locations":["East
@@ -1589,11 +1663,12 @@ http_interactions:
         India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
         India","East Asia","East US 2","East US","Japan East","Japan West","North
         Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"checkProvisioningServiceNameAvailability","locations":[],"apiVersions":["2017-08-21-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
         US","North Europe","East Asia","East US","West Europe","Southeast Asia","Japan
         East","Japan West","Australia East","Australia Southeast","West US 2","West
         Central US","East US 2","Central US","UK South","UK West","South India","Central
-        India"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
+        India","Canada Central","Canada East"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"ProvisioningServices","locations":["East
+        US","West Europe","Southeast Asia"],"apiVersions":["2017-08-21-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
         East","Australia Southeast","Canada Central","Canada East","Central India","Central
         US","East Asia","East US","East US 2","Japan East","Japan West","North Central
         US","North Europe","South Central US","South India","Southeast Asia","West
@@ -1620,16 +1695,16 @@ http_interactions:
         US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"operations","locations":["Brazil
         South","East Asia","East US","Japan East","Japan West","North Central US","North
         Europe","South Central US","West Europe","West US","Southeast Asia","Central
-        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"topics","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operations","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topics","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operations","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","West
         US 2","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
@@ -1727,48 +1802,39 @@ http_interactions:
         Central US","West Europe","Southeast Asia","Japan East","East US 2","West
         Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"commitmentPlans","locations":["South
         Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
-        Central US","West US"],"apiVersions":["2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Media","namespace":"Microsoft.Media","authorization":{"applicationId":"374b2a64-3b6b-436b-934c-b820eacca870","roleDefinitionId":"aab70789-0cec-44b5-95d7-84b64c9487af"},"resourceTypes":[{"resourceType":"mediaservices","locations":["Japan
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningExperimentation","namespace":"Microsoft.MachineLearningExperimentation","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"accounts","locations":["Australia
+        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces","locations":["Australia
+        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces/projects","locations":["Australia
+        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningCompute","namespace":"Microsoft.MachineLearningCompute","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"376aa7d7-51a9-463d-bd4d-7e1691345612","managedByRoleDefinitionId":"91d00862-cf55-46a5-9dce-260bbd92ce25"},"resourceTypes":[{"resourceType":"operationalizationClusters","locations":["East
+        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"operations","locations":["East
+        US 2"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations","locations":["East
+        US 2"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["East
+        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningModelManagement","namespace":"Microsoft.MachineLearningModelManagement","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US 2","West Central US","Australia East"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"operations","locations":["West
+        Central US"],"apiVersions":["2017-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
+        Central US","West US"],"apiVersions":["2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01"]},{"resourceType":"offertypes","locations":["South
+        Central US","West US"],"apiVersions":["2015-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Media","namespace":"Microsoft.Media","authorization":{"applicationId":"374b2a64-3b6b-436b-934c-b820eacca870","roleDefinitionId":"aab70789-0cec-44b5-95d7-84b64c9487af"},"resourceTypes":[{"resourceType":"mediaservices","locations":["Japan
         West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
         US","West US","Australia East","Australia Southeast","Central US","Brazil
         South","Central India","West India","South India","South Central US","Canada
-        Central","Canada East","West Central US"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
+        Central","Canada East","West Central US"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
         Central US","North Central US","East US 2","West US","West Europe","North
         Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
         East","UK South","West India"],"apiVersions":["2016-01-29"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-01-29"]},{"resourceType":"locations/checkNameAvailability","locations":["South
         Central US","North Central US","East US 2","West US","West Europe","North
         Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
-        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"operations","locations":["East
+        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"capacities","locations":["West
+        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
+        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationresults","locations":["West
+        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
+        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"operations","locations":["East
         US 2"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Relay","namespace":"Microsoft.Relay","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US 2","West
         US","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
         India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2017-08-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkPolicyCompliance","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
@@ -1827,8 +1893,11 @@ http_interactions:
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","resourceTypes":[{"resourceType":"operations","locations":["West
-        Central US"],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
+        Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applianceDefinitions","locations":["West
+        Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"locations","locations":["West
+        Central US"],"apiVersions":["2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
+        Central US"],"apiVersions":["2017-09-01","2016-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","West Central US","Japan East","Japan West","Australia East","Australia
         Southeast"],"apiVersions":["2017-06-01","2017-05-15","2017-01-01","2016-10-01","2016-06-01","2015-03-15","2014-09-01"]},{"resourceType":"operations","locations":["West
@@ -1888,11 +1957,17 @@ http_interactions:
         US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RedisLabs.Memcached","namespace":"RedisLabs.Memcached","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-07-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RedisLabs.Redis","namespace":"RedisLabs.Redis","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-07-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RevAPM.MobileCDN","namespace":"RevAPM.MobileCDN","resourceTypes":[{"resourceType":"accounts","locations":["Central
         US","East US","East US 2","North Central US","South Central US","West US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
-        East","Australia Southeast"],"apiVersions":["2016-08-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-24","2016-08-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sendgrid.Email","namespace":"Sendgrid.Email","resourceTypes":[{"resourceType":"accounts","locations":["East
-        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
-        Central US","Central US","North Europe","West Europe","Japan East","Japan
-        West","Brazil South","Australia East","Australia Southeast","Canada Central","Canada
-        East","West Central US","West US 2","UK South","UK West"],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Signiant.Flight","namespace":"Signiant.Flight","resourceTypes":[{"resourceType":"accounts","locations":["East
+        East","Australia Southeast"],"apiVersions":["2016-08-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-24","2016-08-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sendgrid.Email","namespace":"Sendgrid.Email","resourceTypes":[{"resourceType":"accounts","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Signiant.Flight","namespace":"Signiant.Flight","resourceTypes":[{"resourceType":"accounts","locations":["East
         US","Central US","North Central US","South Central US","West US","North Europe","West
         Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast"],"apiVersions":["2015-06-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sparkpost.Basic","namespace":"Sparkpost.Basic","resourceTypes":[{"resourceType":"services","locations":["West
@@ -1909,7 +1984,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:42 GMT
+  recorded_at: Fri, 22 Sep 2017 21:41:55 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
@@ -1926,11 +2001,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1ODIsIm5iZiI6MTUwNDY0MTU4MiwiZXhwIjoxNTA0NjQ1NDgyLCJhaW8iOiJZMkZnWUFnKzFtRFcvRzdCcDNnV0llOFZ6UUw3QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieGQ0RXo1c3F2VXFXbGs2UV82Y2VBQSIsInZlciI6IjEuMCJ9.xt3WR3R1Pll8AY23wUz4BppEYoPLrBZArSr5NrSrApIHJm4_H50MP_dS2HjIig8UkJPQN9WyPNObk9qUbrDPQFN-Oc_7-xSkK-Qd_AjS92GJzzWLq7aPtrxKTTQ_RT2lC4H3cc9rlb3rk9Vl8M1wWY_26ll8Ryd1JUGAnhjbXZoqbTx7IyrfAtOTxP1d6LBk3ErAs84eSMmMXvjomFORUrt6AQdAcmMLvzUCUPc8Fj_dWK0YFGk9Un48OTdbGdqBrRaTHfIgsRRm0QQAofVCluS5GaSocMPRvVM9I7-pRYNT5zVmw8IsYRTcdj6U_AweuwvtpH377bsuqctgVB4MdQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMTQsIm5iZiI6MTUwNjExNjIxNCwiZXhwIjoxNTA2MTIwMTE0LCJhaW8iOiJZMlZnWURoNkxlTFlueWZjdXhLM1AwbGxXakZ0Q3dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiM3RzLXgxNGotVVdQWW50M21LUUtBQSIsInZlciI6IjEuMCJ9.tNfZxYjnzlN9LDikmqxEQ9ZcfV9Yn8I3V3YgPPMCQLu3VgrgqT1_rVmxUL5elZ7234OpvauDuw7T2xQ1ea_cnqFrbD2iIEH3LeIndrF0vmL16m8SaE9Adbufc2txA0w0nKguQnS51reRhW196Cv_p_w7_KFjhOba6m9Xg6w2eAmeRZGVccg0Esjne3ymo09Hvq4cdUq-RfDoTuZk9Sm9QglJEcC9IIargAWz2A37cemo9amSIV1VQrz-UyCgbvXygTJXgMoix96kQ8FvsLtiNTjhsdoFC0jdytz3igNPoUEIJnflKEYUP9nYddgNqO95tJ4jns580aLjg_Yn_mnuTw
       Content-Length:
       - '42'
-      Host:
-      - management.azure.com
   response:
     status:
       code: 202
@@ -1945,34 +2018,34 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/5ea773c0-5510-4e63-ab22-e06174a47ab7?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/9bebab40-09b8-45da-b9ba-a758ad1171a5?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/5ea773c0-5510-4e63-ab22-e06174a47ab7?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/9bebab40-09b8-45da-b9ba-a758ad1171a5?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - 5ea773c0-5510-4e63-ab22-e06174a47ab7
+      - 9bebab40-09b8-45da-b9ba-a758ad1171a5
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1184'
+      - '1173'
       X-Ms-Correlation-Request-Id:
-      - 17df4578-34ce-4521-9a5a-f80dd75a344e
+      - fee3a7c3-1e6f-488a-8bd2-9fc9fae7c332
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200443Z:17df4578-34ce-4521-9a5a-f80dd75a344e
+      - WESTUS:20170922T214157Z:fee3a7c3-1e6f-488a-8bd2-9fc9fae7c332
       Date:
-      - Tue, 05 Sep 2017 20:04:42 GMT
+      - Fri, 22 Sep 2017 21:41:57 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:43 GMT
+  recorded_at: Fri, 22 Sep 2017 21:41:56 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/5ea773c0-5510-4e63-ab22-e06174a47ab7?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/9bebab40-09b8-45da-b9ba-a758ad1171a5?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -1986,9 +2059,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1ODIsIm5iZiI6MTUwNDY0MTU4MiwiZXhwIjoxNTA0NjQ1NDgyLCJhaW8iOiJZMkZnWUFnKzFtRFcvRzdCcDNnV0llOFZ6UUw3QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieGQ0RXo1c3F2VXFXbGs2UV82Y2VBQSIsInZlciI6IjEuMCJ9.xt3WR3R1Pll8AY23wUz4BppEYoPLrBZArSr5NrSrApIHJm4_H50MP_dS2HjIig8UkJPQN9WyPNObk9qUbrDPQFN-Oc_7-xSkK-Qd_AjS92GJzzWLq7aPtrxKTTQ_RT2lC4H3cc9rlb3rk9Vl8M1wWY_26ll8Ryd1JUGAnhjbXZoqbTx7IyrfAtOTxP1d6LBk3ErAs84eSMmMXvjomFORUrt6AQdAcmMLvzUCUPc8Fj_dWK0YFGk9Un48OTdbGdqBrRaTHfIgsRRm0QQAofVCluS5GaSocMPRvVM9I7-pRYNT5zVmw8IsYRTcdj6U_AweuwvtpH377bsuqctgVB4MdQ
-      Host:
-      - management.azure.com
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMTQsIm5iZiI6MTUwNjExNjIxNCwiZXhwIjoxNTA2MTIwMTE0LCJhaW8iOiJZMlZnWURoNkxlTFlueWZjdXhLM1AwbGxXakZ0Q3dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiM3RzLXgxNGotVVdQWW50M21LUUtBQSIsInZlciI6IjEuMCJ9.tNfZxYjnzlN9LDikmqxEQ9ZcfV9Yn8I3V3YgPPMCQLu3VgrgqT1_rVmxUL5elZ7234OpvauDuw7T2xQ1ea_cnqFrbD2iIEH3LeIndrF0vmL16m8SaE9Adbufc2txA0w0nKguQnS51reRhW196Cv_p_w7_KFjhOba6m9Xg6w2eAmeRZGVccg0Esjne3ymo09Hvq4cdUq-RfDoTuZk9Sm9QglJEcC9IIargAWz2A37cemo9amSIV1VQrz-UyCgbvXygTJXgMoix96kQ8FvsLtiNTjhsdoFC0jdytz3igNPoUEIJnflKEYUP9nYddgNqO95tJ4jns580aLjg_Yn_mnuTw
   response:
     status:
       code: 200
@@ -2009,31 +2080,90 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - 892bf9c8-8168-40d6-87eb-6b1f64b9497a
+      - 4a176790-5c73-4402-8fb7-031bbf35015a
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14985'
+      - '14925'
       X-Ms-Correlation-Request-Id:
-      - 40594867-d2d1-4ae4-9233-e84936d5bad0
+      - 94cd658b-b671-4c91-a32f-6fef61992b50
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200443Z:40594867-d2d1-4ae4-9233-e84936d5bad0
+      - WESTUS:20170922T214158Z:94cd658b-b671-4c91-a32f-6fef61992b50
       Date:
-      - Tue, 05 Sep 2017 20:04:43 GMT
+      - Fri, 22 Sep 2017 21:41:58 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-05T20:04:42.1302332+00:00\",\r\n  \"endTime\":
-        \"2017-09-05T20:04:42.270873+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=374ca2d0-dcd0-4dc4-afcd-55444eebb92c&sig=Lk8TNgFf%2FwDQSuB25xHJfVm0GZI4gOaQ7856xYOUzZw%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"5ea773c0-5510-4e63-ab22-e06174a47ab7\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2017-09-22T21:41:58.7916756+00:00\",\r\n  \"endTime\":
+        \"2017-09-22T21:41:59.1511353+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=77e13252-062c-4a6d-8a0c-3b66516ee304&sig=PGH9Q0CjbjMvM%2BIh4k51%2FXTS7ptkQfD8A2bngm5zxfs%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"9bebab40-09b8-45da-b9ba-a758ad1171a5\"\r\n}"
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:43 GMT
+  recorded_at: Fri, 22 Sep 2017 21:41:58 GMT
 - request:
     method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=374ca2d0-dcd0-4dc4-afcd-55444eebb92c&sig=Lk8TNgFf/wDQSuB25xHJfVm0GZI4gOaQ7856xYOUzZw=&sr=b&sv=2016-05-31
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/9bebab40-09b8-45da-b9ba-a758ad1171a5?api-version=2017-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMTQsIm5iZiI6MTUwNjExNjIxNCwiZXhwIjoxNTA2MTIwMTE0LCJhaW8iOiJZMlZnWURoNkxlTFlueWZjdXhLM1AwbGxXakZ0Q3dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiM3RzLXgxNGotVVdQWW50M21LUUtBQSIsInZlciI6IjEuMCJ9.tNfZxYjnzlN9LDikmqxEQ9ZcfV9Yn8I3V3YgPPMCQLu3VgrgqT1_rVmxUL5elZ7234OpvauDuw7T2xQ1ea_cnqFrbD2iIEH3LeIndrF0vmL16m8SaE9Adbufc2txA0w0nKguQnS51reRhW196Cv_p_w7_KFjhOba6m9Xg6w2eAmeRZGVccg0Esjne3ymo09Hvq4cdUq-RfDoTuZk9Sm9QglJEcC9IIargAWz2A37cemo9amSIV1VQrz-UyCgbvXygTJXgMoix96kQ8FvsLtiNTjhsdoFC0jdytz3igNPoUEIJnflKEYUP9nYddgNqO95tJ4jns580aLjg_Yn_mnuTw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
+      X-Ms-Request-Id:
+      - 7cf250ce-edd0-412e-bba1-3ac7ad2f6850
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14922'
+      X-Ms-Correlation-Request-Id:
+      - 4438ed5d-4eef-4623-8fd2-a3e67701abf2
+      X-Ms-Routing-Request-Id:
+      - WESTUS:20170922T214159Z:4438ed5d-4eef-4623-8fd2-a3e67701abf2
+      Date:
+      - Fri, 22 Sep 2017 21:41:59 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"startTime\": \"2017-09-22T21:41:58.7916756+00:00\",\r\n  \"endTime\":
+        \"2017-09-22T21:41:59.1511353+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=77e13252-062c-4a6d-8a0c-3b66516ee304&sig=PGH9Q0CjbjMvM%2BIh4k51%2FXTS7ptkQfD8A2bngm5zxfs%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"9bebab40-09b8-45da-b9ba-a758ad1171a5\"\r\n}"
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 21:41:58 GMT
+- request:
+    method: get
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=77e13252-062c-4a6d-8a0c-3b66516ee304&sig=PGH9Q0CjbjMvM%2BIh4k51/XTS7ptkQfD8A2bngm5zxfs=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2046,8 +2176,6 @@ http_interactions:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
       X-Ms-Range:
       - bytes=0-0
-      Host:
-      - md-t4jdgqqlgszp.blob.core.windows.net
   response:
     status:
       code: 206
@@ -2068,7 +2196,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 7d67799f-001e-0081-6482-26037a000000
+      - f5ca1ede-001e-00e5-4aeb-33b3da000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2094,13 +2222,13 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Tue, 05 Sep 2017 20:04:42 GMT
+      - Fri, 22 Sep 2017 21:42:00 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         6w==
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:43 GMT
+  recorded_at: Fri, 22 Sep 2017 21:41:59 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/EndGetAccess?api-version=2017-03-30
@@ -2117,11 +2245,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1ODIsIm5iZiI6MTUwNDY0MTU4MiwiZXhwIjoxNTA0NjQ1NDgyLCJhaW8iOiJZMkZnWUFnKzFtRFcvRzdCcDNnV0llOFZ6UUw3QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieGQ0RXo1c3F2VXFXbGs2UV82Y2VBQSIsInZlciI6IjEuMCJ9.xt3WR3R1Pll8AY23wUz4BppEYoPLrBZArSr5NrSrApIHJm4_H50MP_dS2HjIig8UkJPQN9WyPNObk9qUbrDPQFN-Oc_7-xSkK-Qd_AjS92GJzzWLq7aPtrxKTTQ_RT2lC4H3cc9rlb3rk9Vl8M1wWY_26ll8Ryd1JUGAnhjbXZoqbTx7IyrfAtOTxP1d6LBk3ErAs84eSMmMXvjomFORUrt6AQdAcmMLvzUCUPc8Fj_dWK0YFGk9Un48OTdbGdqBrRaTHfIgsRRm0QQAofVCluS5GaSocMPRvVM9I7-pRYNT5zVmw8IsYRTcdj6U_AweuwvtpH377bsuqctgVB4MdQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMTQsIm5iZiI6MTUwNjExNjIxNCwiZXhwIjoxNTA2MTIwMTE0LCJhaW8iOiJZMlZnWURoNkxlTFlueWZjdXhLM1AwbGxXakZ0Q3dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiM3RzLXgxNGotVVdQWW50M21LUUtBQSIsInZlciI6IjEuMCJ9.tNfZxYjnzlN9LDikmqxEQ9ZcfV9Yn8I3V3YgPPMCQLu3VgrgqT1_rVmxUL5elZ7234OpvauDuw7T2xQ1ea_cnqFrbD2iIEH3LeIndrF0vmL16m8SaE9Adbufc2txA0w0nKguQnS51reRhW196Cv_p_w7_KFjhOba6m9Xg6w2eAmeRZGVccg0Esjne3ymo09Hvq4cdUq-RfDoTuZk9Sm9QglJEcC9IIargAWz2A37cemo9amSIV1VQrz-UyCgbvXygTJXgMoix96kQ8FvsLtiNTjhsdoFC0jdytz3igNPoUEIJnflKEYUP9nYddgNqO95tJ4jns580aLjg_Yn_mnuTw
       Content-Length:
       - '0'
-      Host:
-      - management.azure.com
   response:
     status:
       code: 202
@@ -2136,31 +2262,31 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/716ce025-664f-40a5-94bf-8affd0a1c146?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/72bde769-4fab-4f16-b7e4-8b99e794ea3f?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/716ce025-664f-40a5-94bf-8affd0a1c146?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/72bde769-4fab-4f16-b7e4-8b99e794ea3f?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - 716ce025-664f-40a5-94bf-8affd0a1c146
+      - 72bde769-4fab-4f16-b7e4-8b99e794ea3f
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1186'
+      - '1182'
       X-Ms-Correlation-Request-Id:
-      - b5e1f978-920d-4d0b-845b-9f9b20f7edb1
+      - 63159f83-669d-4641-bee2-1dbd29bd8a98
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200443Z:b5e1f978-920d-4d0b-845b-9f9b20f7edb1
+      - WESTUS:20170922T214200Z:63159f83-669d-4641-bee2-1dbd29bd8a98
       Date:
-      - Tue, 05 Sep 2017 20:04:43 GMT
+      - Fri, 22 Sep 2017 21:42:00 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:43 GMT
+  recorded_at: Fri, 22 Sep 2017 21:41:59 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
@@ -2177,11 +2303,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1ODIsIm5iZiI6MTUwNDY0MTU4MiwiZXhwIjoxNTA0NjQ1NDgyLCJhaW8iOiJZMkZnWUFnKzFtRFcvRzdCcDNnV0llOFZ6UUw3QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieGQ0RXo1c3F2VXFXbGs2UV82Y2VBQSIsInZlciI6IjEuMCJ9.xt3WR3R1Pll8AY23wUz4BppEYoPLrBZArSr5NrSrApIHJm4_H50MP_dS2HjIig8UkJPQN9WyPNObk9qUbrDPQFN-Oc_7-xSkK-Qd_AjS92GJzzWLq7aPtrxKTTQ_RT2lC4H3cc9rlb3rk9Vl8M1wWY_26ll8Ryd1JUGAnhjbXZoqbTx7IyrfAtOTxP1d6LBk3ErAs84eSMmMXvjomFORUrt6AQdAcmMLvzUCUPc8Fj_dWK0YFGk9Un48OTdbGdqBrRaTHfIgsRRm0QQAofVCluS5GaSocMPRvVM9I7-pRYNT5zVmw8IsYRTcdj6U_AweuwvtpH377bsuqctgVB4MdQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMTQsIm5iZiI6MTUwNjExNjIxNCwiZXhwIjoxNTA2MTIwMTE0LCJhaW8iOiJZMlZnWURoNkxlTFlueWZjdXhLM1AwbGxXakZ0Q3dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiM3RzLXgxNGotVVdQWW50M21LUUtBQSIsInZlciI6IjEuMCJ9.tNfZxYjnzlN9LDikmqxEQ9ZcfV9Yn8I3V3YgPPMCQLu3VgrgqT1_rVmxUL5elZ7234OpvauDuw7T2xQ1ea_cnqFrbD2iIEH3LeIndrF0vmL16m8SaE9Adbufc2txA0w0nKguQnS51reRhW196Cv_p_w7_KFjhOba6m9Xg6w2eAmeRZGVccg0Esjne3ymo09Hvq4cdUq-RfDoTuZk9Sm9QglJEcC9IIargAWz2A37cemo9amSIV1VQrz-UyCgbvXygTJXgMoix96kQ8FvsLtiNTjhsdoFC0jdytz3igNPoUEIJnflKEYUP9nYddgNqO95tJ4jns580aLjg_Yn_mnuTw
       Content-Length:
       - '42'
-      Host:
-      - management.azure.com
   response:
     status:
       code: 202
@@ -2196,34 +2320,34 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/999d2c1a-fcd9-4c54-b97c-fa0e15f041c7?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/4b7060de-ce50-4b4b-9942-459892222e80?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/999d2c1a-fcd9-4c54-b97c-fa0e15f041c7?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/4b7060de-ce50-4b4b-9942-459892222e80?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - 999d2c1a-fcd9-4c54-b97c-fa0e15f041c7
+      - 4b7060de-ce50-4b4b-9942-459892222e80
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1188'
+      - '1183'
       X-Ms-Correlation-Request-Id:
-      - 19bcdd94-1c80-4721-8947-b6a2eea0c96f
+      - b082a3ef-b564-4086-88dc-71d520304a88
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200444Z:19bcdd94-1c80-4721-8947-b6a2eea0c96f
+      - WESTUS:20170922T214203Z:b082a3ef-b564-4086-88dc-71d520304a88
       Date:
-      - Tue, 05 Sep 2017 20:04:43 GMT
+      - Fri, 22 Sep 2017 21:42:02 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:44 GMT
+  recorded_at: Fri, 22 Sep 2017 21:42:02 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/999d2c1a-fcd9-4c54-b97c-fa0e15f041c7?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/4b7060de-ce50-4b4b-9942-459892222e80?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -2237,9 +2361,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1ODIsIm5iZiI6MTUwNDY0MTU4MiwiZXhwIjoxNTA0NjQ1NDgyLCJhaW8iOiJZMkZnWUFnKzFtRFcvRzdCcDNnV0llOFZ6UUw3QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieGQ0RXo1c3F2VXFXbGs2UV82Y2VBQSIsInZlciI6IjEuMCJ9.xt3WR3R1Pll8AY23wUz4BppEYoPLrBZArSr5NrSrApIHJm4_H50MP_dS2HjIig8UkJPQN9WyPNObk9qUbrDPQFN-Oc_7-xSkK-Qd_AjS92GJzzWLq7aPtrxKTTQ_RT2lC4H3cc9rlb3rk9Vl8M1wWY_26ll8Ryd1JUGAnhjbXZoqbTx7IyrfAtOTxP1d6LBk3ErAs84eSMmMXvjomFORUrt6AQdAcmMLvzUCUPc8Fj_dWK0YFGk9Un48OTdbGdqBrRaTHfIgsRRm0QQAofVCluS5GaSocMPRvVM9I7-pRYNT5zVmw8IsYRTcdj6U_AweuwvtpH377bsuqctgVB4MdQ
-      Host:
-      - management.azure.com
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMTQsIm5iZiI6MTUwNjExNjIxNCwiZXhwIjoxNTA2MTIwMTE0LCJhaW8iOiJZMlZnWURoNkxlTFlueWZjdXhLM1AwbGxXakZ0Q3dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiM3RzLXgxNGotVVdQWW50M21LUUtBQSIsInZlciI6IjEuMCJ9.tNfZxYjnzlN9LDikmqxEQ9ZcfV9Yn8I3V3YgPPMCQLu3VgrgqT1_rVmxUL5elZ7234OpvauDuw7T2xQ1ea_cnqFrbD2iIEH3LeIndrF0vmL16m8SaE9Adbufc2txA0w0nKguQnS51reRhW196Cv_p_w7_KFjhOba6m9Xg6w2eAmeRZGVccg0Esjne3ymo09Hvq4cdUq-RfDoTuZk9Sm9QglJEcC9IIargAWz2A37cemo9amSIV1VQrz-UyCgbvXygTJXgMoix96kQ8FvsLtiNTjhsdoFC0jdytz3igNPoUEIJnflKEYUP9nYddgNqO95tJ4jns580aLjg_Yn_mnuTw
   response:
     status:
       code: 200
@@ -2260,31 +2382,90 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - 54a71e2f-8826-4eaa-9fa8-3622f3ebc051
+      - b48ea611-42d2-4625-b04f-6ead71473e88
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14947'
+      - '14927'
       X-Ms-Correlation-Request-Id:
-      - eb03031c-b18d-4b81-b1b7-4a0024114f6e
+      - 2a108c21-40e6-4e0c-9ab2-695f25fd3297
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200444Z:eb03031c-b18d-4b81-b1b7-4a0024114f6e
+      - WESTUS:20170922T214204Z:2a108c21-40e6-4e0c-9ab2-695f25fd3297
       Date:
-      - Tue, 05 Sep 2017 20:04:43 GMT
+      - Fri, 22 Sep 2017 21:42:04 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-05T20:04:43.036497+00:00\",\r\n  \"endTime\":
-        \"2017-09-05T20:04:43.3651308+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=680547c9-e5c9-4c66-8a95-aaa6a359fc45&sig=tzEDbZOb9kUEBQWiplH653cBTZLNtTZ0DmYcv3vZteY%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"999d2c1a-fcd9-4c54-b97c-fa0e15f041c7\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2017-09-22T21:42:04.6837547+00:00\",\r\n  \"endTime\":
+        \"2017-09-22T21:42:04.808805+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=d9916b26-0b87-4700-b9e3-ffba4af4ad7f&sig=YsSuh4BiBjho%2F%2FMYfsE%2FOV0zmwYgUjOofVsMCjhP0Fo%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"4b7060de-ce50-4b4b-9942-459892222e80\"\r\n}"
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:44 GMT
+  recorded_at: Fri, 22 Sep 2017 21:42:03 GMT
 - request:
     method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=680547c9-e5c9-4c66-8a95-aaa6a359fc45&sig=tzEDbZOb9kUEBQWiplH653cBTZLNtTZ0DmYcv3vZteY=&sr=b&sv=2016-05-31
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/4b7060de-ce50-4b4b-9942-459892222e80?api-version=2017-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMTQsIm5iZiI6MTUwNjExNjIxNCwiZXhwIjoxNTA2MTIwMTE0LCJhaW8iOiJZMlZnWURoNkxlTFlueWZjdXhLM1AwbGxXakZ0Q3dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiM3RzLXgxNGotVVdQWW50M21LUUtBQSIsInZlciI6IjEuMCJ9.tNfZxYjnzlN9LDikmqxEQ9ZcfV9Yn8I3V3YgPPMCQLu3VgrgqT1_rVmxUL5elZ7234OpvauDuw7T2xQ1ea_cnqFrbD2iIEH3LeIndrF0vmL16m8SaE9Adbufc2txA0w0nKguQnS51reRhW196Cv_p_w7_KFjhOba6m9Xg6w2eAmeRZGVccg0Esjne3ymo09Hvq4cdUq-RfDoTuZk9Sm9QglJEcC9IIargAWz2A37cemo9amSIV1VQrz-UyCgbvXygTJXgMoix96kQ8FvsLtiNTjhsdoFC0jdytz3igNPoUEIJnflKEYUP9nYddgNqO95tJ4jns580aLjg_Yn_mnuTw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
+      X-Ms-Request-Id:
+      - 457d0b3a-325f-4cad-a657-26868f0b4b08
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14913'
+      X-Ms-Correlation-Request-Id:
+      - 1f687fcd-41fd-4cb2-a052-cf4625fe05fc
+      X-Ms-Routing-Request-Id:
+      - WESTUS:20170922T214205Z:1f687fcd-41fd-4cb2-a052-cf4625fe05fc
+      Date:
+      - Fri, 22 Sep 2017 21:42:05 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"startTime\": \"2017-09-22T21:42:04.6837547+00:00\",\r\n  \"endTime\":
+        \"2017-09-22T21:42:04.808805+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=d9916b26-0b87-4700-b9e3-ffba4af4ad7f&sig=YsSuh4BiBjho%2F%2FMYfsE%2FOV0zmwYgUjOofVsMCjhP0Fo%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"4b7060de-ce50-4b4b-9942-459892222e80\"\r\n}"
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 21:42:04 GMT
+- request:
+    method: get
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=d9916b26-0b87-4700-b9e3-ffba4af4ad7f&sig=YsSuh4BiBjho//MYfsE/OV0zmwYgUjOofVsMCjhP0Fo=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2297,8 +2478,6 @@ http_interactions:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
       X-Ms-Range:
       - bytes=440-443
-      Host:
-      - md-t4jdgqqlgszp.blob.core.windows.net
   response:
     status:
       code: 206
@@ -2319,7 +2498,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - d1243c81-001e-00fb-6882-266937000000
+      - ee137a0f-001e-0018-56eb-338cb8000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2345,13 +2524,13 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Tue, 05 Sep 2017 20:04:44 GMT
+      - Fri, 22 Sep 2017 21:42:05 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         U5MJAA==
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:44 GMT
+  recorded_at: Fri, 22 Sep 2017 21:42:04 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/EndGetAccess?api-version=2017-03-30
@@ -2368,11 +2547,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1ODIsIm5iZiI6MTUwNDY0MTU4MiwiZXhwIjoxNTA0NjQ1NDgyLCJhaW8iOiJZMkZnWUFnKzFtRFcvRzdCcDNnV0llOFZ6UUw3QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieGQ0RXo1c3F2VXFXbGs2UV82Y2VBQSIsInZlciI6IjEuMCJ9.xt3WR3R1Pll8AY23wUz4BppEYoPLrBZArSr5NrSrApIHJm4_H50MP_dS2HjIig8UkJPQN9WyPNObk9qUbrDPQFN-Oc_7-xSkK-Qd_AjS92GJzzWLq7aPtrxKTTQ_RT2lC4H3cc9rlb3rk9Vl8M1wWY_26ll8Ryd1JUGAnhjbXZoqbTx7IyrfAtOTxP1d6LBk3ErAs84eSMmMXvjomFORUrt6AQdAcmMLvzUCUPc8Fj_dWK0YFGk9Un48OTdbGdqBrRaTHfIgsRRm0QQAofVCluS5GaSocMPRvVM9I7-pRYNT5zVmw8IsYRTcdj6U_AweuwvtpH377bsuqctgVB4MdQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMTQsIm5iZiI6MTUwNjExNjIxNCwiZXhwIjoxNTA2MTIwMTE0LCJhaW8iOiJZMlZnWURoNkxlTFlueWZjdXhLM1AwbGxXakZ0Q3dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiM3RzLXgxNGotVVdQWW50M21LUUtBQSIsInZlciI6IjEuMCJ9.tNfZxYjnzlN9LDikmqxEQ9ZcfV9Yn8I3V3YgPPMCQLu3VgrgqT1_rVmxUL5elZ7234OpvauDuw7T2xQ1ea_cnqFrbD2iIEH3LeIndrF0vmL16m8SaE9Adbufc2txA0w0nKguQnS51reRhW196Cv_p_w7_KFjhOba6m9Xg6w2eAmeRZGVccg0Esjne3ymo09Hvq4cdUq-RfDoTuZk9Sm9QglJEcC9IIargAWz2A37cemo9amSIV1VQrz-UyCgbvXygTJXgMoix96kQ8FvsLtiNTjhsdoFC0jdytz3igNPoUEIJnflKEYUP9nYddgNqO95tJ4jns580aLjg_Yn_mnuTw
       Content-Length:
       - '0'
-      Host:
-      - management.azure.com
   response:
     status:
       code: 202
@@ -2387,29 +2564,29 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/13a3c285-943e-43c1-949f-5f9289f9ed35?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/363730c8-248b-4f32-b72f-1caf0d4ef20f?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/13a3c285-943e-43c1-949f-5f9289f9ed35?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/363730c8-248b-4f32-b72f-1caf0d4ef20f?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - 13a3c285-943e-43c1-949f-5f9289f9ed35
+      - 363730c8-248b-4f32-b72f-1caf0d4ef20f
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1179'
+      - '1183'
       X-Ms-Correlation-Request-Id:
-      - 25ec029f-f96c-49e8-8583-33a52f230f38
+      - 7121e902-1466-4569-b6b4-3fd0788c388a
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200445Z:25ec029f-f96c-49e8-8583-33a52f230f38
+      - WESTUS:20170922T214206Z:7121e902-1466-4569-b6b4-3fd0788c388a
       Date:
-      - Tue, 05 Sep 2017 20:04:44 GMT
+      - Fri, 22 Sep 2017 21:42:06 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:45 GMT
+  recorded_at: Fri, 22 Sep 2017 21:42:05 GMT
 recorded_with: VCR 3.0.3

--- a/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_endByteAddr-1.yml
+++ b/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_endByteAddr-1.yml
@@ -17,8 +17,6 @@ http_interactions:
       - '186'
       Content-Type:
       - application/x-www-form-urlencoded
-      Host:
-      - login.microsoftonline.com
   response:
     status:
       code: 200
@@ -39,25 +37,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - a58fa3bb-8ab5-442c-950c-96b653bc1f00
+      - 294c3a76-436c-4d92-900b-21d0165a0d00
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAAA9kTklhVy7SJTGAzR-p1BcXz75THkomxKlMbr3x7dP4_H_mED2RdX6s7XK3JKoeQ05ETqstAxSIQmS0_umGJqTAYabOINoH_9g1MOXzaPkbi3PZCzNwrJgFhObNZ8awnYcBQeuc7ajq4GEArYdHwtavYTntoeVZrCWa6uonbTLcqeTEB-kyQA5rwtiyxCB9sIgAA;
+      - esctx=AQABAAAAAAABlDrqfEFlSaui6xnRjX5EzujB1sWgyAff07ksrrKdj1kzpDLb6ndFCUV4zX2f6T6_Cl2HSfTrjOzCPJ0Zgkmp49lscoDXakb1ZnfOE1ftffhSDa2b-aY_yIVQsP2_yoLScDZhB6ebBm2qb5ygkwsbmg_jhrpWUWEu-jyAx7JACjAqwWcZsc4RkbIVO9drbEsgAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
       - x-ms-gateway-slice=003; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Tue, 05 Sep 2017 20:04:14 GMT
+      - Fri, 22 Sep 2017 21:41:21 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1504645453","not_before":"1504641553","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NTMsIm5iZiI6MTUwNDY0MTU1MywiZXhwIjoxNTA0NjQ1NDUzLCJhaW8iOiJZMkZnWUVnT2trMmF1SUE5Y3Bib0JsM2xmVWZQQWdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidTZPUHBiV0tMRVNWREphMlU3d2ZBQSIsInZlciI6IjEuMCJ9.UxKj8yiT68LmcW7If-nM0VPmQJqann58FCDNDhqCfON5KclE3cY9Y0vz4JZJWu2WEiI_kZgjlsB0dn9TTGw4_jkaiFHQEyuya769pA7rBenvMwTWzXjnzgd3DGnttqnL7AQVu2dBTWUYU0Jwh1FwexKPOLc2IeM0x3zRmunIIfj0U-RnG7whwirVZwucVKUNUfGasHyFHxZIM1RpmEmu9-6690WjnZ8UwkBZ_xZ3FnRfN2FWKKKiTjudICtz0ZxVa22BewjC0PDmWyhRlmDXbvqWVcx2O-9a0K7CAjtxrZ-WDDLw8bFK4J8gx2u4o3-DzprJLMf0egYJcfaDDQwbGw"}'
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1506120081","not_before":"1506116181","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYxODEsIm5iZiI6MTUwNjExNjE4MSwiZXhwIjoxNTA2MTIwMDgxLCJhaW8iOiJZMlZnWU5pV0pXUHdMc2ZWM2ZoSVFWajJIT3N5QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZGpwTUtXeERrazJRQ3lIUUZsb05BQSIsInZlciI6IjEuMCJ9.GW2nffAcmgbaeE599i02qETJnYxCuvceko-eBNV-OBRreyQFQW5sN7oI6JvkbyNZj8IEvjsqhCdlnWX6P4dptVZD_sQxClGAW6mvLq83u4hdtzXVqEhD5rPU1ssRvkt8vxnSJ2LrgwcLud1UTmqwfVIeghqjVQN5qkewahU_YwYkb31LoDkLVbgpPPLxMTTMgjsXFWsE1qB5zTZj74U5Oo4TH312XuTH_KuYCQj3tbwZj4_HUNxxmGW-iT84wWxwTfEQuA1LW_eK9bYGXj_WLClwn-rFFWoYY_YogKayMoolQekRujbk41PCf_4UB2LbQ8QP6zOjsAOZbFMUZhODjw"}'
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:12 GMT
+  recorded_at: Fri, 22 Sep 2017 21:41:21 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -74,9 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NTMsIm5iZiI6MTUwNDY0MTU1MywiZXhwIjoxNTA0NjQ1NDUzLCJhaW8iOiJZMkZnWUVnT2trMmF1SUE5Y3Bib0JsM2xmVWZQQWdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidTZPUHBiV0tMRVNWREphMlU3d2ZBQSIsInZlciI6IjEuMCJ9.UxKj8yiT68LmcW7If-nM0VPmQJqann58FCDNDhqCfON5KclE3cY9Y0vz4JZJWu2WEiI_kZgjlsB0dn9TTGw4_jkaiFHQEyuya769pA7rBenvMwTWzXjnzgd3DGnttqnL7AQVu2dBTWUYU0Jwh1FwexKPOLc2IeM0x3zRmunIIfj0U-RnG7whwirVZwucVKUNUfGasHyFHxZIM1RpmEmu9-6690WjnZ8UwkBZ_xZ3FnRfN2FWKKKiTjudICtz0ZxVa22BewjC0PDmWyhRlmDXbvqWVcx2O-9a0K7CAjtxrZ-WDDLw8bFK4J8gx2u4o3-DzprJLMf0egYJcfaDDQwbGw
-      Host:
-      - management.azure.com
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYxODEsIm5iZiI6MTUwNjExNjE4MSwiZXhwIjoxNTA2MTIwMDgxLCJhaW8iOiJZMlZnWU5pV0pXUHdMc2ZWM2ZoSVFWajJIT3N5QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZGpwTUtXeERrazJRQ3lIUUZsb05BQSIsInZlciI6IjEuMCJ9.GW2nffAcmgbaeE599i02qETJnYxCuvceko-eBNV-OBRreyQFQW5sN7oI6JvkbyNZj8IEvjsqhCdlnWX6P4dptVZD_sQxClGAW6mvLq83u4hdtzXVqEhD5rPU1ssRvkt8vxnSJ2LrgwcLud1UTmqwfVIeghqjVQN5qkewahU_YwYkb31LoDkLVbgpPPLxMTTMgjsXFWsE1qB5zTZj74U5Oo4TH312XuTH_KuYCQj3tbwZj4_HUNxxmGW-iT84wWxwTfEQuA1LW_eK9bYGXj_WLClwn-rFFWoYY_YogKayMoolQekRujbk41PCf_4UB2LbQ8QP6zOjsAOZbFMUZhODjw
   response:
     status:
       code: 200
@@ -95,23 +91,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14996'
+      - '14999'
       X-Ms-Request-Id:
-      - 65e36844-e911-4a5e-913f-839f12a7b121
+      - 9b837ba8-0878-4c91-8349-f5dfb29febe0
       X-Ms-Correlation-Request-Id:
-      - 65e36844-e911-4a5e-913f-839f12a7b121
+      - 9b837ba8-0878-4c91-8349-f5dfb29febe0
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200414Z:65e36844-e911-4a5e-913f-839f12a7b121
+      - WESTUS:20170922T214122Z:9b837ba8-0878-4c91-8349-f5dfb29febe0
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 05 Sep 2017 20:04:13 GMT
+      - Fri, 22 Sep 2017 21:41:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:13 GMT
+  recorded_at: Fri, 22 Sep 2017 21:41:22 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/azure_subscription_id/providers?api-version=2015-01-01
@@ -128,9 +124,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NTMsIm5iZiI6MTUwNDY0MTU1MywiZXhwIjoxNTA0NjQ1NDUzLCJhaW8iOiJZMkZnWUVnT2trMmF1SUE5Y3Bib0JsM2xmVWZQQWdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidTZPUHBiV0tMRVNWREphMlU3d2ZBQSIsInZlciI6IjEuMCJ9.UxKj8yiT68LmcW7If-nM0VPmQJqann58FCDNDhqCfON5KclE3cY9Y0vz4JZJWu2WEiI_kZgjlsB0dn9TTGw4_jkaiFHQEyuya769pA7rBenvMwTWzXjnzgd3DGnttqnL7AQVu2dBTWUYU0Jwh1FwexKPOLc2IeM0x3zRmunIIfj0U-RnG7whwirVZwucVKUNUfGasHyFHxZIM1RpmEmu9-6690WjnZ8UwkBZ_xZ3FnRfN2FWKKKiTjudICtz0ZxVa22BewjC0PDmWyhRlmDXbvqWVcx2O-9a0K7CAjtxrZ-WDDLw8bFK4J8gx2u4o3-DzprJLMf0egYJcfaDDQwbGw
-      Host:
-      - management.azure.com
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYxODEsIm5iZiI6MTUwNjExNjE4MSwiZXhwIjoxNTA2MTIwMDgxLCJhaW8iOiJZMlZnWU5pV0pXUHdMc2ZWM2ZoSVFWajJIT3N5QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZGpwTUtXeERrazJRQ3lIUUZsb05BQSIsInZlciI6IjEuMCJ9.GW2nffAcmgbaeE599i02qETJnYxCuvceko-eBNV-OBRreyQFQW5sN7oI6JvkbyNZj8IEvjsqhCdlnWX6P4dptVZD_sQxClGAW6mvLq83u4hdtzXVqEhD5rPU1ssRvkt8vxnSJ2LrgwcLud1UTmqwfVIeghqjVQN5qkewahU_YwYkb31LoDkLVbgpPPLxMTTMgjsXFWsE1qB5zTZj74U5Oo4TH312XuTH_KuYCQj3tbwZj4_HUNxxmGW-iT84wWxwTfEQuA1LW_eK9bYGXj_WLClwn-rFFWoYY_YogKayMoolQekRujbk41PCf_4UB2LbQ8QP6zOjsAOZbFMUZhODjw
   response:
     status:
       code: 200
@@ -147,22 +141,42 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14974'
+      - '14915'
       X-Ms-Request-Id:
-      - d4b69880-e283-4c0c-a494-a436937b2220
+      - 62da508c-dec0-4408-8576-9c6ba8692e1b
       X-Ms-Correlation-Request-Id:
-      - d4b69880-e283-4c0c-a494-a436937b2220
+      - 62da508c-dec0-4408-8576-9c6ba8692e1b
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200415Z:d4b69880-e283-4c0c-a494-a436937b2220
+      - WESTUS:20170922T214123Z:62da508c-dec0-4408-8576-9c6ba8692e1b
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 05 Sep 2017 20:04:15 GMT
+      - Fri, 22 Sep 2017 21:41:23 GMT
       Content-Length:
-      - '243687'
+      - '254785'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
+      string: '{"value":[{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"operations","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","North Central
         US","South Central US","West Central US","West US","West US 2","Canada Central","Canada
         East","North Europe","West Europe","UK South","UK West","East Asia","Southeast
@@ -437,7 +451,7 @@ http_interactions:
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
         Central US","West US 2","South India","Central India","West India","Canada
-        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
+        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
         East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
@@ -466,7 +480,7 @@ http_interactions:
         Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"}],"resourceTypes":[{"resourceType":"components","locations":["East
         US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
         US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01","2014-04-01"]},{"resourceType":"queries","locations":["East
-        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"alertrules","locations":["West
+        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
@@ -542,7 +556,7 @@ http_interactions:
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorization":{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorizations":[{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},{"applicationId":"7c33bfcb-8d33-48d6-8e60-dc6404003489","roleDefinitionId":"ad6261e4-fa9a-4642-aa5f-104f1b67e9e3"},{"applicationId":"1e3e4475-288f-4018-a376-df66fd7fac5f","roleDefinitionId":"1d538b69-3d87-4e56-8ff8-25786fd48261"},{"applicationId":"a0be0c72-870e-46f0-9c49-c98333a996f7","roleDefinitionId":"7ce22727-ffce-45a9-930c-ddb2e56fa131"}],"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -552,7 +566,7 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -567,7 +581,8 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
+        Central US"],"apiVersions":["2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -577,7 +592,12 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -597,7 +617,7 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -612,7 +632,7 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -622,7 +642,31 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
         East","UK South","Central India","Canada Central"],"apiVersions":["2017-04-26-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"]},{"resourceType":"workspaces/dataSources","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
@@ -641,17 +685,17 @@ http_interactions:
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"consoles","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/consoles","locations":["West
+        East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"consoles","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/consoles","locations":["West
         US","East US","Central India","North Europe","West Europe","South Central
-        US","Southeast Asia"],"apiVersions":["2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
+        US","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
         US","East US","Central India","North Europe","West Europe","South Central
-        US","Southeast Asia"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
+        US","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","Canada Central","Canada East","West Central US","West US 2","UK South","UK
         West","Korea Central","Korea South"],"apiVersions":["2017-07-01","2016-12-01","2016-08-10","2016-06-01","2016-05-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"operations","locations":["Southeast
-        Asia"],"apiVersions":["2016-08-10","2016-06-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01"]},{"resourceType":"locations/backupStatus","locations":["West
+        Asia"],"apiVersions":["2016-08-10","2016-06-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01","2016-06-01"]},{"resourceType":"locations/backupStatus","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
@@ -687,6 +731,7 @@ http_interactions:
         Central US","Central US","North Europe","West Europe","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada Central","Canada East"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"pricings","locations":["Central
+        US","East US"],"apiVersions":["2017-08-01-preview"]},{"resourceType":"securityContacts","locations":["Central
         US","East US"],"apiVersions":["2017-08-01-preview"]},{"resourceType":"workspaceSettings","locations":["Central
         US","East US"],"apiVersions":["2017-08-01-preview"]},{"resourceType":"complianceResults","locations":["Central
         US","East US"],"apiVersions":["2017-08-01"]},{"resourceType":"policies","locations":["Central
@@ -703,6 +748,8 @@ http_interactions:
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatusesSummaries","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/alerts","locations":["Central
         US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/tasks","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"externalSecuritySolutions","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/externalSecuritySolutions","locations":["Central
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.SiteRecovery","namespace":"Microsoft.SiteRecovery","authorization":{"applicationId":"b8340c3b-9267-498f-b21a-15d5547fd85e","roleDefinitionId":"8A00C8EA-8F1B-45A7-8F64-F4CC61EEE9B6"},"resourceTypes":[{"resourceType":"SiteRecoveryVault","locations":["East
         US","West US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","Australia East","Australia Southeast","Brazil South","North
@@ -722,7 +769,7 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -842,7 +889,22 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/databases/transparentDataEncryption","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -1077,6 +1139,26 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
         US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
@@ -1307,6 +1389,11 @@ http_interactions:
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"customApis","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
         East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/managedApis","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
@@ -1358,23 +1445,8 @@ http_interactions:
         US","North Europe","Japan West","Japan East","East Asia","West Europe","East
         US","Southeast Asia","Central US"],"apiVersions":["2016-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Lombiq.DotNest","namespace":"Lombiq.DotNest","resourceTypes":[{"resourceType":"sites","locations":["East
         US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Mailjet.Email","namespace":"Mailjet.Email","resourceTypes":[{"resourceType":"services","locations":["West
-        US"],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
-        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]},{"resourceType":"diagnosticSettings","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"addsservices","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"configuration","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"operations","locations":["West
@@ -1498,8 +1570,10 @@ http_interactions:
         Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
         Central US","Central US","North Europe","West Europe","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","West
-        India","South India"],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CognitiveServices","namespace":"Microsoft.CognitiveServices","authorizations":[{"applicationId":"7d312290-28c8-473c-a0ed-8e53749b6d6d","roleDefinitionId":"5cb87f79-a7c3-4a95-9414-45b65974b51b"}],"resourceTypes":[{"resourceType":"accounts","locations":["Global","West
-        US","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"operations","locations":["Global","Australia
+        India","South India"],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CognitiveServices","namespace":"Microsoft.CognitiveServices","authorizations":[{"applicationId":"7d312290-28c8-473c-a0ed-8e53749b6d6d","roleDefinitionId":"5cb87f79-a7c3-4a95-9414-45b65974b51b"}],"resourceTypes":[{"resourceType":"accounts","locations":["Global","Australia
+        East","Brazil South","West US","West US 2","West Europe","North Europe","Southeast
+        Asia","East Asia","West Central US","South Central US","East US","East US
+        2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"operations","locations":["Global","Australia
         East","Brazil South","West US","West US 2","West Europe","North Europe","Southeast
         Asia","East Asia","West Central US","South Central US","East US","East US
         2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations","locations":["Global","Australia
@@ -1534,13 +1608,13 @@ http_interactions:
         US","West US","Australia East","West Europe","North Europe","Southeast Asia","West
         Central US"],"apiVersions":["2016-03-30","2015-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataFactory","namespace":"Microsoft.DataFactory","resourceTypes":[{"resourceType":"dataFactories","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview","2014-04-01"]},{"resourceType":"factories","locations":["East
-        US"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
-        US"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
+        US","East US 2"],"apiVersions":["2017-09-01-preview","2017-03-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
+        US","East US 2"],"apiVersions":["2017-09-01-preview","2017-03-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
         Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"dataFactories/metricDefinitions","locations":["North
         Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"checkDataFactoryNameAvailability","locations":[],"apiVersions":["2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"checkAzureDataFactoryNameAvailability","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"dataFactorySchema","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"operations","locations":["West
-        US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeAnalytics","namespace":"Microsoft.DataLakeAnalytics","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US","North Europe","East US","West Central US"],"apiVersions":["2017-09-01-preview","2017-03-01-preview","2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeAnalytics","namespace":"Microsoft.DataLakeAnalytics","resourceTypes":[{"resourceType":"accounts","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/dataLakeStoreAccounts","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers","locations":["East
@@ -1589,11 +1663,12 @@ http_interactions:
         India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
         India","East Asia","East US 2","East US","Japan East","Japan West","North
         Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"checkProvisioningServiceNameAvailability","locations":[],"apiVersions":["2017-08-21-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
         US","North Europe","East Asia","East US","West Europe","Southeast Asia","Japan
         East","Japan West","Australia East","Australia Southeast","West US 2","West
         Central US","East US 2","Central US","UK South","UK West","South India","Central
-        India"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
+        India","Canada Central","Canada East"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"ProvisioningServices","locations":["East
+        US","West Europe","Southeast Asia"],"apiVersions":["2017-08-21-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
         East","Australia Southeast","Canada Central","Canada East","Central India","Central
         US","East Asia","East US","East US 2","Japan East","Japan West","North Central
         US","North Europe","South Central US","South India","Southeast Asia","West
@@ -1620,16 +1695,16 @@ http_interactions:
         US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"operations","locations":["Brazil
         South","East Asia","East US","Japan East","Japan West","North Central US","North
         Europe","South Central US","West Europe","West US","Southeast Asia","Central
-        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"topics","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operations","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topics","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operations","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","West
         US 2","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
@@ -1727,48 +1802,39 @@ http_interactions:
         Central US","West Europe","Southeast Asia","Japan East","East US 2","West
         Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"commitmentPlans","locations":["South
         Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
-        Central US","West US"],"apiVersions":["2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Media","namespace":"Microsoft.Media","authorization":{"applicationId":"374b2a64-3b6b-436b-934c-b820eacca870","roleDefinitionId":"aab70789-0cec-44b5-95d7-84b64c9487af"},"resourceTypes":[{"resourceType":"mediaservices","locations":["Japan
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningExperimentation","namespace":"Microsoft.MachineLearningExperimentation","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"accounts","locations":["Australia
+        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces","locations":["Australia
+        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces/projects","locations":["Australia
+        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningCompute","namespace":"Microsoft.MachineLearningCompute","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"376aa7d7-51a9-463d-bd4d-7e1691345612","managedByRoleDefinitionId":"91d00862-cf55-46a5-9dce-260bbd92ce25"},"resourceTypes":[{"resourceType":"operationalizationClusters","locations":["East
+        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"operations","locations":["East
+        US 2"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations","locations":["East
+        US 2"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["East
+        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningModelManagement","namespace":"Microsoft.MachineLearningModelManagement","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US 2","West Central US","Australia East"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"operations","locations":["West
+        Central US"],"apiVersions":["2017-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
+        Central US","West US"],"apiVersions":["2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01"]},{"resourceType":"offertypes","locations":["South
+        Central US","West US"],"apiVersions":["2015-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Media","namespace":"Microsoft.Media","authorization":{"applicationId":"374b2a64-3b6b-436b-934c-b820eacca870","roleDefinitionId":"aab70789-0cec-44b5-95d7-84b64c9487af"},"resourceTypes":[{"resourceType":"mediaservices","locations":["Japan
         West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
         US","West US","Australia East","Australia Southeast","Central US","Brazil
         South","Central India","West India","South India","South Central US","Canada
-        Central","Canada East","West Central US"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
+        Central","Canada East","West Central US"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
         Central US","North Central US","East US 2","West US","West Europe","North
         Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
         East","UK South","West India"],"apiVersions":["2016-01-29"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-01-29"]},{"resourceType":"locations/checkNameAvailability","locations":["South
         Central US","North Central US","East US 2","West US","West Europe","North
         Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
-        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"operations","locations":["East
+        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"capacities","locations":["West
+        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
+        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationresults","locations":["West
+        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
+        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"operations","locations":["East
         US 2"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Relay","namespace":"Microsoft.Relay","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US 2","West
         US","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
         India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2017-08-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkPolicyCompliance","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
@@ -1827,8 +1893,11 @@ http_interactions:
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","resourceTypes":[{"resourceType":"operations","locations":["West
-        Central US"],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
+        Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applianceDefinitions","locations":["West
+        Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"locations","locations":["West
+        Central US"],"apiVersions":["2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
+        Central US"],"apiVersions":["2017-09-01","2016-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","West Central US","Japan East","Japan West","Australia East","Australia
         Southeast"],"apiVersions":["2017-06-01","2017-05-15","2017-01-01","2016-10-01","2016-06-01","2015-03-15","2014-09-01"]},{"resourceType":"operations","locations":["West
@@ -1888,11 +1957,17 @@ http_interactions:
         US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RedisLabs.Memcached","namespace":"RedisLabs.Memcached","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-07-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RedisLabs.Redis","namespace":"RedisLabs.Redis","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-07-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RevAPM.MobileCDN","namespace":"RevAPM.MobileCDN","resourceTypes":[{"resourceType":"accounts","locations":["Central
         US","East US","East US 2","North Central US","South Central US","West US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
-        East","Australia Southeast"],"apiVersions":["2016-08-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-24","2016-08-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sendgrid.Email","namespace":"Sendgrid.Email","resourceTypes":[{"resourceType":"accounts","locations":["East
-        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
-        Central US","Central US","North Europe","West Europe","Japan East","Japan
-        West","Brazil South","Australia East","Australia Southeast","Canada Central","Canada
-        East","West Central US","West US 2","UK South","UK West"],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Signiant.Flight","namespace":"Signiant.Flight","resourceTypes":[{"resourceType":"accounts","locations":["East
+        East","Australia Southeast"],"apiVersions":["2016-08-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-24","2016-08-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sendgrid.Email","namespace":"Sendgrid.Email","resourceTypes":[{"resourceType":"accounts","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Signiant.Flight","namespace":"Signiant.Flight","resourceTypes":[{"resourceType":"accounts","locations":["East
         US","Central US","North Central US","South Central US","West US","North Europe","West
         Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast"],"apiVersions":["2015-06-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sparkpost.Basic","namespace":"Sparkpost.Basic","resourceTypes":[{"resourceType":"services","locations":["West
@@ -1909,7 +1984,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:13 GMT
+  recorded_at: Fri, 22 Sep 2017 21:41:24 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
@@ -1926,11 +2001,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NTMsIm5iZiI6MTUwNDY0MTU1MywiZXhwIjoxNTA0NjQ1NDUzLCJhaW8iOiJZMkZnWUVnT2trMmF1SUE5Y3Bib0JsM2xmVWZQQWdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidTZPUHBiV0tMRVNWREphMlU3d2ZBQSIsInZlciI6IjEuMCJ9.UxKj8yiT68LmcW7If-nM0VPmQJqann58FCDNDhqCfON5KclE3cY9Y0vz4JZJWu2WEiI_kZgjlsB0dn9TTGw4_jkaiFHQEyuya769pA7rBenvMwTWzXjnzgd3DGnttqnL7AQVu2dBTWUYU0Jwh1FwexKPOLc2IeM0x3zRmunIIfj0U-RnG7whwirVZwucVKUNUfGasHyFHxZIM1RpmEmu9-6690WjnZ8UwkBZ_xZ3FnRfN2FWKKKiTjudICtz0ZxVa22BewjC0PDmWyhRlmDXbvqWVcx2O-9a0K7CAjtxrZ-WDDLw8bFK4J8gx2u4o3-DzprJLMf0egYJcfaDDQwbGw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYxODEsIm5iZiI6MTUwNjExNjE4MSwiZXhwIjoxNTA2MTIwMDgxLCJhaW8iOiJZMlZnWU5pV0pXUHdMc2ZWM2ZoSVFWajJIT3N5QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZGpwTUtXeERrazJRQ3lIUUZsb05BQSIsInZlciI6IjEuMCJ9.GW2nffAcmgbaeE599i02qETJnYxCuvceko-eBNV-OBRreyQFQW5sN7oI6JvkbyNZj8IEvjsqhCdlnWX6P4dptVZD_sQxClGAW6mvLq83u4hdtzXVqEhD5rPU1ssRvkt8vxnSJ2LrgwcLud1UTmqwfVIeghqjVQN5qkewahU_YwYkb31LoDkLVbgpPPLxMTTMgjsXFWsE1qB5zTZj74U5Oo4TH312XuTH_KuYCQj3tbwZj4_HUNxxmGW-iT84wWxwTfEQuA1LW_eK9bYGXj_WLClwn-rFFWoYY_YogKayMoolQekRujbk41PCf_4UB2LbQ8QP6zOjsAOZbFMUZhODjw
       Content-Length:
       - '42'
-      Host:
-      - management.azure.com
   response:
     status:
       code: 202
@@ -1945,34 +2018,34 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/d02cc22b-fa5a-4ba8-a907-4821d8a6b9be?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/8973aa0b-9987-47bd-aafe-5840eeed564c?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/d02cc22b-fa5a-4ba8-a907-4821d8a6b9be?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/8973aa0b-9987-47bd-aafe-5840eeed564c?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - d02cc22b-fa5a-4ba8-a907-4821d8a6b9be
+      - 8973aa0b-9987-47bd-aafe-5840eeed564c
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1179'
+      - '1183'
       X-Ms-Correlation-Request-Id:
-      - e1a2370b-8b31-4d1d-a138-5f24850bdde3
+      - 9d1cc8fd-1af1-4d36-8521-fab923c32566
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200415Z:e1a2370b-8b31-4d1d-a138-5f24850bdde3
+      - WESTUS:20170922T214125Z:9d1cc8fd-1af1-4d36-8521-fab923c32566
       Date:
-      - Tue, 05 Sep 2017 20:04:15 GMT
+      - Fri, 22 Sep 2017 21:41:24 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:14 GMT
+  recorded_at: Fri, 22 Sep 2017 21:41:25 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/d02cc22b-fa5a-4ba8-a907-4821d8a6b9be?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/8973aa0b-9987-47bd-aafe-5840eeed564c?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -1986,9 +2059,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NTMsIm5iZiI6MTUwNDY0MTU1MywiZXhwIjoxNTA0NjQ1NDUzLCJhaW8iOiJZMkZnWUVnT2trMmF1SUE5Y3Bib0JsM2xmVWZQQWdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidTZPUHBiV0tMRVNWREphMlU3d2ZBQSIsInZlciI6IjEuMCJ9.UxKj8yiT68LmcW7If-nM0VPmQJqann58FCDNDhqCfON5KclE3cY9Y0vz4JZJWu2WEiI_kZgjlsB0dn9TTGw4_jkaiFHQEyuya769pA7rBenvMwTWzXjnzgd3DGnttqnL7AQVu2dBTWUYU0Jwh1FwexKPOLc2IeM0x3zRmunIIfj0U-RnG7whwirVZwucVKUNUfGasHyFHxZIM1RpmEmu9-6690WjnZ8UwkBZ_xZ3FnRfN2FWKKKiTjudICtz0ZxVa22BewjC0PDmWyhRlmDXbvqWVcx2O-9a0K7CAjtxrZ-WDDLw8bFK4J8gx2u4o3-DzprJLMf0egYJcfaDDQwbGw
-      Host:
-      - management.azure.com
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYxODEsIm5iZiI6MTUwNjExNjE4MSwiZXhwIjoxNTA2MTIwMDgxLCJhaW8iOiJZMlZnWU5pV0pXUHdMc2ZWM2ZoSVFWajJIT3N5QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZGpwTUtXeERrazJRQ3lIUUZsb05BQSIsInZlciI6IjEuMCJ9.GW2nffAcmgbaeE599i02qETJnYxCuvceko-eBNV-OBRreyQFQW5sN7oI6JvkbyNZj8IEvjsqhCdlnWX6P4dptVZD_sQxClGAW6mvLq83u4hdtzXVqEhD5rPU1ssRvkt8vxnSJ2LrgwcLud1UTmqwfVIeghqjVQN5qkewahU_YwYkb31LoDkLVbgpPPLxMTTMgjsXFWsE1qB5zTZj74U5Oo4TH312XuTH_KuYCQj3tbwZj4_HUNxxmGW-iT84wWxwTfEQuA1LW_eK9bYGXj_WLClwn-rFFWoYY_YogKayMoolQekRujbk41PCf_4UB2LbQ8QP6zOjsAOZbFMUZhODjw
   response:
     status:
       code: 200
@@ -2009,31 +2080,90 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - 8490d0b6-41cd-491b-8732-28089499fe66
+      - 13de60c8-686a-461f-816b-f1d0522f3122
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14904'
+      - '14913'
       X-Ms-Correlation-Request-Id:
-      - b0003f9a-98c4-4180-bd52-b54495b38151
+      - a5c59d99-6bce-4422-a520-11d22007a68a
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200416Z:b0003f9a-98c4-4180-bd52-b54495b38151
+      - WESTUS:20170922T214126Z:a5c59d99-6bce-4422-a520-11d22007a68a
       Date:
-      - Tue, 05 Sep 2017 20:04:15 GMT
+      - Fri, 22 Sep 2017 21:41:26 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-05T20:04:14.659688+00:00\",\r\n  \"endTime\":
-        \"2017-09-05T20:04:14.9409622+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=100d0c89-f3b4-4f29-aa8d-bdeba612bfa4&sig=rQ1Y6CIkjAqgQWsuqAvv7aBYpx2LMjt5K17uW4Uef0c%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"d02cc22b-fa5a-4ba8-a907-4821d8a6b9be\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2017-09-22T21:41:26.689495+00:00\",\r\n  \"endTime\":
+        \"2017-09-22T21:41:27.1114835+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=d04f32e5-e61e-4758-b502-0163cabdd37c&sig=V9w2I2ViYlviR9GysjIBNBMGsDcUsfwk%2FxM2scXBJ9I%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"8973aa0b-9987-47bd-aafe-5840eeed564c\"\r\n}"
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:14 GMT
+  recorded_at: Fri, 22 Sep 2017 21:41:26 GMT
 - request:
     method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=100d0c89-f3b4-4f29-aa8d-bdeba612bfa4&sig=rQ1Y6CIkjAqgQWsuqAvv7aBYpx2LMjt5K17uW4Uef0c=&sr=b&sv=2016-05-31
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/8973aa0b-9987-47bd-aafe-5840eeed564c?api-version=2017-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYxODEsIm5iZiI6MTUwNjExNjE4MSwiZXhwIjoxNTA2MTIwMDgxLCJhaW8iOiJZMlZnWU5pV0pXUHdMc2ZWM2ZoSVFWajJIT3N5QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZGpwTUtXeERrazJRQ3lIUUZsb05BQSIsInZlciI6IjEuMCJ9.GW2nffAcmgbaeE599i02qETJnYxCuvceko-eBNV-OBRreyQFQW5sN7oI6JvkbyNZj8IEvjsqhCdlnWX6P4dptVZD_sQxClGAW6mvLq83u4hdtzXVqEhD5rPU1ssRvkt8vxnSJ2LrgwcLud1UTmqwfVIeghqjVQN5qkewahU_YwYkb31LoDkLVbgpPPLxMTTMgjsXFWsE1qB5zTZj74U5Oo4TH312XuTH_KuYCQj3tbwZj4_HUNxxmGW-iT84wWxwTfEQuA1LW_eK9bYGXj_WLClwn-rFFWoYY_YogKayMoolQekRujbk41PCf_4UB2LbQ8QP6zOjsAOZbFMUZhODjw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
+      X-Ms-Request-Id:
+      - 0d0d2bcf-374b-4386-be9e-5f023e81a782
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14941'
+      X-Ms-Correlation-Request-Id:
+      - 4435b746-daab-4812-99b4-5989bb9547c2
+      X-Ms-Routing-Request-Id:
+      - WESTUS:20170922T214127Z:4435b746-daab-4812-99b4-5989bb9547c2
+      Date:
+      - Fri, 22 Sep 2017 21:41:27 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"startTime\": \"2017-09-22T21:41:26.689495+00:00\",\r\n  \"endTime\":
+        \"2017-09-22T21:41:27.1114835+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=d04f32e5-e61e-4758-b502-0163cabdd37c&sig=V9w2I2ViYlviR9GysjIBNBMGsDcUsfwk%2FxM2scXBJ9I%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"8973aa0b-9987-47bd-aafe-5840eeed564c\"\r\n}"
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 21:41:27 GMT
+- request:
+    method: get
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=d04f32e5-e61e-4758-b502-0163cabdd37c&sig=V9w2I2ViYlviR9GysjIBNBMGsDcUsfwk/xM2scXBJ9I=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2046,8 +2176,6 @@ http_interactions:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
       X-Ms-Range:
       - bytes=0-0
-      Host:
-      - md-t4jdgqqlgszp.blob.core.windows.net
   response:
     status:
       code: 206
@@ -2068,7 +2196,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - c2e22b72-001e-0086-4082-26f5ff000000
+      - cc8bcfc6-001e-003c-22eb-3315f6000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2094,13 +2222,13 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Tue, 05 Sep 2017 20:04:15 GMT
+      - Fri, 22 Sep 2017 21:41:28 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         6w==
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:14 GMT
+  recorded_at: Fri, 22 Sep 2017 21:41:28 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/EndGetAccess?api-version=2017-03-30
@@ -2117,11 +2245,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NTMsIm5iZiI6MTUwNDY0MTU1MywiZXhwIjoxNTA0NjQ1NDUzLCJhaW8iOiJZMkZnWUVnT2trMmF1SUE5Y3Bib0JsM2xmVWZQQWdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidTZPUHBiV0tMRVNWREphMlU3d2ZBQSIsInZlciI6IjEuMCJ9.UxKj8yiT68LmcW7If-nM0VPmQJqann58FCDNDhqCfON5KclE3cY9Y0vz4JZJWu2WEiI_kZgjlsB0dn9TTGw4_jkaiFHQEyuya769pA7rBenvMwTWzXjnzgd3DGnttqnL7AQVu2dBTWUYU0Jwh1FwexKPOLc2IeM0x3zRmunIIfj0U-RnG7whwirVZwucVKUNUfGasHyFHxZIM1RpmEmu9-6690WjnZ8UwkBZ_xZ3FnRfN2FWKKKiTjudICtz0ZxVa22BewjC0PDmWyhRlmDXbvqWVcx2O-9a0K7CAjtxrZ-WDDLw8bFK4J8gx2u4o3-DzprJLMf0egYJcfaDDQwbGw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYxODEsIm5iZiI6MTUwNjExNjE4MSwiZXhwIjoxNTA2MTIwMDgxLCJhaW8iOiJZMlZnWU5pV0pXUHdMc2ZWM2ZoSVFWajJIT3N5QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZGpwTUtXeERrazJRQ3lIUUZsb05BQSIsInZlciI6IjEuMCJ9.GW2nffAcmgbaeE599i02qETJnYxCuvceko-eBNV-OBRreyQFQW5sN7oI6JvkbyNZj8IEvjsqhCdlnWX6P4dptVZD_sQxClGAW6mvLq83u4hdtzXVqEhD5rPU1ssRvkt8vxnSJ2LrgwcLud1UTmqwfVIeghqjVQN5qkewahU_YwYkb31LoDkLVbgpPPLxMTTMgjsXFWsE1qB5zTZj74U5Oo4TH312XuTH_KuYCQj3tbwZj4_HUNxxmGW-iT84wWxwTfEQuA1LW_eK9bYGXj_WLClwn-rFFWoYY_YogKayMoolQekRujbk41PCf_4UB2LbQ8QP6zOjsAOZbFMUZhODjw
       Content-Length:
       - '0'
-      Host:
-      - management.azure.com
   response:
     status:
       code: 202
@@ -2136,31 +2262,31 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/efd14b0b-5c5a-4f05-aa8c-ef026382b34e?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/f35d908d-5a14-4258-8e46-5d7c03dd8d8f?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/efd14b0b-5c5a-4f05-aa8c-ef026382b34e?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/f35d908d-5a14-4258-8e46-5d7c03dd8d8f?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - efd14b0b-5c5a-4f05-aa8c-ef026382b34e
+      - f35d908d-5a14-4258-8e46-5d7c03dd8d8f
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1189'
+      - '1186'
       X-Ms-Correlation-Request-Id:
-      - 208f670c-c614-4db4-b78b-a37db0d54b11
+      - 5ccfb444-b67a-47a4-be58-d20d9f816ed1
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200416Z:208f670c-c614-4db4-b78b-a37db0d54b11
+      - WESTUS:20170922T214129Z:5ccfb444-b67a-47a4-be58-d20d9f816ed1
       Date:
-      - Tue, 05 Sep 2017 20:04:16 GMT
+      - Fri, 22 Sep 2017 21:41:29 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:15 GMT
+  recorded_at: Fri, 22 Sep 2017 21:41:29 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
@@ -2177,11 +2303,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NTMsIm5iZiI6MTUwNDY0MTU1MywiZXhwIjoxNTA0NjQ1NDUzLCJhaW8iOiJZMkZnWUVnT2trMmF1SUE5Y3Bib0JsM2xmVWZQQWdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidTZPUHBiV0tMRVNWREphMlU3d2ZBQSIsInZlciI6IjEuMCJ9.UxKj8yiT68LmcW7If-nM0VPmQJqann58FCDNDhqCfON5KclE3cY9Y0vz4JZJWu2WEiI_kZgjlsB0dn9TTGw4_jkaiFHQEyuya769pA7rBenvMwTWzXjnzgd3DGnttqnL7AQVu2dBTWUYU0Jwh1FwexKPOLc2IeM0x3zRmunIIfj0U-RnG7whwirVZwucVKUNUfGasHyFHxZIM1RpmEmu9-6690WjnZ8UwkBZ_xZ3FnRfN2FWKKKiTjudICtz0ZxVa22BewjC0PDmWyhRlmDXbvqWVcx2O-9a0K7CAjtxrZ-WDDLw8bFK4J8gx2u4o3-DzprJLMf0egYJcfaDDQwbGw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYxODEsIm5iZiI6MTUwNjExNjE4MSwiZXhwIjoxNTA2MTIwMDgxLCJhaW8iOiJZMlZnWU5pV0pXUHdMc2ZWM2ZoSVFWajJIT3N5QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZGpwTUtXeERrazJRQ3lIUUZsb05BQSIsInZlciI6IjEuMCJ9.GW2nffAcmgbaeE599i02qETJnYxCuvceko-eBNV-OBRreyQFQW5sN7oI6JvkbyNZj8IEvjsqhCdlnWX6P4dptVZD_sQxClGAW6mvLq83u4hdtzXVqEhD5rPU1ssRvkt8vxnSJ2LrgwcLud1UTmqwfVIeghqjVQN5qkewahU_YwYkb31LoDkLVbgpPPLxMTTMgjsXFWsE1qB5zTZj74U5Oo4TH312XuTH_KuYCQj3tbwZj4_HUNxxmGW-iT84wWxwTfEQuA1LW_eK9bYGXj_WLClwn-rFFWoYY_YogKayMoolQekRujbk41PCf_4UB2LbQ8QP6zOjsAOZbFMUZhODjw
       Content-Length:
       - '42'
-      Host:
-      - management.azure.com
   response:
     status:
       code: 202
@@ -2196,34 +2320,34 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/2c1eab70-2958-44fb-8d41-d1f70d48b6be?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/e93e19f4-b505-4ba6-8aad-068b3e91fd31?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/2c1eab70-2958-44fb-8d41-d1f70d48b6be?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/e93e19f4-b505-4ba6-8aad-068b3e91fd31?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - 2c1eab70-2958-44fb-8d41-d1f70d48b6be
+      - e93e19f4-b505-4ba6-8aad-068b3e91fd31
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1187'
+      - '1179'
       X-Ms-Correlation-Request-Id:
-      - 2cfaaef1-d5e0-4804-93b2-996f5537bb2e
+      - 844297a0-19f4-4b06-a67c-f3ef34ccb942
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200417Z:2cfaaef1-d5e0-4804-93b2-996f5537bb2e
+      - WESTUS:20170922T214130Z:844297a0-19f4-4b06-a67c-f3ef34ccb942
       Date:
-      - Tue, 05 Sep 2017 20:04:16 GMT
+      - Fri, 22 Sep 2017 21:41:29 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:15 GMT
+  recorded_at: Fri, 22 Sep 2017 21:41:30 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/2c1eab70-2958-44fb-8d41-d1f70d48b6be?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/e93e19f4-b505-4ba6-8aad-068b3e91fd31?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -2237,9 +2361,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NTMsIm5iZiI6MTUwNDY0MTU1MywiZXhwIjoxNTA0NjQ1NDUzLCJhaW8iOiJZMkZnWUVnT2trMmF1SUE5Y3Bib0JsM2xmVWZQQWdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidTZPUHBiV0tMRVNWREphMlU3d2ZBQSIsInZlciI6IjEuMCJ9.UxKj8yiT68LmcW7If-nM0VPmQJqann58FCDNDhqCfON5KclE3cY9Y0vz4JZJWu2WEiI_kZgjlsB0dn9TTGw4_jkaiFHQEyuya769pA7rBenvMwTWzXjnzgd3DGnttqnL7AQVu2dBTWUYU0Jwh1FwexKPOLc2IeM0x3zRmunIIfj0U-RnG7whwirVZwucVKUNUfGasHyFHxZIM1RpmEmu9-6690WjnZ8UwkBZ_xZ3FnRfN2FWKKKiTjudICtz0ZxVa22BewjC0PDmWyhRlmDXbvqWVcx2O-9a0K7CAjtxrZ-WDDLw8bFK4J8gx2u4o3-DzprJLMf0egYJcfaDDQwbGw
-      Host:
-      - management.azure.com
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYxODEsIm5iZiI6MTUwNjExNjE4MSwiZXhwIjoxNTA2MTIwMDgxLCJhaW8iOiJZMlZnWU5pV0pXUHdMc2ZWM2ZoSVFWajJIT3N5QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZGpwTUtXeERrazJRQ3lIUUZsb05BQSIsInZlciI6IjEuMCJ9.GW2nffAcmgbaeE599i02qETJnYxCuvceko-eBNV-OBRreyQFQW5sN7oI6JvkbyNZj8IEvjsqhCdlnWX6P4dptVZD_sQxClGAW6mvLq83u4hdtzXVqEhD5rPU1ssRvkt8vxnSJ2LrgwcLud1UTmqwfVIeghqjVQN5qkewahU_YwYkb31LoDkLVbgpPPLxMTTMgjsXFWsE1qB5zTZj74U5Oo4TH312XuTH_KuYCQj3tbwZj4_HUNxxmGW-iT84wWxwTfEQuA1LW_eK9bYGXj_WLClwn-rFFWoYY_YogKayMoolQekRujbk41PCf_4UB2LbQ8QP6zOjsAOZbFMUZhODjw
   response:
     status:
       code: 200
@@ -2260,31 +2382,90 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - f7bdc309-3dc0-473c-b50b-ed40ccb4ad1c
+      - 9ce819f5-6777-4b0d-b45c-fd4cc2ddf58b
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14946'
+      - '14912'
       X-Ms-Correlation-Request-Id:
-      - 1d030a15-118c-4cf8-805b-0653ac7781ab
+      - 9ea32759-170e-4bfa-b3c1-a3d97078e121
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200417Z:1d030a15-118c-4cf8-805b-0653ac7781ab
+      - WESTUS:20170922T214130Z:9ea32759-170e-4bfa-b3c1-a3d97078e121
       Date:
-      - Tue, 05 Sep 2017 20:04:17 GMT
+      - Fri, 22 Sep 2017 21:41:30 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-05T20:04:16.0511114+00:00\",\r\n  \"endTime\":
-        \"2017-09-05T20:04:16.2385927+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=c0791773-b30c-488d-ab10-ff4f9f946d53&sig=BZzM4tX03u9jxMCxiSRNmAHzKvRq3NVwyryEYdEDm2o%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"2c1eab70-2958-44fb-8d41-d1f70d48b6be\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2017-09-22T21:41:31.4629045+00:00\",\r\n  \"endTime\":
+        \"2017-09-22T21:41:31.6817336+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=460f78e9-249b-4746-89e9-8d4eebb08d7e&sig=XnRfEFEBHi3rVTSvztbPRQCqrIWKYINJy5qsNUWXR1o%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"e93e19f4-b505-4ba6-8aad-068b3e91fd31\"\r\n}"
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:15 GMT
+  recorded_at: Fri, 22 Sep 2017 21:41:30 GMT
 - request:
     method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=c0791773-b30c-488d-ab10-ff4f9f946d53&sig=BZzM4tX03u9jxMCxiSRNmAHzKvRq3NVwyryEYdEDm2o=&sr=b&sv=2016-05-31
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/e93e19f4-b505-4ba6-8aad-068b3e91fd31?api-version=2017-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYxODEsIm5iZiI6MTUwNjExNjE4MSwiZXhwIjoxNTA2MTIwMDgxLCJhaW8iOiJZMlZnWU5pV0pXUHdMc2ZWM2ZoSVFWajJIT3N5QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZGpwTUtXeERrazJRQ3lIUUZsb05BQSIsInZlciI6IjEuMCJ9.GW2nffAcmgbaeE599i02qETJnYxCuvceko-eBNV-OBRreyQFQW5sN7oI6JvkbyNZj8IEvjsqhCdlnWX6P4dptVZD_sQxClGAW6mvLq83u4hdtzXVqEhD5rPU1ssRvkt8vxnSJ2LrgwcLud1UTmqwfVIeghqjVQN5qkewahU_YwYkb31LoDkLVbgpPPLxMTTMgjsXFWsE1qB5zTZj74U5Oo4TH312XuTH_KuYCQj3tbwZj4_HUNxxmGW-iT84wWxwTfEQuA1LW_eK9bYGXj_WLClwn-rFFWoYY_YogKayMoolQekRujbk41PCf_4UB2LbQ8QP6zOjsAOZbFMUZhODjw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
+      X-Ms-Request-Id:
+      - 168a3d94-fef9-4c8b-a5b3-7c26dd7daf02
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14905'
+      X-Ms-Correlation-Request-Id:
+      - 87fe5af2-4856-4d16-8a4a-18b34663022d
+      X-Ms-Routing-Request-Id:
+      - WESTUS:20170922T214131Z:87fe5af2-4856-4d16-8a4a-18b34663022d
+      Date:
+      - Fri, 22 Sep 2017 21:41:30 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"startTime\": \"2017-09-22T21:41:31.4629045+00:00\",\r\n  \"endTime\":
+        \"2017-09-22T21:41:31.6817336+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=460f78e9-249b-4746-89e9-8d4eebb08d7e&sig=XnRfEFEBHi3rVTSvztbPRQCqrIWKYINJy5qsNUWXR1o%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"e93e19f4-b505-4ba6-8aad-068b3e91fd31\"\r\n}"
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 21:41:31 GMT
+- request:
+    method: get
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=460f78e9-249b-4746-89e9-8d4eebb08d7e&sig=XnRfEFEBHi3rVTSvztbPRQCqrIWKYINJy5qsNUWXR1o=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2297,8 +2478,6 @@ http_interactions:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
       X-Ms-Range:
       - bytes=440-443
-      Host:
-      - md-t4jdgqqlgszp.blob.core.windows.net
   response:
     status:
       code: 206
@@ -2319,7 +2498,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 1452985a-001e-00a9-3682-2674c5000000
+      - 60947d6b-001e-0037-01eb-330d82000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2345,13 +2524,13 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Tue, 05 Sep 2017 20:04:16 GMT
+      - Fri, 22 Sep 2017 21:41:30 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         U5MJAA==
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:16 GMT
+  recorded_at: Fri, 22 Sep 2017 21:41:31 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/EndGetAccess?api-version=2017-03-30
@@ -2368,11 +2547,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NTMsIm5iZiI6MTUwNDY0MTU1MywiZXhwIjoxNTA0NjQ1NDUzLCJhaW8iOiJZMkZnWUVnT2trMmF1SUE5Y3Bib0JsM2xmVWZQQWdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidTZPUHBiV0tMRVNWREphMlU3d2ZBQSIsInZlciI6IjEuMCJ9.UxKj8yiT68LmcW7If-nM0VPmQJqann58FCDNDhqCfON5KclE3cY9Y0vz4JZJWu2WEiI_kZgjlsB0dn9TTGw4_jkaiFHQEyuya769pA7rBenvMwTWzXjnzgd3DGnttqnL7AQVu2dBTWUYU0Jwh1FwexKPOLc2IeM0x3zRmunIIfj0U-RnG7whwirVZwucVKUNUfGasHyFHxZIM1RpmEmu9-6690WjnZ8UwkBZ_xZ3FnRfN2FWKKKiTjudICtz0ZxVa22BewjC0PDmWyhRlmDXbvqWVcx2O-9a0K7CAjtxrZ-WDDLw8bFK4J8gx2u4o3-DzprJLMf0egYJcfaDDQwbGw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYxODEsIm5iZiI6MTUwNjExNjE4MSwiZXhwIjoxNTA2MTIwMDgxLCJhaW8iOiJZMlZnWU5pV0pXUHdMc2ZWM2ZoSVFWajJIT3N5QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZGpwTUtXeERrazJRQ3lIUUZsb05BQSIsInZlciI6IjEuMCJ9.GW2nffAcmgbaeE599i02qETJnYxCuvceko-eBNV-OBRreyQFQW5sN7oI6JvkbyNZj8IEvjsqhCdlnWX6P4dptVZD_sQxClGAW6mvLq83u4hdtzXVqEhD5rPU1ssRvkt8vxnSJ2LrgwcLud1UTmqwfVIeghqjVQN5qkewahU_YwYkb31LoDkLVbgpPPLxMTTMgjsXFWsE1qB5zTZj74U5Oo4TH312XuTH_KuYCQj3tbwZj4_HUNxxmGW-iT84wWxwTfEQuA1LW_eK9bYGXj_WLClwn-rFFWoYY_YogKayMoolQekRujbk41PCf_4UB2LbQ8QP6zOjsAOZbFMUZhODjw
       Content-Length:
       - '0'
-      Host:
-      - management.azure.com
   response:
     status:
       code: 202
@@ -2387,29 +2564,29 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/e4cb93dd-93af-4250-a15a-081a68f3c3e8?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/6cf194be-322d-41ff-b82d-695ac3ee960a?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/e4cb93dd-93af-4250-a15a-081a68f3c3e8?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/6cf194be-322d-41ff-b82d-695ac3ee960a?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - e4cb93dd-93af-4250-a15a-081a68f3c3e8
+      - 6cf194be-322d-41ff-b82d-695ac3ee960a
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1189'
+      - '1183'
       X-Ms-Correlation-Request-Id:
-      - 61d8f58a-e0c9-4220-81fa-ad2ba664f281
+      - bc7120f7-0ef3-4c4c-8bb8-92c407d797a7
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200418Z:61d8f58a-e0c9-4220-81fa-ad2ba664f281
+      - WESTUS:20170922T214132Z:bc7120f7-0ef3-4c4c-8bb8-92c407d797a7
       Date:
-      - Tue, 05 Sep 2017 20:04:17 GMT
+      - Fri, 22 Sep 2017 21:41:32 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:16 GMT
+  recorded_at: Fri, 22 Sep 2017 21:41:32 GMT
 recorded_with: VCR 3.0.3

--- a/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_endByteAddr-2.yml
+++ b/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_endByteAddr-2.yml
@@ -17,8 +17,6 @@ http_interactions:
       - '186'
       Content-Type:
       - application/x-www-form-urlencoded
-      Host:
-      - login.microsoftonline.com
   response:
     status:
       code: 200
@@ -39,25 +37,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 4f88c7c9-192c-41d1-ae8f-beb2fbf41e00
+      - 1628947a-a24c-4130-b465-548a2d7f0d00
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAAA9kTklhVy7SJTGAzR-p1BcojX5BsrjS9kjxb53OagrsU6--7xMv6-JUE8sMWKq_jI8aswpDPkBjwO1d9eqVS_AndAPFmlqx4oNQ07NMG0J-gMoRf6P8Xg1-KkqUGGdqLPhvTNKgGON_MpnJbfTzu4VjlCEjFR3JKmBTacQTTCy0wD_tkbc33HmyxsBA_L6b1kgAA;
+      - esctx=AQABAAAAAAABlDrqfEFlSaui6xnRjX5EYCsFm1lsqzaGzZXbhdkCVQPU3XvvBnV5btJXBJMNZOpzRqkhcT8_jL5cmzzR4qDSsDTu1nr2x9ZJYKOJmeZ7wbpjjcwKNM6lILopBOLitBCc6k53BNCqKqaOs-0tIMPu6TG9If_4KZRGYKYNAj9-ZDuW_PVAcaEqaPnXLMV5bfAgAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=003; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=005; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Tue, 05 Sep 2017 20:04:18 GMT
+      - Fri, 22 Sep 2017 21:41:33 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1504645458","not_before":"1504641558","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NTgsIm5iZiI6MTUwNDY0MTU1OCwiZXhwIjoxNTA0NjQ1NDU4LCJhaW8iOiJZMkZnWUhBdHNEcjNuV3R0TWYvWmZTOFdyL1IvREFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieWNlSVR5d1owVUd1ajc2eS1fUWVBQSIsInZlciI6IjEuMCJ9.qt7vK1IpK1-q7MwSjJ4AtfVI3i6aumXVtWw97YtNxOnULDZfBylnkHbuMtsrhEwsDLeycQUCUpqTdAur-LbV1dygTScEvNEqAG0F_M2DvZqFyYSibJVwC35rZfGVbW76E8MHKlazA4CZXrQQcOiSnz4Bw_lsLi4Z7S_g_JxdtF23w3q4IXyrA-wqWEl3VsMXTaS_BINafMN42l0_17koCdYV4y_1HLBoVipHMdf9gr180fr1hnzahqGLyt6Nyt9qr5EMZ-nSqeaC6WEsEWz8Wm_Jcy2m5Y5KDCDVeAK-_MS-EyLjIQ9hpjm1S6n6x3nKTYKu_7tSdHdc3457WBX0oQ"}'
+      string: '{"token_type":"Bearer","expires_in":"3600","ext_expires_in":"0","expires_on":"1506120093","not_before":"1506116193","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYxOTMsIm5iZiI6MTUwNjExNjE5MywiZXhwIjoxNTA2MTIwMDkzLCJhaW8iOiJZMlZnWU1oNXVyeWg5YVIrN0RhZVhhdlB2UlozQlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZXBRb0ZreWlNRUcwWlZTS0xYOE5BQSIsInZlciI6IjEuMCJ9.bSUowVQrbB6dhplwG1xITFYrbHN6C5axjxx-z6X6Eus2sxnPfNsQ46XCPdRAbsvdsO1fj-0Z0ZFxESrapH19O0IVF5aY270l5oNKqV_gDsaWMSJ6sz0SxPPhxQYBoQ0PF5PSlGKwTfkyMWIYrJ2PN6ZQIw3aq8MXKGcSqRZNDjq7wCtZG0Z8EHULyK3k5KQZevf_DbhvKzqHsFFbW_cK_c7DgYyOZDq82-Ljhy-Cva8sB2iXrVxYgft9k_WJ0X2siT21MBfE8_kvVrwbjTJ6IFPYCU1faOyqkSTRo3vB686d46mOmPKMhM-NEshNUummfI-DEZ3N27ZXlLU_lv4zFQ"}'
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:16 GMT
+  recorded_at: Fri, 22 Sep 2017 21:41:33 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -74,9 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NTgsIm5iZiI6MTUwNDY0MTU1OCwiZXhwIjoxNTA0NjQ1NDU4LCJhaW8iOiJZMkZnWUhBdHNEcjNuV3R0TWYvWmZTOFdyL1IvREFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieWNlSVR5d1owVUd1ajc2eS1fUWVBQSIsInZlciI6IjEuMCJ9.qt7vK1IpK1-q7MwSjJ4AtfVI3i6aumXVtWw97YtNxOnULDZfBylnkHbuMtsrhEwsDLeycQUCUpqTdAur-LbV1dygTScEvNEqAG0F_M2DvZqFyYSibJVwC35rZfGVbW76E8MHKlazA4CZXrQQcOiSnz4Bw_lsLi4Z7S_g_JxdtF23w3q4IXyrA-wqWEl3VsMXTaS_BINafMN42l0_17koCdYV4y_1HLBoVipHMdf9gr180fr1hnzahqGLyt6Nyt9qr5EMZ-nSqeaC6WEsEWz8Wm_Jcy2m5Y5KDCDVeAK-_MS-EyLjIQ9hpjm1S6n6x3nKTYKu_7tSdHdc3457WBX0oQ
-      Host:
-      - management.azure.com
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYxOTMsIm5iZiI6MTUwNjExNjE5MywiZXhwIjoxNTA2MTIwMDkzLCJhaW8iOiJZMlZnWU1oNXVyeWg5YVIrN0RhZVhhdlB2UlozQlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZXBRb0ZreWlNRUcwWlZTS0xYOE5BQSIsInZlciI6IjEuMCJ9.bSUowVQrbB6dhplwG1xITFYrbHN6C5axjxx-z6X6Eus2sxnPfNsQ46XCPdRAbsvdsO1fj-0Z0ZFxESrapH19O0IVF5aY270l5oNKqV_gDsaWMSJ6sz0SxPPhxQYBoQ0PF5PSlGKwTfkyMWIYrJ2PN6ZQIw3aq8MXKGcSqRZNDjq7wCtZG0Z8EHULyK3k5KQZevf_DbhvKzqHsFFbW_cK_c7DgYyOZDq82-Ljhy-Cva8sB2iXrVxYgft9k_WJ0X2siT21MBfE8_kvVrwbjTJ6IFPYCU1faOyqkSTRo3vB686d46mOmPKMhM-NEshNUummfI-DEZ3N27ZXlLU_lv4zFQ
   response:
     status:
       code: 200
@@ -95,23 +91,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14997'
+      - '14999'
       X-Ms-Request-Id:
-      - 17123f04-1d00-4da8-888a-cedbb160d6ed
+      - ae31f283-1fc3-412f-a677-294ea9112029
       X-Ms-Correlation-Request-Id:
-      - 17123f04-1d00-4da8-888a-cedbb160d6ed
+      - ae31f283-1fc3-412f-a677-294ea9112029
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200418Z:17123f04-1d00-4da8-888a-cedbb160d6ed
+      - WESTUS:20170922T214133Z:ae31f283-1fc3-412f-a677-294ea9112029
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 05 Sep 2017 20:04:18 GMT
+      - Fri, 22 Sep 2017 21:41:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:17 GMT
+  recorded_at: Fri, 22 Sep 2017 21:41:33 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/azure_subscription_id/providers?api-version=2015-01-01
@@ -128,9 +124,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NTgsIm5iZiI6MTUwNDY0MTU1OCwiZXhwIjoxNTA0NjQ1NDU4LCJhaW8iOiJZMkZnWUhBdHNEcjNuV3R0TWYvWmZTOFdyL1IvREFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieWNlSVR5d1owVUd1ajc2eS1fUWVBQSIsInZlciI6IjEuMCJ9.qt7vK1IpK1-q7MwSjJ4AtfVI3i6aumXVtWw97YtNxOnULDZfBylnkHbuMtsrhEwsDLeycQUCUpqTdAur-LbV1dygTScEvNEqAG0F_M2DvZqFyYSibJVwC35rZfGVbW76E8MHKlazA4CZXrQQcOiSnz4Bw_lsLi4Z7S_g_JxdtF23w3q4IXyrA-wqWEl3VsMXTaS_BINafMN42l0_17koCdYV4y_1HLBoVipHMdf9gr180fr1hnzahqGLyt6Nyt9qr5EMZ-nSqeaC6WEsEWz8Wm_Jcy2m5Y5KDCDVeAK-_MS-EyLjIQ9hpjm1S6n6x3nKTYKu_7tSdHdc3457WBX0oQ
-      Host:
-      - management.azure.com
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYxOTMsIm5iZiI6MTUwNjExNjE5MywiZXhwIjoxNTA2MTIwMDkzLCJhaW8iOiJZMlZnWU1oNXVyeWg5YVIrN0RhZVhhdlB2UlozQlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZXBRb0ZreWlNRUcwWlZTS0xYOE5BQSIsInZlciI6IjEuMCJ9.bSUowVQrbB6dhplwG1xITFYrbHN6C5axjxx-z6X6Eus2sxnPfNsQ46XCPdRAbsvdsO1fj-0Z0ZFxESrapH19O0IVF5aY270l5oNKqV_gDsaWMSJ6sz0SxPPhxQYBoQ0PF5PSlGKwTfkyMWIYrJ2PN6ZQIw3aq8MXKGcSqRZNDjq7wCtZG0Z8EHULyK3k5KQZevf_DbhvKzqHsFFbW_cK_c7DgYyOZDq82-Ljhy-Cva8sB2iXrVxYgft9k_WJ0X2siT21MBfE8_kvVrwbjTJ6IFPYCU1faOyqkSTRo3vB686d46mOmPKMhM-NEshNUummfI-DEZ3N27ZXlLU_lv4zFQ
   response:
     status:
       code: 200
@@ -147,22 +141,42 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14941'
+      - '14923'
       X-Ms-Request-Id:
-      - 0cc8a401-e30c-4145-a2d4-c88987978ee4
+      - c8566295-7f12-4ad4-89c8-4a66ab43e863
       X-Ms-Correlation-Request-Id:
-      - 0cc8a401-e30c-4145-a2d4-c88987978ee4
+      - c8566295-7f12-4ad4-89c8-4a66ab43e863
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200419Z:0cc8a401-e30c-4145-a2d4-c88987978ee4
+      - WESTUS:20170922T214135Z:c8566295-7f12-4ad4-89c8-4a66ab43e863
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 05 Sep 2017 20:04:19 GMT
+      - Fri, 22 Sep 2017 21:41:34 GMT
       Content-Length:
-      - '243687'
+      - '254785'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
+      string: '{"value":[{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"operations","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","North Central
         US","South Central US","West Central US","West US","West US 2","Canada Central","Canada
         East","North Europe","West Europe","UK South","UK West","East Asia","Southeast
@@ -437,7 +451,7 @@ http_interactions:
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
         Central US","West US 2","South India","Central India","West India","Canada
-        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
+        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
         East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
@@ -466,7 +480,7 @@ http_interactions:
         Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"}],"resourceTypes":[{"resourceType":"components","locations":["East
         US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
         US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01","2014-04-01"]},{"resourceType":"queries","locations":["East
-        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"alertrules","locations":["West
+        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
@@ -542,7 +556,7 @@ http_interactions:
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorization":{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorizations":[{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},{"applicationId":"7c33bfcb-8d33-48d6-8e60-dc6404003489","roleDefinitionId":"ad6261e4-fa9a-4642-aa5f-104f1b67e9e3"},{"applicationId":"1e3e4475-288f-4018-a376-df66fd7fac5f","roleDefinitionId":"1d538b69-3d87-4e56-8ff8-25786fd48261"},{"applicationId":"a0be0c72-870e-46f0-9c49-c98333a996f7","roleDefinitionId":"7ce22727-ffce-45a9-930c-ddb2e56fa131"}],"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -552,7 +566,7 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -567,7 +581,8 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
+        Central US"],"apiVersions":["2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -577,7 +592,12 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -597,7 +617,7 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -612,7 +632,7 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -622,7 +642,31 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
         East","UK South","Central India","Canada Central"],"apiVersions":["2017-04-26-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"]},{"resourceType":"workspaces/dataSources","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
@@ -641,17 +685,17 @@ http_interactions:
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"consoles","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/consoles","locations":["West
+        East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"consoles","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/consoles","locations":["West
         US","East US","Central India","North Europe","West Europe","South Central
-        US","Southeast Asia"],"apiVersions":["2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
+        US","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
         US","East US","Central India","North Europe","West Europe","South Central
-        US","Southeast Asia"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
+        US","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","Canada Central","Canada East","West Central US","West US 2","UK South","UK
         West","Korea Central","Korea South"],"apiVersions":["2017-07-01","2016-12-01","2016-08-10","2016-06-01","2016-05-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"operations","locations":["Southeast
-        Asia"],"apiVersions":["2016-08-10","2016-06-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01"]},{"resourceType":"locations/backupStatus","locations":["West
+        Asia"],"apiVersions":["2016-08-10","2016-06-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01","2016-06-01"]},{"resourceType":"locations/backupStatus","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
@@ -687,6 +731,7 @@ http_interactions:
         Central US","Central US","North Europe","West Europe","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada Central","Canada East"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"pricings","locations":["Central
+        US","East US"],"apiVersions":["2017-08-01-preview"]},{"resourceType":"securityContacts","locations":["Central
         US","East US"],"apiVersions":["2017-08-01-preview"]},{"resourceType":"workspaceSettings","locations":["Central
         US","East US"],"apiVersions":["2017-08-01-preview"]},{"resourceType":"complianceResults","locations":["Central
         US","East US"],"apiVersions":["2017-08-01"]},{"resourceType":"policies","locations":["Central
@@ -703,6 +748,8 @@ http_interactions:
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatusesSummaries","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/alerts","locations":["Central
         US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/tasks","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"externalSecuritySolutions","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/externalSecuritySolutions","locations":["Central
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.SiteRecovery","namespace":"Microsoft.SiteRecovery","authorization":{"applicationId":"b8340c3b-9267-498f-b21a-15d5547fd85e","roleDefinitionId":"8A00C8EA-8F1B-45A7-8F64-F4CC61EEE9B6"},"resourceTypes":[{"resourceType":"SiteRecoveryVault","locations":["East
         US","West US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","Australia East","Australia Southeast","Brazil South","North
@@ -722,7 +769,7 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -842,7 +889,22 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/databases/transparentDataEncryption","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -1077,6 +1139,26 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
         US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
@@ -1307,6 +1389,11 @@ http_interactions:
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"customApis","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
         East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/managedApis","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
@@ -1358,23 +1445,8 @@ http_interactions:
         US","North Europe","Japan West","Japan East","East Asia","West Europe","East
         US","Southeast Asia","Central US"],"apiVersions":["2016-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Lombiq.DotNest","namespace":"Lombiq.DotNest","resourceTypes":[{"resourceType":"sites","locations":["East
         US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Mailjet.Email","namespace":"Mailjet.Email","resourceTypes":[{"resourceType":"services","locations":["West
-        US"],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
-        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]},{"resourceType":"diagnosticSettings","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"addsservices","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"configuration","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"operations","locations":["West
@@ -1498,8 +1570,10 @@ http_interactions:
         Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
         Central US","Central US","North Europe","West Europe","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","West
-        India","South India"],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CognitiveServices","namespace":"Microsoft.CognitiveServices","authorizations":[{"applicationId":"7d312290-28c8-473c-a0ed-8e53749b6d6d","roleDefinitionId":"5cb87f79-a7c3-4a95-9414-45b65974b51b"}],"resourceTypes":[{"resourceType":"accounts","locations":["Global","West
-        US","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"operations","locations":["Global","Australia
+        India","South India"],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CognitiveServices","namespace":"Microsoft.CognitiveServices","authorizations":[{"applicationId":"7d312290-28c8-473c-a0ed-8e53749b6d6d","roleDefinitionId":"5cb87f79-a7c3-4a95-9414-45b65974b51b"}],"resourceTypes":[{"resourceType":"accounts","locations":["Global","Australia
+        East","Brazil South","West US","West US 2","West Europe","North Europe","Southeast
+        Asia","East Asia","West Central US","South Central US","East US","East US
+        2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"operations","locations":["Global","Australia
         East","Brazil South","West US","West US 2","West Europe","North Europe","Southeast
         Asia","East Asia","West Central US","South Central US","East US","East US
         2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations","locations":["Global","Australia
@@ -1534,13 +1608,13 @@ http_interactions:
         US","West US","Australia East","West Europe","North Europe","Southeast Asia","West
         Central US"],"apiVersions":["2016-03-30","2015-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataFactory","namespace":"Microsoft.DataFactory","resourceTypes":[{"resourceType":"dataFactories","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview","2014-04-01"]},{"resourceType":"factories","locations":["East
-        US"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
-        US"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
+        US","East US 2"],"apiVersions":["2017-09-01-preview","2017-03-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
+        US","East US 2"],"apiVersions":["2017-09-01-preview","2017-03-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
         Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"dataFactories/metricDefinitions","locations":["North
         Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"checkDataFactoryNameAvailability","locations":[],"apiVersions":["2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"checkAzureDataFactoryNameAvailability","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"dataFactorySchema","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"operations","locations":["West
-        US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeAnalytics","namespace":"Microsoft.DataLakeAnalytics","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US","North Europe","East US","West Central US"],"apiVersions":["2017-09-01-preview","2017-03-01-preview","2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeAnalytics","namespace":"Microsoft.DataLakeAnalytics","resourceTypes":[{"resourceType":"accounts","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/dataLakeStoreAccounts","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers","locations":["East
@@ -1589,11 +1663,12 @@ http_interactions:
         India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
         India","East Asia","East US 2","East US","Japan East","Japan West","North
         Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"checkProvisioningServiceNameAvailability","locations":[],"apiVersions":["2017-08-21-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
         US","North Europe","East Asia","East US","West Europe","Southeast Asia","Japan
         East","Japan West","Australia East","Australia Southeast","West US 2","West
         Central US","East US 2","Central US","UK South","UK West","South India","Central
-        India"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
+        India","Canada Central","Canada East"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"ProvisioningServices","locations":["East
+        US","West Europe","Southeast Asia"],"apiVersions":["2017-08-21-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
         East","Australia Southeast","Canada Central","Canada East","Central India","Central
         US","East Asia","East US","East US 2","Japan East","Japan West","North Central
         US","North Europe","South Central US","South India","Southeast Asia","West
@@ -1620,16 +1695,16 @@ http_interactions:
         US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"operations","locations":["Brazil
         South","East Asia","East US","Japan East","Japan West","North Central US","North
         Europe","South Central US","West Europe","West US","Southeast Asia","Central
-        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"topics","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operations","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topics","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operations","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","West
         US 2","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
@@ -1727,48 +1802,39 @@ http_interactions:
         Central US","West Europe","Southeast Asia","Japan East","East US 2","West
         Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"commitmentPlans","locations":["South
         Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
-        Central US","West US"],"apiVersions":["2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Media","namespace":"Microsoft.Media","authorization":{"applicationId":"374b2a64-3b6b-436b-934c-b820eacca870","roleDefinitionId":"aab70789-0cec-44b5-95d7-84b64c9487af"},"resourceTypes":[{"resourceType":"mediaservices","locations":["Japan
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningExperimentation","namespace":"Microsoft.MachineLearningExperimentation","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"accounts","locations":["Australia
+        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces","locations":["Australia
+        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces/projects","locations":["Australia
+        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningCompute","namespace":"Microsoft.MachineLearningCompute","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"376aa7d7-51a9-463d-bd4d-7e1691345612","managedByRoleDefinitionId":"91d00862-cf55-46a5-9dce-260bbd92ce25"},"resourceTypes":[{"resourceType":"operationalizationClusters","locations":["East
+        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"operations","locations":["East
+        US 2"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations","locations":["East
+        US 2"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["East
+        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningModelManagement","namespace":"Microsoft.MachineLearningModelManagement","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US 2","West Central US","Australia East"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"operations","locations":["West
+        Central US"],"apiVersions":["2017-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
+        Central US","West US"],"apiVersions":["2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01"]},{"resourceType":"offertypes","locations":["South
+        Central US","West US"],"apiVersions":["2015-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Media","namespace":"Microsoft.Media","authorization":{"applicationId":"374b2a64-3b6b-436b-934c-b820eacca870","roleDefinitionId":"aab70789-0cec-44b5-95d7-84b64c9487af"},"resourceTypes":[{"resourceType":"mediaservices","locations":["Japan
         West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
         US","West US","Australia East","Australia Southeast","Central US","Brazil
         South","Central India","West India","South India","South Central US","Canada
-        Central","Canada East","West Central US"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
+        Central","Canada East","West Central US"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
         Central US","North Central US","East US 2","West US","West Europe","North
         Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
         East","UK South","West India"],"apiVersions":["2016-01-29"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-01-29"]},{"resourceType":"locations/checkNameAvailability","locations":["South
         Central US","North Central US","East US 2","West US","West Europe","North
         Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
-        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"operations","locations":["East
+        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"capacities","locations":["West
+        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
+        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationresults","locations":["West
+        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
+        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"operations","locations":["East
         US 2"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Relay","namespace":"Microsoft.Relay","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US 2","West
         US","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
         India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2017-08-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkPolicyCompliance","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
@@ -1827,8 +1893,11 @@ http_interactions:
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","resourceTypes":[{"resourceType":"operations","locations":["West
-        Central US"],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
+        Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applianceDefinitions","locations":["West
+        Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"locations","locations":["West
+        Central US"],"apiVersions":["2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
+        Central US"],"apiVersions":["2017-09-01","2016-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","West Central US","Japan East","Japan West","Australia East","Australia
         Southeast"],"apiVersions":["2017-06-01","2017-05-15","2017-01-01","2016-10-01","2016-06-01","2015-03-15","2014-09-01"]},{"resourceType":"operations","locations":["West
@@ -1888,11 +1957,17 @@ http_interactions:
         US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RedisLabs.Memcached","namespace":"RedisLabs.Memcached","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-07-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RedisLabs.Redis","namespace":"RedisLabs.Redis","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-07-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RevAPM.MobileCDN","namespace":"RevAPM.MobileCDN","resourceTypes":[{"resourceType":"accounts","locations":["Central
         US","East US","East US 2","North Central US","South Central US","West US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
-        East","Australia Southeast"],"apiVersions":["2016-08-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-24","2016-08-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sendgrid.Email","namespace":"Sendgrid.Email","resourceTypes":[{"resourceType":"accounts","locations":["East
-        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
-        Central US","Central US","North Europe","West Europe","Japan East","Japan
-        West","Brazil South","Australia East","Australia Southeast","Canada Central","Canada
-        East","West Central US","West US 2","UK South","UK West"],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Signiant.Flight","namespace":"Signiant.Flight","resourceTypes":[{"resourceType":"accounts","locations":["East
+        East","Australia Southeast"],"apiVersions":["2016-08-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-24","2016-08-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sendgrid.Email","namespace":"Sendgrid.Email","resourceTypes":[{"resourceType":"accounts","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Signiant.Flight","namespace":"Signiant.Flight","resourceTypes":[{"resourceType":"accounts","locations":["East
         US","Central US","North Central US","South Central US","West US","North Europe","West
         Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast"],"apiVersions":["2015-06-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sparkpost.Basic","namespace":"Sparkpost.Basic","resourceTypes":[{"resourceType":"services","locations":["West
@@ -1909,7 +1984,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:17 GMT
+  recorded_at: Fri, 22 Sep 2017 21:41:35 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
@@ -1926,11 +2001,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NTgsIm5iZiI6MTUwNDY0MTU1OCwiZXhwIjoxNTA0NjQ1NDU4LCJhaW8iOiJZMkZnWUhBdHNEcjNuV3R0TWYvWmZTOFdyL1IvREFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieWNlSVR5d1owVUd1ajc2eS1fUWVBQSIsInZlciI6IjEuMCJ9.qt7vK1IpK1-q7MwSjJ4AtfVI3i6aumXVtWw97YtNxOnULDZfBylnkHbuMtsrhEwsDLeycQUCUpqTdAur-LbV1dygTScEvNEqAG0F_M2DvZqFyYSibJVwC35rZfGVbW76E8MHKlazA4CZXrQQcOiSnz4Bw_lsLi4Z7S_g_JxdtF23w3q4IXyrA-wqWEl3VsMXTaS_BINafMN42l0_17koCdYV4y_1HLBoVipHMdf9gr180fr1hnzahqGLyt6Nyt9qr5EMZ-nSqeaC6WEsEWz8Wm_Jcy2m5Y5KDCDVeAK-_MS-EyLjIQ9hpjm1S6n6x3nKTYKu_7tSdHdc3457WBX0oQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYxOTMsIm5iZiI6MTUwNjExNjE5MywiZXhwIjoxNTA2MTIwMDkzLCJhaW8iOiJZMlZnWU1oNXVyeWg5YVIrN0RhZVhhdlB2UlozQlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZXBRb0ZreWlNRUcwWlZTS0xYOE5BQSIsInZlciI6IjEuMCJ9.bSUowVQrbB6dhplwG1xITFYrbHN6C5axjxx-z6X6Eus2sxnPfNsQ46XCPdRAbsvdsO1fj-0Z0ZFxESrapH19O0IVF5aY270l5oNKqV_gDsaWMSJ6sz0SxPPhxQYBoQ0PF5PSlGKwTfkyMWIYrJ2PN6ZQIw3aq8MXKGcSqRZNDjq7wCtZG0Z8EHULyK3k5KQZevf_DbhvKzqHsFFbW_cK_c7DgYyOZDq82-Ljhy-Cva8sB2iXrVxYgft9k_WJ0X2siT21MBfE8_kvVrwbjTJ6IFPYCU1faOyqkSTRo3vB686d46mOmPKMhM-NEshNUummfI-DEZ3N27ZXlLU_lv4zFQ
       Content-Length:
       - '42'
-      Host:
-      - management.azure.com
   response:
     status:
       code: 202
@@ -1945,34 +2018,34 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/ada171ce-798c-4bb9-8d90-254c29daaeae?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/07c18977-815a-4d40-ae4b-fcb36eca0515?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/ada171ce-798c-4bb9-8d90-254c29daaeae?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/07c18977-815a-4d40-ae4b-fcb36eca0515?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - ada171ce-798c-4bb9-8d90-254c29daaeae
+      - 07c18977-815a-4d40-ae4b-fcb36eca0515
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1188'
+      - '1183'
       X-Ms-Correlation-Request-Id:
-      - fd331838-cc24-43b1-af69-a789e5d41a8d
+      - 2ac1a9f5-8ab5-4463-865e-29a10c4ca5b6
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200420Z:fd331838-cc24-43b1-af69-a789e5d41a8d
+      - WESTUS:20170922T214136Z:2ac1a9f5-8ab5-4463-865e-29a10c4ca5b6
       Date:
-      - Tue, 05 Sep 2017 20:04:20 GMT
+      - Fri, 22 Sep 2017 21:41:36 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:18 GMT
+  recorded_at: Fri, 22 Sep 2017 21:41:36 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/ada171ce-798c-4bb9-8d90-254c29daaeae?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/07c18977-815a-4d40-ae4b-fcb36eca0515?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -1986,9 +2059,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NTgsIm5iZiI6MTUwNDY0MTU1OCwiZXhwIjoxNTA0NjQ1NDU4LCJhaW8iOiJZMkZnWUhBdHNEcjNuV3R0TWYvWmZTOFdyL1IvREFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieWNlSVR5d1owVUd1ajc2eS1fUWVBQSIsInZlciI6IjEuMCJ9.qt7vK1IpK1-q7MwSjJ4AtfVI3i6aumXVtWw97YtNxOnULDZfBylnkHbuMtsrhEwsDLeycQUCUpqTdAur-LbV1dygTScEvNEqAG0F_M2DvZqFyYSibJVwC35rZfGVbW76E8MHKlazA4CZXrQQcOiSnz4Bw_lsLi4Z7S_g_JxdtF23w3q4IXyrA-wqWEl3VsMXTaS_BINafMN42l0_17koCdYV4y_1HLBoVipHMdf9gr180fr1hnzahqGLyt6Nyt9qr5EMZ-nSqeaC6WEsEWz8Wm_Jcy2m5Y5KDCDVeAK-_MS-EyLjIQ9hpjm1S6n6x3nKTYKu_7tSdHdc3457WBX0oQ
-      Host:
-      - management.azure.com
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYxOTMsIm5iZiI6MTUwNjExNjE5MywiZXhwIjoxNTA2MTIwMDkzLCJhaW8iOiJZMlZnWU1oNXVyeWg5YVIrN0RhZVhhdlB2UlozQlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZXBRb0ZreWlNRUcwWlZTS0xYOE5BQSIsInZlciI6IjEuMCJ9.bSUowVQrbB6dhplwG1xITFYrbHN6C5axjxx-z6X6Eus2sxnPfNsQ46XCPdRAbsvdsO1fj-0Z0ZFxESrapH19O0IVF5aY270l5oNKqV_gDsaWMSJ6sz0SxPPhxQYBoQ0PF5PSlGKwTfkyMWIYrJ2PN6ZQIw3aq8MXKGcSqRZNDjq7wCtZG0Z8EHULyK3k5KQZevf_DbhvKzqHsFFbW_cK_c7DgYyOZDq82-Ljhy-Cva8sB2iXrVxYgft9k_WJ0X2siT21MBfE8_kvVrwbjTJ6IFPYCU1faOyqkSTRo3vB686d46mOmPKMhM-NEshNUummfI-DEZ3N27ZXlLU_lv4zFQ
   response:
     status:
       code: 200
@@ -2009,31 +2080,90 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - 8370fdea-8558-430e-8198-1b9a5fc342ce
+      - 9cba70c6-d6a5-40f7-a3a9-7884eed15925
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14948'
+      - '14923'
       X-Ms-Correlation-Request-Id:
-      - 4f1460e5-2781-4c83-8b1f-a305f890ac70
+      - d9fa3bad-3698-41d6-ae3a-9815119ecea5
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200420Z:4f1460e5-2781-4c83-8b1f-a305f890ac70
+      - WESTUS:20170922T214137Z:d9fa3bad-3698-41d6-ae3a-9815119ecea5
       Date:
-      - Tue, 05 Sep 2017 20:04:20 GMT
+      - Fri, 22 Sep 2017 21:41:36 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-05T20:04:19.176239+00:00\",\r\n  \"endTime\":
-        \"2017-09-05T20:04:19.3637292+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=78eb7e87-6cee-4a3f-978b-61c3c97ebb75&sig=6PGVjqxAVjfJ3hcCn%2F1eYq3VprzY%2BdQmG%2F3GfmtFh4w%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"ada171ce-798c-4bb9-8d90-254c29daaeae\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2017-09-22T21:41:37.9645176+00:00\",\r\n  \"endTime\":
+        \"2017-09-22T21:41:38.1364228+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=4711879f-012c-4b6a-9544-ac180aa21949&sig=eeu%2BMSTte9EeZbqn4z0eFSFCK%2F0na4etIKu6aiLRNsw%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"07c18977-815a-4d40-ae4b-fcb36eca0515\"\r\n}"
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:18 GMT
+  recorded_at: Fri, 22 Sep 2017 21:41:37 GMT
 - request:
     method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=78eb7e87-6cee-4a3f-978b-61c3c97ebb75&sig=6PGVjqxAVjfJ3hcCn/1eYq3VprzY%2BdQmG/3GfmtFh4w=&sr=b&sv=2016-05-31
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/07c18977-815a-4d40-ae4b-fcb36eca0515?api-version=2017-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYxOTMsIm5iZiI6MTUwNjExNjE5MywiZXhwIjoxNTA2MTIwMDkzLCJhaW8iOiJZMlZnWU1oNXVyeWg5YVIrN0RhZVhhdlB2UlozQlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZXBRb0ZreWlNRUcwWlZTS0xYOE5BQSIsInZlciI6IjEuMCJ9.bSUowVQrbB6dhplwG1xITFYrbHN6C5axjxx-z6X6Eus2sxnPfNsQ46XCPdRAbsvdsO1fj-0Z0ZFxESrapH19O0IVF5aY270l5oNKqV_gDsaWMSJ6sz0SxPPhxQYBoQ0PF5PSlGKwTfkyMWIYrJ2PN6ZQIw3aq8MXKGcSqRZNDjq7wCtZG0Z8EHULyK3k5KQZevf_DbhvKzqHsFFbW_cK_c7DgYyOZDq82-Ljhy-Cva8sB2iXrVxYgft9k_WJ0X2siT21MBfE8_kvVrwbjTJ6IFPYCU1faOyqkSTRo3vB686d46mOmPKMhM-NEshNUummfI-DEZ3N27ZXlLU_lv4zFQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
+      X-Ms-Request-Id:
+      - a4086942-e641-4338-9007-c582e1fd6127
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14988'
+      X-Ms-Correlation-Request-Id:
+      - 9158a374-e9fa-492a-8be1-4a74d3d68367
+      X-Ms-Routing-Request-Id:
+      - WESTUS:20170922T214138Z:9158a374-e9fa-492a-8be1-4a74d3d68367
+      Date:
+      - Fri, 22 Sep 2017 21:41:38 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"startTime\": \"2017-09-22T21:41:37.9645176+00:00\",\r\n  \"endTime\":
+        \"2017-09-22T21:41:38.1364228+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=4711879f-012c-4b6a-9544-ac180aa21949&sig=eeu%2BMSTte9EeZbqn4z0eFSFCK%2F0na4etIKu6aiLRNsw%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"07c18977-815a-4d40-ae4b-fcb36eca0515\"\r\n}"
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 21:41:38 GMT
+- request:
+    method: get
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=4711879f-012c-4b6a-9544-ac180aa21949&sig=eeu%2BMSTte9EeZbqn4z0eFSFCK/0na4etIKu6aiLRNsw=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2046,8 +2176,6 @@ http_interactions:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
       X-Ms-Range:
       - bytes=0-0
-      Host:
-      - md-t4jdgqqlgszp.blob.core.windows.net
   response:
     status:
       code: 206
@@ -2068,7 +2196,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - '08b6bdca-001e-00ef-1882-26aa53000000'
+      - a5eb9334-001e-0048-20eb-3393b0000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2094,13 +2222,13 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Tue, 05 Sep 2017 20:04:20 GMT
+      - Fri, 22 Sep 2017 21:41:37 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         6w==
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:18 GMT
+  recorded_at: Fri, 22 Sep 2017 21:41:38 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/EndGetAccess?api-version=2017-03-30
@@ -2117,11 +2245,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NTgsIm5iZiI6MTUwNDY0MTU1OCwiZXhwIjoxNTA0NjQ1NDU4LCJhaW8iOiJZMkZnWUhBdHNEcjNuV3R0TWYvWmZTOFdyL1IvREFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieWNlSVR5d1owVUd1ajc2eS1fUWVBQSIsInZlciI6IjEuMCJ9.qt7vK1IpK1-q7MwSjJ4AtfVI3i6aumXVtWw97YtNxOnULDZfBylnkHbuMtsrhEwsDLeycQUCUpqTdAur-LbV1dygTScEvNEqAG0F_M2DvZqFyYSibJVwC35rZfGVbW76E8MHKlazA4CZXrQQcOiSnz4Bw_lsLi4Z7S_g_JxdtF23w3q4IXyrA-wqWEl3VsMXTaS_BINafMN42l0_17koCdYV4y_1HLBoVipHMdf9gr180fr1hnzahqGLyt6Nyt9qr5EMZ-nSqeaC6WEsEWz8Wm_Jcy2m5Y5KDCDVeAK-_MS-EyLjIQ9hpjm1S6n6x3nKTYKu_7tSdHdc3457WBX0oQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYxOTMsIm5iZiI6MTUwNjExNjE5MywiZXhwIjoxNTA2MTIwMDkzLCJhaW8iOiJZMlZnWU1oNXVyeWg5YVIrN0RhZVhhdlB2UlozQlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZXBRb0ZreWlNRUcwWlZTS0xYOE5BQSIsInZlciI6IjEuMCJ9.bSUowVQrbB6dhplwG1xITFYrbHN6C5axjxx-z6X6Eus2sxnPfNsQ46XCPdRAbsvdsO1fj-0Z0ZFxESrapH19O0IVF5aY270l5oNKqV_gDsaWMSJ6sz0SxPPhxQYBoQ0PF5PSlGKwTfkyMWIYrJ2PN6ZQIw3aq8MXKGcSqRZNDjq7wCtZG0Z8EHULyK3k5KQZevf_DbhvKzqHsFFbW_cK_c7DgYyOZDq82-Ljhy-Cva8sB2iXrVxYgft9k_WJ0X2siT21MBfE8_kvVrwbjTJ6IFPYCU1faOyqkSTRo3vB686d46mOmPKMhM-NEshNUummfI-DEZ3N27ZXlLU_lv4zFQ
       Content-Length:
       - '0'
-      Host:
-      - management.azure.com
   response:
     status:
       code: 202
@@ -2136,31 +2262,31 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/f42eb628-e462-434d-b951-8f4f7b72c5dc?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/958f655e-a5c2-4fda-948f-66bde07d7814?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/f42eb628-e462-434d-b951-8f4f7b72c5dc?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/958f655e-a5c2-4fda-948f-66bde07d7814?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - f42eb628-e462-434d-b951-8f4f7b72c5dc
+      - 958f655e-a5c2-4fda-948f-66bde07d7814
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1188'
+      - '1187'
       X-Ms-Correlation-Request-Id:
-      - 76300a58-fff3-42ce-972e-512ab26de925
+      - 7263498b-3bf3-4c3d-b91f-d77c5dda3e80
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200421Z:76300a58-fff3-42ce-972e-512ab26de925
+      - WESTUS:20170922T214139Z:7263498b-3bf3-4c3d-b91f-d77c5dda3e80
       Date:
-      - Tue, 05 Sep 2017 20:04:20 GMT
+      - Fri, 22 Sep 2017 21:41:39 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:19 GMT
+  recorded_at: Fri, 22 Sep 2017 21:41:39 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
@@ -2177,11 +2303,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NTgsIm5iZiI6MTUwNDY0MTU1OCwiZXhwIjoxNTA0NjQ1NDU4LCJhaW8iOiJZMkZnWUhBdHNEcjNuV3R0TWYvWmZTOFdyL1IvREFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieWNlSVR5d1owVUd1ajc2eS1fUWVBQSIsInZlciI6IjEuMCJ9.qt7vK1IpK1-q7MwSjJ4AtfVI3i6aumXVtWw97YtNxOnULDZfBylnkHbuMtsrhEwsDLeycQUCUpqTdAur-LbV1dygTScEvNEqAG0F_M2DvZqFyYSibJVwC35rZfGVbW76E8MHKlazA4CZXrQQcOiSnz4Bw_lsLi4Z7S_g_JxdtF23w3q4IXyrA-wqWEl3VsMXTaS_BINafMN42l0_17koCdYV4y_1HLBoVipHMdf9gr180fr1hnzahqGLyt6Nyt9qr5EMZ-nSqeaC6WEsEWz8Wm_Jcy2m5Y5KDCDVeAK-_MS-EyLjIQ9hpjm1S6n6x3nKTYKu_7tSdHdc3457WBX0oQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYxOTMsIm5iZiI6MTUwNjExNjE5MywiZXhwIjoxNTA2MTIwMDkzLCJhaW8iOiJZMlZnWU1oNXVyeWg5YVIrN0RhZVhhdlB2UlozQlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZXBRb0ZreWlNRUcwWlZTS0xYOE5BQSIsInZlciI6IjEuMCJ9.bSUowVQrbB6dhplwG1xITFYrbHN6C5axjxx-z6X6Eus2sxnPfNsQ46XCPdRAbsvdsO1fj-0Z0ZFxESrapH19O0IVF5aY270l5oNKqV_gDsaWMSJ6sz0SxPPhxQYBoQ0PF5PSlGKwTfkyMWIYrJ2PN6ZQIw3aq8MXKGcSqRZNDjq7wCtZG0Z8EHULyK3k5KQZevf_DbhvKzqHsFFbW_cK_c7DgYyOZDq82-Ljhy-Cva8sB2iXrVxYgft9k_WJ0X2siT21MBfE8_kvVrwbjTJ6IFPYCU1faOyqkSTRo3vB686d46mOmPKMhM-NEshNUummfI-DEZ3N27ZXlLU_lv4zFQ
       Content-Length:
       - '42'
-      Host:
-      - management.azure.com
   response:
     status:
       code: 202
@@ -2196,34 +2320,34 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/569b231e-8194-40de-a505-4394b0868a1e?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/246c943d-3566-4c53-abc3-438f56f47feb?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/569b231e-8194-40de-a505-4394b0868a1e?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/246c943d-3566-4c53-abc3-438f56f47feb?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - 569b231e-8194-40de-a505-4394b0868a1e
+      - 246c943d-3566-4c53-abc3-438f56f47feb
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1181'
+      - '1183'
       X-Ms-Correlation-Request-Id:
-      - cdda8fc8-b4bc-4699-9eb2-9ff38f0cb5d5
+      - dffcbe3e-523d-408e-bec9-b89577a10743
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200421Z:cdda8fc8-b4bc-4699-9eb2-9ff38f0cb5d5
+      - WESTUS:20170922T214140Z:dffcbe3e-523d-408e-bec9-b89577a10743
       Date:
-      - Tue, 05 Sep 2017 20:04:21 GMT
+      - Fri, 22 Sep 2017 21:41:39 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:19 GMT
+  recorded_at: Fri, 22 Sep 2017 21:41:40 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/569b231e-8194-40de-a505-4394b0868a1e?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/246c943d-3566-4c53-abc3-438f56f47feb?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -2237,9 +2361,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NTgsIm5iZiI6MTUwNDY0MTU1OCwiZXhwIjoxNTA0NjQ1NDU4LCJhaW8iOiJZMkZnWUhBdHNEcjNuV3R0TWYvWmZTOFdyL1IvREFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieWNlSVR5d1owVUd1ajc2eS1fUWVBQSIsInZlciI6IjEuMCJ9.qt7vK1IpK1-q7MwSjJ4AtfVI3i6aumXVtWw97YtNxOnULDZfBylnkHbuMtsrhEwsDLeycQUCUpqTdAur-LbV1dygTScEvNEqAG0F_M2DvZqFyYSibJVwC35rZfGVbW76E8MHKlazA4CZXrQQcOiSnz4Bw_lsLi4Z7S_g_JxdtF23w3q4IXyrA-wqWEl3VsMXTaS_BINafMN42l0_17koCdYV4y_1HLBoVipHMdf9gr180fr1hnzahqGLyt6Nyt9qr5EMZ-nSqeaC6WEsEWz8Wm_Jcy2m5Y5KDCDVeAK-_MS-EyLjIQ9hpjm1S6n6x3nKTYKu_7tSdHdc3457WBX0oQ
-      Host:
-      - management.azure.com
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYxOTMsIm5iZiI6MTUwNjExNjE5MywiZXhwIjoxNTA2MTIwMDkzLCJhaW8iOiJZMlZnWU1oNXVyeWg5YVIrN0RhZVhhdlB2UlozQlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZXBRb0ZreWlNRUcwWlZTS0xYOE5BQSIsInZlciI6IjEuMCJ9.bSUowVQrbB6dhplwG1xITFYrbHN6C5axjxx-z6X6Eus2sxnPfNsQ46XCPdRAbsvdsO1fj-0Z0ZFxESrapH19O0IVF5aY270l5oNKqV_gDsaWMSJ6sz0SxPPhxQYBoQ0PF5PSlGKwTfkyMWIYrJ2PN6ZQIw3aq8MXKGcSqRZNDjq7wCtZG0Z8EHULyK3k5KQZevf_DbhvKzqHsFFbW_cK_c7DgYyOZDq82-Ljhy-Cva8sB2iXrVxYgft9k_WJ0X2siT21MBfE8_kvVrwbjTJ6IFPYCU1faOyqkSTRo3vB686d46mOmPKMhM-NEshNUummfI-DEZ3N27ZXlLU_lv4zFQ
   response:
     status:
       code: 200
@@ -2260,31 +2382,90 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - 26086371-bc13-40ec-9fb6-3a62200ac186
+      - 5d08af2c-64ef-4197-a4e9-2bfbab79172c
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14947'
+      - '14914'
       X-Ms-Correlation-Request-Id:
-      - c9444af8-66c2-4ecf-97df-c79371d04860
+      - 5a653fe9-3929-43ac-b0e2-35e1be1dd7cb
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200421Z:c9444af8-66c2-4ecf-97df-c79371d04860
+      - WESTUS:20170922T214141Z:5a653fe9-3929-43ac-b0e2-35e1be1dd7cb
       Date:
-      - Tue, 05 Sep 2017 20:04:21 GMT
+      - Fri, 22 Sep 2017 21:41:40 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-05T20:04:20.4106163+00:00\",\r\n  \"endTime\":
-        \"2017-09-05T20:04:20.5673989+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=abf523d4-e177-41ec-a5de-d1e8b32965f3&sig=Wwczvj0z9H7Gl3pVYyq7uUNS4yAZuS4nnMJsWyiMuFs%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"569b231e-8194-40de-a505-4394b0868a1e\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2017-09-22T21:41:41.755767+00:00\",\r\n  \"endTime\":
+        \"2017-09-22T21:41:41.8964099+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=8f54bbae-2265-43d0-aaa4-33ce7f94ba5a&sig=zumH0F1f7d52a1x8OpTtnqLhHzhANTJbKzq8vB3TMn0%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"246c943d-3566-4c53-abc3-438f56f47feb\"\r\n}"
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:19 GMT
+  recorded_at: Fri, 22 Sep 2017 21:41:41 GMT
 - request:
     method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=abf523d4-e177-41ec-a5de-d1e8b32965f3&sig=Wwczvj0z9H7Gl3pVYyq7uUNS4yAZuS4nnMJsWyiMuFs=&sr=b&sv=2016-05-31
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/246c943d-3566-4c53-abc3-438f56f47feb?api-version=2017-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYxOTMsIm5iZiI6MTUwNjExNjE5MywiZXhwIjoxNTA2MTIwMDkzLCJhaW8iOiJZMlZnWU1oNXVyeWg5YVIrN0RhZVhhdlB2UlozQlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZXBRb0ZreWlNRUcwWlZTS0xYOE5BQSIsInZlciI6IjEuMCJ9.bSUowVQrbB6dhplwG1xITFYrbHN6C5axjxx-z6X6Eus2sxnPfNsQ46XCPdRAbsvdsO1fj-0Z0ZFxESrapH19O0IVF5aY270l5oNKqV_gDsaWMSJ6sz0SxPPhxQYBoQ0PF5PSlGKwTfkyMWIYrJ2PN6ZQIw3aq8MXKGcSqRZNDjq7wCtZG0Z8EHULyK3k5KQZevf_DbhvKzqHsFFbW_cK_c7DgYyOZDq82-Ljhy-Cva8sB2iXrVxYgft9k_WJ0X2siT21MBfE8_kvVrwbjTJ6IFPYCU1faOyqkSTRo3vB686d46mOmPKMhM-NEshNUummfI-DEZ3N27ZXlLU_lv4zFQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
+      X-Ms-Request-Id:
+      - c458f96b-868b-41f5-b056-89f3346a75bd
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14923'
+      X-Ms-Correlation-Request-Id:
+      - 9037e978-3ad8-4282-be2b-64d39198b95b
+      X-Ms-Routing-Request-Id:
+      - WESTUS:20170922T214141Z:9037e978-3ad8-4282-be2b-64d39198b95b
+      Date:
+      - Fri, 22 Sep 2017 21:41:41 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"startTime\": \"2017-09-22T21:41:41.755767+00:00\",\r\n  \"endTime\":
+        \"2017-09-22T21:41:41.8964099+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=8f54bbae-2265-43d0-aaa4-33ce7f94ba5a&sig=zumH0F1f7d52a1x8OpTtnqLhHzhANTJbKzq8vB3TMn0%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"246c943d-3566-4c53-abc3-438f56f47feb\"\r\n}"
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 21:41:41 GMT
+- request:
+    method: get
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=8f54bbae-2265-43d0-aaa4-33ce7f94ba5a&sig=zumH0F1f7d52a1x8OpTtnqLhHzhANTJbKzq8vB3TMn0=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2297,8 +2478,6 @@ http_interactions:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
       X-Ms-Range:
       - bytes=440-443
-      Host:
-      - md-t4jdgqqlgszp.blob.core.windows.net
   response:
     status:
       code: 206
@@ -2319,7 +2498,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - f44831a9-001e-0107-5482-2611fd000000
+      - 67431d07-001e-00f7-48eb-3387c6000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2345,13 +2524,13 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Tue, 05 Sep 2017 20:04:21 GMT
+      - Fri, 22 Sep 2017 21:41:41 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         U5MJAA==
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:19 GMT
+  recorded_at: Fri, 22 Sep 2017 21:41:41 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/EndGetAccess?api-version=2017-03-30
@@ -2368,11 +2547,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NTgsIm5iZiI6MTUwNDY0MTU1OCwiZXhwIjoxNTA0NjQ1NDU4LCJhaW8iOiJZMkZnWUhBdHNEcjNuV3R0TWYvWmZTOFdyL1IvREFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieWNlSVR5d1owVUd1ajc2eS1fUWVBQSIsInZlciI6IjEuMCJ9.qt7vK1IpK1-q7MwSjJ4AtfVI3i6aumXVtWw97YtNxOnULDZfBylnkHbuMtsrhEwsDLeycQUCUpqTdAur-LbV1dygTScEvNEqAG0F_M2DvZqFyYSibJVwC35rZfGVbW76E8MHKlazA4CZXrQQcOiSnz4Bw_lsLi4Z7S_g_JxdtF23w3q4IXyrA-wqWEl3VsMXTaS_BINafMN42l0_17koCdYV4y_1HLBoVipHMdf9gr180fr1hnzahqGLyt6Nyt9qr5EMZ-nSqeaC6WEsEWz8Wm_Jcy2m5Y5KDCDVeAK-_MS-EyLjIQ9hpjm1S6n6x3nKTYKu_7tSdHdc3457WBX0oQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYxOTMsIm5iZiI6MTUwNjExNjE5MywiZXhwIjoxNTA2MTIwMDkzLCJhaW8iOiJZMlZnWU1oNXVyeWg5YVIrN0RhZVhhdlB2UlozQlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZXBRb0ZreWlNRUcwWlZTS0xYOE5BQSIsInZlciI6IjEuMCJ9.bSUowVQrbB6dhplwG1xITFYrbHN6C5axjxx-z6X6Eus2sxnPfNsQ46XCPdRAbsvdsO1fj-0Z0ZFxESrapH19O0IVF5aY270l5oNKqV_gDsaWMSJ6sz0SxPPhxQYBoQ0PF5PSlGKwTfkyMWIYrJ2PN6ZQIw3aq8MXKGcSqRZNDjq7wCtZG0Z8EHULyK3k5KQZevf_DbhvKzqHsFFbW_cK_c7DgYyOZDq82-Ljhy-Cva8sB2iXrVxYgft9k_WJ0X2siT21MBfE8_kvVrwbjTJ6IFPYCU1faOyqkSTRo3vB686d46mOmPKMhM-NEshNUummfI-DEZ3N27ZXlLU_lv4zFQ
       Content-Length:
       - '0'
-      Host:
-      - management.azure.com
   response:
     status:
       code: 202
@@ -2387,29 +2564,29 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/7feec8cf-5476-4e0a-bb95-e20846a1bcff?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/05490e04-8794-4ba7-9e76-9ed2f661bc2b?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/7feec8cf-5476-4e0a-bb95-e20846a1bcff?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/05490e04-8794-4ba7-9e76-9ed2f661bc2b?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - 7feec8cf-5476-4e0a-bb95-e20846a1bcff
+      - 05490e04-8794-4ba7-9e76-9ed2f661bc2b
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1186'
+      - '1183'
       X-Ms-Correlation-Request-Id:
-      - 8107ff91-d673-4695-868f-4da00d847929
+      - 519d6ef4-912b-46eb-83b0-16a57c42a2b8
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200422Z:8107ff91-d673-4695-868f-4da00d847929
+      - WESTUS:20170922T214143Z:519d6ef4-912b-46eb-83b0-16a57c42a2b8
       Date:
-      - Tue, 05 Sep 2017 20:04:21 GMT
+      - Fri, 22 Sep 2017 21:41:42 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:20 GMT
+  recorded_at: Fri, 22 Sep 2017 21:41:42 GMT
 recorded_with: VCR 3.0.3

--- a/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_getPartitions-1.yml
+++ b/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_getPartitions-1.yml
@@ -17,8 +17,6 @@ http_interactions:
       - '186'
       Content-Type:
       - application/x-www-form-urlencoded
-      Host:
-      - login.microsoftonline.com
   response:
     status:
       code: 200
@@ -39,25 +37,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 84fc2761-0052-402e-9f3f-5ee0861c1f00
+      - fbe1b25e-78df-4a2f-ac74-5cbec9be0c00
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAAA9kTklhVy7SJTGAzR-p1BcmopbQcJf6qW3yucTPnv6_ECqBbUoTYB3OhQDFY3oaG6TrElhi2utrbbaLgWiq4tLLLN9FK5u8k6Afle6Y8QLhuz1jAOoxsPIfGbrEVVwaHtzOORiqQX3O61sMlcjx6HOvkwtFVpSZPRNS3_nrnNo6eqiFRs86dBRGivnb4EaPBcgAA;
+      - esctx=AQABAAAAAAABlDrqfEFlSaui6xnRjX5E-gLcU8v_PiOOjdXcKp7DKg_6MSjal_rtCLGr17DFpkFBIVuJayBdXGkIl2jcG8PJpNUuG6K7y7bG_8XWbJrKn2YJXI56dtmHWvMTX0ExK_pWR6Gnm7sFweHazc6-ztHXh8p2ujP68DxJkJFpz5r6IEFR1Av-vEQgdX2yX3lIgPsgAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
       - x-ms-gateway-slice=008; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Tue, 05 Sep 2017 20:04:26 GMT
+      - Fri, 22 Sep 2017 21:42:49 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1504645466","not_before":"1504641566","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NjYsIm5iZiI6MTUwNDY0MTU2NiwiZXhwIjoxNTA0NjQ1NDY2LCJhaW8iOiJZMkZnWUxCdktWZ1FmVEVpNDZmNnEzUEhPS1F0QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWVNmOGhGSUFMa0NmUDE3Z2hod2ZBQSIsInZlciI6IjEuMCJ9.mP__L3HXuXMyqoBB1QBKEBrFZqIGX3r-qfOCssiSDJWDcowCtUs2Ezi9c94Ux2IHaKQQhbQkGWCwSX738I8PDZRur4b9YvQFuS1CiK5eqIgVbMKKI01xgfLInuCK6vJnEpWL0Osn5F38eKN4Ie-XScCnok1boTKi6nBYDiUDoFpfAzs482nvi5kmOhWrYnhhzHR10d3PspPkjEh1jyYOQ5hH-VSkcruSr_5SOcKAuK2_eTZnxLLBVVyqSOxZpLtbDwJ4jmxHqd5GXQgm1Vmlyeog9qdeJNtqIavEI4ghv0BMwF-kbGl3tITh_zL0ccsKFKW86NLO0xDO1vgowlKQsA"}'
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1506120170","not_before":"1506116270","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNzAsIm5iZiI6MTUwNjExNjI3MCwiZXhwIjoxNTA2MTIwMTcwLCJhaW8iOiJZMlZnWUpEd25SaVpIekpYMS8ycHBhK3M5KzlPQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWHJMaC05OTRMMHFzZEZ5LXliNE1BQSIsInZlciI6IjEuMCJ9.RYqwva04HYBBTt1elTlp5jG6GmjsEcWxLG6GSuCn5W2jLTQ0hZjO8rhC7fzGkbReFh2orTx368wcKypoKDLl1SzkCpJkbNDTa_L1MQDUo9Mam6Nm5b7pEs4QGl7O1zqK2JYZwyBWD6kcWdT3yXosVIWwv3vMUor9JgwR1X0chCObJAed--plBG0QFsXkztVWEjO0gw42iqLedAGz9Juzt3aZdQOiuQNTO_4Mog-_piCb3b5A-NZkfsaqr1RUNj00nPkoNpZGorw5euIeW7ikqWyjaR_CCefaP97a46djlIha9y3JAjpFkp1GdjJt06Udr8J6soVuZKzK6RTYsIEFYg"}'
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:24 GMT
+  recorded_at: Fri, 22 Sep 2017 21:42:49 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -74,9 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NjYsIm5iZiI6MTUwNDY0MTU2NiwiZXhwIjoxNTA0NjQ1NDY2LCJhaW8iOiJZMkZnWUxCdktWZ1FmVEVpNDZmNnEzUEhPS1F0QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWVNmOGhGSUFMa0NmUDE3Z2hod2ZBQSIsInZlciI6IjEuMCJ9.mP__L3HXuXMyqoBB1QBKEBrFZqIGX3r-qfOCssiSDJWDcowCtUs2Ezi9c94Ux2IHaKQQhbQkGWCwSX738I8PDZRur4b9YvQFuS1CiK5eqIgVbMKKI01xgfLInuCK6vJnEpWL0Osn5F38eKN4Ie-XScCnok1boTKi6nBYDiUDoFpfAzs482nvi5kmOhWrYnhhzHR10d3PspPkjEh1jyYOQ5hH-VSkcruSr_5SOcKAuK2_eTZnxLLBVVyqSOxZpLtbDwJ4jmxHqd5GXQgm1Vmlyeog9qdeJNtqIavEI4ghv0BMwF-kbGl3tITh_zL0ccsKFKW86NLO0xDO1vgowlKQsA
-      Host:
-      - management.azure.com
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNzAsIm5iZiI6MTUwNjExNjI3MCwiZXhwIjoxNTA2MTIwMTcwLCJhaW8iOiJZMlZnWUpEd25SaVpIekpYMS8ycHBhK3M5KzlPQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWHJMaC05OTRMMHFzZEZ5LXliNE1BQSIsInZlciI6IjEuMCJ9.RYqwva04HYBBTt1elTlp5jG6GmjsEcWxLG6GSuCn5W2jLTQ0hZjO8rhC7fzGkbReFh2orTx368wcKypoKDLl1SzkCpJkbNDTa_L1MQDUo9Mam6Nm5b7pEs4QGl7O1zqK2JYZwyBWD6kcWdT3yXosVIWwv3vMUor9JgwR1X0chCObJAed--plBG0QFsXkztVWEjO0gw42iqLedAGz9Juzt3aZdQOiuQNTO_4Mog-_piCb3b5A-NZkfsaqr1RUNj00nPkoNpZGorw5euIeW7ikqWyjaR_CCefaP97a46djlIha9y3JAjpFkp1GdjJt06Udr8J6soVuZKzK6RTYsIEFYg
   response:
     status:
       code: 200
@@ -95,23 +91,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14996'
+      - '14999'
       X-Ms-Request-Id:
-      - 4c6122fa-88f5-4c79-8764-7da4a2ed4dd7
+      - 81d5198d-653a-4ff1-a942-0267e79f0bfd
       X-Ms-Correlation-Request-Id:
-      - 4c6122fa-88f5-4c79-8764-7da4a2ed4dd7
+      - 81d5198d-653a-4ff1-a942-0267e79f0bfd
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200427Z:4c6122fa-88f5-4c79-8764-7da4a2ed4dd7
+      - WESTUS:20170922T214251Z:81d5198d-653a-4ff1-a942-0267e79f0bfd
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 05 Sep 2017 20:04:26 GMT
+      - Fri, 22 Sep 2017 21:42:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:24 GMT
+  recorded_at: Fri, 22 Sep 2017 21:42:50 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/azure_subscription_id/providers?api-version=2015-01-01
@@ -128,9 +124,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NjYsIm5iZiI6MTUwNDY0MTU2NiwiZXhwIjoxNTA0NjQ1NDY2LCJhaW8iOiJZMkZnWUxCdktWZ1FmVEVpNDZmNnEzUEhPS1F0QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWVNmOGhGSUFMa0NmUDE3Z2hod2ZBQSIsInZlciI6IjEuMCJ9.mP__L3HXuXMyqoBB1QBKEBrFZqIGX3r-qfOCssiSDJWDcowCtUs2Ezi9c94Ux2IHaKQQhbQkGWCwSX738I8PDZRur4b9YvQFuS1CiK5eqIgVbMKKI01xgfLInuCK6vJnEpWL0Osn5F38eKN4Ie-XScCnok1boTKi6nBYDiUDoFpfAzs482nvi5kmOhWrYnhhzHR10d3PspPkjEh1jyYOQ5hH-VSkcruSr_5SOcKAuK2_eTZnxLLBVVyqSOxZpLtbDwJ4jmxHqd5GXQgm1Vmlyeog9qdeJNtqIavEI4ghv0BMwF-kbGl3tITh_zL0ccsKFKW86NLO0xDO1vgowlKQsA
-      Host:
-      - management.azure.com
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNzAsIm5iZiI6MTUwNjExNjI3MCwiZXhwIjoxNTA2MTIwMTcwLCJhaW8iOiJZMlZnWUpEd25SaVpIekpYMS8ycHBhK3M5KzlPQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWHJMaC05OTRMMHFzZEZ5LXliNE1BQSIsInZlciI6IjEuMCJ9.RYqwva04HYBBTt1elTlp5jG6GmjsEcWxLG6GSuCn5W2jLTQ0hZjO8rhC7fzGkbReFh2orTx368wcKypoKDLl1SzkCpJkbNDTa_L1MQDUo9Mam6Nm5b7pEs4QGl7O1zqK2JYZwyBWD6kcWdT3yXosVIWwv3vMUor9JgwR1X0chCObJAed--plBG0QFsXkztVWEjO0gw42iqLedAGz9Juzt3aZdQOiuQNTO_4Mog-_piCb3b5A-NZkfsaqr1RUNj00nPkoNpZGorw5euIeW7ikqWyjaR_CCefaP97a46djlIha9y3JAjpFkp1GdjJt06Udr8J6soVuZKzK6RTYsIEFYg
   response:
     status:
       code: 200
@@ -147,22 +141,42 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14945'
+      - '14922'
       X-Ms-Request-Id:
-      - 6e2a93b7-9b24-4368-9960-ea5318e6ddd6
+      - 0a28d784-136f-4189-9522-ac265e355d3c
       X-Ms-Correlation-Request-Id:
-      - 6e2a93b7-9b24-4368-9960-ea5318e6ddd6
+      - 0a28d784-136f-4189-9522-ac265e355d3c
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200427Z:6e2a93b7-9b24-4368-9960-ea5318e6ddd6
+      - WESTUS:20170922T214252Z:0a28d784-136f-4189-9522-ac265e355d3c
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 05 Sep 2017 20:04:27 GMT
+      - Fri, 22 Sep 2017 21:42:52 GMT
       Content-Length:
-      - '243687'
+      - '254785'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
+      string: '{"value":[{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"operations","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","North Central
         US","South Central US","West Central US","West US","West US 2","Canada Central","Canada
         East","North Europe","West Europe","UK South","UK West","East Asia","Southeast
@@ -437,7 +451,7 @@ http_interactions:
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
         Central US","West US 2","South India","Central India","West India","Canada
-        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
+        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
         East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
@@ -466,7 +480,7 @@ http_interactions:
         Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"}],"resourceTypes":[{"resourceType":"components","locations":["East
         US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
         US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01","2014-04-01"]},{"resourceType":"queries","locations":["East
-        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"alertrules","locations":["West
+        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
@@ -542,7 +556,7 @@ http_interactions:
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorization":{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorizations":[{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},{"applicationId":"7c33bfcb-8d33-48d6-8e60-dc6404003489","roleDefinitionId":"ad6261e4-fa9a-4642-aa5f-104f1b67e9e3"},{"applicationId":"1e3e4475-288f-4018-a376-df66fd7fac5f","roleDefinitionId":"1d538b69-3d87-4e56-8ff8-25786fd48261"},{"applicationId":"a0be0c72-870e-46f0-9c49-c98333a996f7","roleDefinitionId":"7ce22727-ffce-45a9-930c-ddb2e56fa131"}],"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -552,7 +566,7 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -567,7 +581,8 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
+        Central US"],"apiVersions":["2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -577,7 +592,12 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -597,7 +617,7 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -612,7 +632,7 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -622,7 +642,31 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
         East","UK South","Central India","Canada Central"],"apiVersions":["2017-04-26-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"]},{"resourceType":"workspaces/dataSources","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
@@ -641,17 +685,17 @@ http_interactions:
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"consoles","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/consoles","locations":["West
+        East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"consoles","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/consoles","locations":["West
         US","East US","Central India","North Europe","West Europe","South Central
-        US","Southeast Asia"],"apiVersions":["2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
+        US","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
         US","East US","Central India","North Europe","West Europe","South Central
-        US","Southeast Asia"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
+        US","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","Canada Central","Canada East","West Central US","West US 2","UK South","UK
         West","Korea Central","Korea South"],"apiVersions":["2017-07-01","2016-12-01","2016-08-10","2016-06-01","2016-05-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"operations","locations":["Southeast
-        Asia"],"apiVersions":["2016-08-10","2016-06-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01"]},{"resourceType":"locations/backupStatus","locations":["West
+        Asia"],"apiVersions":["2016-08-10","2016-06-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01","2016-06-01"]},{"resourceType":"locations/backupStatus","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
@@ -687,6 +731,7 @@ http_interactions:
         Central US","Central US","North Europe","West Europe","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada Central","Canada East"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"pricings","locations":["Central
+        US","East US"],"apiVersions":["2017-08-01-preview"]},{"resourceType":"securityContacts","locations":["Central
         US","East US"],"apiVersions":["2017-08-01-preview"]},{"resourceType":"workspaceSettings","locations":["Central
         US","East US"],"apiVersions":["2017-08-01-preview"]},{"resourceType":"complianceResults","locations":["Central
         US","East US"],"apiVersions":["2017-08-01"]},{"resourceType":"policies","locations":["Central
@@ -703,6 +748,8 @@ http_interactions:
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatusesSummaries","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/alerts","locations":["Central
         US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/tasks","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"externalSecuritySolutions","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/externalSecuritySolutions","locations":["Central
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.SiteRecovery","namespace":"Microsoft.SiteRecovery","authorization":{"applicationId":"b8340c3b-9267-498f-b21a-15d5547fd85e","roleDefinitionId":"8A00C8EA-8F1B-45A7-8F64-F4CC61EEE9B6"},"resourceTypes":[{"resourceType":"SiteRecoveryVault","locations":["East
         US","West US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","Australia East","Australia Southeast","Brazil South","North
@@ -722,7 +769,7 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -842,7 +889,22 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/databases/transparentDataEncryption","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -1077,6 +1139,26 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
         US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
@@ -1307,6 +1389,11 @@ http_interactions:
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"customApis","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
         East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/managedApis","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
@@ -1358,23 +1445,8 @@ http_interactions:
         US","North Europe","Japan West","Japan East","East Asia","West Europe","East
         US","Southeast Asia","Central US"],"apiVersions":["2016-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Lombiq.DotNest","namespace":"Lombiq.DotNest","resourceTypes":[{"resourceType":"sites","locations":["East
         US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Mailjet.Email","namespace":"Mailjet.Email","resourceTypes":[{"resourceType":"services","locations":["West
-        US"],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
-        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]},{"resourceType":"diagnosticSettings","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"addsservices","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"configuration","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"operations","locations":["West
@@ -1498,8 +1570,10 @@ http_interactions:
         Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
         Central US","Central US","North Europe","West Europe","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","West
-        India","South India"],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CognitiveServices","namespace":"Microsoft.CognitiveServices","authorizations":[{"applicationId":"7d312290-28c8-473c-a0ed-8e53749b6d6d","roleDefinitionId":"5cb87f79-a7c3-4a95-9414-45b65974b51b"}],"resourceTypes":[{"resourceType":"accounts","locations":["Global","West
-        US","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"operations","locations":["Global","Australia
+        India","South India"],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CognitiveServices","namespace":"Microsoft.CognitiveServices","authorizations":[{"applicationId":"7d312290-28c8-473c-a0ed-8e53749b6d6d","roleDefinitionId":"5cb87f79-a7c3-4a95-9414-45b65974b51b"}],"resourceTypes":[{"resourceType":"accounts","locations":["Global","Australia
+        East","Brazil South","West US","West US 2","West Europe","North Europe","Southeast
+        Asia","East Asia","West Central US","South Central US","East US","East US
+        2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"operations","locations":["Global","Australia
         East","Brazil South","West US","West US 2","West Europe","North Europe","Southeast
         Asia","East Asia","West Central US","South Central US","East US","East US
         2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations","locations":["Global","Australia
@@ -1534,13 +1608,13 @@ http_interactions:
         US","West US","Australia East","West Europe","North Europe","Southeast Asia","West
         Central US"],"apiVersions":["2016-03-30","2015-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataFactory","namespace":"Microsoft.DataFactory","resourceTypes":[{"resourceType":"dataFactories","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview","2014-04-01"]},{"resourceType":"factories","locations":["East
-        US"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
-        US"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
+        US","East US 2"],"apiVersions":["2017-09-01-preview","2017-03-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
+        US","East US 2"],"apiVersions":["2017-09-01-preview","2017-03-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
         Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"dataFactories/metricDefinitions","locations":["North
         Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"checkDataFactoryNameAvailability","locations":[],"apiVersions":["2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"checkAzureDataFactoryNameAvailability","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"dataFactorySchema","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"operations","locations":["West
-        US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeAnalytics","namespace":"Microsoft.DataLakeAnalytics","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US","North Europe","East US","West Central US"],"apiVersions":["2017-09-01-preview","2017-03-01-preview","2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeAnalytics","namespace":"Microsoft.DataLakeAnalytics","resourceTypes":[{"resourceType":"accounts","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/dataLakeStoreAccounts","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers","locations":["East
@@ -1589,11 +1663,12 @@ http_interactions:
         India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
         India","East Asia","East US 2","East US","Japan East","Japan West","North
         Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"checkProvisioningServiceNameAvailability","locations":[],"apiVersions":["2017-08-21-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
         US","North Europe","East Asia","East US","West Europe","Southeast Asia","Japan
         East","Japan West","Australia East","Australia Southeast","West US 2","West
         Central US","East US 2","Central US","UK South","UK West","South India","Central
-        India"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
+        India","Canada Central","Canada East"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"ProvisioningServices","locations":["East
+        US","West Europe","Southeast Asia"],"apiVersions":["2017-08-21-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
         East","Australia Southeast","Canada Central","Canada East","Central India","Central
         US","East Asia","East US","East US 2","Japan East","Japan West","North Central
         US","North Europe","South Central US","South India","Southeast Asia","West
@@ -1620,16 +1695,16 @@ http_interactions:
         US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"operations","locations":["Brazil
         South","East Asia","East US","Japan East","Japan West","North Central US","North
         Europe","South Central US","West Europe","West US","Southeast Asia","Central
-        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"topics","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operations","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topics","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operations","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","West
         US 2","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
@@ -1727,48 +1802,39 @@ http_interactions:
         Central US","West Europe","Southeast Asia","Japan East","East US 2","West
         Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"commitmentPlans","locations":["South
         Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
-        Central US","West US"],"apiVersions":["2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Media","namespace":"Microsoft.Media","authorization":{"applicationId":"374b2a64-3b6b-436b-934c-b820eacca870","roleDefinitionId":"aab70789-0cec-44b5-95d7-84b64c9487af"},"resourceTypes":[{"resourceType":"mediaservices","locations":["Japan
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningExperimentation","namespace":"Microsoft.MachineLearningExperimentation","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"accounts","locations":["Australia
+        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces","locations":["Australia
+        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces/projects","locations":["Australia
+        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningCompute","namespace":"Microsoft.MachineLearningCompute","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"376aa7d7-51a9-463d-bd4d-7e1691345612","managedByRoleDefinitionId":"91d00862-cf55-46a5-9dce-260bbd92ce25"},"resourceTypes":[{"resourceType":"operationalizationClusters","locations":["East
+        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"operations","locations":["East
+        US 2"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations","locations":["East
+        US 2"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["East
+        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningModelManagement","namespace":"Microsoft.MachineLearningModelManagement","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US 2","West Central US","Australia East"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"operations","locations":["West
+        Central US"],"apiVersions":["2017-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
+        Central US","West US"],"apiVersions":["2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01"]},{"resourceType":"offertypes","locations":["South
+        Central US","West US"],"apiVersions":["2015-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Media","namespace":"Microsoft.Media","authorization":{"applicationId":"374b2a64-3b6b-436b-934c-b820eacca870","roleDefinitionId":"aab70789-0cec-44b5-95d7-84b64c9487af"},"resourceTypes":[{"resourceType":"mediaservices","locations":["Japan
         West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
         US","West US","Australia East","Australia Southeast","Central US","Brazil
         South","Central India","West India","South India","South Central US","Canada
-        Central","Canada East","West Central US"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
+        Central","Canada East","West Central US"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
         Central US","North Central US","East US 2","West US","West Europe","North
         Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
         East","UK South","West India"],"apiVersions":["2016-01-29"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-01-29"]},{"resourceType":"locations/checkNameAvailability","locations":["South
         Central US","North Central US","East US 2","West US","West Europe","North
         Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
-        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"operations","locations":["East
+        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"capacities","locations":["West
+        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
+        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationresults","locations":["West
+        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
+        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"operations","locations":["East
         US 2"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Relay","namespace":"Microsoft.Relay","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US 2","West
         US","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
         India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2017-08-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkPolicyCompliance","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
@@ -1827,8 +1893,11 @@ http_interactions:
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","resourceTypes":[{"resourceType":"operations","locations":["West
-        Central US"],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
+        Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applianceDefinitions","locations":["West
+        Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"locations","locations":["West
+        Central US"],"apiVersions":["2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
+        Central US"],"apiVersions":["2017-09-01","2016-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","West Central US","Japan East","Japan West","Australia East","Australia
         Southeast"],"apiVersions":["2017-06-01","2017-05-15","2017-01-01","2016-10-01","2016-06-01","2015-03-15","2014-09-01"]},{"resourceType":"operations","locations":["West
@@ -1888,11 +1957,17 @@ http_interactions:
         US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RedisLabs.Memcached","namespace":"RedisLabs.Memcached","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-07-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RedisLabs.Redis","namespace":"RedisLabs.Redis","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-07-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RevAPM.MobileCDN","namespace":"RevAPM.MobileCDN","resourceTypes":[{"resourceType":"accounts","locations":["Central
         US","East US","East US 2","North Central US","South Central US","West US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
-        East","Australia Southeast"],"apiVersions":["2016-08-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-24","2016-08-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sendgrid.Email","namespace":"Sendgrid.Email","resourceTypes":[{"resourceType":"accounts","locations":["East
-        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
-        Central US","Central US","North Europe","West Europe","Japan East","Japan
-        West","Brazil South","Australia East","Australia Southeast","Canada Central","Canada
-        East","West Central US","West US 2","UK South","UK West"],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Signiant.Flight","namespace":"Signiant.Flight","resourceTypes":[{"resourceType":"accounts","locations":["East
+        East","Australia Southeast"],"apiVersions":["2016-08-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-24","2016-08-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sendgrid.Email","namespace":"Sendgrid.Email","resourceTypes":[{"resourceType":"accounts","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Signiant.Flight","namespace":"Signiant.Flight","resourceTypes":[{"resourceType":"accounts","locations":["East
         US","Central US","North Central US","South Central US","West US","North Europe","West
         Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast"],"apiVersions":["2015-06-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sparkpost.Basic","namespace":"Sparkpost.Basic","resourceTypes":[{"resourceType":"services","locations":["West
@@ -1909,7 +1984,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:25 GMT
+  recorded_at: Fri, 22 Sep 2017 21:42:51 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
@@ -1926,11 +2001,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NjYsIm5iZiI6MTUwNDY0MTU2NiwiZXhwIjoxNTA0NjQ1NDY2LCJhaW8iOiJZMkZnWUxCdktWZ1FmVEVpNDZmNnEzUEhPS1F0QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWVNmOGhGSUFMa0NmUDE3Z2hod2ZBQSIsInZlciI6IjEuMCJ9.mP__L3HXuXMyqoBB1QBKEBrFZqIGX3r-qfOCssiSDJWDcowCtUs2Ezi9c94Ux2IHaKQQhbQkGWCwSX738I8PDZRur4b9YvQFuS1CiK5eqIgVbMKKI01xgfLInuCK6vJnEpWL0Osn5F38eKN4Ie-XScCnok1boTKi6nBYDiUDoFpfAzs482nvi5kmOhWrYnhhzHR10d3PspPkjEh1jyYOQ5hH-VSkcruSr_5SOcKAuK2_eTZnxLLBVVyqSOxZpLtbDwJ4jmxHqd5GXQgm1Vmlyeog9qdeJNtqIavEI4ghv0BMwF-kbGl3tITh_zL0ccsKFKW86NLO0xDO1vgowlKQsA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNzAsIm5iZiI6MTUwNjExNjI3MCwiZXhwIjoxNTA2MTIwMTcwLCJhaW8iOiJZMlZnWUpEd25SaVpIekpYMS8ycHBhK3M5KzlPQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWHJMaC05OTRMMHFzZEZ5LXliNE1BQSIsInZlciI6IjEuMCJ9.RYqwva04HYBBTt1elTlp5jG6GmjsEcWxLG6GSuCn5W2jLTQ0hZjO8rhC7fzGkbReFh2orTx368wcKypoKDLl1SzkCpJkbNDTa_L1MQDUo9Mam6Nm5b7pEs4QGl7O1zqK2JYZwyBWD6kcWdT3yXosVIWwv3vMUor9JgwR1X0chCObJAed--plBG0QFsXkztVWEjO0gw42iqLedAGz9Juzt3aZdQOiuQNTO_4Mog-_piCb3b5A-NZkfsaqr1RUNj00nPkoNpZGorw5euIeW7ikqWyjaR_CCefaP97a46djlIha9y3JAjpFkp1GdjJt06Udr8J6soVuZKzK6RTYsIEFYg
       Content-Length:
       - '42'
-      Host:
-      - management.azure.com
   response:
     status:
       code: 202
@@ -1945,34 +2018,34 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/f0eb90d5-ce81-4b71-b194-82576bf17981?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/6aa793e5-ae23-4c00-97ff-8a473abd2172?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/f0eb90d5-ce81-4b71-b194-82576bf17981?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/6aa793e5-ae23-4c00-97ff-8a473abd2172?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - f0eb90d5-ce81-4b71-b194-82576bf17981
+      - 6aa793e5-ae23-4c00-97ff-8a473abd2172
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1178'
+      - '1182'
       X-Ms-Correlation-Request-Id:
-      - 15440b6d-4917-4e07-8da7-9b03312cf25d
+      - 103739ce-8f02-44d9-ae37-2b89741f3e10
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200428Z:15440b6d-4917-4e07-8da7-9b03312cf25d
+      - WESTUS:20170922T214253Z:103739ce-8f02-44d9-ae37-2b89741f3e10
       Date:
-      - Tue, 05 Sep 2017 20:04:28 GMT
+      - Fri, 22 Sep 2017 21:42:53 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:25 GMT
+  recorded_at: Fri, 22 Sep 2017 21:42:52 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/f0eb90d5-ce81-4b71-b194-82576bf17981?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/6aa793e5-ae23-4c00-97ff-8a473abd2172?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -1986,9 +2059,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NjYsIm5iZiI6MTUwNDY0MTU2NiwiZXhwIjoxNTA0NjQ1NDY2LCJhaW8iOiJZMkZnWUxCdktWZ1FmVEVpNDZmNnEzUEhPS1F0QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWVNmOGhGSUFMa0NmUDE3Z2hod2ZBQSIsInZlciI6IjEuMCJ9.mP__L3HXuXMyqoBB1QBKEBrFZqIGX3r-qfOCssiSDJWDcowCtUs2Ezi9c94Ux2IHaKQQhbQkGWCwSX738I8PDZRur4b9YvQFuS1CiK5eqIgVbMKKI01xgfLInuCK6vJnEpWL0Osn5F38eKN4Ie-XScCnok1boTKi6nBYDiUDoFpfAzs482nvi5kmOhWrYnhhzHR10d3PspPkjEh1jyYOQ5hH-VSkcruSr_5SOcKAuK2_eTZnxLLBVVyqSOxZpLtbDwJ4jmxHqd5GXQgm1Vmlyeog9qdeJNtqIavEI4ghv0BMwF-kbGl3tITh_zL0ccsKFKW86NLO0xDO1vgowlKQsA
-      Host:
-      - management.azure.com
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNzAsIm5iZiI6MTUwNjExNjI3MCwiZXhwIjoxNTA2MTIwMTcwLCJhaW8iOiJZMlZnWUpEd25SaVpIekpYMS8ycHBhK3M5KzlPQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWHJMaC05OTRMMHFzZEZ5LXliNE1BQSIsInZlciI6IjEuMCJ9.RYqwva04HYBBTt1elTlp5jG6GmjsEcWxLG6GSuCn5W2jLTQ0hZjO8rhC7fzGkbReFh2orTx368wcKypoKDLl1SzkCpJkbNDTa_L1MQDUo9Mam6Nm5b7pEs4QGl7O1zqK2JYZwyBWD6kcWdT3yXosVIWwv3vMUor9JgwR1X0chCObJAed--plBG0QFsXkztVWEjO0gw42iqLedAGz9Juzt3aZdQOiuQNTO_4Mog-_piCb3b5A-NZkfsaqr1RUNj00nPkoNpZGorw5euIeW7ikqWyjaR_CCefaP97a46djlIha9y3JAjpFkp1GdjJt06Udr8J6soVuZKzK6RTYsIEFYg
   response:
     status:
       code: 200
@@ -2009,31 +2080,90 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - 4abf07ed-894f-42ff-b8f3-ee7f8700cc64
+      - a9c891ed-855e-4583-9120-e6fbc9da4d66
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14949'
+      - '14920'
       X-Ms-Correlation-Request-Id:
-      - b57ebdbc-5aaa-472d-8b4c-f3eafc1a9454
+      - 6a541593-6db3-43b2-bade-609f4a5e4f88
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200428Z:b57ebdbc-5aaa-472d-8b4c-f3eafc1a9454
+      - WESTUS:20170922T214255Z:6a541593-6db3-43b2-bade-609f4a5e4f88
       Date:
-      - Tue, 05 Sep 2017 20:04:28 GMT
+      - Fri, 22 Sep 2017 21:42:54 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-05T20:04:27.1783057+00:00\",\r\n  \"endTime\":
-        \"2017-09-05T20:04:27.4283236+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=844d1bea-05b1-4321-b7ec-2c953a87c3f2&sig=BESF2o8SfmIbMg27Yiwsx9oJWRTOOJwcKAeYJRY5uRQ%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"f0eb90d5-ce81-4b71-b194-82576bf17981\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2017-09-22T21:42:55.357306+00:00\",\r\n  \"endTime\":
+        \"2017-09-22T21:42:55.5147962+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=65d8ae5d-a416-4835-bdc3-3a99e7e0c3f5&sig=YLdZxP8AEHTzzV7mOTbUI52z2zwTTf9GhUNLeqGQxK8%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"6aa793e5-ae23-4c00-97ff-8a473abd2172\"\r\n}"
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:26 GMT
+  recorded_at: Fri, 22 Sep 2017 21:42:54 GMT
 - request:
     method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=844d1bea-05b1-4321-b7ec-2c953a87c3f2&sig=BESF2o8SfmIbMg27Yiwsx9oJWRTOOJwcKAeYJRY5uRQ=&sr=b&sv=2016-05-31
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/6aa793e5-ae23-4c00-97ff-8a473abd2172?api-version=2017-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNzAsIm5iZiI6MTUwNjExNjI3MCwiZXhwIjoxNTA2MTIwMTcwLCJhaW8iOiJZMlZnWUpEd25SaVpIekpYMS8ycHBhK3M5KzlPQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWHJMaC05OTRMMHFzZEZ5LXliNE1BQSIsInZlciI6IjEuMCJ9.RYqwva04HYBBTt1elTlp5jG6GmjsEcWxLG6GSuCn5W2jLTQ0hZjO8rhC7fzGkbReFh2orTx368wcKypoKDLl1SzkCpJkbNDTa_L1MQDUo9Mam6Nm5b7pEs4QGl7O1zqK2JYZwyBWD6kcWdT3yXosVIWwv3vMUor9JgwR1X0chCObJAed--plBG0QFsXkztVWEjO0gw42iqLedAGz9Juzt3aZdQOiuQNTO_4Mog-_piCb3b5A-NZkfsaqr1RUNj00nPkoNpZGorw5euIeW7ikqWyjaR_CCefaP97a46djlIha9y3JAjpFkp1GdjJt06Udr8J6soVuZKzK6RTYsIEFYg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
+      X-Ms-Request-Id:
+      - a84567ff-f2b1-4319-b64d-23f3afb0f87f
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14927'
+      X-Ms-Correlation-Request-Id:
+      - 60ddcc2a-28e4-4c2d-900a-aa453714ae96
+      X-Ms-Routing-Request-Id:
+      - WESTUS:20170922T214256Z:60ddcc2a-28e4-4c2d-900a-aa453714ae96
+      Date:
+      - Fri, 22 Sep 2017 21:42:55 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"startTime\": \"2017-09-22T21:42:55.357306+00:00\",\r\n  \"endTime\":
+        \"2017-09-22T21:42:55.5147962+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=65d8ae5d-a416-4835-bdc3-3a99e7e0c3f5&sig=YLdZxP8AEHTzzV7mOTbUI52z2zwTTf9GhUNLeqGQxK8%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"6aa793e5-ae23-4c00-97ff-8a473abd2172\"\r\n}"
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 21:42:55 GMT
+- request:
+    method: get
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=65d8ae5d-a416-4835-bdc3-3a99e7e0c3f5&sig=YLdZxP8AEHTzzV7mOTbUI52z2zwTTf9GhUNLeqGQxK8=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2046,8 +2176,6 @@ http_interactions:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
       X-Ms-Range:
       - bytes=0-0
-      Host:
-      - md-t4jdgqqlgszp.blob.core.windows.net
   response:
     status:
       code: 206
@@ -2068,7 +2196,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 70abcb4a-001e-006e-6f82-260804000000
+      - 7f106389-001e-00cf-40eb-33c69f000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2094,13 +2222,13 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Tue, 05 Sep 2017 20:04:28 GMT
+      - Fri, 22 Sep 2017 21:42:56 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         6w==
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:26 GMT
+  recorded_at: Fri, 22 Sep 2017 21:42:55 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/EndGetAccess?api-version=2017-03-30
@@ -2117,11 +2245,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NjYsIm5iZiI6MTUwNDY0MTU2NiwiZXhwIjoxNTA0NjQ1NDY2LCJhaW8iOiJZMkZnWUxCdktWZ1FmVEVpNDZmNnEzUEhPS1F0QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWVNmOGhGSUFMa0NmUDE3Z2hod2ZBQSIsInZlciI6IjEuMCJ9.mP__L3HXuXMyqoBB1QBKEBrFZqIGX3r-qfOCssiSDJWDcowCtUs2Ezi9c94Ux2IHaKQQhbQkGWCwSX738I8PDZRur4b9YvQFuS1CiK5eqIgVbMKKI01xgfLInuCK6vJnEpWL0Osn5F38eKN4Ie-XScCnok1boTKi6nBYDiUDoFpfAzs482nvi5kmOhWrYnhhzHR10d3PspPkjEh1jyYOQ5hH-VSkcruSr_5SOcKAuK2_eTZnxLLBVVyqSOxZpLtbDwJ4jmxHqd5GXQgm1Vmlyeog9qdeJNtqIavEI4ghv0BMwF-kbGl3tITh_zL0ccsKFKW86NLO0xDO1vgowlKQsA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNzAsIm5iZiI6MTUwNjExNjI3MCwiZXhwIjoxNTA2MTIwMTcwLCJhaW8iOiJZMlZnWUpEd25SaVpIekpYMS8ycHBhK3M5KzlPQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWHJMaC05OTRMMHFzZEZ5LXliNE1BQSIsInZlciI6IjEuMCJ9.RYqwva04HYBBTt1elTlp5jG6GmjsEcWxLG6GSuCn5W2jLTQ0hZjO8rhC7fzGkbReFh2orTx368wcKypoKDLl1SzkCpJkbNDTa_L1MQDUo9Mam6Nm5b7pEs4QGl7O1zqK2JYZwyBWD6kcWdT3yXosVIWwv3vMUor9JgwR1X0chCObJAed--plBG0QFsXkztVWEjO0gw42iqLedAGz9Juzt3aZdQOiuQNTO_4Mog-_piCb3b5A-NZkfsaqr1RUNj00nPkoNpZGorw5euIeW7ikqWyjaR_CCefaP97a46djlIha9y3JAjpFkp1GdjJt06Udr8J6soVuZKzK6RTYsIEFYg
       Content-Length:
       - '0'
-      Host:
-      - management.azure.com
   response:
     status:
       code: 202
@@ -2136,31 +2262,31 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/d2b33557-3ed6-4ffe-8372-2703650171cc?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/de55c9f4-48bf-4946-9723-35a223c6217b?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/d2b33557-3ed6-4ffe-8372-2703650171cc?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/de55c9f4-48bf-4946-9723-35a223c6217b?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - d2b33557-3ed6-4ffe-8372-2703650171cc
+      - de55c9f4-48bf-4946-9723-35a223c6217b
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1198'
+      - '1181'
       X-Ms-Correlation-Request-Id:
-      - 07ce980d-8ce4-4a24-b825-e6eed2aface3
+      - 255dd4a4-728d-44a8-91e6-75610f65606d
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200429Z:07ce980d-8ce4-4a24-b825-e6eed2aface3
+      - WESTUS:20170922T214257Z:255dd4a4-728d-44a8-91e6-75610f65606d
       Date:
-      - Tue, 05 Sep 2017 20:04:28 GMT
+      - Fri, 22 Sep 2017 21:42:57 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:26 GMT
+  recorded_at: Fri, 22 Sep 2017 21:42:56 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
@@ -2177,11 +2303,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NjYsIm5iZiI6MTUwNDY0MTU2NiwiZXhwIjoxNTA0NjQ1NDY2LCJhaW8iOiJZMkZnWUxCdktWZ1FmVEVpNDZmNnEzUEhPS1F0QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWVNmOGhGSUFMa0NmUDE3Z2hod2ZBQSIsInZlciI6IjEuMCJ9.mP__L3HXuXMyqoBB1QBKEBrFZqIGX3r-qfOCssiSDJWDcowCtUs2Ezi9c94Ux2IHaKQQhbQkGWCwSX738I8PDZRur4b9YvQFuS1CiK5eqIgVbMKKI01xgfLInuCK6vJnEpWL0Osn5F38eKN4Ie-XScCnok1boTKi6nBYDiUDoFpfAzs482nvi5kmOhWrYnhhzHR10d3PspPkjEh1jyYOQ5hH-VSkcruSr_5SOcKAuK2_eTZnxLLBVVyqSOxZpLtbDwJ4jmxHqd5GXQgm1Vmlyeog9qdeJNtqIavEI4ghv0BMwF-kbGl3tITh_zL0ccsKFKW86NLO0xDO1vgowlKQsA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNzAsIm5iZiI6MTUwNjExNjI3MCwiZXhwIjoxNTA2MTIwMTcwLCJhaW8iOiJZMlZnWUpEd25SaVpIekpYMS8ycHBhK3M5KzlPQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWHJMaC05OTRMMHFzZEZ5LXliNE1BQSIsInZlciI6IjEuMCJ9.RYqwva04HYBBTt1elTlp5jG6GmjsEcWxLG6GSuCn5W2jLTQ0hZjO8rhC7fzGkbReFh2orTx368wcKypoKDLl1SzkCpJkbNDTa_L1MQDUo9Mam6Nm5b7pEs4QGl7O1zqK2JYZwyBWD6kcWdT3yXosVIWwv3vMUor9JgwR1X0chCObJAed--plBG0QFsXkztVWEjO0gw42iqLedAGz9Juzt3aZdQOiuQNTO_4Mog-_piCb3b5A-NZkfsaqr1RUNj00nPkoNpZGorw5euIeW7ikqWyjaR_CCefaP97a46djlIha9y3JAjpFkp1GdjJt06Udr8J6soVuZKzK6RTYsIEFYg
       Content-Length:
       - '42'
-      Host:
-      - management.azure.com
   response:
     status:
       code: 202
@@ -2196,34 +2320,34 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/a4108c07-ea6d-4f35-8276-2fddab472ebe?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/2cdbb173-e41d-4750-a162-62f1009d00ba?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/a4108c07-ea6d-4f35-8276-2fddab472ebe?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/2cdbb173-e41d-4750-a162-62f1009d00ba?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - a4108c07-ea6d-4f35-8276-2fddab472ebe
+      - 2cdbb173-e41d-4750-a162-62f1009d00ba
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1182'
+      - '1180'
       X-Ms-Correlation-Request-Id:
-      - 5c8ed921-0484-4714-8c36-0cbbcf84f988
+      - 2cf1bf97-6633-4c9c-9d13-aee31511d1d8
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200429Z:5c8ed921-0484-4714-8c36-0cbbcf84f988
+      - WESTUS:20170922T214258Z:2cf1bf97-6633-4c9c-9d13-aee31511d1d8
       Date:
-      - Tue, 05 Sep 2017 20:04:29 GMT
+      - Fri, 22 Sep 2017 21:42:58 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:26 GMT
+  recorded_at: Fri, 22 Sep 2017 21:42:57 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/a4108c07-ea6d-4f35-8276-2fddab472ebe?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/2cdbb173-e41d-4750-a162-62f1009d00ba?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -2237,9 +2361,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NjYsIm5iZiI6MTUwNDY0MTU2NiwiZXhwIjoxNTA0NjQ1NDY2LCJhaW8iOiJZMkZnWUxCdktWZ1FmVEVpNDZmNnEzUEhPS1F0QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWVNmOGhGSUFMa0NmUDE3Z2hod2ZBQSIsInZlciI6IjEuMCJ9.mP__L3HXuXMyqoBB1QBKEBrFZqIGX3r-qfOCssiSDJWDcowCtUs2Ezi9c94Ux2IHaKQQhbQkGWCwSX738I8PDZRur4b9YvQFuS1CiK5eqIgVbMKKI01xgfLInuCK6vJnEpWL0Osn5F38eKN4Ie-XScCnok1boTKi6nBYDiUDoFpfAzs482nvi5kmOhWrYnhhzHR10d3PspPkjEh1jyYOQ5hH-VSkcruSr_5SOcKAuK2_eTZnxLLBVVyqSOxZpLtbDwJ4jmxHqd5GXQgm1Vmlyeog9qdeJNtqIavEI4ghv0BMwF-kbGl3tITh_zL0ccsKFKW86NLO0xDO1vgowlKQsA
-      Host:
-      - management.azure.com
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNzAsIm5iZiI6MTUwNjExNjI3MCwiZXhwIjoxNTA2MTIwMTcwLCJhaW8iOiJZMlZnWUpEd25SaVpIekpYMS8ycHBhK3M5KzlPQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWHJMaC05OTRMMHFzZEZ5LXliNE1BQSIsInZlciI6IjEuMCJ9.RYqwva04HYBBTt1elTlp5jG6GmjsEcWxLG6GSuCn5W2jLTQ0hZjO8rhC7fzGkbReFh2orTx368wcKypoKDLl1SzkCpJkbNDTa_L1MQDUo9Mam6Nm5b7pEs4QGl7O1zqK2JYZwyBWD6kcWdT3yXosVIWwv3vMUor9JgwR1X0chCObJAed--plBG0QFsXkztVWEjO0gw42iqLedAGz9Juzt3aZdQOiuQNTO_4Mog-_piCb3b5A-NZkfsaqr1RUNj00nPkoNpZGorw5euIeW7ikqWyjaR_CCefaP97a46djlIha9y3JAjpFkp1GdjJt06Udr8J6soVuZKzK6RTYsIEFYg
   response:
     status:
       code: 200
@@ -2260,31 +2382,90 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - ba07e26a-1bd3-4035-acaa-1f2e99e8110f
+      - 4ec9ce09-db78-485d-915e-f5cab72ef2a5
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14955'
+      - '14998'
       X-Ms-Correlation-Request-Id:
-      - 1918f9c5-a0ac-42e9-ba3e-e7a35fb7618f
+      - 48850c2b-183f-48ed-be81-0ecbdef17fcf
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200429Z:1918f9c5-a0ac-42e9-ba3e-e7a35fb7618f
+      - WESTUS:20170922T214259Z:48850c2b-183f-48ed-be81-0ecbdef17fcf
       Date:
-      - Tue, 05 Sep 2017 20:04:29 GMT
+      - Fri, 22 Sep 2017 21:42:58 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-05T20:04:28.3501893+00:00\",\r\n  \"endTime\":
-        \"2017-09-05T20:04:28.5689259+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=6cd09a52-995f-43af-a281-864c4cfc40d7&sig=WVWSmUnwMI5%2FOPsYCr7ejx6OIc%2BdrAeW76C3qMPiHsA%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"a4108c07-ea6d-4f35-8276-2fddab472ebe\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2017-09-22T21:43:00.4077627+00:00\",\r\n  \"endTime\":
+        \"2017-09-22T21:43:00.6422048+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=0e9ab2eb-a1cd-4eb8-bd2f-17fdbd8a0ffa&sig=2kWDvUpAqkGAD2PFchNRWypCpFMc2zqtF%2BLFpHvHouo%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"2cdbb173-e41d-4750-a162-62f1009d00ba\"\r\n}"
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:27 GMT
+  recorded_at: Fri, 22 Sep 2017 21:42:58 GMT
 - request:
     method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=6cd09a52-995f-43af-a281-864c4cfc40d7&sig=WVWSmUnwMI5/OPsYCr7ejx6OIc%2BdrAeW76C3qMPiHsA=&sr=b&sv=2016-05-31
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/2cdbb173-e41d-4750-a162-62f1009d00ba?api-version=2017-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNzAsIm5iZiI6MTUwNjExNjI3MCwiZXhwIjoxNTA2MTIwMTcwLCJhaW8iOiJZMlZnWUpEd25SaVpIekpYMS8ycHBhK3M5KzlPQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWHJMaC05OTRMMHFzZEZ5LXliNE1BQSIsInZlciI6IjEuMCJ9.RYqwva04HYBBTt1elTlp5jG6GmjsEcWxLG6GSuCn5W2jLTQ0hZjO8rhC7fzGkbReFh2orTx368wcKypoKDLl1SzkCpJkbNDTa_L1MQDUo9Mam6Nm5b7pEs4QGl7O1zqK2JYZwyBWD6kcWdT3yXosVIWwv3vMUor9JgwR1X0chCObJAed--plBG0QFsXkztVWEjO0gw42iqLedAGz9Juzt3aZdQOiuQNTO_4Mog-_piCb3b5A-NZkfsaqr1RUNj00nPkoNpZGorw5euIeW7ikqWyjaR_CCefaP97a46djlIha9y3JAjpFkp1GdjJt06Udr8J6soVuZKzK6RTYsIEFYg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
+      X-Ms-Request-Id:
+      - dadcbf77-704a-4830-bfc9-cc3c249fa3e6
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14911'
+      X-Ms-Correlation-Request-Id:
+      - 0dfef1e9-66de-408e-ac13-31bc8028e98d
+      X-Ms-Routing-Request-Id:
+      - WESTUS:20170922T214300Z:0dfef1e9-66de-408e-ac13-31bc8028e98d
+      Date:
+      - Fri, 22 Sep 2017 21:42:59 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"startTime\": \"2017-09-22T21:43:00.4077627+00:00\",\r\n  \"endTime\":
+        \"2017-09-22T21:43:00.6422048+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=0e9ab2eb-a1cd-4eb8-bd2f-17fdbd8a0ffa&sig=2kWDvUpAqkGAD2PFchNRWypCpFMc2zqtF%2BLFpHvHouo%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"2cdbb173-e41d-4750-a162-62f1009d00ba\"\r\n}"
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 21:42:59 GMT
+- request:
+    method: get
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=0e9ab2eb-a1cd-4eb8-bd2f-17fdbd8a0ffa&sig=2kWDvUpAqkGAD2PFchNRWypCpFMc2zqtF%2BLFpHvHouo=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2297,8 +2478,6 @@ http_interactions:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
       X-Ms-Range:
       - bytes=440-443
-      Host:
-      - md-t4jdgqqlgszp.blob.core.windows.net
   response:
     status:
       code: 206
@@ -2319,7 +2498,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 51ae6287-001e-00bb-0582-2640d9000000
+      - 368bf9ed-001e-0113-6feb-33d299000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2345,13 +2524,13 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Tue, 05 Sep 2017 20:04:29 GMT
+      - Fri, 22 Sep 2017 21:43:00 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         U5MJAA==
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:27 GMT
+  recorded_at: Fri, 22 Sep 2017 21:42:59 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/EndGetAccess?api-version=2017-03-30
@@ -2368,11 +2547,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NjYsIm5iZiI6MTUwNDY0MTU2NiwiZXhwIjoxNTA0NjQ1NDY2LCJhaW8iOiJZMkZnWUxCdktWZ1FmVEVpNDZmNnEzUEhPS1F0QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWVNmOGhGSUFMa0NmUDE3Z2hod2ZBQSIsInZlciI6IjEuMCJ9.mP__L3HXuXMyqoBB1QBKEBrFZqIGX3r-qfOCssiSDJWDcowCtUs2Ezi9c94Ux2IHaKQQhbQkGWCwSX738I8PDZRur4b9YvQFuS1CiK5eqIgVbMKKI01xgfLInuCK6vJnEpWL0Osn5F38eKN4Ie-XScCnok1boTKi6nBYDiUDoFpfAzs482nvi5kmOhWrYnhhzHR10d3PspPkjEh1jyYOQ5hH-VSkcruSr_5SOcKAuK2_eTZnxLLBVVyqSOxZpLtbDwJ4jmxHqd5GXQgm1Vmlyeog9qdeJNtqIavEI4ghv0BMwF-kbGl3tITh_zL0ccsKFKW86NLO0xDO1vgowlKQsA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNzAsIm5iZiI6MTUwNjExNjI3MCwiZXhwIjoxNTA2MTIwMTcwLCJhaW8iOiJZMlZnWUpEd25SaVpIekpYMS8ycHBhK3M5KzlPQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWHJMaC05OTRMMHFzZEZ5LXliNE1BQSIsInZlciI6IjEuMCJ9.RYqwva04HYBBTt1elTlp5jG6GmjsEcWxLG6GSuCn5W2jLTQ0hZjO8rhC7fzGkbReFh2orTx368wcKypoKDLl1SzkCpJkbNDTa_L1MQDUo9Mam6Nm5b7pEs4QGl7O1zqK2JYZwyBWD6kcWdT3yXosVIWwv3vMUor9JgwR1X0chCObJAed--plBG0QFsXkztVWEjO0gw42iqLedAGz9Juzt3aZdQOiuQNTO_4Mog-_piCb3b5A-NZkfsaqr1RUNj00nPkoNpZGorw5euIeW7ikqWyjaR_CCefaP97a46djlIha9y3JAjpFkp1GdjJt06Udr8J6soVuZKzK6RTYsIEFYg
       Content-Length:
       - '0'
-      Host:
-      - management.azure.com
   response:
     status:
       code: 202
@@ -2387,31 +2564,31 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/10220ada-097d-43b6-883e-3a79682c6782?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/0629eff0-a2ac-42af-9987-269a7cc5fe68?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/10220ada-097d-43b6-883e-3a79682c6782?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/0629eff0-a2ac-42af-9987-269a7cc5fe68?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - 10220ada-097d-43b6-883e-3a79682c6782
+      - 0629eff0-a2ac-42af-9987-269a7cc5fe68
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1197'
+      - '1177'
       X-Ms-Correlation-Request-Id:
-      - 6bd0ed82-3b1c-43df-b675-8bd4273863ee
+      - 31614b12-a1f2-4716-975c-719f7677b8f0
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200430Z:6bd0ed82-3b1c-43df-b675-8bd4273863ee
+      - WESTUS:20170922T214301Z:31614b12-a1f2-4716-975c-719f7677b8f0
       Date:
-      - Tue, 05 Sep 2017 20:04:30 GMT
+      - Fri, 22 Sep 2017 21:43:00 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:27 GMT
+  recorded_at: Fri, 22 Sep 2017 21:43:00 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
@@ -2428,11 +2605,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NjYsIm5iZiI6MTUwNDY0MTU2NiwiZXhwIjoxNTA0NjQ1NDY2LCJhaW8iOiJZMkZnWUxCdktWZ1FmVEVpNDZmNnEzUEhPS1F0QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWVNmOGhGSUFMa0NmUDE3Z2hod2ZBQSIsInZlciI6IjEuMCJ9.mP__L3HXuXMyqoBB1QBKEBrFZqIGX3r-qfOCssiSDJWDcowCtUs2Ezi9c94Ux2IHaKQQhbQkGWCwSX738I8PDZRur4b9YvQFuS1CiK5eqIgVbMKKI01xgfLInuCK6vJnEpWL0Osn5F38eKN4Ie-XScCnok1boTKi6nBYDiUDoFpfAzs482nvi5kmOhWrYnhhzHR10d3PspPkjEh1jyYOQ5hH-VSkcruSr_5SOcKAuK2_eTZnxLLBVVyqSOxZpLtbDwJ4jmxHqd5GXQgm1Vmlyeog9qdeJNtqIavEI4ghv0BMwF-kbGl3tITh_zL0ccsKFKW86NLO0xDO1vgowlKQsA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNzAsIm5iZiI6MTUwNjExNjI3MCwiZXhwIjoxNTA2MTIwMTcwLCJhaW8iOiJZMlZnWUpEd25SaVpIekpYMS8ycHBhK3M5KzlPQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWHJMaC05OTRMMHFzZEZ5LXliNE1BQSIsInZlciI6IjEuMCJ9.RYqwva04HYBBTt1elTlp5jG6GmjsEcWxLG6GSuCn5W2jLTQ0hZjO8rhC7fzGkbReFh2orTx368wcKypoKDLl1SzkCpJkbNDTa_L1MQDUo9Mam6Nm5b7pEs4QGl7O1zqK2JYZwyBWD6kcWdT3yXosVIWwv3vMUor9JgwR1X0chCObJAed--plBG0QFsXkztVWEjO0gw42iqLedAGz9Juzt3aZdQOiuQNTO_4Mog-_piCb3b5A-NZkfsaqr1RUNj00nPkoNpZGorw5euIeW7ikqWyjaR_CCefaP97a46djlIha9y3JAjpFkp1GdjJt06Udr8J6soVuZKzK6RTYsIEFYg
       Content-Length:
       - '42'
-      Host:
-      - management.azure.com
   response:
     status:
       code: 202
@@ -2447,34 +2622,34 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/5a0d0130-e482-4853-a07b-f9545cd8784c?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/6425bb7e-d962-49b3-a5ec-d7777b2c75ee?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/5a0d0130-e482-4853-a07b-f9545cd8784c?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/6425bb7e-d962-49b3-a5ec-d7777b2c75ee?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - 5a0d0130-e482-4853-a07b-f9545cd8784c
+      - 6425bb7e-d962-49b3-a5ec-d7777b2c75ee
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1190'
+      - '1182'
       X-Ms-Correlation-Request-Id:
-      - d754dce3-0416-4ff6-838d-aa2ed88c5cec
+      - 945472b2-fe3e-46d1-8a88-6e7202291204
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200430Z:d754dce3-0416-4ff6-838d-aa2ed88c5cec
+      - WESTUS:20170922T214302Z:945472b2-fe3e-46d1-8a88-6e7202291204
       Date:
-      - Tue, 05 Sep 2017 20:04:30 GMT
+      - Fri, 22 Sep 2017 21:43:01 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:27 GMT
+  recorded_at: Fri, 22 Sep 2017 21:43:01 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/5a0d0130-e482-4853-a07b-f9545cd8784c?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/6425bb7e-d962-49b3-a5ec-d7777b2c75ee?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -2488,9 +2663,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NjYsIm5iZiI6MTUwNDY0MTU2NiwiZXhwIjoxNTA0NjQ1NDY2LCJhaW8iOiJZMkZnWUxCdktWZ1FmVEVpNDZmNnEzUEhPS1F0QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWVNmOGhGSUFMa0NmUDE3Z2hod2ZBQSIsInZlciI6IjEuMCJ9.mP__L3HXuXMyqoBB1QBKEBrFZqIGX3r-qfOCssiSDJWDcowCtUs2Ezi9c94Ux2IHaKQQhbQkGWCwSX738I8PDZRur4b9YvQFuS1CiK5eqIgVbMKKI01xgfLInuCK6vJnEpWL0Osn5F38eKN4Ie-XScCnok1boTKi6nBYDiUDoFpfAzs482nvi5kmOhWrYnhhzHR10d3PspPkjEh1jyYOQ5hH-VSkcruSr_5SOcKAuK2_eTZnxLLBVVyqSOxZpLtbDwJ4jmxHqd5GXQgm1Vmlyeog9qdeJNtqIavEI4ghv0BMwF-kbGl3tITh_zL0ccsKFKW86NLO0xDO1vgowlKQsA
-      Host:
-      - management.azure.com
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNzAsIm5iZiI6MTUwNjExNjI3MCwiZXhwIjoxNTA2MTIwMTcwLCJhaW8iOiJZMlZnWUpEd25SaVpIekpYMS8ycHBhK3M5KzlPQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWHJMaC05OTRMMHFzZEZ5LXliNE1BQSIsInZlciI6IjEuMCJ9.RYqwva04HYBBTt1elTlp5jG6GmjsEcWxLG6GSuCn5W2jLTQ0hZjO8rhC7fzGkbReFh2orTx368wcKypoKDLl1SzkCpJkbNDTa_L1MQDUo9Mam6Nm5b7pEs4QGl7O1zqK2JYZwyBWD6kcWdT3yXosVIWwv3vMUor9JgwR1X0chCObJAed--plBG0QFsXkztVWEjO0gw42iqLedAGz9Juzt3aZdQOiuQNTO_4Mog-_piCb3b5A-NZkfsaqr1RUNj00nPkoNpZGorw5euIeW7ikqWyjaR_CCefaP97a46djlIha9y3JAjpFkp1GdjJt06Udr8J6soVuZKzK6RTYsIEFYg
   response:
     status:
       code: 200
@@ -2511,31 +2684,90 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - b926dacb-8189-44bc-b4c4-5cbcfb1982ab
+      - baf58614-1e08-4ab4-a2e2-38e054ac53bc
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14925'
+      - '14941'
       X-Ms-Correlation-Request-Id:
-      - 26b79db7-87a7-480b-8679-b1b2d3770d48
+      - 16d5d6c0-f58c-4829-a1a0-a916641444df
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200430Z:26b79db7-87a7-480b-8679-b1b2d3770d48
+      - WESTUS:20170922T214303Z:16d5d6c0-f58c-4829-a1a0-a916641444df
       Date:
-      - Tue, 05 Sep 2017 20:04:30 GMT
+      - Fri, 22 Sep 2017 21:43:03 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-05T20:04:29.5694554+00:00\",\r\n  \"endTime\":
-        \"2017-09-05T20:04:29.7882102+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=81850e52-e01b-4880-9d9c-1dd0009e5047&sig=7SlhYfnFO8PbH19rp6IA%2BEKRMFPbeimR9wwhP%2Bi06AA%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"5a0d0130-e482-4853-a07b-f9545cd8784c\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2017-09-22T21:43:03.9399025+00:00\",\r\n  \"endTime\":
+        \"2017-09-22T21:43:04.1587247+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=926afda5-f8d5-463f-a682-f5472a797c2e&sig=x22VtokL4uZ%2B9ZoYvUK1ssM28NodijwPdWjwp%2BUubjA%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"6425bb7e-d962-49b3-a5ec-d7777b2c75ee\"\r\n}"
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:28 GMT
+  recorded_at: Fri, 22 Sep 2017 21:43:01 GMT
 - request:
     method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=81850e52-e01b-4880-9d9c-1dd0009e5047&sig=7SlhYfnFO8PbH19rp6IA%2BEKRMFPbeimR9wwhP%2Bi06AA=&sr=b&sv=2016-05-31
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/6425bb7e-d962-49b3-a5ec-d7777b2c75ee?api-version=2017-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNzAsIm5iZiI6MTUwNjExNjI3MCwiZXhwIjoxNTA2MTIwMTcwLCJhaW8iOiJZMlZnWUpEd25SaVpIekpYMS8ycHBhK3M5KzlPQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWHJMaC05OTRMMHFzZEZ5LXliNE1BQSIsInZlciI6IjEuMCJ9.RYqwva04HYBBTt1elTlp5jG6GmjsEcWxLG6GSuCn5W2jLTQ0hZjO8rhC7fzGkbReFh2orTx368wcKypoKDLl1SzkCpJkbNDTa_L1MQDUo9Mam6Nm5b7pEs4QGl7O1zqK2JYZwyBWD6kcWdT3yXosVIWwv3vMUor9JgwR1X0chCObJAed--plBG0QFsXkztVWEjO0gw42iqLedAGz9Juzt3aZdQOiuQNTO_4Mog-_piCb3b5A-NZkfsaqr1RUNj00nPkoNpZGorw5euIeW7ikqWyjaR_CCefaP97a46djlIha9y3JAjpFkp1GdjJt06Udr8J6soVuZKzK6RTYsIEFYg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
+      X-Ms-Request-Id:
+      - 6a23fbba-dac1-4942-8a80-82dc9deec4be
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14912'
+      X-Ms-Correlation-Request-Id:
+      - ce0c78a6-adbd-4b2b-a965-d711294edd84
+      X-Ms-Routing-Request-Id:
+      - WESTUS:20170922T214304Z:ce0c78a6-adbd-4b2b-a965-d711294edd84
+      Date:
+      - Fri, 22 Sep 2017 21:43:04 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"startTime\": \"2017-09-22T21:43:03.9399025+00:00\",\r\n  \"endTime\":
+        \"2017-09-22T21:43:04.1587247+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=926afda5-f8d5-463f-a682-f5472a797c2e&sig=x22VtokL4uZ%2B9ZoYvUK1ssM28NodijwPdWjwp%2BUubjA%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"6425bb7e-d962-49b3-a5ec-d7777b2c75ee\"\r\n}"
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 21:43:03 GMT
+- request:
+    method: get
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=926afda5-f8d5-463f-a682-f5472a797c2e&sig=x22VtokL4uZ%2B9ZoYvUK1ssM28NodijwPdWjwp%2BUubjA=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2548,8 +2780,6 @@ http_interactions:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
       X-Ms-Range:
       - bytes=0-511
-      Host:
-      - md-t4jdgqqlgszp.blob.core.windows.net
   response:
     status:
       code: 206
@@ -2570,7 +2800,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 6dfb2dc0-001e-0079-0582-26c867000000
+      - 5808dce3-001e-011c-60eb-333f6f000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2596,13 +2826,24 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Tue, 05 Sep 2017 20:04:29 GMT
+      - Fri, 22 Sep 2017 21:43:04 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        62OQEI7QvACwuAAAjtiOwPu+AHy/AAa5AALzpOohBgAAvr4HOAR1C4PGEIH+/gd18+sWtAKwAbsAfLKAinQBi0wCzRPqAHwAAOv+AAAAAAAAAAAAAAAAAAAAAIABAAAAAAAAAP/6kJD2woB0BfbCcHQCsoDqeXwAADHAjtiO0LwAIPugZHw8/3QCiMJSvgV8tEG7qlXNE1pScj2B+1WqdTeD4QF0MjHAiUQEQIhE/4lEAscEEABmix5cfGaJXAhmix5gfGaJXAzHRAYAcLRCzRNyBbsAcOt2tAjNE3MNWoTSD4PeAL6FfemCAGYPtsaIZP9AZolEBA+20cHiAojoiPRAiUQID7bCwOgCZokEZqFgfGYJwHVOZqFcfGYx0mb3NIjRMdJm93QEO0QIfTf+wYjFMMDB6AIIwYjQWojGuwBwjsMx27gBAs0Tch6Mw2AeuQABjtsx9r8AgI7G/POlH2H/Jlp8voB96wO+j33oNAC+lH3oLgDNGOv+R1JVQiAAR2VvbQBIYXJkIERpc2sAUmVhZAAgRXJyb3INCgC7AQC0Ds0QrDwAdfTDAAAAAAAAAAAAAAAAAABTkwkAAACAICEAg90ePwAIAAAAoA8AAN0fP4P+//8AqA8AAFjwAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVao=
+        62OQEI7QvACwuAAAjtiOwPu+AHy/AAa5AALzpOohBgAAvr4HOAR1C4PGEIH+
+        /gd18+sWtAKwAbsAfLKAinQBi0wCzRPqAHwAAOv+AAAAAAAAAAAAAAAAAAAA
+        AIABAAAAAAAAAP/6kJD2woB0BfbCcHQCsoDqeXwAADHAjtiO0LwAIPugZHw8
+        /3QCiMJSvgV8tEG7qlXNE1pScj2B+1WqdTeD4QF0MjHAiUQEQIhE/4lEAscE
+        EABmix5cfGaJXAhmix5gfGaJXAzHRAYAcLRCzRNyBbsAcOt2tAjNE3MNWoTS
+        D4PeAL6FfemCAGYPtsaIZP9AZolEBA+20cHiAojoiPRAiUQID7bCwOgCZokE
+        ZqFgfGYJwHVOZqFcfGYx0mb3NIjRMdJm93QEO0QIfTf+wYjFMMDB6AIIwYjQ
+        WojGuwBwjsMx27gBAs0Tch6Mw2AeuQABjtsx9r8AgI7G/POlH2H/Jlp8voB9
+        6wO+j33oNAC+lH3oLgDNGOv+R1JVQiAAR2VvbQBIYXJkIERpc2sAUmVhZAAg
+        RXJyb3INCgC7AQC0Ds0QrDwAdfTDAAAAAAAAAAAAAAAAAABTkwkAAACAICEA
+        g90ePwAIAAAAoA8AAN0fP4P+//8AqA8AAFjwAwAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAVao=
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:28 GMT
+  recorded_at: Fri, 22 Sep 2017 21:43:03 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/EndGetAccess?api-version=2017-03-30
@@ -2619,11 +2860,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NjYsIm5iZiI6MTUwNDY0MTU2NiwiZXhwIjoxNTA0NjQ1NDY2LCJhaW8iOiJZMkZnWUxCdktWZ1FmVEVpNDZmNnEzUEhPS1F0QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWVNmOGhGSUFMa0NmUDE3Z2hod2ZBQSIsInZlciI6IjEuMCJ9.mP__L3HXuXMyqoBB1QBKEBrFZqIGX3r-qfOCssiSDJWDcowCtUs2Ezi9c94Ux2IHaKQQhbQkGWCwSX738I8PDZRur4b9YvQFuS1CiK5eqIgVbMKKI01xgfLInuCK6vJnEpWL0Osn5F38eKN4Ie-XScCnok1boTKi6nBYDiUDoFpfAzs482nvi5kmOhWrYnhhzHR10d3PspPkjEh1jyYOQ5hH-VSkcruSr_5SOcKAuK2_eTZnxLLBVVyqSOxZpLtbDwJ4jmxHqd5GXQgm1Vmlyeog9qdeJNtqIavEI4ghv0BMwF-kbGl3tITh_zL0ccsKFKW86NLO0xDO1vgowlKQsA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNzAsIm5iZiI6MTUwNjExNjI3MCwiZXhwIjoxNTA2MTIwMTcwLCJhaW8iOiJZMlZnWUpEd25SaVpIekpYMS8ycHBhK3M5KzlPQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWHJMaC05OTRMMHFzZEZ5LXliNE1BQSIsInZlciI6IjEuMCJ9.RYqwva04HYBBTt1elTlp5jG6GmjsEcWxLG6GSuCn5W2jLTQ0hZjO8rhC7fzGkbReFh2orTx368wcKypoKDLl1SzkCpJkbNDTa_L1MQDUo9Mam6Nm5b7pEs4QGl7O1zqK2JYZwyBWD6kcWdT3yXosVIWwv3vMUor9JgwR1X0chCObJAed--plBG0QFsXkztVWEjO0gw42iqLedAGz9Juzt3aZdQOiuQNTO_4Mog-_piCb3b5A-NZkfsaqr1RUNj00nPkoNpZGorw5euIeW7ikqWyjaR_CCefaP97a46djlIha9y3JAjpFkp1GdjJt06Udr8J6soVuZKzK6RTYsIEFYg
       Content-Length:
       - '0'
-      Host:
-      - management.azure.com
   response:
     status:
       code: 202
@@ -2638,29 +2877,29 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/efb82a34-dab2-45aa-8efe-c51751f3f80f?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/05c0f6ab-b0de-4569-baa2-91052ec6b2df?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/efb82a34-dab2-45aa-8efe-c51751f3f80f?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/05c0f6ab-b0de-4569-baa2-91052ec6b2df?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - efb82a34-dab2-45aa-8efe-c51751f3f80f
+      - 05c0f6ab-b0de-4569-baa2-91052ec6b2df
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1193'
+      - '1185'
       X-Ms-Correlation-Request-Id:
-      - 9cee7600-cce5-45ac-8467-601a97de26fd
+      - d2a1d112-2d32-4bc6-a9b4-4f6d0c0f6e6c
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200431Z:9cee7600-cce5-45ac-8467-601a97de26fd
+      - WESTUS:20170922T214305Z:d2a1d112-2d32-4bc6-a9b4-4f6d0c0f6e6c
       Date:
-      - Tue, 05 Sep 2017 20:04:31 GMT
+      - Fri, 22 Sep 2017 21:43:04 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:28 GMT
+  recorded_at: Fri, 22 Sep 2017 21:43:03 GMT
 recorded_with: VCR 3.0.3

--- a/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_lbaEnd-1.yml
+++ b/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_lbaEnd-1.yml
@@ -17,8 +17,6 @@ http_interactions:
       - '186'
       Content-Type:
       - application/x-www-form-urlencoded
-      Host:
-      - login.microsoftonline.com
   response:
     status:
       code: 200
@@ -39,25 +37,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 3959d3e6-46f5-47db-bab4-f81d73391f00
+      - 43168b3a-d2d8-43dc-b8be-9b0662000b00
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAAA9kTklhVy7SJTGAzR-p1Bcx27ramkDIOksDzjP04gnAb4IRwzMD7syJ8HUniJ6Fxjr5094Vy3PA4lM8DfvpoMgHhDrTIie93qE5Cf9gmw_YL7XJL9iuezh7Y1IaiYo1sR54qj15SeLHxbAN-0zUmgKTyVdDMgPmnow5fLY-GxPa2BKYPuTEzaX5KREJN4P6HggAA;
+      - esctx=AQABAAAAAAABlDrqfEFlSaui6xnRjX5ESA_ph76_avmigByRA1M3ULQJKGu8j-ECkoRFbWO266pEqLQzqX4ybIZF01FGGG6s42aOPx2ypSA2Jlo2g-b2ZVcScE4LWP_yxQTKx-6YHVIychW3T3QM_reu_BKS-3ppde1SOSASOPMcg3IhM2o1fMwrKiOVZ_LvKyPumHRI8qQgAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=008; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=004; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Tue, 05 Sep 2017 20:04:48 GMT
+      - Fri, 22 Sep 2017 21:41:43 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1504645489","not_before":"1504641589","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1ODksIm5iZiI6MTUwNDY0MTU4OSwiZXhwIjoxNTA0NjQ1NDg5LCJhaW8iOiJZMkZnWUxCSzM3bGVXOHh2MmowNUliNjRBbzc3QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNXROWk9mVkcyMGU2dFBnZGN6a2ZBQSIsInZlciI6IjEuMCJ9.TiPxpZlr9Y9auJy9TUEZ0f2hfoZJphyiXJAPpzTUcXd6AHKwlacfRwpV_vVqBzmrwbZPWROG1lzRYnXd4MCBVUp7_64tCikAy586-XNIfwVaggvrwvR5maVyCIpyR4hoo5RxaG2F82cTn22mdt9AhAOz0HrNySvwGNBlmHGE2wfJc_u4qJMjqdTcG0Boonq6oFTakpeTbP8nWgq1ISEdOWHVUtkSREjjSWpQltglye2FKoIwBM3NK4Rbgy9bati3Nv0h-Y49g1StdQXw5fI_z6sAvYadlTwWfxxqbF0vh3NwGAhYyGN8gvubZ32OYftiZIA61K46zlG8-0TKrAKKyw"}'
+      string: '{"token_type":"Bearer","expires_in":"3600","ext_expires_in":"0","expires_on":"1506120103","not_before":"1506116203","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMDMsIm5iZiI6MTUwNjExNjIwMywiZXhwIjoxNTA2MTIwMTAzLCJhaW8iOiJZMlZnWVBDVnFid3k0MUdUOWhQeFIvczVwZlJlQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiT29zV1E5alMzRU80dnBzR1lnQUxBQSIsInZlciI6IjEuMCJ9.qW2dETkABqLKjPpG1kNgiKjWDSGCrK2O436_yOUSiUEbgpEPPUqJy_4XcMu7FneQJg1gaLLLIl7ViyzJVBs_rftEdrJmuoUjufj8MetXeIaJQUh8hx-fNOrb9UEYpwK4mSK01HfRe3U-A3DT-6POIQFwbLf78M_nXJohlijBYEL0WZ02Vx2ZRqGVwpGQ8Jo--Iqcf3IELsE8RSuhDJAbLk4JAjxIen7f04U3S4dU4DxvN87n0tODuGTOD58uuY-Fsk8JMGfg47p_OQrhhZI8rg6qLu4vGVlZk_JjDqzFaVbRBWgB1QnwqnHjUqrtgjD9AsVlhuvWgUvG1swYo97bCQ"}'
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:49 GMT
+  recorded_at: Fri, 22 Sep 2017 21:41:43 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -74,9 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1ODksIm5iZiI6MTUwNDY0MTU4OSwiZXhwIjoxNTA0NjQ1NDg5LCJhaW8iOiJZMkZnWUxCSzM3bGVXOHh2MmowNUliNjRBbzc3QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNXROWk9mVkcyMGU2dFBnZGN6a2ZBQSIsInZlciI6IjEuMCJ9.TiPxpZlr9Y9auJy9TUEZ0f2hfoZJphyiXJAPpzTUcXd6AHKwlacfRwpV_vVqBzmrwbZPWROG1lzRYnXd4MCBVUp7_64tCikAy586-XNIfwVaggvrwvR5maVyCIpyR4hoo5RxaG2F82cTn22mdt9AhAOz0HrNySvwGNBlmHGE2wfJc_u4qJMjqdTcG0Boonq6oFTakpeTbP8nWgq1ISEdOWHVUtkSREjjSWpQltglye2FKoIwBM3NK4Rbgy9bati3Nv0h-Y49g1StdQXw5fI_z6sAvYadlTwWfxxqbF0vh3NwGAhYyGN8gvubZ32OYftiZIA61K46zlG8-0TKrAKKyw
-      Host:
-      - management.azure.com
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMDMsIm5iZiI6MTUwNjExNjIwMywiZXhwIjoxNTA2MTIwMTAzLCJhaW8iOiJZMlZnWVBDVnFid3k0MUdUOWhQeFIvczVwZlJlQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiT29zV1E5alMzRU80dnBzR1lnQUxBQSIsInZlciI6IjEuMCJ9.qW2dETkABqLKjPpG1kNgiKjWDSGCrK2O436_yOUSiUEbgpEPPUqJy_4XcMu7FneQJg1gaLLLIl7ViyzJVBs_rftEdrJmuoUjufj8MetXeIaJQUh8hx-fNOrb9UEYpwK4mSK01HfRe3U-A3DT-6POIQFwbLf78M_nXJohlijBYEL0WZ02Vx2ZRqGVwpGQ8Jo--Iqcf3IELsE8RSuhDJAbLk4JAjxIen7f04U3S4dU4DxvN87n0tODuGTOD58uuY-Fsk8JMGfg47p_OQrhhZI8rg6qLu4vGVlZk_JjDqzFaVbRBWgB1QnwqnHjUqrtgjD9AsVlhuvWgUvG1swYo97bCQ
   response:
     status:
       code: 200
@@ -95,23 +91,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14998'
+      - '14999'
       X-Ms-Request-Id:
-      - b2430bd8-7e3e-4ace-87c3-da86761b6227
+      - 87bf4022-19de-4aca-8eda-e27e3ef51cb0
       X-Ms-Correlation-Request-Id:
-      - b2430bd8-7e3e-4ace-87c3-da86761b6227
+      - 87bf4022-19de-4aca-8eda-e27e3ef51cb0
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200449Z:b2430bd8-7e3e-4ace-87c3-da86761b6227
+      - WESTUS:20170922T214144Z:87bf4022-19de-4aca-8eda-e27e3ef51cb0
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 05 Sep 2017 20:04:49 GMT
+      - Fri, 22 Sep 2017 21:41:43 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:49 GMT
+  recorded_at: Fri, 22 Sep 2017 21:41:43 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/azure_subscription_id/providers?api-version=2015-01-01
@@ -128,9 +124,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1ODksIm5iZiI6MTUwNDY0MTU4OSwiZXhwIjoxNTA0NjQ1NDg5LCJhaW8iOiJZMkZnWUxCSzM3bGVXOHh2MmowNUliNjRBbzc3QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNXROWk9mVkcyMGU2dFBnZGN6a2ZBQSIsInZlciI6IjEuMCJ9.TiPxpZlr9Y9auJy9TUEZ0f2hfoZJphyiXJAPpzTUcXd6AHKwlacfRwpV_vVqBzmrwbZPWROG1lzRYnXd4MCBVUp7_64tCikAy586-XNIfwVaggvrwvR5maVyCIpyR4hoo5RxaG2F82cTn22mdt9AhAOz0HrNySvwGNBlmHGE2wfJc_u4qJMjqdTcG0Boonq6oFTakpeTbP8nWgq1ISEdOWHVUtkSREjjSWpQltglye2FKoIwBM3NK4Rbgy9bati3Nv0h-Y49g1StdQXw5fI_z6sAvYadlTwWfxxqbF0vh3NwGAhYyGN8gvubZ32OYftiZIA61K46zlG8-0TKrAKKyw
-      Host:
-      - management.azure.com
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMDMsIm5iZiI6MTUwNjExNjIwMywiZXhwIjoxNTA2MTIwMTAzLCJhaW8iOiJZMlZnWVBDVnFid3k0MUdUOWhQeFIvczVwZlJlQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiT29zV1E5alMzRU80dnBzR1lnQUxBQSIsInZlciI6IjEuMCJ9.qW2dETkABqLKjPpG1kNgiKjWDSGCrK2O436_yOUSiUEbgpEPPUqJy_4XcMu7FneQJg1gaLLLIl7ViyzJVBs_rftEdrJmuoUjufj8MetXeIaJQUh8hx-fNOrb9UEYpwK4mSK01HfRe3U-A3DT-6POIQFwbLf78M_nXJohlijBYEL0WZ02Vx2ZRqGVwpGQ8Jo--Iqcf3IELsE8RSuhDJAbLk4JAjxIen7f04U3S4dU4DxvN87n0tODuGTOD58uuY-Fsk8JMGfg47p_OQrhhZI8rg6qLu4vGVlZk_JjDqzFaVbRBWgB1QnwqnHjUqrtgjD9AsVlhuvWgUvG1swYo97bCQ
   response:
     status:
       code: 200
@@ -147,22 +141,42 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14985'
+      - '14914'
       X-Ms-Request-Id:
-      - eb8324dd-f6f8-4abf-858a-b2ba33cfd3ba
+      - 4be550d8-aab4-44eb-be95-8ddfe92c1fdd
       X-Ms-Correlation-Request-Id:
-      - eb8324dd-f6f8-4abf-858a-b2ba33cfd3ba
+      - 4be550d8-aab4-44eb-be95-8ddfe92c1fdd
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200450Z:eb8324dd-f6f8-4abf-858a-b2ba33cfd3ba
+      - WESTUS:20170922T214145Z:4be550d8-aab4-44eb-be95-8ddfe92c1fdd
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 05 Sep 2017 20:04:50 GMT
+      - Fri, 22 Sep 2017 21:41:45 GMT
       Content-Length:
-      - '243687'
+      - '254785'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
+      string: '{"value":[{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"operations","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","North Central
         US","South Central US","West Central US","West US","West US 2","Canada Central","Canada
         East","North Europe","West Europe","UK South","UK West","East Asia","Southeast
@@ -437,7 +451,7 @@ http_interactions:
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
         Central US","West US 2","South India","Central India","West India","Canada
-        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
+        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
         East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
@@ -466,7 +480,7 @@ http_interactions:
         Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"}],"resourceTypes":[{"resourceType":"components","locations":["East
         US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
         US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01","2014-04-01"]},{"resourceType":"queries","locations":["East
-        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"alertrules","locations":["West
+        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
@@ -542,7 +556,7 @@ http_interactions:
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorization":{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorizations":[{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},{"applicationId":"7c33bfcb-8d33-48d6-8e60-dc6404003489","roleDefinitionId":"ad6261e4-fa9a-4642-aa5f-104f1b67e9e3"},{"applicationId":"1e3e4475-288f-4018-a376-df66fd7fac5f","roleDefinitionId":"1d538b69-3d87-4e56-8ff8-25786fd48261"},{"applicationId":"a0be0c72-870e-46f0-9c49-c98333a996f7","roleDefinitionId":"7ce22727-ffce-45a9-930c-ddb2e56fa131"}],"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -552,7 +566,7 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -567,7 +581,8 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
+        Central US"],"apiVersions":["2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -577,7 +592,12 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -597,7 +617,7 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -612,7 +632,7 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -622,7 +642,31 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
         East","UK South","Central India","Canada Central"],"apiVersions":["2017-04-26-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"]},{"resourceType":"workspaces/dataSources","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
@@ -641,17 +685,17 @@ http_interactions:
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"consoles","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/consoles","locations":["West
+        East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"consoles","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/consoles","locations":["West
         US","East US","Central India","North Europe","West Europe","South Central
-        US","Southeast Asia"],"apiVersions":["2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
+        US","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
         US","East US","Central India","North Europe","West Europe","South Central
-        US","Southeast Asia"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
+        US","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","Canada Central","Canada East","West Central US","West US 2","UK South","UK
         West","Korea Central","Korea South"],"apiVersions":["2017-07-01","2016-12-01","2016-08-10","2016-06-01","2016-05-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"operations","locations":["Southeast
-        Asia"],"apiVersions":["2016-08-10","2016-06-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01"]},{"resourceType":"locations/backupStatus","locations":["West
+        Asia"],"apiVersions":["2016-08-10","2016-06-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01","2016-06-01"]},{"resourceType":"locations/backupStatus","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
@@ -687,6 +731,7 @@ http_interactions:
         Central US","Central US","North Europe","West Europe","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada Central","Canada East"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"pricings","locations":["Central
+        US","East US"],"apiVersions":["2017-08-01-preview"]},{"resourceType":"securityContacts","locations":["Central
         US","East US"],"apiVersions":["2017-08-01-preview"]},{"resourceType":"workspaceSettings","locations":["Central
         US","East US"],"apiVersions":["2017-08-01-preview"]},{"resourceType":"complianceResults","locations":["Central
         US","East US"],"apiVersions":["2017-08-01"]},{"resourceType":"policies","locations":["Central
@@ -703,6 +748,8 @@ http_interactions:
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatusesSummaries","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/alerts","locations":["Central
         US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/tasks","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"externalSecuritySolutions","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/externalSecuritySolutions","locations":["Central
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.SiteRecovery","namespace":"Microsoft.SiteRecovery","authorization":{"applicationId":"b8340c3b-9267-498f-b21a-15d5547fd85e","roleDefinitionId":"8A00C8EA-8F1B-45A7-8F64-F4CC61EEE9B6"},"resourceTypes":[{"resourceType":"SiteRecoveryVault","locations":["East
         US","West US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","Australia East","Australia Southeast","Brazil South","North
@@ -722,7 +769,7 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -842,7 +889,22 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/databases/transparentDataEncryption","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -1077,6 +1139,26 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
         US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
@@ -1307,6 +1389,11 @@ http_interactions:
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"customApis","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
         East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/managedApis","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
@@ -1358,23 +1445,8 @@ http_interactions:
         US","North Europe","Japan West","Japan East","East Asia","West Europe","East
         US","Southeast Asia","Central US"],"apiVersions":["2016-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Lombiq.DotNest","namespace":"Lombiq.DotNest","resourceTypes":[{"resourceType":"sites","locations":["East
         US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Mailjet.Email","namespace":"Mailjet.Email","resourceTypes":[{"resourceType":"services","locations":["West
-        US"],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
-        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]},{"resourceType":"diagnosticSettings","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"addsservices","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"configuration","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"operations","locations":["West
@@ -1498,8 +1570,10 @@ http_interactions:
         Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
         Central US","Central US","North Europe","West Europe","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","West
-        India","South India"],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CognitiveServices","namespace":"Microsoft.CognitiveServices","authorizations":[{"applicationId":"7d312290-28c8-473c-a0ed-8e53749b6d6d","roleDefinitionId":"5cb87f79-a7c3-4a95-9414-45b65974b51b"}],"resourceTypes":[{"resourceType":"accounts","locations":["Global","West
-        US","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"operations","locations":["Global","Australia
+        India","South India"],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CognitiveServices","namespace":"Microsoft.CognitiveServices","authorizations":[{"applicationId":"7d312290-28c8-473c-a0ed-8e53749b6d6d","roleDefinitionId":"5cb87f79-a7c3-4a95-9414-45b65974b51b"}],"resourceTypes":[{"resourceType":"accounts","locations":["Global","Australia
+        East","Brazil South","West US","West US 2","West Europe","North Europe","Southeast
+        Asia","East Asia","West Central US","South Central US","East US","East US
+        2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"operations","locations":["Global","Australia
         East","Brazil South","West US","West US 2","West Europe","North Europe","Southeast
         Asia","East Asia","West Central US","South Central US","East US","East US
         2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations","locations":["Global","Australia
@@ -1534,13 +1608,13 @@ http_interactions:
         US","West US","Australia East","West Europe","North Europe","Southeast Asia","West
         Central US"],"apiVersions":["2016-03-30","2015-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataFactory","namespace":"Microsoft.DataFactory","resourceTypes":[{"resourceType":"dataFactories","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview","2014-04-01"]},{"resourceType":"factories","locations":["East
-        US"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
-        US"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
+        US","East US 2"],"apiVersions":["2017-09-01-preview","2017-03-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
+        US","East US 2"],"apiVersions":["2017-09-01-preview","2017-03-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
         Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"dataFactories/metricDefinitions","locations":["North
         Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"checkDataFactoryNameAvailability","locations":[],"apiVersions":["2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"checkAzureDataFactoryNameAvailability","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"dataFactorySchema","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"operations","locations":["West
-        US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeAnalytics","namespace":"Microsoft.DataLakeAnalytics","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US","North Europe","East US","West Central US"],"apiVersions":["2017-09-01-preview","2017-03-01-preview","2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeAnalytics","namespace":"Microsoft.DataLakeAnalytics","resourceTypes":[{"resourceType":"accounts","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/dataLakeStoreAccounts","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers","locations":["East
@@ -1589,11 +1663,12 @@ http_interactions:
         India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
         India","East Asia","East US 2","East US","Japan East","Japan West","North
         Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"checkProvisioningServiceNameAvailability","locations":[],"apiVersions":["2017-08-21-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
         US","North Europe","East Asia","East US","West Europe","Southeast Asia","Japan
         East","Japan West","Australia East","Australia Southeast","West US 2","West
         Central US","East US 2","Central US","UK South","UK West","South India","Central
-        India"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
+        India","Canada Central","Canada East"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"ProvisioningServices","locations":["East
+        US","West Europe","Southeast Asia"],"apiVersions":["2017-08-21-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
         East","Australia Southeast","Canada Central","Canada East","Central India","Central
         US","East Asia","East US","East US 2","Japan East","Japan West","North Central
         US","North Europe","South Central US","South India","Southeast Asia","West
@@ -1620,16 +1695,16 @@ http_interactions:
         US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"operations","locations":["Brazil
         South","East Asia","East US","Japan East","Japan West","North Central US","North
         Europe","South Central US","West Europe","West US","Southeast Asia","Central
-        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"topics","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operations","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topics","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operations","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","West
         US 2","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
@@ -1727,48 +1802,39 @@ http_interactions:
         Central US","West Europe","Southeast Asia","Japan East","East US 2","West
         Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"commitmentPlans","locations":["South
         Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
-        Central US","West US"],"apiVersions":["2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Media","namespace":"Microsoft.Media","authorization":{"applicationId":"374b2a64-3b6b-436b-934c-b820eacca870","roleDefinitionId":"aab70789-0cec-44b5-95d7-84b64c9487af"},"resourceTypes":[{"resourceType":"mediaservices","locations":["Japan
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningExperimentation","namespace":"Microsoft.MachineLearningExperimentation","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"accounts","locations":["Australia
+        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces","locations":["Australia
+        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces/projects","locations":["Australia
+        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningCompute","namespace":"Microsoft.MachineLearningCompute","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"376aa7d7-51a9-463d-bd4d-7e1691345612","managedByRoleDefinitionId":"91d00862-cf55-46a5-9dce-260bbd92ce25"},"resourceTypes":[{"resourceType":"operationalizationClusters","locations":["East
+        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"operations","locations":["East
+        US 2"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations","locations":["East
+        US 2"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["East
+        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningModelManagement","namespace":"Microsoft.MachineLearningModelManagement","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US 2","West Central US","Australia East"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"operations","locations":["West
+        Central US"],"apiVersions":["2017-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
+        Central US","West US"],"apiVersions":["2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01"]},{"resourceType":"offertypes","locations":["South
+        Central US","West US"],"apiVersions":["2015-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Media","namespace":"Microsoft.Media","authorization":{"applicationId":"374b2a64-3b6b-436b-934c-b820eacca870","roleDefinitionId":"aab70789-0cec-44b5-95d7-84b64c9487af"},"resourceTypes":[{"resourceType":"mediaservices","locations":["Japan
         West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
         US","West US","Australia East","Australia Southeast","Central US","Brazil
         South","Central India","West India","South India","South Central US","Canada
-        Central","Canada East","West Central US"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
+        Central","Canada East","West Central US"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
         Central US","North Central US","East US 2","West US","West Europe","North
         Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
         East","UK South","West India"],"apiVersions":["2016-01-29"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-01-29"]},{"resourceType":"locations/checkNameAvailability","locations":["South
         Central US","North Central US","East US 2","West US","West Europe","North
         Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
-        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"operations","locations":["East
+        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"capacities","locations":["West
+        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
+        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationresults","locations":["West
+        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
+        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"operations","locations":["East
         US 2"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Relay","namespace":"Microsoft.Relay","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US 2","West
         US","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
         India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2017-08-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkPolicyCompliance","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
@@ -1827,8 +1893,11 @@ http_interactions:
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","resourceTypes":[{"resourceType":"operations","locations":["West
-        Central US"],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
+        Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applianceDefinitions","locations":["West
+        Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"locations","locations":["West
+        Central US"],"apiVersions":["2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
+        Central US"],"apiVersions":["2017-09-01","2016-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","West Central US","Japan East","Japan West","Australia East","Australia
         Southeast"],"apiVersions":["2017-06-01","2017-05-15","2017-01-01","2016-10-01","2016-06-01","2015-03-15","2014-09-01"]},{"resourceType":"operations","locations":["West
@@ -1888,11 +1957,17 @@ http_interactions:
         US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RedisLabs.Memcached","namespace":"RedisLabs.Memcached","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-07-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RedisLabs.Redis","namespace":"RedisLabs.Redis","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-07-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RevAPM.MobileCDN","namespace":"RevAPM.MobileCDN","resourceTypes":[{"resourceType":"accounts","locations":["Central
         US","East US","East US 2","North Central US","South Central US","West US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
-        East","Australia Southeast"],"apiVersions":["2016-08-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-24","2016-08-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sendgrid.Email","namespace":"Sendgrid.Email","resourceTypes":[{"resourceType":"accounts","locations":["East
-        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
-        Central US","Central US","North Europe","West Europe","Japan East","Japan
-        West","Brazil South","Australia East","Australia Southeast","Canada Central","Canada
-        East","West Central US","West US 2","UK South","UK West"],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Signiant.Flight","namespace":"Signiant.Flight","resourceTypes":[{"resourceType":"accounts","locations":["East
+        East","Australia Southeast"],"apiVersions":["2016-08-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-24","2016-08-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sendgrid.Email","namespace":"Sendgrid.Email","resourceTypes":[{"resourceType":"accounts","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Signiant.Flight","namespace":"Signiant.Flight","resourceTypes":[{"resourceType":"accounts","locations":["East
         US","Central US","North Central US","South Central US","West US","North Europe","West
         Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast"],"apiVersions":["2015-06-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sparkpost.Basic","namespace":"Sparkpost.Basic","resourceTypes":[{"resourceType":"services","locations":["West
@@ -1909,7 +1984,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:50 GMT
+  recorded_at: Fri, 22 Sep 2017 21:41:45 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
@@ -1926,11 +2001,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1ODksIm5iZiI6MTUwNDY0MTU4OSwiZXhwIjoxNTA0NjQ1NDg5LCJhaW8iOiJZMkZnWUxCSzM3bGVXOHh2MmowNUliNjRBbzc3QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNXROWk9mVkcyMGU2dFBnZGN6a2ZBQSIsInZlciI6IjEuMCJ9.TiPxpZlr9Y9auJy9TUEZ0f2hfoZJphyiXJAPpzTUcXd6AHKwlacfRwpV_vVqBzmrwbZPWROG1lzRYnXd4MCBVUp7_64tCikAy586-XNIfwVaggvrwvR5maVyCIpyR4hoo5RxaG2F82cTn22mdt9AhAOz0HrNySvwGNBlmHGE2wfJc_u4qJMjqdTcG0Boonq6oFTakpeTbP8nWgq1ISEdOWHVUtkSREjjSWpQltglye2FKoIwBM3NK4Rbgy9bati3Nv0h-Y49g1StdQXw5fI_z6sAvYadlTwWfxxqbF0vh3NwGAhYyGN8gvubZ32OYftiZIA61K46zlG8-0TKrAKKyw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMDMsIm5iZiI6MTUwNjExNjIwMywiZXhwIjoxNTA2MTIwMTAzLCJhaW8iOiJZMlZnWVBDVnFid3k0MUdUOWhQeFIvczVwZlJlQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiT29zV1E5alMzRU80dnBzR1lnQUxBQSIsInZlciI6IjEuMCJ9.qW2dETkABqLKjPpG1kNgiKjWDSGCrK2O436_yOUSiUEbgpEPPUqJy_4XcMu7FneQJg1gaLLLIl7ViyzJVBs_rftEdrJmuoUjufj8MetXeIaJQUh8hx-fNOrb9UEYpwK4mSK01HfRe3U-A3DT-6POIQFwbLf78M_nXJohlijBYEL0WZ02Vx2ZRqGVwpGQ8Jo--Iqcf3IELsE8RSuhDJAbLk4JAjxIen7f04U3S4dU4DxvN87n0tODuGTOD58uuY-Fsk8JMGfg47p_OQrhhZI8rg6qLu4vGVlZk_JjDqzFaVbRBWgB1QnwqnHjUqrtgjD9AsVlhuvWgUvG1swYo97bCQ
       Content-Length:
       - '42'
-      Host:
-      - management.azure.com
   response:
     status:
       code: 202
@@ -1945,34 +2018,34 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/9c067949-b11f-4f8a-8242-0106348a4f76?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/da68c226-01b6-45a7-a0f1-159e65965942?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/9c067949-b11f-4f8a-8242-0106348a4f76?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/da68c226-01b6-45a7-a0f1-159e65965942?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - 9c067949-b11f-4f8a-8242-0106348a4f76
+      - da68c226-01b6-45a7-a0f1-159e65965942
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1196'
+      - '1178'
       X-Ms-Correlation-Request-Id:
-      - 7346a754-a601-49f6-b500-5c1a004d341e
+      - 60bfa6f0-3cf3-4f1d-b1d7-5e57ad7b1b11
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200451Z:7346a754-a601-49f6-b500-5c1a004d341e
+      - WESTUS:20170922T214146Z:60bfa6f0-3cf3-4f1d-b1d7-5e57ad7b1b11
       Date:
-      - Tue, 05 Sep 2017 20:04:51 GMT
+      - Fri, 22 Sep 2017 21:41:46 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:51 GMT
+  recorded_at: Fri, 22 Sep 2017 21:41:46 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/9c067949-b11f-4f8a-8242-0106348a4f76?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/da68c226-01b6-45a7-a0f1-159e65965942?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -1986,9 +2059,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1ODksIm5iZiI6MTUwNDY0MTU4OSwiZXhwIjoxNTA0NjQ1NDg5LCJhaW8iOiJZMkZnWUxCSzM3bGVXOHh2MmowNUliNjRBbzc3QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNXROWk9mVkcyMGU2dFBnZGN6a2ZBQSIsInZlciI6IjEuMCJ9.TiPxpZlr9Y9auJy9TUEZ0f2hfoZJphyiXJAPpzTUcXd6AHKwlacfRwpV_vVqBzmrwbZPWROG1lzRYnXd4MCBVUp7_64tCikAy586-XNIfwVaggvrwvR5maVyCIpyR4hoo5RxaG2F82cTn22mdt9AhAOz0HrNySvwGNBlmHGE2wfJc_u4qJMjqdTcG0Boonq6oFTakpeTbP8nWgq1ISEdOWHVUtkSREjjSWpQltglye2FKoIwBM3NK4Rbgy9bati3Nv0h-Y49g1StdQXw5fI_z6sAvYadlTwWfxxqbF0vh3NwGAhYyGN8gvubZ32OYftiZIA61K46zlG8-0TKrAKKyw
-      Host:
-      - management.azure.com
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMDMsIm5iZiI6MTUwNjExNjIwMywiZXhwIjoxNTA2MTIwMTAzLCJhaW8iOiJZMlZnWVBDVnFid3k0MUdUOWhQeFIvczVwZlJlQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiT29zV1E5alMzRU80dnBzR1lnQUxBQSIsInZlciI6IjEuMCJ9.qW2dETkABqLKjPpG1kNgiKjWDSGCrK2O436_yOUSiUEbgpEPPUqJy_4XcMu7FneQJg1gaLLLIl7ViyzJVBs_rftEdrJmuoUjufj8MetXeIaJQUh8hx-fNOrb9UEYpwK4mSK01HfRe3U-A3DT-6POIQFwbLf78M_nXJohlijBYEL0WZ02Vx2ZRqGVwpGQ8Jo--Iqcf3IELsE8RSuhDJAbLk4JAjxIen7f04U3S4dU4DxvN87n0tODuGTOD58uuY-Fsk8JMGfg47p_OQrhhZI8rg6qLu4vGVlZk_JjDqzFaVbRBWgB1QnwqnHjUqrtgjD9AsVlhuvWgUvG1swYo97bCQ
   response:
     status:
       code: 200
@@ -2009,31 +2080,90 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - a329f5dc-ef38-4256-b44e-ba79d3ed2fa0
+      - df967679-4d4c-4d11-abec-19a23017359c
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14881'
+      - '14911'
       X-Ms-Correlation-Request-Id:
-      - c33e9034-4101-42e7-a3fa-9998e88fbb5b
+      - d5c4bfde-bf57-4a2b-bb2c-ff665f137e22
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200451Z:c33e9034-4101-42e7-a3fa-9998e88fbb5b
+      - WESTUS:20170922T214147Z:d5c4bfde-bf57-4a2b-bb2c-ff665f137e22
       Date:
-      - Tue, 05 Sep 2017 20:04:50 GMT
+      - Fri, 22 Sep 2017 21:41:46 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-05T20:04:50.1482866+00:00\",\r\n  \"endTime\":
-        \"2017-09-05T20:04:50.3201741+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=05e78921-8ba0-4a0a-b6ed-5985846559dd&sig=dvm2Ajd3LSb3pc%2FrrUk6xIsgTO4mfcZI8Vsquv3lRj8%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"9c067949-b11f-4f8a-8242-0106348a4f76\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2017-09-22T21:41:48.0574635+00:00\",\r\n  \"endTime\":
+        \"2017-09-22T21:41:48.2162393+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=641d18d6-8fe5-4023-9d31-f1f209e7ed48&sig=amflQ53Pr%2BaHg2JIkhbNR0qHc%2BCZbvV4TDuqIZjQH3o%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"da68c226-01b6-45a7-a0f1-159e65965942\"\r\n}"
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:51 GMT
+  recorded_at: Fri, 22 Sep 2017 21:41:47 GMT
 - request:
     method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=05e78921-8ba0-4a0a-b6ed-5985846559dd&sig=dvm2Ajd3LSb3pc/rrUk6xIsgTO4mfcZI8Vsquv3lRj8=&sr=b&sv=2016-05-31
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/da68c226-01b6-45a7-a0f1-159e65965942?api-version=2017-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMDMsIm5iZiI6MTUwNjExNjIwMywiZXhwIjoxNTA2MTIwMTAzLCJhaW8iOiJZMlZnWVBDVnFid3k0MUdUOWhQeFIvczVwZlJlQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiT29zV1E5alMzRU80dnBzR1lnQUxBQSIsInZlciI6IjEuMCJ9.qW2dETkABqLKjPpG1kNgiKjWDSGCrK2O436_yOUSiUEbgpEPPUqJy_4XcMu7FneQJg1gaLLLIl7ViyzJVBs_rftEdrJmuoUjufj8MetXeIaJQUh8hx-fNOrb9UEYpwK4mSK01HfRe3U-A3DT-6POIQFwbLf78M_nXJohlijBYEL0WZ02Vx2ZRqGVwpGQ8Jo--Iqcf3IELsE8RSuhDJAbLk4JAjxIen7f04U3S4dU4DxvN87n0tODuGTOD58uuY-Fsk8JMGfg47p_OQrhhZI8rg6qLu4vGVlZk_JjDqzFaVbRBWgB1QnwqnHjUqrtgjD9AsVlhuvWgUvG1swYo97bCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
+      X-Ms-Request-Id:
+      - 7be82a89-3410-4a72-aafd-6db42ed7868f
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14904'
+      X-Ms-Correlation-Request-Id:
+      - 3c9771e1-2d83-4c34-a6c6-b2e8f89d194e
+      X-Ms-Routing-Request-Id:
+      - WESTUS:20170922T214148Z:3c9771e1-2d83-4c34-a6c6-b2e8f89d194e
+      Date:
+      - Fri, 22 Sep 2017 21:41:48 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"startTime\": \"2017-09-22T21:41:48.0574635+00:00\",\r\n  \"endTime\":
+        \"2017-09-22T21:41:48.2162393+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=641d18d6-8fe5-4023-9d31-f1f209e7ed48&sig=amflQ53Pr%2BaHg2JIkhbNR0qHc%2BCZbvV4TDuqIZjQH3o%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"da68c226-01b6-45a7-a0f1-159e65965942\"\r\n}"
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 21:41:48 GMT
+- request:
+    method: get
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=641d18d6-8fe5-4023-9d31-f1f209e7ed48&sig=amflQ53Pr%2BaHg2JIkhbNR0qHc%2BCZbvV4TDuqIZjQH3o=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2046,8 +2176,6 @@ http_interactions:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
       X-Ms-Range:
       - bytes=0-0
-      Host:
-      - md-t4jdgqqlgszp.blob.core.windows.net
   response:
     status:
       code: 206
@@ -2068,7 +2196,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - d1fcf4ee-001e-0072-1082-26d013000000
+      - 7e6fa2da-001e-00cb-3deb-33331d000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2094,13 +2222,13 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Tue, 05 Sep 2017 20:04:51 GMT
+      - Fri, 22 Sep 2017 21:41:48 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         6w==
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:51 GMT
+  recorded_at: Fri, 22 Sep 2017 21:41:48 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/EndGetAccess?api-version=2017-03-30
@@ -2117,11 +2245,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1ODksIm5iZiI6MTUwNDY0MTU4OSwiZXhwIjoxNTA0NjQ1NDg5LCJhaW8iOiJZMkZnWUxCSzM3bGVXOHh2MmowNUliNjRBbzc3QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNXROWk9mVkcyMGU2dFBnZGN6a2ZBQSIsInZlciI6IjEuMCJ9.TiPxpZlr9Y9auJy9TUEZ0f2hfoZJphyiXJAPpzTUcXd6AHKwlacfRwpV_vVqBzmrwbZPWROG1lzRYnXd4MCBVUp7_64tCikAy586-XNIfwVaggvrwvR5maVyCIpyR4hoo5RxaG2F82cTn22mdt9AhAOz0HrNySvwGNBlmHGE2wfJc_u4qJMjqdTcG0Boonq6oFTakpeTbP8nWgq1ISEdOWHVUtkSREjjSWpQltglye2FKoIwBM3NK4Rbgy9bati3Nv0h-Y49g1StdQXw5fI_z6sAvYadlTwWfxxqbF0vh3NwGAhYyGN8gvubZ32OYftiZIA61K46zlG8-0TKrAKKyw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMDMsIm5iZiI6MTUwNjExNjIwMywiZXhwIjoxNTA2MTIwMTAzLCJhaW8iOiJZMlZnWVBDVnFid3k0MUdUOWhQeFIvczVwZlJlQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiT29zV1E5alMzRU80dnBzR1lnQUxBQSIsInZlciI6IjEuMCJ9.qW2dETkABqLKjPpG1kNgiKjWDSGCrK2O436_yOUSiUEbgpEPPUqJy_4XcMu7FneQJg1gaLLLIl7ViyzJVBs_rftEdrJmuoUjufj8MetXeIaJQUh8hx-fNOrb9UEYpwK4mSK01HfRe3U-A3DT-6POIQFwbLf78M_nXJohlijBYEL0WZ02Vx2ZRqGVwpGQ8Jo--Iqcf3IELsE8RSuhDJAbLk4JAjxIen7f04U3S4dU4DxvN87n0tODuGTOD58uuY-Fsk8JMGfg47p_OQrhhZI8rg6qLu4vGVlZk_JjDqzFaVbRBWgB1QnwqnHjUqrtgjD9AsVlhuvWgUvG1swYo97bCQ
       Content-Length:
       - '0'
-      Host:
-      - management.azure.com
   response:
     status:
       code: 202
@@ -2136,31 +2262,31 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/45239977-49f6-4fe3-a0aa-7e3796fd4fcd?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/af30100b-1bb4-466a-a212-52e724af9005?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/45239977-49f6-4fe3-a0aa-7e3796fd4fcd?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/af30100b-1bb4-466a-a212-52e724af9005?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - 45239977-49f6-4fe3-a0aa-7e3796fd4fcd
+      - af30100b-1bb4-466a-a212-52e724af9005
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1191'
+      - '1181'
       X-Ms-Correlation-Request-Id:
-      - b80ba6d2-30d0-4352-a46b-4eeaae01ca8a
+      - bb3a0c1f-cb97-40ac-959a-124556dbb591
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200452Z:b80ba6d2-30d0-4352-a46b-4eeaae01ca8a
+      - WESTUS:20170922T214150Z:bb3a0c1f-cb97-40ac-959a-124556dbb591
       Date:
-      - Tue, 05 Sep 2017 20:04:51 GMT
+      - Fri, 22 Sep 2017 21:41:49 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:52 GMT
+  recorded_at: Fri, 22 Sep 2017 21:41:49 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
@@ -2177,11 +2303,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1ODksIm5iZiI6MTUwNDY0MTU4OSwiZXhwIjoxNTA0NjQ1NDg5LCJhaW8iOiJZMkZnWUxCSzM3bGVXOHh2MmowNUliNjRBbzc3QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNXROWk9mVkcyMGU2dFBnZGN6a2ZBQSIsInZlciI6IjEuMCJ9.TiPxpZlr9Y9auJy9TUEZ0f2hfoZJphyiXJAPpzTUcXd6AHKwlacfRwpV_vVqBzmrwbZPWROG1lzRYnXd4MCBVUp7_64tCikAy586-XNIfwVaggvrwvR5maVyCIpyR4hoo5RxaG2F82cTn22mdt9AhAOz0HrNySvwGNBlmHGE2wfJc_u4qJMjqdTcG0Boonq6oFTakpeTbP8nWgq1ISEdOWHVUtkSREjjSWpQltglye2FKoIwBM3NK4Rbgy9bati3Nv0h-Y49g1StdQXw5fI_z6sAvYadlTwWfxxqbF0vh3NwGAhYyGN8gvubZ32OYftiZIA61K46zlG8-0TKrAKKyw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMDMsIm5iZiI6MTUwNjExNjIwMywiZXhwIjoxNTA2MTIwMTAzLCJhaW8iOiJZMlZnWVBDVnFid3k0MUdUOWhQeFIvczVwZlJlQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiT29zV1E5alMzRU80dnBzR1lnQUxBQSIsInZlciI6IjEuMCJ9.qW2dETkABqLKjPpG1kNgiKjWDSGCrK2O436_yOUSiUEbgpEPPUqJy_4XcMu7FneQJg1gaLLLIl7ViyzJVBs_rftEdrJmuoUjufj8MetXeIaJQUh8hx-fNOrb9UEYpwK4mSK01HfRe3U-A3DT-6POIQFwbLf78M_nXJohlijBYEL0WZ02Vx2ZRqGVwpGQ8Jo--Iqcf3IELsE8RSuhDJAbLk4JAjxIen7f04U3S4dU4DxvN87n0tODuGTOD58uuY-Fsk8JMGfg47p_OQrhhZI8rg6qLu4vGVlZk_JjDqzFaVbRBWgB1QnwqnHjUqrtgjD9AsVlhuvWgUvG1swYo97bCQ
       Content-Length:
       - '42'
-      Host:
-      - management.azure.com
   response:
     status:
       code: 202
@@ -2196,34 +2320,34 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/920bcaae-fbce-47e8-a618-6d5a66f8514b?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/69dbf036-9cf5-408c-af0e-57893cf89c56?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/920bcaae-fbce-47e8-a618-6d5a66f8514b?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/69dbf036-9cf5-408c-af0e-57893cf89c56?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - 920bcaae-fbce-47e8-a618-6d5a66f8514b
+      - 69dbf036-9cf5-408c-af0e-57893cf89c56
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1178'
+      - '1186'
       X-Ms-Correlation-Request-Id:
-      - 3998e641-ed5f-4d46-a208-a7c45f337186
+      - d6096a60-f768-4d53-8f35-c08a5a448e6d
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200452Z:3998e641-ed5f-4d46-a208-a7c45f337186
+      - WESTUS:20170922T214150Z:d6096a60-f768-4d53-8f35-c08a5a448e6d
       Date:
-      - Tue, 05 Sep 2017 20:04:51 GMT
+      - Fri, 22 Sep 2017 21:41:50 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:52 GMT
+  recorded_at: Fri, 22 Sep 2017 21:41:50 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/920bcaae-fbce-47e8-a618-6d5a66f8514b?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/69dbf036-9cf5-408c-af0e-57893cf89c56?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -2237,9 +2361,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1ODksIm5iZiI6MTUwNDY0MTU4OSwiZXhwIjoxNTA0NjQ1NDg5LCJhaW8iOiJZMkZnWUxCSzM3bGVXOHh2MmowNUliNjRBbzc3QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNXROWk9mVkcyMGU2dFBnZGN6a2ZBQSIsInZlciI6IjEuMCJ9.TiPxpZlr9Y9auJy9TUEZ0f2hfoZJphyiXJAPpzTUcXd6AHKwlacfRwpV_vVqBzmrwbZPWROG1lzRYnXd4MCBVUp7_64tCikAy586-XNIfwVaggvrwvR5maVyCIpyR4hoo5RxaG2F82cTn22mdt9AhAOz0HrNySvwGNBlmHGE2wfJc_u4qJMjqdTcG0Boonq6oFTakpeTbP8nWgq1ISEdOWHVUtkSREjjSWpQltglye2FKoIwBM3NK4Rbgy9bati3Nv0h-Y49g1StdQXw5fI_z6sAvYadlTwWfxxqbF0vh3NwGAhYyGN8gvubZ32OYftiZIA61K46zlG8-0TKrAKKyw
-      Host:
-      - management.azure.com
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMDMsIm5iZiI6MTUwNjExNjIwMywiZXhwIjoxNTA2MTIwMTAzLCJhaW8iOiJZMlZnWVBDVnFid3k0MUdUOWhQeFIvczVwZlJlQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiT29zV1E5alMzRU80dnBzR1lnQUxBQSIsInZlciI6IjEuMCJ9.qW2dETkABqLKjPpG1kNgiKjWDSGCrK2O436_yOUSiUEbgpEPPUqJy_4XcMu7FneQJg1gaLLLIl7ViyzJVBs_rftEdrJmuoUjufj8MetXeIaJQUh8hx-fNOrb9UEYpwK4mSK01HfRe3U-A3DT-6POIQFwbLf78M_nXJohlijBYEL0WZ02Vx2ZRqGVwpGQ8Jo--Iqcf3IELsE8RSuhDJAbLk4JAjxIen7f04U3S4dU4DxvN87n0tODuGTOD58uuY-Fsk8JMGfg47p_OQrhhZI8rg6qLu4vGVlZk_JjDqzFaVbRBWgB1QnwqnHjUqrtgjD9AsVlhuvWgUvG1swYo97bCQ
   response:
     status:
       code: 200
@@ -2260,31 +2382,90 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - dbc37529-e9b3-4f15-86c2-3bdc20a6faa4
+      - ec5da85e-f8d8-4eb4-9199-3e8c46a49a84
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14968'
+      - '14921'
       X-Ms-Correlation-Request-Id:
-      - 02e47978-f9e3-4388-9acf-8baaed517c9d
+      - c6476883-0fb2-4034-b111-de7a6963d900
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200452Z:02e47978-f9e3-4388-9acf-8baaed517c9d
+      - WESTUS:20170922T214151Z:c6476883-0fb2-4034-b111-de7a6963d900
       Date:
-      - Tue, 05 Sep 2017 20:04:52 GMT
+      - Fri, 22 Sep 2017 21:41:51 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-05T20:04:51.4140352+00:00\",\r\n  \"endTime\":
-        \"2017-09-05T20:04:51.6015403+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=cb2cb7ca-25bd-480a-89ec-0968f49f8a8d&sig=lFvRif0pAGC2KhYkoNQu3s7VLdiq0a%2BFW0%2BNB6MJn2k%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"920bcaae-fbce-47e8-a618-6d5a66f8514b\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2017-09-22T21:41:52.3581004+00:00\",\r\n  \"endTime\":
+        \"2017-09-22T21:41:52.594276+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=64852b9d-2a51-461d-b415-c28bb8520816&sig=loSy7VN2kupGTjvGgsMKM6ryuAMtabEV0llH2wqtn%2FI%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"69dbf036-9cf5-408c-af0e-57893cf89c56\"\r\n}"
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:52 GMT
+  recorded_at: Fri, 22 Sep 2017 21:41:51 GMT
 - request:
     method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=cb2cb7ca-25bd-480a-89ec-0968f49f8a8d&sig=lFvRif0pAGC2KhYkoNQu3s7VLdiq0a%2BFW0%2BNB6MJn2k=&sr=b&sv=2016-05-31
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/69dbf036-9cf5-408c-af0e-57893cf89c56?api-version=2017-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMDMsIm5iZiI6MTUwNjExNjIwMywiZXhwIjoxNTA2MTIwMTAzLCJhaW8iOiJZMlZnWVBDVnFid3k0MUdUOWhQeFIvczVwZlJlQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiT29zV1E5alMzRU80dnBzR1lnQUxBQSIsInZlciI6IjEuMCJ9.qW2dETkABqLKjPpG1kNgiKjWDSGCrK2O436_yOUSiUEbgpEPPUqJy_4XcMu7FneQJg1gaLLLIl7ViyzJVBs_rftEdrJmuoUjufj8MetXeIaJQUh8hx-fNOrb9UEYpwK4mSK01HfRe3U-A3DT-6POIQFwbLf78M_nXJohlijBYEL0WZ02Vx2ZRqGVwpGQ8Jo--Iqcf3IELsE8RSuhDJAbLk4JAjxIen7f04U3S4dU4DxvN87n0tODuGTOD58uuY-Fsk8JMGfg47p_OQrhhZI8rg6qLu4vGVlZk_JjDqzFaVbRBWgB1QnwqnHjUqrtgjD9AsVlhuvWgUvG1swYo97bCQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
+      X-Ms-Request-Id:
+      - 1b5fda29-11ff-43e7-9459-30718b5f8347
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14914'
+      X-Ms-Correlation-Request-Id:
+      - 37e7686c-e36f-4d46-b075-0b46e34dbc57
+      X-Ms-Routing-Request-Id:
+      - WESTUS:20170922T214152Z:37e7686c-e36f-4d46-b075-0b46e34dbc57
+      Date:
+      - Fri, 22 Sep 2017 21:41:51 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"startTime\": \"2017-09-22T21:41:52.3581004+00:00\",\r\n  \"endTime\":
+        \"2017-09-22T21:41:52.594276+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=64852b9d-2a51-461d-b415-c28bb8520816&sig=loSy7VN2kupGTjvGgsMKM6ryuAMtabEV0llH2wqtn%2FI%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"69dbf036-9cf5-408c-af0e-57893cf89c56\"\r\n}"
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 21:41:52 GMT
+- request:
+    method: get
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=64852b9d-2a51-461d-b415-c28bb8520816&sig=loSy7VN2kupGTjvGgsMKM6ryuAMtabEV0llH2wqtn/I=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2297,8 +2478,6 @@ http_interactions:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
       X-Ms-Range:
       - bytes=440-443
-      Host:
-      - md-t4jdgqqlgszp.blob.core.windows.net
   response:
     status:
       code: 206
@@ -2319,7 +2498,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - dcfa42a9-001e-002e-4f82-2621ea000000
+      - d6dcc4ad-001e-0027-23eb-333b64000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2345,13 +2524,13 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Tue, 05 Sep 2017 20:04:52 GMT
+      - Fri, 22 Sep 2017 21:41:52 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         U5MJAA==
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:53 GMT
+  recorded_at: Fri, 22 Sep 2017 21:41:52 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/EndGetAccess?api-version=2017-03-30
@@ -2368,11 +2547,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1ODksIm5iZiI6MTUwNDY0MTU4OSwiZXhwIjoxNTA0NjQ1NDg5LCJhaW8iOiJZMkZnWUxCSzM3bGVXOHh2MmowNUliNjRBbzc3QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNXROWk9mVkcyMGU2dFBnZGN6a2ZBQSIsInZlciI6IjEuMCJ9.TiPxpZlr9Y9auJy9TUEZ0f2hfoZJphyiXJAPpzTUcXd6AHKwlacfRwpV_vVqBzmrwbZPWROG1lzRYnXd4MCBVUp7_64tCikAy586-XNIfwVaggvrwvR5maVyCIpyR4hoo5RxaG2F82cTn22mdt9AhAOz0HrNySvwGNBlmHGE2wfJc_u4qJMjqdTcG0Boonq6oFTakpeTbP8nWgq1ISEdOWHVUtkSREjjSWpQltglye2FKoIwBM3NK4Rbgy9bati3Nv0h-Y49g1StdQXw5fI_z6sAvYadlTwWfxxqbF0vh3NwGAhYyGN8gvubZ32OYftiZIA61K46zlG8-0TKrAKKyw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMDMsIm5iZiI6MTUwNjExNjIwMywiZXhwIjoxNTA2MTIwMTAzLCJhaW8iOiJZMlZnWVBDVnFid3k0MUdUOWhQeFIvczVwZlJlQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiT29zV1E5alMzRU80dnBzR1lnQUxBQSIsInZlciI6IjEuMCJ9.qW2dETkABqLKjPpG1kNgiKjWDSGCrK2O436_yOUSiUEbgpEPPUqJy_4XcMu7FneQJg1gaLLLIl7ViyzJVBs_rftEdrJmuoUjufj8MetXeIaJQUh8hx-fNOrb9UEYpwK4mSK01HfRe3U-A3DT-6POIQFwbLf78M_nXJohlijBYEL0WZ02Vx2ZRqGVwpGQ8Jo--Iqcf3IELsE8RSuhDJAbLk4JAjxIen7f04U3S4dU4DxvN87n0tODuGTOD58uuY-Fsk8JMGfg47p_OQrhhZI8rg6qLu4vGVlZk_JjDqzFaVbRBWgB1QnwqnHjUqrtgjD9AsVlhuvWgUvG1swYo97bCQ
       Content-Length:
       - '0'
-      Host:
-      - management.azure.com
   response:
     status:
       code: 202
@@ -2387,29 +2564,29 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/21d92b5a-94f6-467f-8264-2282ebbf0bf2?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/e35bd637-4d5b-4888-9943-f3b9903baedd?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/21d92b5a-94f6-467f-8264-2282ebbf0bf2?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/e35bd637-4d5b-4888-9943-f3b9903baedd?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - 21d92b5a-94f6-467f-8264-2282ebbf0bf2
+      - e35bd637-4d5b-4888-9943-f3b9903baedd
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1177'
+      - '1182'
       X-Ms-Correlation-Request-Id:
-      - 40aacaed-fc26-46d0-a8a0-fe9f918d2c84
+      - 79de296e-0ffd-40e6-aab8-2f1345edf33f
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200453Z:40aacaed-fc26-46d0-a8a0-fe9f918d2c84
+      - WESTUS:20170922T214153Z:79de296e-0ffd-40e6-aab8-2f1345edf33f
       Date:
-      - Tue, 05 Sep 2017 20:04:52 GMT
+      - Fri, 22 Sep 2017 21:41:53 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:53 GMT
+  recorded_at: Fri, 22 Sep 2017 21:41:53 GMT
 recorded_with: VCR 3.0.3

--- a/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_lbaStart-1.yml
+++ b/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_lbaStart-1.yml
@@ -17,8 +17,6 @@ http_interactions:
       - '186'
       Content-Type:
       - application/x-www-form-urlencoded
-      Host:
-      - login.microsoftonline.com
   response:
     status:
       code: 200
@@ -39,25 +37,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - e978c10d-cefd-4190-ac11-22ee8a001f00
+      - c44a7350-236a-4714-b889-f8c46b9f0c00
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAAA9kTklhVy7SJTGAzR-p1BcLgWuj6qzy-5Jiwlj1s20mv7D5MTH5GE-ho-CWVeqFL98pcvgTpqkmJ2afLbzzDBlpHGBcruNRFkQ7ybEZ5c0uPwPmF04rYo9Ig10in63un4rhU7Axpb7qp5VtQhNPGj7lnQviX9MeNOxx-URV-pZ5GF5Iom6U9Ljru2bPSJVXHggAA;
+      - esctx=AQABAAAAAAABlDrqfEFlSaui6xnRjX5Eq3yr1efzPbR178z4MbrDBH2hCMrgrd4h-1MtyOfWCMSyz3Wj_3B8Zdyxl2klCYcF1LkptIMNnjq4ikDUtbGjUQ_YNouKumjFgv0NrllNDsqZJJUcHPEkuI8SL4dMrZE2BJKxmIMLUET5i7q343DvV8LFcGtQQnHJeGn4gq4Qg1AgAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=004; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=007; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Tue, 05 Sep 2017 20:04:09 GMT
+      - Fri, 22 Sep 2017 21:42:16 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1504645449","not_before":"1504641549","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NDksIm5iZiI6MTUwNDY0MTU0OSwiZXhwIjoxNTA0NjQ1NDQ5LCJhaW8iOiJZMkZnWUNoZGZKRk5mZUxMN3B5cmw1M3NndFEzQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRGNGNDZmM09rRUdzRVNMdWlnQWZBQSIsInZlciI6IjEuMCJ9.AR_jrsHpdawxmobSw-5a1K9fdF9e1Rm4M7Qz769NmejPrLr0R2XyzdKtfWsBbmuNPdHhz9mnG1Vp8ZKEnTCODJTf0AH_zu1HFQTYyDAbfWCj8kJO3_Xc6KzB-EnpgW_Aq6LpDKpyIkY2LiiU1V50dpqGTO7zxt2dIhgZbypNeLejbO9FeBHdjED7KwPvGQ3T-IKEE02uTOKm_1Agd89IuSJDTh4yKVxs19oc4KryrBTVj7dcwXOW2JrrK_A6PMVH1Nn6Nqer_vED6qDMGyU_UVTGvxtxmheWJDcabfZftNHyvhITCNpd7Jp_X0bezAX_o1Wz-abuqO3DTootCwTzKg"}'
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1506120137","not_before":"1506116237","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMzcsIm5iZiI6MTUwNjExNjIzNywiZXhwIjoxNTA2MTIwMTM3LCJhaW8iOiJZMlZnWUNpcG5ibDUwYk83RmV0ZjNTdFh5VlpLQmdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUhOS3hHb2pGRWU0aWZqRWE1OE1BQSIsInZlciI6IjEuMCJ9.YoVpr2T3l2iTzavKGXCTyf7I6tpWQ7zFH1yhWYBQeIjEzRiKEt0bBk2ImDTlqEedvQtTrES-7Py8sCKgj9fjeCAnXzOh2dl5fd2Z7U7DjzkPWeE33qylquZMhYOugI7yymgGAvh-EouKAflV3rJuYyo8ftiuQ1rHPv7D0KHuBqxSiNvYnlVf84-CepHlNUP5x_lJ7sX8rsZRWwjVLCoWU-Twz3VmqbQYyyeyqlpGBzfKns130Wa5vLLkwKoT5IxtKtW47uk1gL4M5PwZaxJIkm3bWSiOGebmzKEMSu8nWSSc2O_ZdI0XFMjKeDlOgX0CwCgzTrQpXeJ7lospdprQ8w"}'
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:09 GMT
+  recorded_at: Fri, 22 Sep 2017 21:42:16 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -74,9 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NDksIm5iZiI6MTUwNDY0MTU0OSwiZXhwIjoxNTA0NjQ1NDQ5LCJhaW8iOiJZMkZnWUNoZGZKRk5mZUxMN3B5cmw1M3NndFEzQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRGNGNDZmM09rRUdzRVNMdWlnQWZBQSIsInZlciI6IjEuMCJ9.AR_jrsHpdawxmobSw-5a1K9fdF9e1Rm4M7Qz769NmejPrLr0R2XyzdKtfWsBbmuNPdHhz9mnG1Vp8ZKEnTCODJTf0AH_zu1HFQTYyDAbfWCj8kJO3_Xc6KzB-EnpgW_Aq6LpDKpyIkY2LiiU1V50dpqGTO7zxt2dIhgZbypNeLejbO9FeBHdjED7KwPvGQ3T-IKEE02uTOKm_1Agd89IuSJDTh4yKVxs19oc4KryrBTVj7dcwXOW2JrrK_A6PMVH1Nn6Nqer_vED6qDMGyU_UVTGvxtxmheWJDcabfZftNHyvhITCNpd7Jp_X0bezAX_o1Wz-abuqO3DTootCwTzKg
-      Host:
-      - management.azure.com
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMzcsIm5iZiI6MTUwNjExNjIzNywiZXhwIjoxNTA2MTIwMTM3LCJhaW8iOiJZMlZnWUNpcG5ibDUwYk83RmV0ZjNTdFh5VlpLQmdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUhOS3hHb2pGRWU0aWZqRWE1OE1BQSIsInZlciI6IjEuMCJ9.YoVpr2T3l2iTzavKGXCTyf7I6tpWQ7zFH1yhWYBQeIjEzRiKEt0bBk2ImDTlqEedvQtTrES-7Py8sCKgj9fjeCAnXzOh2dl5fd2Z7U7DjzkPWeE33qylquZMhYOugI7yymgGAvh-EouKAflV3rJuYyo8ftiuQ1rHPv7D0KHuBqxSiNvYnlVf84-CepHlNUP5x_lJ7sX8rsZRWwjVLCoWU-Twz3VmqbQYyyeyqlpGBzfKns130Wa5vLLkwKoT5IxtKtW47uk1gL4M5PwZaxJIkm3bWSiOGebmzKEMSu8nWSSc2O_ZdI0XFMjKeDlOgX0CwCgzTrQpXeJ7lospdprQ8w
   response:
     status:
       code: 200
@@ -95,23 +91,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14997'
+      - '14999'
       X-Ms-Request-Id:
-      - 0b1bfbda-4df5-474f-a900-c8093a31f73e
+      - f7a987b3-e327-4447-8c86-e8a80358410c
       X-Ms-Correlation-Request-Id:
-      - 0b1bfbda-4df5-474f-a900-c8093a31f73e
+      - f7a987b3-e327-4447-8c86-e8a80358410c
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200410Z:0b1bfbda-4df5-474f-a900-c8093a31f73e
+      - WESTUS:20170922T214218Z:f7a987b3-e327-4447-8c86-e8a80358410c
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 05 Sep 2017 20:04:10 GMT
+      - Fri, 22 Sep 2017 21:42:17 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:09 GMT
+  recorded_at: Fri, 22 Sep 2017 21:42:17 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/azure_subscription_id/providers?api-version=2015-01-01
@@ -128,9 +124,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NDksIm5iZiI6MTUwNDY0MTU0OSwiZXhwIjoxNTA0NjQ1NDQ5LCJhaW8iOiJZMkZnWUNoZGZKRk5mZUxMN3B5cmw1M3NndFEzQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRGNGNDZmM09rRUdzRVNMdWlnQWZBQSIsInZlciI6IjEuMCJ9.AR_jrsHpdawxmobSw-5a1K9fdF9e1Rm4M7Qz769NmejPrLr0R2XyzdKtfWsBbmuNPdHhz9mnG1Vp8ZKEnTCODJTf0AH_zu1HFQTYyDAbfWCj8kJO3_Xc6KzB-EnpgW_Aq6LpDKpyIkY2LiiU1V50dpqGTO7zxt2dIhgZbypNeLejbO9FeBHdjED7KwPvGQ3T-IKEE02uTOKm_1Agd89IuSJDTh4yKVxs19oc4KryrBTVj7dcwXOW2JrrK_A6PMVH1Nn6Nqer_vED6qDMGyU_UVTGvxtxmheWJDcabfZftNHyvhITCNpd7Jp_X0bezAX_o1Wz-abuqO3DTootCwTzKg
-      Host:
-      - management.azure.com
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMzcsIm5iZiI6MTUwNjExNjIzNywiZXhwIjoxNTA2MTIwMTM3LCJhaW8iOiJZMlZnWUNpcG5ibDUwYk83RmV0ZjNTdFh5VlpLQmdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUhOS3hHb2pGRWU0aWZqRWE1OE1BQSIsInZlciI6IjEuMCJ9.YoVpr2T3l2iTzavKGXCTyf7I6tpWQ7zFH1yhWYBQeIjEzRiKEt0bBk2ImDTlqEedvQtTrES-7Py8sCKgj9fjeCAnXzOh2dl5fd2Z7U7DjzkPWeE33qylquZMhYOugI7yymgGAvh-EouKAflV3rJuYyo8ftiuQ1rHPv7D0KHuBqxSiNvYnlVf84-CepHlNUP5x_lJ7sX8rsZRWwjVLCoWU-Twz3VmqbQYyyeyqlpGBzfKns130Wa5vLLkwKoT5IxtKtW47uk1gL4M5PwZaxJIkm3bWSiOGebmzKEMSu8nWSSc2O_ZdI0XFMjKeDlOgX0CwCgzTrQpXeJ7lospdprQ8w
   response:
     status:
       code: 200
@@ -147,22 +141,42 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14975'
+      - '14908'
       X-Ms-Request-Id:
-      - 74ec8dc8-ccae-447e-bda5-7b51d4068dfc
+      - 4b688839-35e8-4277-a471-18d97a0a4f62
       X-Ms-Correlation-Request-Id:
-      - 74ec8dc8-ccae-447e-bda5-7b51d4068dfc
+      - 4b688839-35e8-4277-a471-18d97a0a4f62
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200411Z:74ec8dc8-ccae-447e-bda5-7b51d4068dfc
+      - WESTUS:20170922T214219Z:4b688839-35e8-4277-a471-18d97a0a4f62
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 05 Sep 2017 20:04:11 GMT
+      - Fri, 22 Sep 2017 21:42:18 GMT
       Content-Length:
-      - '243687'
+      - '254785'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
+      string: '{"value":[{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"operations","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","North Central
         US","South Central US","West Central US","West US","West US 2","Canada Central","Canada
         East","North Europe","West Europe","UK South","UK West","East Asia","Southeast
@@ -437,7 +451,7 @@ http_interactions:
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
         Central US","West US 2","South India","Central India","West India","Canada
-        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
+        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
         East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
@@ -466,7 +480,7 @@ http_interactions:
         Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"}],"resourceTypes":[{"resourceType":"components","locations":["East
         US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
         US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01","2014-04-01"]},{"resourceType":"queries","locations":["East
-        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"alertrules","locations":["West
+        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
@@ -542,7 +556,7 @@ http_interactions:
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorization":{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorizations":[{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},{"applicationId":"7c33bfcb-8d33-48d6-8e60-dc6404003489","roleDefinitionId":"ad6261e4-fa9a-4642-aa5f-104f1b67e9e3"},{"applicationId":"1e3e4475-288f-4018-a376-df66fd7fac5f","roleDefinitionId":"1d538b69-3d87-4e56-8ff8-25786fd48261"},{"applicationId":"a0be0c72-870e-46f0-9c49-c98333a996f7","roleDefinitionId":"7ce22727-ffce-45a9-930c-ddb2e56fa131"}],"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -552,7 +566,7 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -567,7 +581,8 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
+        Central US"],"apiVersions":["2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -577,7 +592,12 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -597,7 +617,7 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -612,7 +632,7 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -622,7 +642,31 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
         East","UK South","Central India","Canada Central"],"apiVersions":["2017-04-26-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"]},{"resourceType":"workspaces/dataSources","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
@@ -641,17 +685,17 @@ http_interactions:
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"consoles","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/consoles","locations":["West
+        East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"consoles","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/consoles","locations":["West
         US","East US","Central India","North Europe","West Europe","South Central
-        US","Southeast Asia"],"apiVersions":["2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
+        US","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
         US","East US","Central India","North Europe","West Europe","South Central
-        US","Southeast Asia"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
+        US","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","Canada Central","Canada East","West Central US","West US 2","UK South","UK
         West","Korea Central","Korea South"],"apiVersions":["2017-07-01","2016-12-01","2016-08-10","2016-06-01","2016-05-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"operations","locations":["Southeast
-        Asia"],"apiVersions":["2016-08-10","2016-06-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01"]},{"resourceType":"locations/backupStatus","locations":["West
+        Asia"],"apiVersions":["2016-08-10","2016-06-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01","2016-06-01"]},{"resourceType":"locations/backupStatus","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
@@ -687,6 +731,7 @@ http_interactions:
         Central US","Central US","North Europe","West Europe","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada Central","Canada East"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"pricings","locations":["Central
+        US","East US"],"apiVersions":["2017-08-01-preview"]},{"resourceType":"securityContacts","locations":["Central
         US","East US"],"apiVersions":["2017-08-01-preview"]},{"resourceType":"workspaceSettings","locations":["Central
         US","East US"],"apiVersions":["2017-08-01-preview"]},{"resourceType":"complianceResults","locations":["Central
         US","East US"],"apiVersions":["2017-08-01"]},{"resourceType":"policies","locations":["Central
@@ -703,6 +748,8 @@ http_interactions:
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatusesSummaries","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/alerts","locations":["Central
         US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/tasks","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"externalSecuritySolutions","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/externalSecuritySolutions","locations":["Central
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.SiteRecovery","namespace":"Microsoft.SiteRecovery","authorization":{"applicationId":"b8340c3b-9267-498f-b21a-15d5547fd85e","roleDefinitionId":"8A00C8EA-8F1B-45A7-8F64-F4CC61EEE9B6"},"resourceTypes":[{"resourceType":"SiteRecoveryVault","locations":["East
         US","West US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","Australia East","Australia Southeast","Brazil South","North
@@ -722,7 +769,7 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -842,7 +889,22 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/databases/transparentDataEncryption","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -1077,6 +1139,26 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
         US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
@@ -1307,6 +1389,11 @@ http_interactions:
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"customApis","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
         East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/managedApis","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
@@ -1358,23 +1445,8 @@ http_interactions:
         US","North Europe","Japan West","Japan East","East Asia","West Europe","East
         US","Southeast Asia","Central US"],"apiVersions":["2016-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Lombiq.DotNest","namespace":"Lombiq.DotNest","resourceTypes":[{"resourceType":"sites","locations":["East
         US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Mailjet.Email","namespace":"Mailjet.Email","resourceTypes":[{"resourceType":"services","locations":["West
-        US"],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
-        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]},{"resourceType":"diagnosticSettings","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"addsservices","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"configuration","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"operations","locations":["West
@@ -1498,8 +1570,10 @@ http_interactions:
         Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
         Central US","Central US","North Europe","West Europe","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","West
-        India","South India"],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CognitiveServices","namespace":"Microsoft.CognitiveServices","authorizations":[{"applicationId":"7d312290-28c8-473c-a0ed-8e53749b6d6d","roleDefinitionId":"5cb87f79-a7c3-4a95-9414-45b65974b51b"}],"resourceTypes":[{"resourceType":"accounts","locations":["Global","West
-        US","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"operations","locations":["Global","Australia
+        India","South India"],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CognitiveServices","namespace":"Microsoft.CognitiveServices","authorizations":[{"applicationId":"7d312290-28c8-473c-a0ed-8e53749b6d6d","roleDefinitionId":"5cb87f79-a7c3-4a95-9414-45b65974b51b"}],"resourceTypes":[{"resourceType":"accounts","locations":["Global","Australia
+        East","Brazil South","West US","West US 2","West Europe","North Europe","Southeast
+        Asia","East Asia","West Central US","South Central US","East US","East US
+        2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"operations","locations":["Global","Australia
         East","Brazil South","West US","West US 2","West Europe","North Europe","Southeast
         Asia","East Asia","West Central US","South Central US","East US","East US
         2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations","locations":["Global","Australia
@@ -1534,13 +1608,13 @@ http_interactions:
         US","West US","Australia East","West Europe","North Europe","Southeast Asia","West
         Central US"],"apiVersions":["2016-03-30","2015-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataFactory","namespace":"Microsoft.DataFactory","resourceTypes":[{"resourceType":"dataFactories","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview","2014-04-01"]},{"resourceType":"factories","locations":["East
-        US"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
-        US"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
+        US","East US 2"],"apiVersions":["2017-09-01-preview","2017-03-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
+        US","East US 2"],"apiVersions":["2017-09-01-preview","2017-03-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
         Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"dataFactories/metricDefinitions","locations":["North
         Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"checkDataFactoryNameAvailability","locations":[],"apiVersions":["2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"checkAzureDataFactoryNameAvailability","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"dataFactorySchema","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"operations","locations":["West
-        US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeAnalytics","namespace":"Microsoft.DataLakeAnalytics","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US","North Europe","East US","West Central US"],"apiVersions":["2017-09-01-preview","2017-03-01-preview","2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeAnalytics","namespace":"Microsoft.DataLakeAnalytics","resourceTypes":[{"resourceType":"accounts","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/dataLakeStoreAccounts","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers","locations":["East
@@ -1589,11 +1663,12 @@ http_interactions:
         India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
         India","East Asia","East US 2","East US","Japan East","Japan West","North
         Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"checkProvisioningServiceNameAvailability","locations":[],"apiVersions":["2017-08-21-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
         US","North Europe","East Asia","East US","West Europe","Southeast Asia","Japan
         East","Japan West","Australia East","Australia Southeast","West US 2","West
         Central US","East US 2","Central US","UK South","UK West","South India","Central
-        India"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
+        India","Canada Central","Canada East"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"ProvisioningServices","locations":["East
+        US","West Europe","Southeast Asia"],"apiVersions":["2017-08-21-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
         East","Australia Southeast","Canada Central","Canada East","Central India","Central
         US","East Asia","East US","East US 2","Japan East","Japan West","North Central
         US","North Europe","South Central US","South India","Southeast Asia","West
@@ -1620,16 +1695,16 @@ http_interactions:
         US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"operations","locations":["Brazil
         South","East Asia","East US","Japan East","Japan West","North Central US","North
         Europe","South Central US","West Europe","West US","Southeast Asia","Central
-        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"topics","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operations","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topics","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operations","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","West
         US 2","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
@@ -1727,48 +1802,39 @@ http_interactions:
         Central US","West Europe","Southeast Asia","Japan East","East US 2","West
         Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"commitmentPlans","locations":["South
         Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
-        Central US","West US"],"apiVersions":["2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Media","namespace":"Microsoft.Media","authorization":{"applicationId":"374b2a64-3b6b-436b-934c-b820eacca870","roleDefinitionId":"aab70789-0cec-44b5-95d7-84b64c9487af"},"resourceTypes":[{"resourceType":"mediaservices","locations":["Japan
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningExperimentation","namespace":"Microsoft.MachineLearningExperimentation","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"accounts","locations":["Australia
+        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces","locations":["Australia
+        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces/projects","locations":["Australia
+        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningCompute","namespace":"Microsoft.MachineLearningCompute","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"376aa7d7-51a9-463d-bd4d-7e1691345612","managedByRoleDefinitionId":"91d00862-cf55-46a5-9dce-260bbd92ce25"},"resourceTypes":[{"resourceType":"operationalizationClusters","locations":["East
+        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"operations","locations":["East
+        US 2"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations","locations":["East
+        US 2"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["East
+        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningModelManagement","namespace":"Microsoft.MachineLearningModelManagement","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US 2","West Central US","Australia East"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"operations","locations":["West
+        Central US"],"apiVersions":["2017-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
+        Central US","West US"],"apiVersions":["2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01"]},{"resourceType":"offertypes","locations":["South
+        Central US","West US"],"apiVersions":["2015-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Media","namespace":"Microsoft.Media","authorization":{"applicationId":"374b2a64-3b6b-436b-934c-b820eacca870","roleDefinitionId":"aab70789-0cec-44b5-95d7-84b64c9487af"},"resourceTypes":[{"resourceType":"mediaservices","locations":["Japan
         West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
         US","West US","Australia East","Australia Southeast","Central US","Brazil
         South","Central India","West India","South India","South Central US","Canada
-        Central","Canada East","West Central US"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
+        Central","Canada East","West Central US"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
         Central US","North Central US","East US 2","West US","West Europe","North
         Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
         East","UK South","West India"],"apiVersions":["2016-01-29"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-01-29"]},{"resourceType":"locations/checkNameAvailability","locations":["South
         Central US","North Central US","East US 2","West US","West Europe","North
         Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
-        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"operations","locations":["East
+        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"capacities","locations":["West
+        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
+        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationresults","locations":["West
+        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
+        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"operations","locations":["East
         US 2"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Relay","namespace":"Microsoft.Relay","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US 2","West
         US","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
         India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2017-08-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkPolicyCompliance","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
@@ -1827,8 +1893,11 @@ http_interactions:
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","resourceTypes":[{"resourceType":"operations","locations":["West
-        Central US"],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
+        Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applianceDefinitions","locations":["West
+        Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"locations","locations":["West
+        Central US"],"apiVersions":["2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
+        Central US"],"apiVersions":["2017-09-01","2016-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","West Central US","Japan East","Japan West","Australia East","Australia
         Southeast"],"apiVersions":["2017-06-01","2017-05-15","2017-01-01","2016-10-01","2016-06-01","2015-03-15","2014-09-01"]},{"resourceType":"operations","locations":["West
@@ -1888,11 +1957,17 @@ http_interactions:
         US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RedisLabs.Memcached","namespace":"RedisLabs.Memcached","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-07-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RedisLabs.Redis","namespace":"RedisLabs.Redis","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-07-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RevAPM.MobileCDN","namespace":"RevAPM.MobileCDN","resourceTypes":[{"resourceType":"accounts","locations":["Central
         US","East US","East US 2","North Central US","South Central US","West US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
-        East","Australia Southeast"],"apiVersions":["2016-08-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-24","2016-08-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sendgrid.Email","namespace":"Sendgrid.Email","resourceTypes":[{"resourceType":"accounts","locations":["East
-        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
-        Central US","Central US","North Europe","West Europe","Japan East","Japan
-        West","Brazil South","Australia East","Australia Southeast","Canada Central","Canada
-        East","West Central US","West US 2","UK South","UK West"],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Signiant.Flight","namespace":"Signiant.Flight","resourceTypes":[{"resourceType":"accounts","locations":["East
+        East","Australia Southeast"],"apiVersions":["2016-08-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-24","2016-08-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sendgrid.Email","namespace":"Sendgrid.Email","resourceTypes":[{"resourceType":"accounts","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Signiant.Flight","namespace":"Signiant.Flight","resourceTypes":[{"resourceType":"accounts","locations":["East
         US","Central US","North Central US","South Central US","West US","North Europe","West
         Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast"],"apiVersions":["2015-06-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sparkpost.Basic","namespace":"Sparkpost.Basic","resourceTypes":[{"resourceType":"services","locations":["West
@@ -1909,7 +1984,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:10 GMT
+  recorded_at: Fri, 22 Sep 2017 21:42:18 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
@@ -1926,11 +2001,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NDksIm5iZiI6MTUwNDY0MTU0OSwiZXhwIjoxNTA0NjQ1NDQ5LCJhaW8iOiJZMkZnWUNoZGZKRk5mZUxMN3B5cmw1M3NndFEzQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRGNGNDZmM09rRUdzRVNMdWlnQWZBQSIsInZlciI6IjEuMCJ9.AR_jrsHpdawxmobSw-5a1K9fdF9e1Rm4M7Qz769NmejPrLr0R2XyzdKtfWsBbmuNPdHhz9mnG1Vp8ZKEnTCODJTf0AH_zu1HFQTYyDAbfWCj8kJO3_Xc6KzB-EnpgW_Aq6LpDKpyIkY2LiiU1V50dpqGTO7zxt2dIhgZbypNeLejbO9FeBHdjED7KwPvGQ3T-IKEE02uTOKm_1Agd89IuSJDTh4yKVxs19oc4KryrBTVj7dcwXOW2JrrK_A6PMVH1Nn6Nqer_vED6qDMGyU_UVTGvxtxmheWJDcabfZftNHyvhITCNpd7Jp_X0bezAX_o1Wz-abuqO3DTootCwTzKg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMzcsIm5iZiI6MTUwNjExNjIzNywiZXhwIjoxNTA2MTIwMTM3LCJhaW8iOiJZMlZnWUNpcG5ibDUwYk83RmV0ZjNTdFh5VlpLQmdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUhOS3hHb2pGRWU0aWZqRWE1OE1BQSIsInZlciI6IjEuMCJ9.YoVpr2T3l2iTzavKGXCTyf7I6tpWQ7zFH1yhWYBQeIjEzRiKEt0bBk2ImDTlqEedvQtTrES-7Py8sCKgj9fjeCAnXzOh2dl5fd2Z7U7DjzkPWeE33qylquZMhYOugI7yymgGAvh-EouKAflV3rJuYyo8ftiuQ1rHPv7D0KHuBqxSiNvYnlVf84-CepHlNUP5x_lJ7sX8rsZRWwjVLCoWU-Twz3VmqbQYyyeyqlpGBzfKns130Wa5vLLkwKoT5IxtKtW47uk1gL4M5PwZaxJIkm3bWSiOGebmzKEMSu8nWSSc2O_ZdI0XFMjKeDlOgX0CwCgzTrQpXeJ7lospdprQ8w
       Content-Length:
       - '42'
-      Host:
-      - management.azure.com
   response:
     status:
       code: 202
@@ -1945,34 +2018,34 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/aba9273c-4512-42f3-8784-0da77f118f0b?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/1fc03e7c-56c6-4c4a-a6ff-8b7ef21827fb?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/aba9273c-4512-42f3-8784-0da77f118f0b?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/1fc03e7c-56c6-4c4a-a6ff-8b7ef21827fb?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - aba9273c-4512-42f3-8784-0da77f118f0b
+      - 1fc03e7c-56c6-4c4a-a6ff-8b7ef21827fb
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1199'
+      - '1182'
       X-Ms-Correlation-Request-Id:
-      - bcb6ba11-c525-4b7c-8d1d-96da8287efd4
+      - 836f77e4-cdd0-436c-9b76-d0e51e146ff7
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200412Z:bcb6ba11-c525-4b7c-8d1d-96da8287efd4
+      - WESTUS:20170922T214220Z:836f77e4-cdd0-436c-9b76-d0e51e146ff7
       Date:
-      - Tue, 05 Sep 2017 20:04:11 GMT
+      - Fri, 22 Sep 2017 21:42:20 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:10 GMT
+  recorded_at: Fri, 22 Sep 2017 21:42:20 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/aba9273c-4512-42f3-8784-0da77f118f0b?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/1fc03e7c-56c6-4c4a-a6ff-8b7ef21827fb?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -1986,9 +2059,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NDksIm5iZiI6MTUwNDY0MTU0OSwiZXhwIjoxNTA0NjQ1NDQ5LCJhaW8iOiJZMkZnWUNoZGZKRk5mZUxMN3B5cmw1M3NndFEzQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRGNGNDZmM09rRUdzRVNMdWlnQWZBQSIsInZlciI6IjEuMCJ9.AR_jrsHpdawxmobSw-5a1K9fdF9e1Rm4M7Qz769NmejPrLr0R2XyzdKtfWsBbmuNPdHhz9mnG1Vp8ZKEnTCODJTf0AH_zu1HFQTYyDAbfWCj8kJO3_Xc6KzB-EnpgW_Aq6LpDKpyIkY2LiiU1V50dpqGTO7zxt2dIhgZbypNeLejbO9FeBHdjED7KwPvGQ3T-IKEE02uTOKm_1Agd89IuSJDTh4yKVxs19oc4KryrBTVj7dcwXOW2JrrK_A6PMVH1Nn6Nqer_vED6qDMGyU_UVTGvxtxmheWJDcabfZftNHyvhITCNpd7Jp_X0bezAX_o1Wz-abuqO3DTootCwTzKg
-      Host:
-      - management.azure.com
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMzcsIm5iZiI6MTUwNjExNjIzNywiZXhwIjoxNTA2MTIwMTM3LCJhaW8iOiJZMlZnWUNpcG5ibDUwYk83RmV0ZjNTdFh5VlpLQmdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUhOS3hHb2pGRWU0aWZqRWE1OE1BQSIsInZlciI6IjEuMCJ9.YoVpr2T3l2iTzavKGXCTyf7I6tpWQ7zFH1yhWYBQeIjEzRiKEt0bBk2ImDTlqEedvQtTrES-7Py8sCKgj9fjeCAnXzOh2dl5fd2Z7U7DjzkPWeE33qylquZMhYOugI7yymgGAvh-EouKAflV3rJuYyo8ftiuQ1rHPv7D0KHuBqxSiNvYnlVf84-CepHlNUP5x_lJ7sX8rsZRWwjVLCoWU-Twz3VmqbQYyyeyqlpGBzfKns130Wa5vLLkwKoT5IxtKtW47uk1gL4M5PwZaxJIkm3bWSiOGebmzKEMSu8nWSSc2O_ZdI0XFMjKeDlOgX0CwCgzTrQpXeJ7lospdprQ8w
   response:
     status:
       code: 200
@@ -2009,31 +2080,90 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - a051370d-a307-4b62-b920-32ff82791879
+      - ebf45581-67ea-47f8-b9d0-c726e55f13eb
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14991'
+      - '14926'
       X-Ms-Correlation-Request-Id:
-      - b52eb77e-177d-4a31-ac31-98f42acd084c
+      - eb92bb95-1a2f-4ab2-a42a-168c42d387b5
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200412Z:b52eb77e-177d-4a31-ac31-98f42acd084c
+      - WESTUS:20170922T214221Z:eb92bb95-1a2f-4ab2-a42a-168c42d387b5
       Date:
-      - Tue, 05 Sep 2017 20:04:11 GMT
+      - Fri, 22 Sep 2017 21:42:21 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-05T20:04:10.8398348+00:00\",\r\n  \"endTime\":
-        \"2017-09-05T20:04:10.9804778+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=4b1a8972-03e5-4868-82d8-3b1d5f84dd63&sig=GGkAww3LdegTSWOBl6W%2FisM6lJpAnMTgBHU6C12aT5o%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"aba9273c-4512-42f3-8784-0da77f118f0b\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2017-09-22T21:42:22.2770117+00:00\",\r\n  \"endTime\":
+        \"2017-09-22T21:42:22.4957963+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=8c3fd0d4-af3e-492a-a165-b6c714523fc7&sig=XOviiyOJG%2FRmyir%2BMLy6b9XxHEkYHTZ9xxhIV8SwG3w%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"1fc03e7c-56c6-4c4a-a6ff-8b7ef21827fb\"\r\n}"
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:11 GMT
+  recorded_at: Fri, 22 Sep 2017 21:42:21 GMT
 - request:
     method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=4b1a8972-03e5-4868-82d8-3b1d5f84dd63&sig=GGkAww3LdegTSWOBl6W/isM6lJpAnMTgBHU6C12aT5o=&sr=b&sv=2016-05-31
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/1fc03e7c-56c6-4c4a-a6ff-8b7ef21827fb?api-version=2017-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMzcsIm5iZiI6MTUwNjExNjIzNywiZXhwIjoxNTA2MTIwMTM3LCJhaW8iOiJZMlZnWUNpcG5ibDUwYk83RmV0ZjNTdFh5VlpLQmdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUhOS3hHb2pGRWU0aWZqRWE1OE1BQSIsInZlciI6IjEuMCJ9.YoVpr2T3l2iTzavKGXCTyf7I6tpWQ7zFH1yhWYBQeIjEzRiKEt0bBk2ImDTlqEedvQtTrES-7Py8sCKgj9fjeCAnXzOh2dl5fd2Z7U7DjzkPWeE33qylquZMhYOugI7yymgGAvh-EouKAflV3rJuYyo8ftiuQ1rHPv7D0KHuBqxSiNvYnlVf84-CepHlNUP5x_lJ7sX8rsZRWwjVLCoWU-Twz3VmqbQYyyeyqlpGBzfKns130Wa5vLLkwKoT5IxtKtW47uk1gL4M5PwZaxJIkm3bWSiOGebmzKEMSu8nWSSc2O_ZdI0XFMjKeDlOgX0CwCgzTrQpXeJ7lospdprQ8w
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
+      X-Ms-Request-Id:
+      - 9e979d98-d0d1-464a-9953-f9432a019bc5
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14926'
+      X-Ms-Correlation-Request-Id:
+      - 43403207-4162-40f2-a508-a0fb38d5411b
+      X-Ms-Routing-Request-Id:
+      - WESTUS:20170922T214223Z:43403207-4162-40f2-a508-a0fb38d5411b
+      Date:
+      - Fri, 22 Sep 2017 21:42:22 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"startTime\": \"2017-09-22T21:42:22.2770117+00:00\",\r\n  \"endTime\":
+        \"2017-09-22T21:42:22.4957963+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=8c3fd0d4-af3e-492a-a165-b6c714523fc7&sig=XOviiyOJG%2FRmyir%2BMLy6b9XxHEkYHTZ9xxhIV8SwG3w%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"1fc03e7c-56c6-4c4a-a6ff-8b7ef21827fb\"\r\n}"
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 21:42:22 GMT
+- request:
+    method: get
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=8c3fd0d4-af3e-492a-a165-b6c714523fc7&sig=XOviiyOJG/Rmyir%2BMLy6b9XxHEkYHTZ9xxhIV8SwG3w=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2046,8 +2176,6 @@ http_interactions:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
       X-Ms-Range:
       - bytes=0-0
-      Host:
-      - md-t4jdgqqlgszp.blob.core.windows.net
   response:
     status:
       code: 206
@@ -2068,7 +2196,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 0a8f71df-001e-013c-1a82-2653a3000000
+      - 49bb9997-001e-008b-4beb-331af3000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2094,13 +2222,13 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Tue, 05 Sep 2017 20:04:10 GMT
+      - Fri, 22 Sep 2017 21:42:23 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         6w==
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:11 GMT
+  recorded_at: Fri, 22 Sep 2017 21:42:22 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/EndGetAccess?api-version=2017-03-30
@@ -2117,11 +2245,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NDksIm5iZiI6MTUwNDY0MTU0OSwiZXhwIjoxNTA0NjQ1NDQ5LCJhaW8iOiJZMkZnWUNoZGZKRk5mZUxMN3B5cmw1M3NndFEzQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRGNGNDZmM09rRUdzRVNMdWlnQWZBQSIsInZlciI6IjEuMCJ9.AR_jrsHpdawxmobSw-5a1K9fdF9e1Rm4M7Qz769NmejPrLr0R2XyzdKtfWsBbmuNPdHhz9mnG1Vp8ZKEnTCODJTf0AH_zu1HFQTYyDAbfWCj8kJO3_Xc6KzB-EnpgW_Aq6LpDKpyIkY2LiiU1V50dpqGTO7zxt2dIhgZbypNeLejbO9FeBHdjED7KwPvGQ3T-IKEE02uTOKm_1Agd89IuSJDTh4yKVxs19oc4KryrBTVj7dcwXOW2JrrK_A6PMVH1Nn6Nqer_vED6qDMGyU_UVTGvxtxmheWJDcabfZftNHyvhITCNpd7Jp_X0bezAX_o1Wz-abuqO3DTootCwTzKg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMzcsIm5iZiI6MTUwNjExNjIzNywiZXhwIjoxNTA2MTIwMTM3LCJhaW8iOiJZMlZnWUNpcG5ibDUwYk83RmV0ZjNTdFh5VlpLQmdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUhOS3hHb2pGRWU0aWZqRWE1OE1BQSIsInZlciI6IjEuMCJ9.YoVpr2T3l2iTzavKGXCTyf7I6tpWQ7zFH1yhWYBQeIjEzRiKEt0bBk2ImDTlqEedvQtTrES-7Py8sCKgj9fjeCAnXzOh2dl5fd2Z7U7DjzkPWeE33qylquZMhYOugI7yymgGAvh-EouKAflV3rJuYyo8ftiuQ1rHPv7D0KHuBqxSiNvYnlVf84-CepHlNUP5x_lJ7sX8rsZRWwjVLCoWU-Twz3VmqbQYyyeyqlpGBzfKns130Wa5vLLkwKoT5IxtKtW47uk1gL4M5PwZaxJIkm3bWSiOGebmzKEMSu8nWSSc2O_ZdI0XFMjKeDlOgX0CwCgzTrQpXeJ7lospdprQ8w
       Content-Length:
       - '0'
-      Host:
-      - management.azure.com
   response:
     status:
       code: 202
@@ -2136,31 +2262,31 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/5f7953d7-1f68-4e41-8d8b-33c314d17266?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/fc8dcbdd-56cd-43e3-aeb5-1207bfad20c7?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/5f7953d7-1f68-4e41-8d8b-33c314d17266?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/fc8dcbdd-56cd-43e3-aeb5-1207bfad20c7?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - 5f7953d7-1f68-4e41-8d8b-33c314d17266
+      - fc8dcbdd-56cd-43e3-aeb5-1207bfad20c7
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1182'
+      - '1180'
       X-Ms-Correlation-Request-Id:
-      - a3697c6e-0e6a-4e43-ad93-3ef423f69978
+      - 1d360859-9e52-41df-aa87-8672e859fc03
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200412Z:a3697c6e-0e6a-4e43-ad93-3ef423f69978
+      - WESTUS:20170922T214224Z:1d360859-9e52-41df-aa87-8672e859fc03
       Date:
-      - Tue, 05 Sep 2017 20:04:12 GMT
+      - Fri, 22 Sep 2017 21:42:23 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:11 GMT
+  recorded_at: Fri, 22 Sep 2017 21:42:23 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
@@ -2177,11 +2303,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NDksIm5iZiI6MTUwNDY0MTU0OSwiZXhwIjoxNTA0NjQ1NDQ5LCJhaW8iOiJZMkZnWUNoZGZKRk5mZUxMN3B5cmw1M3NndFEzQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRGNGNDZmM09rRUdzRVNMdWlnQWZBQSIsInZlciI6IjEuMCJ9.AR_jrsHpdawxmobSw-5a1K9fdF9e1Rm4M7Qz769NmejPrLr0R2XyzdKtfWsBbmuNPdHhz9mnG1Vp8ZKEnTCODJTf0AH_zu1HFQTYyDAbfWCj8kJO3_Xc6KzB-EnpgW_Aq6LpDKpyIkY2LiiU1V50dpqGTO7zxt2dIhgZbypNeLejbO9FeBHdjED7KwPvGQ3T-IKEE02uTOKm_1Agd89IuSJDTh4yKVxs19oc4KryrBTVj7dcwXOW2JrrK_A6PMVH1Nn6Nqer_vED6qDMGyU_UVTGvxtxmheWJDcabfZftNHyvhITCNpd7Jp_X0bezAX_o1Wz-abuqO3DTootCwTzKg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMzcsIm5iZiI6MTUwNjExNjIzNywiZXhwIjoxNTA2MTIwMTM3LCJhaW8iOiJZMlZnWUNpcG5ibDUwYk83RmV0ZjNTdFh5VlpLQmdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUhOS3hHb2pGRWU0aWZqRWE1OE1BQSIsInZlciI6IjEuMCJ9.YoVpr2T3l2iTzavKGXCTyf7I6tpWQ7zFH1yhWYBQeIjEzRiKEt0bBk2ImDTlqEedvQtTrES-7Py8sCKgj9fjeCAnXzOh2dl5fd2Z7U7DjzkPWeE33qylquZMhYOugI7yymgGAvh-EouKAflV3rJuYyo8ftiuQ1rHPv7D0KHuBqxSiNvYnlVf84-CepHlNUP5x_lJ7sX8rsZRWwjVLCoWU-Twz3VmqbQYyyeyqlpGBzfKns130Wa5vLLkwKoT5IxtKtW47uk1gL4M5PwZaxJIkm3bWSiOGebmzKEMSu8nWSSc2O_ZdI0XFMjKeDlOgX0CwCgzTrQpXeJ7lospdprQ8w
       Content-Length:
       - '42'
-      Host:
-      - management.azure.com
   response:
     status:
       code: 202
@@ -2196,34 +2320,34 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/b84cfcb9-a4ae-4ebc-a20a-6610891a5cf0?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/2048457c-601a-4e3a-974a-36c6ad1134c0?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/b84cfcb9-a4ae-4ebc-a20a-6610891a5cf0?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/2048457c-601a-4e3a-974a-36c6ad1134c0?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - b84cfcb9-a4ae-4ebc-a20a-6610891a5cf0
+      - 2048457c-601a-4e3a-974a-36c6ad1134c0
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1182'
+      - '1183'
       X-Ms-Correlation-Request-Id:
-      - 8d41bc1c-b033-4a40-950d-540a1b20a8fd
+      - d699cb9e-93c0-42fd-bd1c-a7282016c9f6
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200413Z:8d41bc1c-b033-4a40-950d-540a1b20a8fd
+      - WESTUS:20170922T214224Z:d699cb9e-93c0-42fd-bd1c-a7282016c9f6
       Date:
-      - Tue, 05 Sep 2017 20:04:12 GMT
+      - Fri, 22 Sep 2017 21:42:24 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:11 GMT
+  recorded_at: Fri, 22 Sep 2017 21:42:24 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/b84cfcb9-a4ae-4ebc-a20a-6610891a5cf0?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/2048457c-601a-4e3a-974a-36c6ad1134c0?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -2237,9 +2361,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NDksIm5iZiI6MTUwNDY0MTU0OSwiZXhwIjoxNTA0NjQ1NDQ5LCJhaW8iOiJZMkZnWUNoZGZKRk5mZUxMN3B5cmw1M3NndFEzQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRGNGNDZmM09rRUdzRVNMdWlnQWZBQSIsInZlciI6IjEuMCJ9.AR_jrsHpdawxmobSw-5a1K9fdF9e1Rm4M7Qz769NmejPrLr0R2XyzdKtfWsBbmuNPdHhz9mnG1Vp8ZKEnTCODJTf0AH_zu1HFQTYyDAbfWCj8kJO3_Xc6KzB-EnpgW_Aq6LpDKpyIkY2LiiU1V50dpqGTO7zxt2dIhgZbypNeLejbO9FeBHdjED7KwPvGQ3T-IKEE02uTOKm_1Agd89IuSJDTh4yKVxs19oc4KryrBTVj7dcwXOW2JrrK_A6PMVH1Nn6Nqer_vED6qDMGyU_UVTGvxtxmheWJDcabfZftNHyvhITCNpd7Jp_X0bezAX_o1Wz-abuqO3DTootCwTzKg
-      Host:
-      - management.azure.com
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMzcsIm5iZiI6MTUwNjExNjIzNywiZXhwIjoxNTA2MTIwMTM3LCJhaW8iOiJZMlZnWUNpcG5ibDUwYk83RmV0ZjNTdFh5VlpLQmdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUhOS3hHb2pGRWU0aWZqRWE1OE1BQSIsInZlciI6IjEuMCJ9.YoVpr2T3l2iTzavKGXCTyf7I6tpWQ7zFH1yhWYBQeIjEzRiKEt0bBk2ImDTlqEedvQtTrES-7Py8sCKgj9fjeCAnXzOh2dl5fd2Z7U7DjzkPWeE33qylquZMhYOugI7yymgGAvh-EouKAflV3rJuYyo8ftiuQ1rHPv7D0KHuBqxSiNvYnlVf84-CepHlNUP5x_lJ7sX8rsZRWwjVLCoWU-Twz3VmqbQYyyeyqlpGBzfKns130Wa5vLLkwKoT5IxtKtW47uk1gL4M5PwZaxJIkm3bWSiOGebmzKEMSu8nWSSc2O_ZdI0XFMjKeDlOgX0CwCgzTrQpXeJ7lospdprQ8w
   response:
     status:
       code: 200
@@ -2260,31 +2382,90 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - 46117c51-9c5f-4ba6-b19f-0c201afbbc27
+      - 419f00ed-c5ac-4df9-8ea9-9c6c52f4834a
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14982'
+      - '14928'
       X-Ms-Correlation-Request-Id:
-      - a9fe4789-45fb-41ed-9792-449751d4c51b
+      - 495e8477-0ab0-4f1d-8672-e6fef55c2d5f
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200413Z:a9fe4789-45fb-41ed-9792-449751d4c51b
+      - WESTUS:20170922T214225Z:495e8477-0ab0-4f1d-8672-e6fef55c2d5f
       Date:
-      - Tue, 05 Sep 2017 20:04:12 GMT
+      - Fri, 22 Sep 2017 21:42:25 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-05T20:04:12.0130126+00:00\",\r\n  \"endTime\":
-        \"2017-09-05T20:04:12.2317714+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=bbac6fcb-e317-4c5b-a8cc-4b6fbf66a30e&sig=90WL7Y7ntPcqDKdNxpWwAaaCj%2BQC5X7qPgRbsTUCck4%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"b84cfcb9-a4ae-4ebc-a20a-6610891a5cf0\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2017-09-22T21:42:26.371799+00:00\",\r\n  \"endTime\":
+        \"2017-09-22T21:42:26.5906056+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=933cf519-c18c-41c9-b869-296ad550c8ec&sig=ySPlelOr4JnSGD3oVObmAUGkFA3bE%2Fdh4AHc9QiseCQ%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"2048457c-601a-4e3a-974a-36c6ad1134c0\"\r\n}"
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:12 GMT
+  recorded_at: Fri, 22 Sep 2017 21:42:25 GMT
 - request:
     method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=bbac6fcb-e317-4c5b-a8cc-4b6fbf66a30e&sig=90WL7Y7ntPcqDKdNxpWwAaaCj%2BQC5X7qPgRbsTUCck4=&sr=b&sv=2016-05-31
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/2048457c-601a-4e3a-974a-36c6ad1134c0?api-version=2017-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMzcsIm5iZiI6MTUwNjExNjIzNywiZXhwIjoxNTA2MTIwMTM3LCJhaW8iOiJZMlZnWUNpcG5ibDUwYk83RmV0ZjNTdFh5VlpLQmdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUhOS3hHb2pGRWU0aWZqRWE1OE1BQSIsInZlciI6IjEuMCJ9.YoVpr2T3l2iTzavKGXCTyf7I6tpWQ7zFH1yhWYBQeIjEzRiKEt0bBk2ImDTlqEedvQtTrES-7Py8sCKgj9fjeCAnXzOh2dl5fd2Z7U7DjzkPWeE33qylquZMhYOugI7yymgGAvh-EouKAflV3rJuYyo8ftiuQ1rHPv7D0KHuBqxSiNvYnlVf84-CepHlNUP5x_lJ7sX8rsZRWwjVLCoWU-Twz3VmqbQYyyeyqlpGBzfKns130Wa5vLLkwKoT5IxtKtW47uk1gL4M5PwZaxJIkm3bWSiOGebmzKEMSu8nWSSc2O_ZdI0XFMjKeDlOgX0CwCgzTrQpXeJ7lospdprQ8w
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
+      X-Ms-Request-Id:
+      - 50473a99-076e-40c3-adac-b93ccca7066f
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14943'
+      X-Ms-Correlation-Request-Id:
+      - 2b602f54-51f3-490a-985e-f2228f898e82
+      X-Ms-Routing-Request-Id:
+      - WESTUS:20170922T214226Z:2b602f54-51f3-490a-985e-f2228f898e82
+      Date:
+      - Fri, 22 Sep 2017 21:42:26 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"startTime\": \"2017-09-22T21:42:26.371799+00:00\",\r\n  \"endTime\":
+        \"2017-09-22T21:42:26.5906056+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=933cf519-c18c-41c9-b869-296ad550c8ec&sig=ySPlelOr4JnSGD3oVObmAUGkFA3bE%2Fdh4AHc9QiseCQ%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"2048457c-601a-4e3a-974a-36c6ad1134c0\"\r\n}"
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 21:42:26 GMT
+- request:
+    method: get
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=933cf519-c18c-41c9-b869-296ad550c8ec&sig=ySPlelOr4JnSGD3oVObmAUGkFA3bE/dh4AHc9QiseCQ=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2297,8 +2478,6 @@ http_interactions:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
       X-Ms-Range:
       - bytes=440-443
-      Host:
-      - md-t4jdgqqlgszp.blob.core.windows.net
   response:
     status:
       code: 206
@@ -2319,7 +2498,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - abda2fb4-001e-00a1-2282-266fb6000000
+      - 80c8611f-001e-009b-33eb-332c15000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2345,13 +2524,13 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Tue, 05 Sep 2017 20:04:13 GMT
+      - Fri, 22 Sep 2017 21:42:30 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         U5MJAA==
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:12 GMT
+  recorded_at: Fri, 22 Sep 2017 21:42:29 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/EndGetAccess?api-version=2017-03-30
@@ -2368,11 +2547,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NDksIm5iZiI6MTUwNDY0MTU0OSwiZXhwIjoxNTA0NjQ1NDQ5LCJhaW8iOiJZMkZnWUNoZGZKRk5mZUxMN3B5cmw1M3NndFEzQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRGNGNDZmM09rRUdzRVNMdWlnQWZBQSIsInZlciI6IjEuMCJ9.AR_jrsHpdawxmobSw-5a1K9fdF9e1Rm4M7Qz769NmejPrLr0R2XyzdKtfWsBbmuNPdHhz9mnG1Vp8ZKEnTCODJTf0AH_zu1HFQTYyDAbfWCj8kJO3_Xc6KzB-EnpgW_Aq6LpDKpyIkY2LiiU1V50dpqGTO7zxt2dIhgZbypNeLejbO9FeBHdjED7KwPvGQ3T-IKEE02uTOKm_1Agd89IuSJDTh4yKVxs19oc4KryrBTVj7dcwXOW2JrrK_A6PMVH1Nn6Nqer_vED6qDMGyU_UVTGvxtxmheWJDcabfZftNHyvhITCNpd7Jp_X0bezAX_o1Wz-abuqO3DTootCwTzKg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMzcsIm5iZiI6MTUwNjExNjIzNywiZXhwIjoxNTA2MTIwMTM3LCJhaW8iOiJZMlZnWUNpcG5ibDUwYk83RmV0ZjNTdFh5VlpLQmdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUhOS3hHb2pGRWU0aWZqRWE1OE1BQSIsInZlciI6IjEuMCJ9.YoVpr2T3l2iTzavKGXCTyf7I6tpWQ7zFH1yhWYBQeIjEzRiKEt0bBk2ImDTlqEedvQtTrES-7Py8sCKgj9fjeCAnXzOh2dl5fd2Z7U7DjzkPWeE33qylquZMhYOugI7yymgGAvh-EouKAflV3rJuYyo8ftiuQ1rHPv7D0KHuBqxSiNvYnlVf84-CepHlNUP5x_lJ7sX8rsZRWwjVLCoWU-Twz3VmqbQYyyeyqlpGBzfKns130Wa5vLLkwKoT5IxtKtW47uk1gL4M5PwZaxJIkm3bWSiOGebmzKEMSu8nWSSc2O_ZdI0XFMjKeDlOgX0CwCgzTrQpXeJ7lospdprQ8w
       Content-Length:
       - '0'
-      Host:
-      - management.azure.com
   response:
     status:
       code: 202
@@ -2387,29 +2564,29 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/798ac150-9713-4c17-9c3c-1849063d9ea4?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/9b522a12-b704-48e5-9efc-7920d493d8dc?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/798ac150-9713-4c17-9c3c-1849063d9ea4?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/9b522a12-b704-48e5-9efc-7920d493d8dc?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - 798ac150-9713-4c17-9c3c-1849063d9ea4
+      - 9b522a12-b704-48e5-9efc-7920d493d8dc
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1181'
+      - '1177'
       X-Ms-Correlation-Request-Id:
-      - 2b090f10-1552-486a-a45c-95b42c8c9b57
+      - 3302db5f-a03d-4ebc-81c4-8fbffe218f30
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200413Z:2b090f10-1552-486a-a45c-95b42c8c9b57
+      - WESTUS:20170922T214230Z:3302db5f-a03d-4ebc-81c4-8fbffe218f30
       Date:
-      - Tue, 05 Sep 2017 20:04:13 GMT
+      - Fri, 22 Sep 2017 21:42:30 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:12 GMT
+  recorded_at: Fri, 22 Sep 2017 21:42:30 GMT
 recorded_with: VCR 3.0.3

--- a/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_new-1.yml
+++ b/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_new-1.yml
@@ -17,8 +17,6 @@ http_interactions:
       - '186'
       Content-Type:
       - application/x-www-form-urlencoded
-      Host:
-      - login.microsoftonline.com
   response:
     status:
       code: 200
@@ -39,25 +37,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 4b24dc7b-1010-4705-824f-e3fa531c1d00
+      - ed511c08-abee-4123-8e41-a93724010d00
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAAA9kTklhVy7SJTGAzR-p1BcdsjTd2EsAlrPrGGIoYBDdcG8_KNdmOyDrYBNAMh1kQnfty3TbuwsjH8I-80KbZTJ-MCpeMJ6jLnMuzsXxfZpfFcGEtiIydwYqRhZckVIzOCsEtei-7f710eGbZR2LIQi833JkLKTtFM_cEsblj8HtKQgoxmV5kfvqj1e_BRECP8gAA;
+      - esctx=AQABAAAAAAABlDrqfEFlSaui6xnRjX5EGo42CVlw-l8Ik8h_hIG2vsbGvVhULffsyLnvqL5qizJrtQBv2VBrB-gb58b5zlttn8rlb8fOU8JXWwpHVBsRZKQupn2jP_O6xXtVw9kfb_1vJMHhIKn_IIjxOrju6roV_YACL1wU57J8Q-CsKFc2IY2p63EP75HZNOmN6pCXmaUgAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=002; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=005; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Tue, 05 Sep 2017 20:03:57 GMT
+      - Fri, 22 Sep 2017 21:43:39 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1504645439","not_before":"1504641539","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1MzksIm5iZiI6MTUwNDY0MTUzOSwiZXhwIjoxNTA0NjQ1NDM5LCJhaW8iOiJZMkZnWUZpWEx5cktrbVVvMzlSN3czekdIOWN2QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZTl3a1N4QVFCVWVDVC1QNlV4d2RBQSIsInZlciI6IjEuMCJ9.eeWMHD_dduRthW3OFtAoqWtjr9JlEV6KRd35rF6EaLKrcIbVRLGJyGZRQAIPKO47H7V3--BhPBT09Xx4RZy5lJ7lpihig5216r3yT45pCiUA92hC3k8cZiaQVNAiaKjGbfcHMb7TxGgz3erDwzfl9SgxOvRZbMSCuniI_vfhpu0RzIqCuIohx9-IQLzn1RG43xAyV_7g5u5dkzjzvG-xtwjW3e5vKTabzW25XxUpqmbyawdXOZAVaeZVdcMydHEln7mZVAfgYjkHK4GQcUXQCs29nPb9zT1GXwtpquwgqe99QY0bQULhBYyGT2tPqKXvZA1hz-k7q1ng7VeuAr4cnw"}'
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1506120220","not_before":"1506116320","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYzMjAsIm5iZiI6MTUwNjExNjMyMCwiZXhwIjoxNTA2MTIwMjIwLCJhaW8iOiJZMlZnWU9nNGtxRHdabVYwQUYvY0RITmpzOWh5QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ0J4UjdlNnJJMEdPUWFrM0pBRU5BQSIsInZlciI6IjEuMCJ9.WcnPWRma_ZSUbEE2NtUD-qb0F63lFLuWHSnqlmMMY9EfGNjuB1Uin2svpt-lMGI2Yw36TYTE7KGdgYQsJKVDNfW1UuAii49CZVAFrV-4Shz7Xui_AHFNhqWSJhq_sniUWJO9WZpH5x86cp1kWVIPUfpEO0YO3ec69N_7FFK_rE4v8uTrXCxoMP2G_FQQrC3wKwghy6aLWgvP0e1mDGajn52q7AG7PQwDSFAkefAKGMs53rWOwYVc5iv0voFziAe0gp1vZDFxyPfkbxueJQNpyC8EbFbcpZorzRMIwm3qMFIU162wiFZf-qFJ3ni_BWs_wzR1NFjLow-PxaMumIsl9w"}'
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:03:59 GMT
+  recorded_at: Fri, 22 Sep 2017 21:43:39 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -74,9 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1MzksIm5iZiI6MTUwNDY0MTUzOSwiZXhwIjoxNTA0NjQ1NDM5LCJhaW8iOiJZMkZnWUZpWEx5cktrbVVvMzlSN3czekdIOWN2QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZTl3a1N4QVFCVWVDVC1QNlV4d2RBQSIsInZlciI6IjEuMCJ9.eeWMHD_dduRthW3OFtAoqWtjr9JlEV6KRd35rF6EaLKrcIbVRLGJyGZRQAIPKO47H7V3--BhPBT09Xx4RZy5lJ7lpihig5216r3yT45pCiUA92hC3k8cZiaQVNAiaKjGbfcHMb7TxGgz3erDwzfl9SgxOvRZbMSCuniI_vfhpu0RzIqCuIohx9-IQLzn1RG43xAyV_7g5u5dkzjzvG-xtwjW3e5vKTabzW25XxUpqmbyawdXOZAVaeZVdcMydHEln7mZVAfgYjkHK4GQcUXQCs29nPb9zT1GXwtpquwgqe99QY0bQULhBYyGT2tPqKXvZA1hz-k7q1ng7VeuAr4cnw
-      Host:
-      - management.azure.com
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYzMjAsIm5iZiI6MTUwNjExNjMyMCwiZXhwIjoxNTA2MTIwMjIwLCJhaW8iOiJZMlZnWU9nNGtxRHdabVYwQUYvY0RITmpzOWh5QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ0J4UjdlNnJJMEdPUWFrM0pBRU5BQSIsInZlciI6IjEuMCJ9.WcnPWRma_ZSUbEE2NtUD-qb0F63lFLuWHSnqlmMMY9EfGNjuB1Uin2svpt-lMGI2Yw36TYTE7KGdgYQsJKVDNfW1UuAii49CZVAFrV-4Shz7Xui_AHFNhqWSJhq_sniUWJO9WZpH5x86cp1kWVIPUfpEO0YO3ec69N_7FFK_rE4v8uTrXCxoMP2G_FQQrC3wKwghy6aLWgvP0e1mDGajn52q7AG7PQwDSFAkefAKGMs53rWOwYVc5iv0voFziAe0gp1vZDFxyPfkbxueJQNpyC8EbFbcpZorzRMIwm3qMFIU162wiFZf-qFJ3ni_BWs_wzR1NFjLow-PxaMumIsl9w
   response:
     status:
       code: 200
@@ -97,21 +93,21 @@ http_interactions:
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
       - '14998'
       X-Ms-Request-Id:
-      - 88b2e9e3-d020-4e34-864f-e97927f33abc
+      - 97633e9d-7cce-4701-8248-e5ccd7e0cde3
       X-Ms-Correlation-Request-Id:
-      - 88b2e9e3-d020-4e34-864f-e97927f33abc
+      - 97633e9d-7cce-4701-8248-e5ccd7e0cde3
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200400Z:88b2e9e3-d020-4e34-864f-e97927f33abc
+      - WESTUS:20170922T214340Z:97633e9d-7cce-4701-8248-e5ccd7e0cde3
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 05 Sep 2017 20:03:59 GMT
+      - Fri, 22 Sep 2017 21:43:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:03:59 GMT
+  recorded_at: Fri, 22 Sep 2017 21:43:40 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/azure_subscription_id/providers?api-version=2015-01-01
@@ -128,9 +124,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1MzksIm5iZiI6MTUwNDY0MTUzOSwiZXhwIjoxNTA0NjQ1NDM5LCJhaW8iOiJZMkZnWUZpWEx5cktrbVVvMzlSN3czekdIOWN2QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZTl3a1N4QVFCVWVDVC1QNlV4d2RBQSIsInZlciI6IjEuMCJ9.eeWMHD_dduRthW3OFtAoqWtjr9JlEV6KRd35rF6EaLKrcIbVRLGJyGZRQAIPKO47H7V3--BhPBT09Xx4RZy5lJ7lpihig5216r3yT45pCiUA92hC3k8cZiaQVNAiaKjGbfcHMb7TxGgz3erDwzfl9SgxOvRZbMSCuniI_vfhpu0RzIqCuIohx9-IQLzn1RG43xAyV_7g5u5dkzjzvG-xtwjW3e5vKTabzW25XxUpqmbyawdXOZAVaeZVdcMydHEln7mZVAfgYjkHK4GQcUXQCs29nPb9zT1GXwtpquwgqe99QY0bQULhBYyGT2tPqKXvZA1hz-k7q1ng7VeuAr4cnw
-      Host:
-      - management.azure.com
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYzMjAsIm5iZiI6MTUwNjExNjMyMCwiZXhwIjoxNTA2MTIwMjIwLCJhaW8iOiJZMlZnWU9nNGtxRHdabVYwQUYvY0RITmpzOWh5QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ0J4UjdlNnJJMEdPUWFrM0pBRU5BQSIsInZlciI6IjEuMCJ9.WcnPWRma_ZSUbEE2NtUD-qb0F63lFLuWHSnqlmMMY9EfGNjuB1Uin2svpt-lMGI2Yw36TYTE7KGdgYQsJKVDNfW1UuAii49CZVAFrV-4Shz7Xui_AHFNhqWSJhq_sniUWJO9WZpH5x86cp1kWVIPUfpEO0YO3ec69N_7FFK_rE4v8uTrXCxoMP2G_FQQrC3wKwghy6aLWgvP0e1mDGajn52q7AG7PQwDSFAkefAKGMs53rWOwYVc5iv0voFziAe0gp1vZDFxyPfkbxueJQNpyC8EbFbcpZorzRMIwm3qMFIU162wiFZf-qFJ3ni_BWs_wzR1NFjLow-PxaMumIsl9w
   response:
     status:
       code: 200
@@ -147,22 +141,42 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14942'
+      - '14917'
       X-Ms-Request-Id:
-      - 1b3d97de-b23b-428e-973d-db6a5e1b9764
+      - 8cca1ef7-7c62-4981-afe2-326cfcd07981
       X-Ms-Correlation-Request-Id:
-      - 1b3d97de-b23b-428e-973d-db6a5e1b9764
+      - 8cca1ef7-7c62-4981-afe2-326cfcd07981
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200400Z:1b3d97de-b23b-428e-973d-db6a5e1b9764
+      - WESTUS:20170922T214341Z:8cca1ef7-7c62-4981-afe2-326cfcd07981
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 05 Sep 2017 20:04:00 GMT
+      - Fri, 22 Sep 2017 21:43:41 GMT
       Content-Length:
-      - '243687'
+      - '254785'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
+      string: '{"value":[{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"operations","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","North Central
         US","South Central US","West Central US","West US","West US 2","Canada Central","Canada
         East","North Europe","West Europe","UK South","UK West","East Asia","Southeast
@@ -437,7 +451,7 @@ http_interactions:
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
         Central US","West US 2","South India","Central India","West India","Canada
-        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
+        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
         East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
@@ -466,7 +480,7 @@ http_interactions:
         Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"}],"resourceTypes":[{"resourceType":"components","locations":["East
         US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
         US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01","2014-04-01"]},{"resourceType":"queries","locations":["East
-        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"alertrules","locations":["West
+        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
@@ -542,7 +556,7 @@ http_interactions:
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorization":{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorizations":[{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},{"applicationId":"7c33bfcb-8d33-48d6-8e60-dc6404003489","roleDefinitionId":"ad6261e4-fa9a-4642-aa5f-104f1b67e9e3"},{"applicationId":"1e3e4475-288f-4018-a376-df66fd7fac5f","roleDefinitionId":"1d538b69-3d87-4e56-8ff8-25786fd48261"},{"applicationId":"a0be0c72-870e-46f0-9c49-c98333a996f7","roleDefinitionId":"7ce22727-ffce-45a9-930c-ddb2e56fa131"}],"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -552,7 +566,7 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -567,7 +581,8 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
+        Central US"],"apiVersions":["2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -577,7 +592,12 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -597,7 +617,7 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -612,7 +632,7 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -622,7 +642,31 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
         East","UK South","Central India","Canada Central"],"apiVersions":["2017-04-26-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"]},{"resourceType":"workspaces/dataSources","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
@@ -641,17 +685,17 @@ http_interactions:
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"consoles","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/consoles","locations":["West
+        East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"consoles","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/consoles","locations":["West
         US","East US","Central India","North Europe","West Europe","South Central
-        US","Southeast Asia"],"apiVersions":["2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
+        US","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
         US","East US","Central India","North Europe","West Europe","South Central
-        US","Southeast Asia"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
+        US","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","Canada Central","Canada East","West Central US","West US 2","UK South","UK
         West","Korea Central","Korea South"],"apiVersions":["2017-07-01","2016-12-01","2016-08-10","2016-06-01","2016-05-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"operations","locations":["Southeast
-        Asia"],"apiVersions":["2016-08-10","2016-06-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01"]},{"resourceType":"locations/backupStatus","locations":["West
+        Asia"],"apiVersions":["2016-08-10","2016-06-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01","2016-06-01"]},{"resourceType":"locations/backupStatus","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
@@ -687,6 +731,7 @@ http_interactions:
         Central US","Central US","North Europe","West Europe","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada Central","Canada East"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"pricings","locations":["Central
+        US","East US"],"apiVersions":["2017-08-01-preview"]},{"resourceType":"securityContacts","locations":["Central
         US","East US"],"apiVersions":["2017-08-01-preview"]},{"resourceType":"workspaceSettings","locations":["Central
         US","East US"],"apiVersions":["2017-08-01-preview"]},{"resourceType":"complianceResults","locations":["Central
         US","East US"],"apiVersions":["2017-08-01"]},{"resourceType":"policies","locations":["Central
@@ -703,6 +748,8 @@ http_interactions:
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatusesSummaries","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/alerts","locations":["Central
         US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/tasks","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"externalSecuritySolutions","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/externalSecuritySolutions","locations":["Central
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.SiteRecovery","namespace":"Microsoft.SiteRecovery","authorization":{"applicationId":"b8340c3b-9267-498f-b21a-15d5547fd85e","roleDefinitionId":"8A00C8EA-8F1B-45A7-8F64-F4CC61EEE9B6"},"resourceTypes":[{"resourceType":"SiteRecoveryVault","locations":["East
         US","West US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","Australia East","Australia Southeast","Brazil South","North
@@ -722,7 +769,7 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -842,7 +889,22 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/databases/transparentDataEncryption","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -1077,6 +1139,26 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
         US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
@@ -1307,6 +1389,11 @@ http_interactions:
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"customApis","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
         East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/managedApis","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
@@ -1358,23 +1445,8 @@ http_interactions:
         US","North Europe","Japan West","Japan East","East Asia","West Europe","East
         US","Southeast Asia","Central US"],"apiVersions":["2016-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Lombiq.DotNest","namespace":"Lombiq.DotNest","resourceTypes":[{"resourceType":"sites","locations":["East
         US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Mailjet.Email","namespace":"Mailjet.Email","resourceTypes":[{"resourceType":"services","locations":["West
-        US"],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
-        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]},{"resourceType":"diagnosticSettings","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"addsservices","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"configuration","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"operations","locations":["West
@@ -1498,8 +1570,10 @@ http_interactions:
         Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
         Central US","Central US","North Europe","West Europe","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","West
-        India","South India"],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CognitiveServices","namespace":"Microsoft.CognitiveServices","authorizations":[{"applicationId":"7d312290-28c8-473c-a0ed-8e53749b6d6d","roleDefinitionId":"5cb87f79-a7c3-4a95-9414-45b65974b51b"}],"resourceTypes":[{"resourceType":"accounts","locations":["Global","West
-        US","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"operations","locations":["Global","Australia
+        India","South India"],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CognitiveServices","namespace":"Microsoft.CognitiveServices","authorizations":[{"applicationId":"7d312290-28c8-473c-a0ed-8e53749b6d6d","roleDefinitionId":"5cb87f79-a7c3-4a95-9414-45b65974b51b"}],"resourceTypes":[{"resourceType":"accounts","locations":["Global","Australia
+        East","Brazil South","West US","West US 2","West Europe","North Europe","Southeast
+        Asia","East Asia","West Central US","South Central US","East US","East US
+        2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"operations","locations":["Global","Australia
         East","Brazil South","West US","West US 2","West Europe","North Europe","Southeast
         Asia","East Asia","West Central US","South Central US","East US","East US
         2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations","locations":["Global","Australia
@@ -1534,13 +1608,13 @@ http_interactions:
         US","West US","Australia East","West Europe","North Europe","Southeast Asia","West
         Central US"],"apiVersions":["2016-03-30","2015-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataFactory","namespace":"Microsoft.DataFactory","resourceTypes":[{"resourceType":"dataFactories","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview","2014-04-01"]},{"resourceType":"factories","locations":["East
-        US"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
-        US"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
+        US","East US 2"],"apiVersions":["2017-09-01-preview","2017-03-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
+        US","East US 2"],"apiVersions":["2017-09-01-preview","2017-03-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
         Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"dataFactories/metricDefinitions","locations":["North
         Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"checkDataFactoryNameAvailability","locations":[],"apiVersions":["2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"checkAzureDataFactoryNameAvailability","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"dataFactorySchema","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"operations","locations":["West
-        US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeAnalytics","namespace":"Microsoft.DataLakeAnalytics","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US","North Europe","East US","West Central US"],"apiVersions":["2017-09-01-preview","2017-03-01-preview","2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeAnalytics","namespace":"Microsoft.DataLakeAnalytics","resourceTypes":[{"resourceType":"accounts","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/dataLakeStoreAccounts","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers","locations":["East
@@ -1589,11 +1663,12 @@ http_interactions:
         India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
         India","East Asia","East US 2","East US","Japan East","Japan West","North
         Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"checkProvisioningServiceNameAvailability","locations":[],"apiVersions":["2017-08-21-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
         US","North Europe","East Asia","East US","West Europe","Southeast Asia","Japan
         East","Japan West","Australia East","Australia Southeast","West US 2","West
         Central US","East US 2","Central US","UK South","UK West","South India","Central
-        India"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
+        India","Canada Central","Canada East"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"ProvisioningServices","locations":["East
+        US","West Europe","Southeast Asia"],"apiVersions":["2017-08-21-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
         East","Australia Southeast","Canada Central","Canada East","Central India","Central
         US","East Asia","East US","East US 2","Japan East","Japan West","North Central
         US","North Europe","South Central US","South India","Southeast Asia","West
@@ -1620,16 +1695,16 @@ http_interactions:
         US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"operations","locations":["Brazil
         South","East Asia","East US","Japan East","Japan West","North Central US","North
         Europe","South Central US","West Europe","West US","Southeast Asia","Central
-        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"topics","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operations","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topics","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operations","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","West
         US 2","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
@@ -1727,48 +1802,39 @@ http_interactions:
         Central US","West Europe","Southeast Asia","Japan East","East US 2","West
         Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"commitmentPlans","locations":["South
         Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
-        Central US","West US"],"apiVersions":["2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Media","namespace":"Microsoft.Media","authorization":{"applicationId":"374b2a64-3b6b-436b-934c-b820eacca870","roleDefinitionId":"aab70789-0cec-44b5-95d7-84b64c9487af"},"resourceTypes":[{"resourceType":"mediaservices","locations":["Japan
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningExperimentation","namespace":"Microsoft.MachineLearningExperimentation","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"accounts","locations":["Australia
+        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces","locations":["Australia
+        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces/projects","locations":["Australia
+        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningCompute","namespace":"Microsoft.MachineLearningCompute","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"376aa7d7-51a9-463d-bd4d-7e1691345612","managedByRoleDefinitionId":"91d00862-cf55-46a5-9dce-260bbd92ce25"},"resourceTypes":[{"resourceType":"operationalizationClusters","locations":["East
+        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"operations","locations":["East
+        US 2"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations","locations":["East
+        US 2"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["East
+        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningModelManagement","namespace":"Microsoft.MachineLearningModelManagement","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US 2","West Central US","Australia East"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"operations","locations":["West
+        Central US"],"apiVersions":["2017-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
+        Central US","West US"],"apiVersions":["2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01"]},{"resourceType":"offertypes","locations":["South
+        Central US","West US"],"apiVersions":["2015-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Media","namespace":"Microsoft.Media","authorization":{"applicationId":"374b2a64-3b6b-436b-934c-b820eacca870","roleDefinitionId":"aab70789-0cec-44b5-95d7-84b64c9487af"},"resourceTypes":[{"resourceType":"mediaservices","locations":["Japan
         West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
         US","West US","Australia East","Australia Southeast","Central US","Brazil
         South","Central India","West India","South India","South Central US","Canada
-        Central","Canada East","West Central US"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
+        Central","Canada East","West Central US"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
         Central US","North Central US","East US 2","West US","West Europe","North
         Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
         East","UK South","West India"],"apiVersions":["2016-01-29"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-01-29"]},{"resourceType":"locations/checkNameAvailability","locations":["South
         Central US","North Central US","East US 2","West US","West Europe","North
         Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
-        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"operations","locations":["East
+        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"capacities","locations":["West
+        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
+        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationresults","locations":["West
+        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
+        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"operations","locations":["East
         US 2"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Relay","namespace":"Microsoft.Relay","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US 2","West
         US","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
         India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2017-08-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkPolicyCompliance","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
@@ -1827,8 +1893,11 @@ http_interactions:
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","resourceTypes":[{"resourceType":"operations","locations":["West
-        Central US"],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
+        Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applianceDefinitions","locations":["West
+        Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"locations","locations":["West
+        Central US"],"apiVersions":["2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
+        Central US"],"apiVersions":["2017-09-01","2016-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","West Central US","Japan East","Japan West","Australia East","Australia
         Southeast"],"apiVersions":["2017-06-01","2017-05-15","2017-01-01","2016-10-01","2016-06-01","2015-03-15","2014-09-01"]},{"resourceType":"operations","locations":["West
@@ -1888,11 +1957,17 @@ http_interactions:
         US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RedisLabs.Memcached","namespace":"RedisLabs.Memcached","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-07-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RedisLabs.Redis","namespace":"RedisLabs.Redis","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-07-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RevAPM.MobileCDN","namespace":"RevAPM.MobileCDN","resourceTypes":[{"resourceType":"accounts","locations":["Central
         US","East US","East US 2","North Central US","South Central US","West US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
-        East","Australia Southeast"],"apiVersions":["2016-08-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-24","2016-08-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sendgrid.Email","namespace":"Sendgrid.Email","resourceTypes":[{"resourceType":"accounts","locations":["East
-        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
-        Central US","Central US","North Europe","West Europe","Japan East","Japan
-        West","Brazil South","Australia East","Australia Southeast","Canada Central","Canada
-        East","West Central US","West US 2","UK South","UK West"],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Signiant.Flight","namespace":"Signiant.Flight","resourceTypes":[{"resourceType":"accounts","locations":["East
+        East","Australia Southeast"],"apiVersions":["2016-08-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-24","2016-08-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sendgrid.Email","namespace":"Sendgrid.Email","resourceTypes":[{"resourceType":"accounts","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Signiant.Flight","namespace":"Signiant.Flight","resourceTypes":[{"resourceType":"accounts","locations":["East
         US","Central US","North Central US","South Central US","West US","North Europe","West
         Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast"],"apiVersions":["2015-06-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sparkpost.Basic","namespace":"Sparkpost.Basic","resourceTypes":[{"resourceType":"services","locations":["West
@@ -1909,7 +1984,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:00 GMT
+  recorded_at: Fri, 22 Sep 2017 21:43:41 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/this_is_not_a_disk_name/BeginGetAccess?api-version=2017-03-30
@@ -1926,11 +2001,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1MzksIm5iZiI6MTUwNDY0MTUzOSwiZXhwIjoxNTA0NjQ1NDM5LCJhaW8iOiJZMkZnWUZpWEx5cktrbVVvMzlSN3czekdIOWN2QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZTl3a1N4QVFCVWVDVC1QNlV4d2RBQSIsInZlciI6IjEuMCJ9.eeWMHD_dduRthW3OFtAoqWtjr9JlEV6KRd35rF6EaLKrcIbVRLGJyGZRQAIPKO47H7V3--BhPBT09Xx4RZy5lJ7lpihig5216r3yT45pCiUA92hC3k8cZiaQVNAiaKjGbfcHMb7TxGgz3erDwzfl9SgxOvRZbMSCuniI_vfhpu0RzIqCuIohx9-IQLzn1RG43xAyV_7g5u5dkzjzvG-xtwjW3e5vKTabzW25XxUpqmbyawdXOZAVaeZVdcMydHEln7mZVAfgYjkHK4GQcUXQCs29nPb9zT1GXwtpquwgqe99QY0bQULhBYyGT2tPqKXvZA1hz-k7q1ng7VeuAr4cnw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYzMjAsIm5iZiI6MTUwNjExNjMyMCwiZXhwIjoxNTA2MTIwMjIwLCJhaW8iOiJZMlZnWU9nNGtxRHdabVYwQUYvY0RITmpzOWh5QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ0J4UjdlNnJJMEdPUWFrM0pBRU5BQSIsInZlciI6IjEuMCJ9.WcnPWRma_ZSUbEE2NtUD-qb0F63lFLuWHSnqlmMMY9EfGNjuB1Uin2svpt-lMGI2Yw36TYTE7KGdgYQsJKVDNfW1UuAii49CZVAFrV-4Shz7Xui_AHFNhqWSJhq_sniUWJO9WZpH5x86cp1kWVIPUfpEO0YO3ec69N_7FFK_rE4v8uTrXCxoMP2G_FQQrC3wKwghy6aLWgvP0e1mDGajn52q7AG7PQwDSFAkefAKGMs53rWOwYVc5iv0voFziAe0gp1vZDFxyPfkbxueJQNpyC8EbFbcpZorzRMIwm3qMFIU162wiFZf-qFJ3ni_BWs_wzR1NFjLow-PxaMumIsl9w
       Content-Length:
       - '42'
-      Host:
-      - management.azure.com
   response:
     status:
       code: 404
@@ -1947,15 +2020,15 @@ http_interactions:
       X-Ms-Failure-Cause:
       - gateway
       X-Ms-Request-Id:
-      - 9683f40e-4d8a-4424-a2c0-f1965a19e187
+      - db3ba159-d7d3-4d38-89df-62a5e755332e
       X-Ms-Correlation-Request-Id:
-      - 9683f40e-4d8a-4424-a2c0-f1965a19e187
+      - db3ba159-d7d3-4d38-89df-62a5e755332e
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200401Z:9683f40e-4d8a-4424-a2c0-f1965a19e187
+      - WESTUS:20170922T214343Z:db3ba159-d7d3-4d38-89df-62a5e755332e
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 05 Sep 2017 20:04:00 GMT
+      - Fri, 22 Sep 2017 21:43:43 GMT
       Content-Length:
       - '166'
     body:
@@ -1963,5 +2036,5 @@ http_interactions:
       string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Compute/disks/this_is_not_a_disk_name''
         under resource group ''my-azure-resource-group'' was not found."}}'
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:01 GMT
+  recorded_at: Fri, 22 Sep 2017 21:43:42 GMT
 recorded_with: VCR 3.0.3

--- a/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_new-2.yml
+++ b/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_new-2.yml
@@ -17,8 +17,6 @@ http_interactions:
       - '186'
       Content-Type:
       - application/x-www-form-urlencoded
-      Host:
-      - login.microsoftonline.com
   response:
     status:
       code: 200
@@ -39,25 +37,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 3bbd1baf-aad5-4beb-9a42-ce13d0c41800
+      - a59a9509-a849-4fbf-a344-1598ca2d0c00
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAAA9kTklhVy7SJTGAzR-p1BcX12DacLfJMnrKPLIb8RoQxbFoMKQoRmCTbSroHqPZ0xsk6AizTUc18F-8kbMq0tBeQqHGh7_BeddssbOOWloozW0wf_P95VltzmzHM_tZn82wdU3OgYg8gltb_gCA0OOiLMnUQ_Hpme3s_RlTjyeBL2GnLi45lLRI-4W-ixDzGwgAA;
+      - esctx=AQABAAAAAAABlDrqfEFlSaui6xnRjX5EUiQpzAckYBLeZhmfBUgUM68usW6qb34PWlmBZ4jmtdfSNy-wULLCKDKoVGcaowAxYut8ZyR39xJX7j4jPDGPiog2k3cdI4jNm8iyfklPCpcUr4Gqgvgj8d-zoYq-zTHbtyhlcBvsJ04LKIFf0HRsqoCfJUqORGoB-jjhFY5_BssgAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=006; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=007; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Tue, 05 Sep 2017 20:04:02 GMT
+      - Fri, 22 Sep 2017 21:43:27 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3600","ext_expires_in":"0","expires_on":"1504645442","not_before":"1504641542","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NDIsIm5iZiI6MTUwNDY0MTU0MiwiZXhwIjoxNTA0NjQ1NDQyLCJhaW8iOiJZMkZnWU9DZkZ0TC9MdFZxMXNrSE81UEVHVmZQQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoicnh1OU85V3E2MHVhUXM0VDBNUVlBQSIsInZlciI6IjEuMCJ9.CcTo2jVKNlp0BSTvWomSMl_vG8zmIcyLm0pXnWCw3r_3_2qf-Rj85vtMVoIk39TJDMkaTvnW2u4nmqxUbdoC7xEPj5QeRmR4uqehIm8RkTJX1fe0MFZk7-sQ9t-ECEG8Tm1kwKfD38tGn2OfD8E9TRoik4iA85dEP5doo1otQodKT0gkHbjGOsexy61-oaP7Z5q1Vg4Rr0HBE23ajuVGOhFP6HGu40G0KQpU6DQUsDf_qQB_hzAXxrywnN-YvlJpj6gGhCnOMT4WIKA9BCliOs7r0EuaKRC71Kn7JXDraYZDHwWAcnxrA_rQYa4e2Gmehan3wiKb0ZRngb2aRfxK9w"}'
+      string: '{"token_type":"Bearer","expires_in":"3600","ext_expires_in":"0","expires_on":"1506120208","not_before":"1506116308","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYzMDgsIm5iZiI6MTUwNjExNjMwOCwiZXhwIjoxNTA2MTIwMjA4LCJhaW8iOiJZMlZnWUZELys4NzZrY3hyOWJ5d0x2NGdHOTJiQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ1pXYXBVbW92MC1qUkJXWXlpME1BQSIsInZlciI6IjEuMCJ9.Jl8LBRzHw1JW6L_k40ZwqM7HM82e2tGTkWajlzMMoLesa04Ha-HCpzvzk-w4v-vQcPDl67S3dygKPu-luwtN4zN4ktalhxTcyEayD7-vBEv2QY1rCpaIbGvvXYWW4oKoJVu2iWhsk1p7sxucpRclKb7F-CshnuE4ysJvWA97KS3zIBouFfNIqA9_4kUA02qk186ey2JALUFGKdxcv9R_C5Lx2FpGQ5UXQe3Zb7yjlfrH6PB_wgyyFvs4N-2z3YC6G1EAIPiRgI_j-R0RZnM0X8TrHk_u6-8WtjJOL7VLyEz5VRl3qRRGp1UgYh5MkIkxX7_LRjaPi4raJiM0DfLXhA"}'
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:01 GMT
+  recorded_at: Fri, 22 Sep 2017 21:43:28 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -74,9 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NDIsIm5iZiI6MTUwNDY0MTU0MiwiZXhwIjoxNTA0NjQ1NDQyLCJhaW8iOiJZMkZnWU9DZkZ0TC9MdFZxMXNrSE81UEVHVmZQQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoicnh1OU85V3E2MHVhUXM0VDBNUVlBQSIsInZlciI6IjEuMCJ9.CcTo2jVKNlp0BSTvWomSMl_vG8zmIcyLm0pXnWCw3r_3_2qf-Rj85vtMVoIk39TJDMkaTvnW2u4nmqxUbdoC7xEPj5QeRmR4uqehIm8RkTJX1fe0MFZk7-sQ9t-ECEG8Tm1kwKfD38tGn2OfD8E9TRoik4iA85dEP5doo1otQodKT0gkHbjGOsexy61-oaP7Z5q1Vg4Rr0HBE23ajuVGOhFP6HGu40G0KQpU6DQUsDf_qQB_hzAXxrywnN-YvlJpj6gGhCnOMT4WIKA9BCliOs7r0EuaKRC71Kn7JXDraYZDHwWAcnxrA_rQYa4e2Gmehan3wiKb0ZRngb2aRfxK9w
-      Host:
-      - management.azure.com
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYzMDgsIm5iZiI6MTUwNjExNjMwOCwiZXhwIjoxNTA2MTIwMjA4LCJhaW8iOiJZMlZnWUZELys4NzZrY3hyOWJ5d0x2NGdHOTJiQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ1pXYXBVbW92MC1qUkJXWXlpME1BQSIsInZlciI6IjEuMCJ9.Jl8LBRzHw1JW6L_k40ZwqM7HM82e2tGTkWajlzMMoLesa04Ha-HCpzvzk-w4v-vQcPDl67S3dygKPu-luwtN4zN4ktalhxTcyEayD7-vBEv2QY1rCpaIbGvvXYWW4oKoJVu2iWhsk1p7sxucpRclKb7F-CshnuE4ysJvWA97KS3zIBouFfNIqA9_4kUA02qk186ey2JALUFGKdxcv9R_C5Lx2FpGQ5UXQe3Zb7yjlfrH6PB_wgyyFvs4N-2z3YC6G1EAIPiRgI_j-R0RZnM0X8TrHk_u6-8WtjJOL7VLyEz5VRl3qRRGp1UgYh5MkIkxX7_LRjaPi4raJiM0DfLXhA
   response:
     status:
       code: 200
@@ -95,23 +91,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14992'
+      - '14999'
       X-Ms-Request-Id:
-      - 7e55238a-066a-453d-a59a-55a5350a5174
+      - f598ffd4-1707-41e8-88fa-bfb1ecb374a6
       X-Ms-Correlation-Request-Id:
-      - 7e55238a-066a-453d-a59a-55a5350a5174
+      - f598ffd4-1707-41e8-88fa-bfb1ecb374a6
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200402Z:7e55238a-066a-453d-a59a-55a5350a5174
+      - WESTUS:20170922T214329Z:f598ffd4-1707-41e8-88fa-bfb1ecb374a6
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 05 Sep 2017 20:04:01 GMT
+      - Fri, 22 Sep 2017 21:43:28 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:01 GMT
+  recorded_at: Fri, 22 Sep 2017 21:43:29 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/azure_subscription_id/providers?api-version=2015-01-01
@@ -128,9 +124,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NDIsIm5iZiI6MTUwNDY0MTU0MiwiZXhwIjoxNTA0NjQ1NDQyLCJhaW8iOiJZMkZnWU9DZkZ0TC9MdFZxMXNrSE81UEVHVmZQQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoicnh1OU85V3E2MHVhUXM0VDBNUVlBQSIsInZlciI6IjEuMCJ9.CcTo2jVKNlp0BSTvWomSMl_vG8zmIcyLm0pXnWCw3r_3_2qf-Rj85vtMVoIk39TJDMkaTvnW2u4nmqxUbdoC7xEPj5QeRmR4uqehIm8RkTJX1fe0MFZk7-sQ9t-ECEG8Tm1kwKfD38tGn2OfD8E9TRoik4iA85dEP5doo1otQodKT0gkHbjGOsexy61-oaP7Z5q1Vg4Rr0HBE23ajuVGOhFP6HGu40G0KQpU6DQUsDf_qQB_hzAXxrywnN-YvlJpj6gGhCnOMT4WIKA9BCliOs7r0EuaKRC71Kn7JXDraYZDHwWAcnxrA_rQYa4e2Gmehan3wiKb0ZRngb2aRfxK9w
-      Host:
-      - management.azure.com
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYzMDgsIm5iZiI6MTUwNjExNjMwOCwiZXhwIjoxNTA2MTIwMjA4LCJhaW8iOiJZMlZnWUZELys4NzZrY3hyOWJ5d0x2NGdHOTJiQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ1pXYXBVbW92MC1qUkJXWXlpME1BQSIsInZlciI6IjEuMCJ9.Jl8LBRzHw1JW6L_k40ZwqM7HM82e2tGTkWajlzMMoLesa04Ha-HCpzvzk-w4v-vQcPDl67S3dygKPu-luwtN4zN4ktalhxTcyEayD7-vBEv2QY1rCpaIbGvvXYWW4oKoJVu2iWhsk1p7sxucpRclKb7F-CshnuE4ysJvWA97KS3zIBouFfNIqA9_4kUA02qk186ey2JALUFGKdxcv9R_C5Lx2FpGQ5UXQe3Zb7yjlfrH6PB_wgyyFvs4N-2z3YC6G1EAIPiRgI_j-R0RZnM0X8TrHk_u6-8WtjJOL7VLyEz5VRl3qRRGp1UgYh5MkIkxX7_LRjaPi4raJiM0DfLXhA
   response:
     status:
       code: 200
@@ -147,22 +141,42 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14922'
       X-Ms-Request-Id:
-      - b466e831-a0a8-4e37-81ec-e3478c750cb0
+      - 05a30e2f-68d5-403f-994a-2173a0fb5450
       X-Ms-Correlation-Request-Id:
-      - b466e831-a0a8-4e37-81ec-e3478c750cb0
+      - 05a30e2f-68d5-403f-994a-2173a0fb5450
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200402Z:b466e831-a0a8-4e37-81ec-e3478c750cb0
+      - WESTUS:20170922T214330Z:05a30e2f-68d5-403f-994a-2173a0fb5450
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 05 Sep 2017 20:04:02 GMT
+      - Fri, 22 Sep 2017 21:43:30 GMT
       Content-Length:
-      - '243687'
+      - '254785'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
+      string: '{"value":[{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"operations","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","North Central
         US","South Central US","West Central US","West US","West US 2","Canada Central","Canada
         East","North Europe","West Europe","UK South","UK West","East Asia","Southeast
@@ -437,7 +451,7 @@ http_interactions:
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
         Central US","West US 2","South India","Central India","West India","Canada
-        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
+        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
         East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
@@ -466,7 +480,7 @@ http_interactions:
         Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"}],"resourceTypes":[{"resourceType":"components","locations":["East
         US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
         US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01","2014-04-01"]},{"resourceType":"queries","locations":["East
-        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"alertrules","locations":["West
+        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
@@ -542,7 +556,7 @@ http_interactions:
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorization":{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorizations":[{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},{"applicationId":"7c33bfcb-8d33-48d6-8e60-dc6404003489","roleDefinitionId":"ad6261e4-fa9a-4642-aa5f-104f1b67e9e3"},{"applicationId":"1e3e4475-288f-4018-a376-df66fd7fac5f","roleDefinitionId":"1d538b69-3d87-4e56-8ff8-25786fd48261"},{"applicationId":"a0be0c72-870e-46f0-9c49-c98333a996f7","roleDefinitionId":"7ce22727-ffce-45a9-930c-ddb2e56fa131"}],"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -552,7 +566,7 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -567,7 +581,8 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
+        Central US"],"apiVersions":["2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -577,7 +592,12 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -597,7 +617,7 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -612,7 +632,7 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -622,7 +642,31 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
         East","UK South","Central India","Canada Central"],"apiVersions":["2017-04-26-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"]},{"resourceType":"workspaces/dataSources","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
@@ -641,17 +685,17 @@ http_interactions:
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"consoles","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/consoles","locations":["West
+        East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"consoles","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/consoles","locations":["West
         US","East US","Central India","North Europe","West Europe","South Central
-        US","Southeast Asia"],"apiVersions":["2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
+        US","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
         US","East US","Central India","North Europe","West Europe","South Central
-        US","Southeast Asia"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
+        US","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","Canada Central","Canada East","West Central US","West US 2","UK South","UK
         West","Korea Central","Korea South"],"apiVersions":["2017-07-01","2016-12-01","2016-08-10","2016-06-01","2016-05-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"operations","locations":["Southeast
-        Asia"],"apiVersions":["2016-08-10","2016-06-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01"]},{"resourceType":"locations/backupStatus","locations":["West
+        Asia"],"apiVersions":["2016-08-10","2016-06-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01","2016-06-01"]},{"resourceType":"locations/backupStatus","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
@@ -687,6 +731,7 @@ http_interactions:
         Central US","Central US","North Europe","West Europe","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada Central","Canada East"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"pricings","locations":["Central
+        US","East US"],"apiVersions":["2017-08-01-preview"]},{"resourceType":"securityContacts","locations":["Central
         US","East US"],"apiVersions":["2017-08-01-preview"]},{"resourceType":"workspaceSettings","locations":["Central
         US","East US"],"apiVersions":["2017-08-01-preview"]},{"resourceType":"complianceResults","locations":["Central
         US","East US"],"apiVersions":["2017-08-01"]},{"resourceType":"policies","locations":["Central
@@ -703,6 +748,8 @@ http_interactions:
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatusesSummaries","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/alerts","locations":["Central
         US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/tasks","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"externalSecuritySolutions","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/externalSecuritySolutions","locations":["Central
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.SiteRecovery","namespace":"Microsoft.SiteRecovery","authorization":{"applicationId":"b8340c3b-9267-498f-b21a-15d5547fd85e","roleDefinitionId":"8A00C8EA-8F1B-45A7-8F64-F4CC61EEE9B6"},"resourceTypes":[{"resourceType":"SiteRecoveryVault","locations":["East
         US","West US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","Australia East","Australia Southeast","Brazil South","North
@@ -722,7 +769,7 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -842,7 +889,22 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/databases/transparentDataEncryption","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -1077,6 +1139,26 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
         US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
@@ -1307,6 +1389,11 @@ http_interactions:
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"customApis","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
         East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/managedApis","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
@@ -1358,23 +1445,8 @@ http_interactions:
         US","North Europe","Japan West","Japan East","East Asia","West Europe","East
         US","Southeast Asia","Central US"],"apiVersions":["2016-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Lombiq.DotNest","namespace":"Lombiq.DotNest","resourceTypes":[{"resourceType":"sites","locations":["East
         US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Mailjet.Email","namespace":"Mailjet.Email","resourceTypes":[{"resourceType":"services","locations":["West
-        US"],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
-        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]},{"resourceType":"diagnosticSettings","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"addsservices","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"configuration","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"operations","locations":["West
@@ -1498,8 +1570,10 @@ http_interactions:
         Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
         Central US","Central US","North Europe","West Europe","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","West
-        India","South India"],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CognitiveServices","namespace":"Microsoft.CognitiveServices","authorizations":[{"applicationId":"7d312290-28c8-473c-a0ed-8e53749b6d6d","roleDefinitionId":"5cb87f79-a7c3-4a95-9414-45b65974b51b"}],"resourceTypes":[{"resourceType":"accounts","locations":["Global","West
-        US","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"operations","locations":["Global","Australia
+        India","South India"],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CognitiveServices","namespace":"Microsoft.CognitiveServices","authorizations":[{"applicationId":"7d312290-28c8-473c-a0ed-8e53749b6d6d","roleDefinitionId":"5cb87f79-a7c3-4a95-9414-45b65974b51b"}],"resourceTypes":[{"resourceType":"accounts","locations":["Global","Australia
+        East","Brazil South","West US","West US 2","West Europe","North Europe","Southeast
+        Asia","East Asia","West Central US","South Central US","East US","East US
+        2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"operations","locations":["Global","Australia
         East","Brazil South","West US","West US 2","West Europe","North Europe","Southeast
         Asia","East Asia","West Central US","South Central US","East US","East US
         2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations","locations":["Global","Australia
@@ -1534,13 +1608,13 @@ http_interactions:
         US","West US","Australia East","West Europe","North Europe","Southeast Asia","West
         Central US"],"apiVersions":["2016-03-30","2015-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataFactory","namespace":"Microsoft.DataFactory","resourceTypes":[{"resourceType":"dataFactories","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview","2014-04-01"]},{"resourceType":"factories","locations":["East
-        US"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
-        US"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
+        US","East US 2"],"apiVersions":["2017-09-01-preview","2017-03-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
+        US","East US 2"],"apiVersions":["2017-09-01-preview","2017-03-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
         Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"dataFactories/metricDefinitions","locations":["North
         Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"checkDataFactoryNameAvailability","locations":[],"apiVersions":["2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"checkAzureDataFactoryNameAvailability","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"dataFactorySchema","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"operations","locations":["West
-        US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeAnalytics","namespace":"Microsoft.DataLakeAnalytics","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US","North Europe","East US","West Central US"],"apiVersions":["2017-09-01-preview","2017-03-01-preview","2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeAnalytics","namespace":"Microsoft.DataLakeAnalytics","resourceTypes":[{"resourceType":"accounts","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/dataLakeStoreAccounts","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers","locations":["East
@@ -1589,11 +1663,12 @@ http_interactions:
         India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
         India","East Asia","East US 2","East US","Japan East","Japan West","North
         Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"checkProvisioningServiceNameAvailability","locations":[],"apiVersions":["2017-08-21-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
         US","North Europe","East Asia","East US","West Europe","Southeast Asia","Japan
         East","Japan West","Australia East","Australia Southeast","West US 2","West
         Central US","East US 2","Central US","UK South","UK West","South India","Central
-        India"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
+        India","Canada Central","Canada East"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"ProvisioningServices","locations":["East
+        US","West Europe","Southeast Asia"],"apiVersions":["2017-08-21-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
         East","Australia Southeast","Canada Central","Canada East","Central India","Central
         US","East Asia","East US","East US 2","Japan East","Japan West","North Central
         US","North Europe","South Central US","South India","Southeast Asia","West
@@ -1620,16 +1695,16 @@ http_interactions:
         US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"operations","locations":["Brazil
         South","East Asia","East US","Japan East","Japan West","North Central US","North
         Europe","South Central US","West Europe","West US","Southeast Asia","Central
-        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"topics","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operations","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topics","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operations","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","West
         US 2","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
@@ -1727,48 +1802,39 @@ http_interactions:
         Central US","West Europe","Southeast Asia","Japan East","East US 2","West
         Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"commitmentPlans","locations":["South
         Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
-        Central US","West US"],"apiVersions":["2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Media","namespace":"Microsoft.Media","authorization":{"applicationId":"374b2a64-3b6b-436b-934c-b820eacca870","roleDefinitionId":"aab70789-0cec-44b5-95d7-84b64c9487af"},"resourceTypes":[{"resourceType":"mediaservices","locations":["Japan
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningExperimentation","namespace":"Microsoft.MachineLearningExperimentation","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"accounts","locations":["Australia
+        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces","locations":["Australia
+        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces/projects","locations":["Australia
+        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningCompute","namespace":"Microsoft.MachineLearningCompute","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"376aa7d7-51a9-463d-bd4d-7e1691345612","managedByRoleDefinitionId":"91d00862-cf55-46a5-9dce-260bbd92ce25"},"resourceTypes":[{"resourceType":"operationalizationClusters","locations":["East
+        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"operations","locations":["East
+        US 2"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations","locations":["East
+        US 2"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["East
+        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningModelManagement","namespace":"Microsoft.MachineLearningModelManagement","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US 2","West Central US","Australia East"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"operations","locations":["West
+        Central US"],"apiVersions":["2017-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
+        Central US","West US"],"apiVersions":["2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01"]},{"resourceType":"offertypes","locations":["South
+        Central US","West US"],"apiVersions":["2015-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Media","namespace":"Microsoft.Media","authorization":{"applicationId":"374b2a64-3b6b-436b-934c-b820eacca870","roleDefinitionId":"aab70789-0cec-44b5-95d7-84b64c9487af"},"resourceTypes":[{"resourceType":"mediaservices","locations":["Japan
         West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
         US","West US","Australia East","Australia Southeast","Central US","Brazil
         South","Central India","West India","South India","South Central US","Canada
-        Central","Canada East","West Central US"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
+        Central","Canada East","West Central US"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
         Central US","North Central US","East US 2","West US","West Europe","North
         Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
         East","UK South","West India"],"apiVersions":["2016-01-29"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-01-29"]},{"resourceType":"locations/checkNameAvailability","locations":["South
         Central US","North Central US","East US 2","West US","West Europe","North
         Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
-        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"operations","locations":["East
+        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"capacities","locations":["West
+        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
+        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationresults","locations":["West
+        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
+        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"operations","locations":["East
         US 2"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Relay","namespace":"Microsoft.Relay","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US 2","West
         US","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
         India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2017-08-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkPolicyCompliance","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
@@ -1827,8 +1893,11 @@ http_interactions:
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","resourceTypes":[{"resourceType":"operations","locations":["West
-        Central US"],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
+        Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applianceDefinitions","locations":["West
+        Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"locations","locations":["West
+        Central US"],"apiVersions":["2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
+        Central US"],"apiVersions":["2017-09-01","2016-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","West Central US","Japan East","Japan West","Australia East","Australia
         Southeast"],"apiVersions":["2017-06-01","2017-05-15","2017-01-01","2016-10-01","2016-06-01","2015-03-15","2014-09-01"]},{"resourceType":"operations","locations":["West
@@ -1888,11 +1957,17 @@ http_interactions:
         US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RedisLabs.Memcached","namespace":"RedisLabs.Memcached","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-07-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RedisLabs.Redis","namespace":"RedisLabs.Redis","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-07-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RevAPM.MobileCDN","namespace":"RevAPM.MobileCDN","resourceTypes":[{"resourceType":"accounts","locations":["Central
         US","East US","East US 2","North Central US","South Central US","West US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
-        East","Australia Southeast"],"apiVersions":["2016-08-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-24","2016-08-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sendgrid.Email","namespace":"Sendgrid.Email","resourceTypes":[{"resourceType":"accounts","locations":["East
-        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
-        Central US","Central US","North Europe","West Europe","Japan East","Japan
-        West","Brazil South","Australia East","Australia Southeast","Canada Central","Canada
-        East","West Central US","West US 2","UK South","UK West"],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Signiant.Flight","namespace":"Signiant.Flight","resourceTypes":[{"resourceType":"accounts","locations":["East
+        East","Australia Southeast"],"apiVersions":["2016-08-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-24","2016-08-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sendgrid.Email","namespace":"Sendgrid.Email","resourceTypes":[{"resourceType":"accounts","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Signiant.Flight","namespace":"Signiant.Flight","resourceTypes":[{"resourceType":"accounts","locations":["East
         US","Central US","North Central US","South Central US","West US","North Europe","West
         Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast"],"apiVersions":["2015-06-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sparkpost.Basic","namespace":"Sparkpost.Basic","resourceTypes":[{"resourceType":"services","locations":["West
@@ -1909,7 +1984,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:02 GMT
+  recorded_at: Fri, 22 Sep 2017 21:43:30 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
@@ -1926,11 +2001,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NDIsIm5iZiI6MTUwNDY0MTU0MiwiZXhwIjoxNTA0NjQ1NDQyLCJhaW8iOiJZMkZnWU9DZkZ0TC9MdFZxMXNrSE81UEVHVmZQQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoicnh1OU85V3E2MHVhUXM0VDBNUVlBQSIsInZlciI6IjEuMCJ9.CcTo2jVKNlp0BSTvWomSMl_vG8zmIcyLm0pXnWCw3r_3_2qf-Rj85vtMVoIk39TJDMkaTvnW2u4nmqxUbdoC7xEPj5QeRmR4uqehIm8RkTJX1fe0MFZk7-sQ9t-ECEG8Tm1kwKfD38tGn2OfD8E9TRoik4iA85dEP5doo1otQodKT0gkHbjGOsexy61-oaP7Z5q1Vg4Rr0HBE23ajuVGOhFP6HGu40G0KQpU6DQUsDf_qQB_hzAXxrywnN-YvlJpj6gGhCnOMT4WIKA9BCliOs7r0EuaKRC71Kn7JXDraYZDHwWAcnxrA_rQYa4e2Gmehan3wiKb0ZRngb2aRfxK9w
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYzMDgsIm5iZiI6MTUwNjExNjMwOCwiZXhwIjoxNTA2MTIwMjA4LCJhaW8iOiJZMlZnWUZELys4NzZrY3hyOWJ5d0x2NGdHOTJiQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ1pXYXBVbW92MC1qUkJXWXlpME1BQSIsInZlciI6IjEuMCJ9.Jl8LBRzHw1JW6L_k40ZwqM7HM82e2tGTkWajlzMMoLesa04Ha-HCpzvzk-w4v-vQcPDl67S3dygKPu-luwtN4zN4ktalhxTcyEayD7-vBEv2QY1rCpaIbGvvXYWW4oKoJVu2iWhsk1p7sxucpRclKb7F-CshnuE4ysJvWA97KS3zIBouFfNIqA9_4kUA02qk186ey2JALUFGKdxcv9R_C5Lx2FpGQ5UXQe3Zb7yjlfrH6PB_wgyyFvs4N-2z3YC6G1EAIPiRgI_j-R0RZnM0X8TrHk_u6-8WtjJOL7VLyEz5VRl3qRRGp1UgYh5MkIkxX7_LRjaPi4raJiM0DfLXhA
       Content-Length:
       - '42'
-      Host:
-      - management.azure.com
   response:
     status:
       code: 202
@@ -1945,34 +2018,34 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/ad79b8b8-f9e6-485e-a099-ee9b59ffdab4?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/d94ca538-dc9c-4582-91bf-e1beb060944f?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/ad79b8b8-f9e6-485e-a099-ee9b59ffdab4?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/d94ca538-dc9c-4582-91bf-e1beb060944f?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - ad79b8b8-f9e6-485e-a099-ee9b59ffdab4
+      - d94ca538-dc9c-4582-91bf-e1beb060944f
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1190'
+      - '1180'
       X-Ms-Correlation-Request-Id:
-      - cbed9860-d3a2-4d2e-9b8d-8fa2ccd1713c
+      - 66844874-7f7d-4ce0-85af-e3bd2a76d7f8
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200403Z:cbed9860-d3a2-4d2e-9b8d-8fa2ccd1713c
+      - WESTUS:20170922T214332Z:66844874-7f7d-4ce0-85af-e3bd2a76d7f8
       Date:
-      - Tue, 05 Sep 2017 20:04:03 GMT
+      - Fri, 22 Sep 2017 21:43:31 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:03 GMT
+  recorded_at: Fri, 22 Sep 2017 21:43:31 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/ad79b8b8-f9e6-485e-a099-ee9b59ffdab4?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/d94ca538-dc9c-4582-91bf-e1beb060944f?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -1986,9 +2059,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NDIsIm5iZiI6MTUwNDY0MTU0MiwiZXhwIjoxNTA0NjQ1NDQyLCJhaW8iOiJZMkZnWU9DZkZ0TC9MdFZxMXNrSE81UEVHVmZQQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoicnh1OU85V3E2MHVhUXM0VDBNUVlBQSIsInZlciI6IjEuMCJ9.CcTo2jVKNlp0BSTvWomSMl_vG8zmIcyLm0pXnWCw3r_3_2qf-Rj85vtMVoIk39TJDMkaTvnW2u4nmqxUbdoC7xEPj5QeRmR4uqehIm8RkTJX1fe0MFZk7-sQ9t-ECEG8Tm1kwKfD38tGn2OfD8E9TRoik4iA85dEP5doo1otQodKT0gkHbjGOsexy61-oaP7Z5q1Vg4Rr0HBE23ajuVGOhFP6HGu40G0KQpU6DQUsDf_qQB_hzAXxrywnN-YvlJpj6gGhCnOMT4WIKA9BCliOs7r0EuaKRC71Kn7JXDraYZDHwWAcnxrA_rQYa4e2Gmehan3wiKb0ZRngb2aRfxK9w
-      Host:
-      - management.azure.com
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYzMDgsIm5iZiI6MTUwNjExNjMwOCwiZXhwIjoxNTA2MTIwMjA4LCJhaW8iOiJZMlZnWUZELys4NzZrY3hyOWJ5d0x2NGdHOTJiQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ1pXYXBVbW92MC1qUkJXWXlpME1BQSIsInZlciI6IjEuMCJ9.Jl8LBRzHw1JW6L_k40ZwqM7HM82e2tGTkWajlzMMoLesa04Ha-HCpzvzk-w4v-vQcPDl67S3dygKPu-luwtN4zN4ktalhxTcyEayD7-vBEv2QY1rCpaIbGvvXYWW4oKoJVu2iWhsk1p7sxucpRclKb7F-CshnuE4ysJvWA97KS3zIBouFfNIqA9_4kUA02qk186ey2JALUFGKdxcv9R_C5Lx2FpGQ5UXQe3Zb7yjlfrH6PB_wgyyFvs4N-2z3YC6G1EAIPiRgI_j-R0RZnM0X8TrHk_u6-8WtjJOL7VLyEz5VRl3qRRGp1UgYh5MkIkxX7_LRjaPi4raJiM0DfLXhA
   response:
     status:
       code: 200
@@ -2009,31 +2080,90 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - 2f186867-14d4-4bc7-b5a8-368105861714
+      - 328151af-0e62-4654-8495-9f6ecddf55b0
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14992'
+      - '14938'
       X-Ms-Correlation-Request-Id:
-      - c85abe6f-e99e-408e-8889-597b8c200dee
+      - d3ab743f-801d-40ac-a854-c34a76639d4e
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200403Z:c85abe6f-e99e-408e-8889-597b8c200dee
+      - WESTUS:20170922T214332Z:d3ab743f-801d-40ac-a854-c34a76639d4e
       Date:
-      - Tue, 05 Sep 2017 20:04:03 GMT
+      - Fri, 22 Sep 2017 21:43:32 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-05T20:04:02.2220989+00:00\",\r\n  \"endTime\":
-        \"2017-09-05T20:04:02.5346521+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=acc06b04-b73e-4f0e-83ad-18c4bf712308&sig=5OA437XjOp9pEWn%2FcXIwRY3cR0DF%2BRhOUu06VzbesSA%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"ad79b8b8-f9e6-485e-a099-ee9b59ffdab4\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2017-09-22T21:43:33.4720872+00:00\",\r\n  \"endTime\":
+        \"2017-09-22T21:43:33.7065363+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=5116297c-32cb-44ad-9687-6454756a885c&sig=G67U0CODLeGIHBDB3pLurMAlBNW9Wc%2FGz%2FHN3LOClbQ%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"d94ca538-dc9c-4582-91bf-e1beb060944f\"\r\n}"
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:03 GMT
+  recorded_at: Fri, 22 Sep 2017 21:43:32 GMT
 - request:
     method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=acc06b04-b73e-4f0e-83ad-18c4bf712308&sig=5OA437XjOp9pEWn/cXIwRY3cR0DF%2BRhOUu06VzbesSA=&sr=b&sv=2016-05-31
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/d94ca538-dc9c-4582-91bf-e1beb060944f?api-version=2017-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYzMDgsIm5iZiI6MTUwNjExNjMwOCwiZXhwIjoxNTA2MTIwMjA4LCJhaW8iOiJZMlZnWUZELys4NzZrY3hyOWJ5d0x2NGdHOTJiQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ1pXYXBVbW92MC1qUkJXWXlpME1BQSIsInZlciI6IjEuMCJ9.Jl8LBRzHw1JW6L_k40ZwqM7HM82e2tGTkWajlzMMoLesa04Ha-HCpzvzk-w4v-vQcPDl67S3dygKPu-luwtN4zN4ktalhxTcyEayD7-vBEv2QY1rCpaIbGvvXYWW4oKoJVu2iWhsk1p7sxucpRclKb7F-CshnuE4ysJvWA97KS3zIBouFfNIqA9_4kUA02qk186ey2JALUFGKdxcv9R_C5Lx2FpGQ5UXQe3Zb7yjlfrH6PB_wgyyFvs4N-2z3YC6G1EAIPiRgI_j-R0RZnM0X8TrHk_u6-8WtjJOL7VLyEz5VRl3qRRGp1UgYh5MkIkxX7_LRjaPi4raJiM0DfLXhA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
+      X-Ms-Request-Id:
+      - bcccd8c2-712b-40cf-9c35-c9facd75227d
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Correlation-Request-Id:
+      - a6c2f1bb-8c64-4876-aa27-020c921bb3d4
+      X-Ms-Routing-Request-Id:
+      - WESTUS:20170922T214333Z:a6c2f1bb-8c64-4876-aa27-020c921bb3d4
+      Date:
+      - Fri, 22 Sep 2017 21:43:33 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"startTime\": \"2017-09-22T21:43:33.4720872+00:00\",\r\n  \"endTime\":
+        \"2017-09-22T21:43:33.7065363+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=5116297c-32cb-44ad-9687-6454756a885c&sig=G67U0CODLeGIHBDB3pLurMAlBNW9Wc%2FGz%2FHN3LOClbQ%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"d94ca538-dc9c-4582-91bf-e1beb060944f\"\r\n}"
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 21:43:33 GMT
+- request:
+    method: get
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=5116297c-32cb-44ad-9687-6454756a885c&sig=G67U0CODLeGIHBDB3pLurMAlBNW9Wc/Gz/HN3LOClbQ=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2046,8 +2176,6 @@ http_interactions:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
       X-Ms-Range:
       - bytes=0-0
-      Host:
-      - md-t4jdgqqlgszp.blob.core.windows.net
   response:
     status:
       code: 206
@@ -2068,7 +2196,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - f72b7cad-001e-010e-0982-260b73000000
+      - b837bff1-001e-00ac-72eb-3380ba000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2094,13 +2222,13 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Tue, 05 Sep 2017 20:04:03 GMT
+      - Fri, 22 Sep 2017 21:43:34 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         6w==
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:03 GMT
+  recorded_at: Fri, 22 Sep 2017 21:43:33 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/EndGetAccess?api-version=2017-03-30
@@ -2117,11 +2245,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NDIsIm5iZiI6MTUwNDY0MTU0MiwiZXhwIjoxNTA0NjQ1NDQyLCJhaW8iOiJZMkZnWU9DZkZ0TC9MdFZxMXNrSE81UEVHVmZQQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoicnh1OU85V3E2MHVhUXM0VDBNUVlBQSIsInZlciI6IjEuMCJ9.CcTo2jVKNlp0BSTvWomSMl_vG8zmIcyLm0pXnWCw3r_3_2qf-Rj85vtMVoIk39TJDMkaTvnW2u4nmqxUbdoC7xEPj5QeRmR4uqehIm8RkTJX1fe0MFZk7-sQ9t-ECEG8Tm1kwKfD38tGn2OfD8E9TRoik4iA85dEP5doo1otQodKT0gkHbjGOsexy61-oaP7Z5q1Vg4Rr0HBE23ajuVGOhFP6HGu40G0KQpU6DQUsDf_qQB_hzAXxrywnN-YvlJpj6gGhCnOMT4WIKA9BCliOs7r0EuaKRC71Kn7JXDraYZDHwWAcnxrA_rQYa4e2Gmehan3wiKb0ZRngb2aRfxK9w
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYzMDgsIm5iZiI6MTUwNjExNjMwOCwiZXhwIjoxNTA2MTIwMjA4LCJhaW8iOiJZMlZnWUZELys4NzZrY3hyOWJ5d0x2NGdHOTJiQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ1pXYXBVbW92MC1qUkJXWXlpME1BQSIsInZlciI6IjEuMCJ9.Jl8LBRzHw1JW6L_k40ZwqM7HM82e2tGTkWajlzMMoLesa04Ha-HCpzvzk-w4v-vQcPDl67S3dygKPu-luwtN4zN4ktalhxTcyEayD7-vBEv2QY1rCpaIbGvvXYWW4oKoJVu2iWhsk1p7sxucpRclKb7F-CshnuE4ysJvWA97KS3zIBouFfNIqA9_4kUA02qk186ey2JALUFGKdxcv9R_C5Lx2FpGQ5UXQe3Zb7yjlfrH6PB_wgyyFvs4N-2z3YC6G1EAIPiRgI_j-R0RZnM0X8TrHk_u6-8WtjJOL7VLyEz5VRl3qRRGp1UgYh5MkIkxX7_LRjaPi4raJiM0DfLXhA
       Content-Length:
       - '0'
-      Host:
-      - management.azure.com
   response:
     status:
       code: 202
@@ -2136,31 +2262,31 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/9a6d225c-98bc-4361-8e83-bb5913da387b?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/33569068-8e4e-428f-bb7d-4aea877ce8c0?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/9a6d225c-98bc-4361-8e83-bb5913da387b?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/33569068-8e4e-428f-bb7d-4aea877ce8c0?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - 9a6d225c-98bc-4361-8e83-bb5913da387b
+      - 33569068-8e4e-428f-bb7d-4aea877ce8c0
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1194'
+      - '1185'
       X-Ms-Correlation-Request-Id:
-      - 4f742407-24c0-494b-97a3-cb9d44081003
+      - 7049eacf-3168-4153-a66b-385268a1c57f
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200404Z:4f742407-24c0-494b-97a3-cb9d44081003
+      - WESTUS:20170922T214335Z:7049eacf-3168-4153-a66b-385268a1c57f
       Date:
-      - Tue, 05 Sep 2017 20:04:04 GMT
+      - Fri, 22 Sep 2017 21:43:34 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:04 GMT
+  recorded_at: Fri, 22 Sep 2017 21:43:34 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
@@ -2177,11 +2303,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NDIsIm5iZiI6MTUwNDY0MTU0MiwiZXhwIjoxNTA0NjQ1NDQyLCJhaW8iOiJZMkZnWU9DZkZ0TC9MdFZxMXNrSE81UEVHVmZQQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoicnh1OU85V3E2MHVhUXM0VDBNUVlBQSIsInZlciI6IjEuMCJ9.CcTo2jVKNlp0BSTvWomSMl_vG8zmIcyLm0pXnWCw3r_3_2qf-Rj85vtMVoIk39TJDMkaTvnW2u4nmqxUbdoC7xEPj5QeRmR4uqehIm8RkTJX1fe0MFZk7-sQ9t-ECEG8Tm1kwKfD38tGn2OfD8E9TRoik4iA85dEP5doo1otQodKT0gkHbjGOsexy61-oaP7Z5q1Vg4Rr0HBE23ajuVGOhFP6HGu40G0KQpU6DQUsDf_qQB_hzAXxrywnN-YvlJpj6gGhCnOMT4WIKA9BCliOs7r0EuaKRC71Kn7JXDraYZDHwWAcnxrA_rQYa4e2Gmehan3wiKb0ZRngb2aRfxK9w
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYzMDgsIm5iZiI6MTUwNjExNjMwOCwiZXhwIjoxNTA2MTIwMjA4LCJhaW8iOiJZMlZnWUZELys4NzZrY3hyOWJ5d0x2NGdHOTJiQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ1pXYXBVbW92MC1qUkJXWXlpME1BQSIsInZlciI6IjEuMCJ9.Jl8LBRzHw1JW6L_k40ZwqM7HM82e2tGTkWajlzMMoLesa04Ha-HCpzvzk-w4v-vQcPDl67S3dygKPu-luwtN4zN4ktalhxTcyEayD7-vBEv2QY1rCpaIbGvvXYWW4oKoJVu2iWhsk1p7sxucpRclKb7F-CshnuE4ysJvWA97KS3zIBouFfNIqA9_4kUA02qk186ey2JALUFGKdxcv9R_C5Lx2FpGQ5UXQe3Zb7yjlfrH6PB_wgyyFvs4N-2z3YC6G1EAIPiRgI_j-R0RZnM0X8TrHk_u6-8WtjJOL7VLyEz5VRl3qRRGp1UgYh5MkIkxX7_LRjaPi4raJiM0DfLXhA
       Content-Length:
       - '42'
-      Host:
-      - management.azure.com
   response:
     status:
       code: 202
@@ -2196,34 +2320,34 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/f7e5e783-2487-468f-9a20-cb5c8d55f8d6?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/8d00b98e-979c-4428-b9d0-a5fae8bbb693?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/f7e5e783-2487-468f-9a20-cb5c8d55f8d6?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/8d00b98e-979c-4428-b9d0-a5fae8bbb693?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - f7e5e783-2487-468f-9a20-cb5c8d55f8d6
+      - 8d00b98e-979c-4428-b9d0-a5fae8bbb693
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1191'
+      - '1175'
       X-Ms-Correlation-Request-Id:
-      - 7d37a83d-cae4-4295-bf85-4f202e2be147
+      - 6228290d-dc55-44a8-bcc7-88deff53c4c6
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200405Z:7d37a83d-cae4-4295-bf85-4f202e2be147
+      - WESTUS:20170922T214336Z:6228290d-dc55-44a8-bcc7-88deff53c4c6
       Date:
-      - Tue, 05 Sep 2017 20:04:04 GMT
+      - Fri, 22 Sep 2017 21:43:35 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:04 GMT
+  recorded_at: Fri, 22 Sep 2017 21:43:35 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/f7e5e783-2487-468f-9a20-cb5c8d55f8d6?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/8d00b98e-979c-4428-b9d0-a5fae8bbb693?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -2237,9 +2361,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NDIsIm5iZiI6MTUwNDY0MTU0MiwiZXhwIjoxNTA0NjQ1NDQyLCJhaW8iOiJZMkZnWU9DZkZ0TC9MdFZxMXNrSE81UEVHVmZQQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoicnh1OU85V3E2MHVhUXM0VDBNUVlBQSIsInZlciI6IjEuMCJ9.CcTo2jVKNlp0BSTvWomSMl_vG8zmIcyLm0pXnWCw3r_3_2qf-Rj85vtMVoIk39TJDMkaTvnW2u4nmqxUbdoC7xEPj5QeRmR4uqehIm8RkTJX1fe0MFZk7-sQ9t-ECEG8Tm1kwKfD38tGn2OfD8E9TRoik4iA85dEP5doo1otQodKT0gkHbjGOsexy61-oaP7Z5q1Vg4Rr0HBE23ajuVGOhFP6HGu40G0KQpU6DQUsDf_qQB_hzAXxrywnN-YvlJpj6gGhCnOMT4WIKA9BCliOs7r0EuaKRC71Kn7JXDraYZDHwWAcnxrA_rQYa4e2Gmehan3wiKb0ZRngb2aRfxK9w
-      Host:
-      - management.azure.com
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYzMDgsIm5iZiI6MTUwNjExNjMwOCwiZXhwIjoxNTA2MTIwMjA4LCJhaW8iOiJZMlZnWUZELys4NzZrY3hyOWJ5d0x2NGdHOTJiQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ1pXYXBVbW92MC1qUkJXWXlpME1BQSIsInZlciI6IjEuMCJ9.Jl8LBRzHw1JW6L_k40ZwqM7HM82e2tGTkWajlzMMoLesa04Ha-HCpzvzk-w4v-vQcPDl67S3dygKPu-luwtN4zN4ktalhxTcyEayD7-vBEv2QY1rCpaIbGvvXYWW4oKoJVu2iWhsk1p7sxucpRclKb7F-CshnuE4ysJvWA97KS3zIBouFfNIqA9_4kUA02qk186ey2JALUFGKdxcv9R_C5Lx2FpGQ5UXQe3Zb7yjlfrH6PB_wgyyFvs4N-2z3YC6G1EAIPiRgI_j-R0RZnM0X8TrHk_u6-8WtjJOL7VLyEz5VRl3qRRGp1UgYh5MkIkxX7_LRjaPi4raJiM0DfLXhA
   response:
     status:
       code: 200
@@ -2260,31 +2382,90 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - 563ac557-fcc6-4464-b0c4-ac561c86451a
+      - 615de0c9-1301-4fa1-8b51-9a2334b69d18
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14927'
+      - '14909'
       X-Ms-Correlation-Request-Id:
-      - 6ead957a-4667-4463-ac72-f539ad520ecc
+      - a50bb732-bc09-4ab9-93dc-357a25a12f38
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200405Z:6ead957a-4667-4463-ac72-f539ad520ecc
+      - WESTUS:20170922T214336Z:a50bb732-bc09-4ab9-93dc-357a25a12f38
       Date:
-      - Tue, 05 Sep 2017 20:04:04 GMT
+      - Fri, 22 Sep 2017 21:43:35 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-05T20:04:03.9015623+00:00\",\r\n  \"endTime\":
-        \"2017-09-05T20:04:04.0421731+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=0da37b3f-9bab-446a-9363-9e2a38c87cb9&sig=CJzEUtog2LeLxOVaI4L1AAKjNvWxtrsTr5R36Pt8Xog%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"f7e5e783-2487-468f-9a20-cb5c8d55f8d6\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2017-09-22T21:43:37.5517003+00:00\",\r\n  \"endTime\":
+        \"2017-09-22T21:43:37.7705384+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=1b394f0c-0ac1-4baf-89ba-97c5dd8198ec&sig=U8ntZTm3PMHrOn1r6CXU1fPDuw%2FEQ%2B4N5QedNTDu9j0%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"8d00b98e-979c-4428-b9d0-a5fae8bbb693\"\r\n}"
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:04 GMT
+  recorded_at: Fri, 22 Sep 2017 21:43:36 GMT
 - request:
     method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=0da37b3f-9bab-446a-9363-9e2a38c87cb9&sig=CJzEUtog2LeLxOVaI4L1AAKjNvWxtrsTr5R36Pt8Xog=&sr=b&sv=2016-05-31
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/8d00b98e-979c-4428-b9d0-a5fae8bbb693?api-version=2017-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYzMDgsIm5iZiI6MTUwNjExNjMwOCwiZXhwIjoxNTA2MTIwMjA4LCJhaW8iOiJZMlZnWUZELys4NzZrY3hyOWJ5d0x2NGdHOTJiQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ1pXYXBVbW92MC1qUkJXWXlpME1BQSIsInZlciI6IjEuMCJ9.Jl8LBRzHw1JW6L_k40ZwqM7HM82e2tGTkWajlzMMoLesa04Ha-HCpzvzk-w4v-vQcPDl67S3dygKPu-luwtN4zN4ktalhxTcyEayD7-vBEv2QY1rCpaIbGvvXYWW4oKoJVu2iWhsk1p7sxucpRclKb7F-CshnuE4ysJvWA97KS3zIBouFfNIqA9_4kUA02qk186ey2JALUFGKdxcv9R_C5Lx2FpGQ5UXQe3Zb7yjlfrH6PB_wgyyFvs4N-2z3YC6G1EAIPiRgI_j-R0RZnM0X8TrHk_u6-8WtjJOL7VLyEz5VRl3qRRGp1UgYh5MkIkxX7_LRjaPi4raJiM0DfLXhA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
+      X-Ms-Request-Id:
+      - 4204cd4f-08c5-41ff-8e47-49977fd065b3
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14897'
+      X-Ms-Correlation-Request-Id:
+      - fbacdac9-f65e-4719-b2bb-c70146e21c70
+      X-Ms-Routing-Request-Id:
+      - WESTUS:20170922T214338Z:fbacdac9-f65e-4719-b2bb-c70146e21c70
+      Date:
+      - Fri, 22 Sep 2017 21:43:38 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"startTime\": \"2017-09-22T21:43:37.5517003+00:00\",\r\n  \"endTime\":
+        \"2017-09-22T21:43:37.7705384+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=1b394f0c-0ac1-4baf-89ba-97c5dd8198ec&sig=U8ntZTm3PMHrOn1r6CXU1fPDuw%2FEQ%2B4N5QedNTDu9j0%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"8d00b98e-979c-4428-b9d0-a5fae8bbb693\"\r\n}"
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 21:43:37 GMT
+- request:
+    method: get
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=1b394f0c-0ac1-4baf-89ba-97c5dd8198ec&sig=U8ntZTm3PMHrOn1r6CXU1fPDuw/EQ%2B4N5QedNTDu9j0=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2297,8 +2478,6 @@ http_interactions:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
       X-Ms-Range:
       - bytes=440-443
-      Host:
-      - md-t4jdgqqlgszp.blob.core.windows.net
   response:
     status:
       code: 206
@@ -2319,7 +2498,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - e3fa172c-001e-009a-4a82-262de8000000
+      - eca6ae76-001e-00c2-28eb-332993000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2345,13 +2524,13 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Tue, 05 Sep 2017 20:04:05 GMT
+      - Fri, 22 Sep 2017 21:43:38 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         U5MJAA==
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:04 GMT
+  recorded_at: Fri, 22 Sep 2017 21:43:37 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/EndGetAccess?api-version=2017-03-30
@@ -2368,11 +2547,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NDIsIm5iZiI6MTUwNDY0MTU0MiwiZXhwIjoxNTA0NjQ1NDQyLCJhaW8iOiJZMkZnWU9DZkZ0TC9MdFZxMXNrSE81UEVHVmZQQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoicnh1OU85V3E2MHVhUXM0VDBNUVlBQSIsInZlciI6IjEuMCJ9.CcTo2jVKNlp0BSTvWomSMl_vG8zmIcyLm0pXnWCw3r_3_2qf-Rj85vtMVoIk39TJDMkaTvnW2u4nmqxUbdoC7xEPj5QeRmR4uqehIm8RkTJX1fe0MFZk7-sQ9t-ECEG8Tm1kwKfD38tGn2OfD8E9TRoik4iA85dEP5doo1otQodKT0gkHbjGOsexy61-oaP7Z5q1Vg4Rr0HBE23ajuVGOhFP6HGu40G0KQpU6DQUsDf_qQB_hzAXxrywnN-YvlJpj6gGhCnOMT4WIKA9BCliOs7r0EuaKRC71Kn7JXDraYZDHwWAcnxrA_rQYa4e2Gmehan3wiKb0ZRngb2aRfxK9w
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYzMDgsIm5iZiI6MTUwNjExNjMwOCwiZXhwIjoxNTA2MTIwMjA4LCJhaW8iOiJZMlZnWUZELys4NzZrY3hyOWJ5d0x2NGdHOTJiQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ1pXYXBVbW92MC1qUkJXWXlpME1BQSIsInZlciI6IjEuMCJ9.Jl8LBRzHw1JW6L_k40ZwqM7HM82e2tGTkWajlzMMoLesa04Ha-HCpzvzk-w4v-vQcPDl67S3dygKPu-luwtN4zN4ktalhxTcyEayD7-vBEv2QY1rCpaIbGvvXYWW4oKoJVu2iWhsk1p7sxucpRclKb7F-CshnuE4ysJvWA97KS3zIBouFfNIqA9_4kUA02qk186ey2JALUFGKdxcv9R_C5Lx2FpGQ5UXQe3Zb7yjlfrH6PB_wgyyFvs4N-2z3YC6G1EAIPiRgI_j-R0RZnM0X8TrHk_u6-8WtjJOL7VLyEz5VRl3qRRGp1UgYh5MkIkxX7_LRjaPi4raJiM0DfLXhA
       Content-Length:
       - '0'
-      Host:
-      - management.azure.com
   response:
     status:
       code: 202
@@ -2387,29 +2564,29 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/6faa1e62-8576-4c0e-bb45-64b0182e828a?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/ac77e3a3-69d9-472a-b174-b67d754a0ee7?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/6faa1e62-8576-4c0e-bb45-64b0182e828a?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/ac77e3a3-69d9-472a-b174-b67d754a0ee7?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - 6faa1e62-8576-4c0e-bb45-64b0182e828a
+      - ac77e3a3-69d9-472a-b174-b67d754a0ee7
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1190'
+      - '1180'
       X-Ms-Correlation-Request-Id:
-      - 804f64fc-ab50-4bf4-84e5-4d21bf9f89b7
+      - 25c6824e-5748-4680-8c2a-53a9266e3dcd
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200405Z:804f64fc-ab50-4bf4-84e5-4d21bf9f89b7
+      - WESTUS:20170922T214339Z:25c6824e-5748-4680-8c2a-53a9266e3dcd
       Date:
-      - Tue, 05 Sep 2017 20:04:05 GMT
+      - Fri, 22 Sep 2017 21:43:38 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:05 GMT
+  recorded_at: Fri, 22 Sep 2017 21:43:39 GMT
 recorded_with: VCR 3.0.3

--- a/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_partNum-1.yml
+++ b/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_partNum-1.yml
@@ -17,8 +17,6 @@ http_interactions:
       - '186'
       Content-Type:
       - application/x-www-form-urlencoded
-      Host:
-      - login.microsoftonline.com
   response:
     status:
       code: 200
@@ -39,25 +37,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 5acc073c-df53-4942-b6da-cc8e1cc11800
+      - f738d7f7-83e3-4dc7-bba5-c25180380d00
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAAA9kTklhVy7SJTGAzR-p1BcETbzKNU_IalYTzgUHdoV8IKD5eZUYieFFJ0W6hbdl9Tt1YgByaYG3isKN-IxCZrEfNoBXwL-ukJ-hsbPxrECtJKVJywnya6gwsx0dh2NCVJSoFPB1zvFBc-u-lBZfBAE5uZJT2E_Z0nyPaRSWHmeEv5Jx8Q4kyIkAXtFbk7D_ScgAA;
+      - esctx=AQABAAAAAAABlDrqfEFlSaui6xnRjX5EXrtiQ1invhLWk75_uzj9A_UsNBd3Gq2ol3WJiwp4KKLXdxbajpme5uTAUCN38xtWy6I2DVkPiJxGxo5FPUPnesqu_RrHFe8NhyRX0dQ8D5n4pbBYvgQ8vVB4gHo2fd9Yu7qqegSgnK4pbtPBlSSwYlEDjlaopysaDgqxnNi_nLAgAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=006; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=005; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Tue, 05 Sep 2017 20:04:31 GMT
+      - Fri, 22 Sep 2017 21:43:07 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1504645473","not_before":"1504641573","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NzMsIm5iZiI6MTUwNDY0MTU3MywiZXhwIjoxNTA0NjQ1NDczLCJhaW8iOiJZMkZnWUhBdHNEcjNuV3R0TWYvWmZTOFdyL1IvREFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUEFmTVdsUGZRa20yMnN5T0hNRVlBQSIsInZlciI6IjEuMCJ9.PKElQI3zgGjmUqPnsfHlnTHKsXgjuDYuwmKDoWIvH3KIGwHt7njKZTcz7Hpgj0EKEigFnYXd6egn-36s7XO93ebZdj2Z-dV3raQ3aFmNtSpUI1PFd1jyUi3fyzKAp5v-rNY1oUZ_BfkKkps0Gv_jEdEU21LR0-n_WInvwrJcKpXJOCqfFxbyfKsPBGw6WNPeT066nIqsIP6R9IwUovQqFL-iq6P32STALjR-DC_FRxAaa14KxQZeeaxMH_JDictjUOS9TvZNSJshne5NSFeSdFExFFqV73nhj5fRnqOwI7M6_T0h-HA70KZPkOUmFA2xh45IdXVDd90H0vLsh-5Bpw"}'
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1506120187","not_before":"1506116287","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyODcsIm5iZiI6MTUwNjExNjI4NywiZXhwIjoxNTA2MTIwMTg3LCJhaW8iOiJZMlZnWURBN2FjaFIvNVAvekU3TjI5dTc5V2VsQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiOTljNDktT0R4MDI3cGNKUmdEZ05BQSIsInZlciI6IjEuMCJ9.NVvVVwlnwXscLIZM4jdqDK2ouoMS2L5w7AjwjdDU2wodpK-G6FUfumZxjqKHGtihz2-o0Y6xbQBepjPMjIIiyASFXwHpAUJu4_yhjkeJPYTOVeoy-XCVDGUve-Lr4Mo10MKw1kK3jq3Fvoa8_YvcCAx9BkMTfbTjiTaBHtMKELmMSxoVHJGGXGyKQWPfL66ovHgwDUBo8XWmUeZ2J_msc0YeTMIkN30LYl456-UhmriXN2aggJZUHw8-4y7bhtCZeeXM6Wi6B1Duh0HKh8JZ4vea4mLk7Zu1yc3oCBNvsANa3Bgp7zQSZB4_WXI1in_6Phc52A4Myt_E9HodzFgRog"}'
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:30 GMT
+  recorded_at: Fri, 22 Sep 2017 21:43:07 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -74,9 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NzMsIm5iZiI6MTUwNDY0MTU3MywiZXhwIjoxNTA0NjQ1NDczLCJhaW8iOiJZMkZnWUhBdHNEcjNuV3R0TWYvWmZTOFdyL1IvREFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUEFmTVdsUGZRa20yMnN5T0hNRVlBQSIsInZlciI6IjEuMCJ9.PKElQI3zgGjmUqPnsfHlnTHKsXgjuDYuwmKDoWIvH3KIGwHt7njKZTcz7Hpgj0EKEigFnYXd6egn-36s7XO93ebZdj2Z-dV3raQ3aFmNtSpUI1PFd1jyUi3fyzKAp5v-rNY1oUZ_BfkKkps0Gv_jEdEU21LR0-n_WInvwrJcKpXJOCqfFxbyfKsPBGw6WNPeT066nIqsIP6R9IwUovQqFL-iq6P32STALjR-DC_FRxAaa14KxQZeeaxMH_JDictjUOS9TvZNSJshne5NSFeSdFExFFqV73nhj5fRnqOwI7M6_T0h-HA70KZPkOUmFA2xh45IdXVDd90H0vLsh-5Bpw
-      Host:
-      - management.azure.com
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyODcsIm5iZiI6MTUwNjExNjI4NywiZXhwIjoxNTA2MTIwMTg3LCJhaW8iOiJZMlZnWURBN2FjaFIvNVAvekU3TjI5dTc5V2VsQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiOTljNDktT0R4MDI3cGNKUmdEZ05BQSIsInZlciI6IjEuMCJ9.NVvVVwlnwXscLIZM4jdqDK2ouoMS2L5w7AjwjdDU2wodpK-G6FUfumZxjqKHGtihz2-o0Y6xbQBepjPMjIIiyASFXwHpAUJu4_yhjkeJPYTOVeoy-XCVDGUve-Lr4Mo10MKw1kK3jq3Fvoa8_YvcCAx9BkMTfbTjiTaBHtMKELmMSxoVHJGGXGyKQWPfL66ovHgwDUBo8XWmUeZ2J_msc0YeTMIkN30LYl456-UhmriXN2aggJZUHw8-4y7bhtCZeeXM6Wi6B1Duh0HKh8JZ4vea4mLk7Zu1yc3oCBNvsANa3Bgp7zQSZB4_WXI1in_6Phc52A4Myt_E9HodzFgRog
   response:
     status:
       code: 200
@@ -95,23 +91,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14995'
+      - '14999'
       X-Ms-Request-Id:
-      - f7567047-be8c-4d2a-9c3f-fee82c144659
+      - 1d85e7d7-1c08-4975-beab-598cfcad8873
       X-Ms-Correlation-Request-Id:
-      - f7567047-be8c-4d2a-9c3f-fee82c144659
+      - 1d85e7d7-1c08-4975-beab-598cfcad8873
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200433Z:f7567047-be8c-4d2a-9c3f-fee82c144659
+      - WESTUS:20170922T214307Z:1d85e7d7-1c08-4975-beab-598cfcad8873
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 05 Sep 2017 20:04:33 GMT
+      - Fri, 22 Sep 2017 21:43:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:30 GMT
+  recorded_at: Fri, 22 Sep 2017 21:43:07 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/azure_subscription_id/providers?api-version=2015-01-01
@@ -128,9 +124,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NzMsIm5iZiI6MTUwNDY0MTU3MywiZXhwIjoxNTA0NjQ1NDczLCJhaW8iOiJZMkZnWUhBdHNEcjNuV3R0TWYvWmZTOFdyL1IvREFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUEFmTVdsUGZRa20yMnN5T0hNRVlBQSIsInZlciI6IjEuMCJ9.PKElQI3zgGjmUqPnsfHlnTHKsXgjuDYuwmKDoWIvH3KIGwHt7njKZTcz7Hpgj0EKEigFnYXd6egn-36s7XO93ebZdj2Z-dV3raQ3aFmNtSpUI1PFd1jyUi3fyzKAp5v-rNY1oUZ_BfkKkps0Gv_jEdEU21LR0-n_WInvwrJcKpXJOCqfFxbyfKsPBGw6WNPeT066nIqsIP6R9IwUovQqFL-iq6P32STALjR-DC_FRxAaa14KxQZeeaxMH_JDictjUOS9TvZNSJshne5NSFeSdFExFFqV73nhj5fRnqOwI7M6_T0h-HA70KZPkOUmFA2xh45IdXVDd90H0vLsh-5Bpw
-      Host:
-      - management.azure.com
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyODcsIm5iZiI6MTUwNjExNjI4NywiZXhwIjoxNTA2MTIwMTg3LCJhaW8iOiJZMlZnWURBN2FjaFIvNVAvekU3TjI5dTc5V2VsQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiOTljNDktT0R4MDI3cGNKUmdEZ05BQSIsInZlciI6IjEuMCJ9.NVvVVwlnwXscLIZM4jdqDK2ouoMS2L5w7AjwjdDU2wodpK-G6FUfumZxjqKHGtihz2-o0Y6xbQBepjPMjIIiyASFXwHpAUJu4_yhjkeJPYTOVeoy-XCVDGUve-Lr4Mo10MKw1kK3jq3Fvoa8_YvcCAx9BkMTfbTjiTaBHtMKELmMSxoVHJGGXGyKQWPfL66ovHgwDUBo8XWmUeZ2J_msc0YeTMIkN30LYl456-UhmriXN2aggJZUHw8-4y7bhtCZeeXM6Wi6B1Duh0HKh8JZ4vea4mLk7Zu1yc3oCBNvsANa3Bgp7zQSZB4_WXI1in_6Phc52A4Myt_E9HodzFgRog
   response:
     status:
       code: 200
@@ -147,22 +141,42 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14958'
+      - '14927'
       X-Ms-Request-Id:
-      - e61bb1b4-8bd7-495b-a97a-5efdaa3944d1
+      - bec77f80-b0b6-4d30-b436-d4caf90d8a09
       X-Ms-Correlation-Request-Id:
-      - e61bb1b4-8bd7-495b-a97a-5efdaa3944d1
+      - bec77f80-b0b6-4d30-b436-d4caf90d8a09
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200434Z:e61bb1b4-8bd7-495b-a97a-5efdaa3944d1
+      - WESTUS:20170922T214310Z:bec77f80-b0b6-4d30-b436-d4caf90d8a09
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 05 Sep 2017 20:04:33 GMT
+      - Fri, 22 Sep 2017 21:43:10 GMT
       Content-Length:
-      - '243687'
+      - '254785'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
+      string: '{"value":[{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"operations","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","North Central
         US","South Central US","West Central US","West US","West US 2","Canada Central","Canada
         East","North Europe","West Europe","UK South","UK West","East Asia","Southeast
@@ -437,7 +451,7 @@ http_interactions:
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
         Central US","West US 2","South India","Central India","West India","Canada
-        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
+        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
         East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
@@ -466,7 +480,7 @@ http_interactions:
         Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"}],"resourceTypes":[{"resourceType":"components","locations":["East
         US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
         US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01","2014-04-01"]},{"resourceType":"queries","locations":["East
-        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"alertrules","locations":["West
+        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
@@ -542,7 +556,7 @@ http_interactions:
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorization":{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorizations":[{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},{"applicationId":"7c33bfcb-8d33-48d6-8e60-dc6404003489","roleDefinitionId":"ad6261e4-fa9a-4642-aa5f-104f1b67e9e3"},{"applicationId":"1e3e4475-288f-4018-a376-df66fd7fac5f","roleDefinitionId":"1d538b69-3d87-4e56-8ff8-25786fd48261"},{"applicationId":"a0be0c72-870e-46f0-9c49-c98333a996f7","roleDefinitionId":"7ce22727-ffce-45a9-930c-ddb2e56fa131"}],"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -552,7 +566,7 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -567,7 +581,8 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
+        Central US"],"apiVersions":["2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -577,7 +592,12 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -597,7 +617,7 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -612,7 +632,7 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -622,7 +642,31 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
         East","UK South","Central India","Canada Central"],"apiVersions":["2017-04-26-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"]},{"resourceType":"workspaces/dataSources","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
@@ -641,17 +685,17 @@ http_interactions:
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"consoles","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/consoles","locations":["West
+        East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"consoles","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/consoles","locations":["West
         US","East US","Central India","North Europe","West Europe","South Central
-        US","Southeast Asia"],"apiVersions":["2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
+        US","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
         US","East US","Central India","North Europe","West Europe","South Central
-        US","Southeast Asia"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
+        US","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","Canada Central","Canada East","West Central US","West US 2","UK South","UK
         West","Korea Central","Korea South"],"apiVersions":["2017-07-01","2016-12-01","2016-08-10","2016-06-01","2016-05-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"operations","locations":["Southeast
-        Asia"],"apiVersions":["2016-08-10","2016-06-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01"]},{"resourceType":"locations/backupStatus","locations":["West
+        Asia"],"apiVersions":["2016-08-10","2016-06-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01","2016-06-01"]},{"resourceType":"locations/backupStatus","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
@@ -687,6 +731,7 @@ http_interactions:
         Central US","Central US","North Europe","West Europe","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada Central","Canada East"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"pricings","locations":["Central
+        US","East US"],"apiVersions":["2017-08-01-preview"]},{"resourceType":"securityContacts","locations":["Central
         US","East US"],"apiVersions":["2017-08-01-preview"]},{"resourceType":"workspaceSettings","locations":["Central
         US","East US"],"apiVersions":["2017-08-01-preview"]},{"resourceType":"complianceResults","locations":["Central
         US","East US"],"apiVersions":["2017-08-01"]},{"resourceType":"policies","locations":["Central
@@ -703,6 +748,8 @@ http_interactions:
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatusesSummaries","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/alerts","locations":["Central
         US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/tasks","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"externalSecuritySolutions","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/externalSecuritySolutions","locations":["Central
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.SiteRecovery","namespace":"Microsoft.SiteRecovery","authorization":{"applicationId":"b8340c3b-9267-498f-b21a-15d5547fd85e","roleDefinitionId":"8A00C8EA-8F1B-45A7-8F64-F4CC61EEE9B6"},"resourceTypes":[{"resourceType":"SiteRecoveryVault","locations":["East
         US","West US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","Australia East","Australia Southeast","Brazil South","North
@@ -722,7 +769,7 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -842,7 +889,22 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/databases/transparentDataEncryption","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -1077,6 +1139,26 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
         US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
@@ -1307,6 +1389,11 @@ http_interactions:
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"customApis","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
         East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/managedApis","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
@@ -1358,23 +1445,8 @@ http_interactions:
         US","North Europe","Japan West","Japan East","East Asia","West Europe","East
         US","Southeast Asia","Central US"],"apiVersions":["2016-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Lombiq.DotNest","namespace":"Lombiq.DotNest","resourceTypes":[{"resourceType":"sites","locations":["East
         US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Mailjet.Email","namespace":"Mailjet.Email","resourceTypes":[{"resourceType":"services","locations":["West
-        US"],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
-        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]},{"resourceType":"diagnosticSettings","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"addsservices","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"configuration","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"operations","locations":["West
@@ -1498,8 +1570,10 @@ http_interactions:
         Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
         Central US","Central US","North Europe","West Europe","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","West
-        India","South India"],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CognitiveServices","namespace":"Microsoft.CognitiveServices","authorizations":[{"applicationId":"7d312290-28c8-473c-a0ed-8e53749b6d6d","roleDefinitionId":"5cb87f79-a7c3-4a95-9414-45b65974b51b"}],"resourceTypes":[{"resourceType":"accounts","locations":["Global","West
-        US","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"operations","locations":["Global","Australia
+        India","South India"],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CognitiveServices","namespace":"Microsoft.CognitiveServices","authorizations":[{"applicationId":"7d312290-28c8-473c-a0ed-8e53749b6d6d","roleDefinitionId":"5cb87f79-a7c3-4a95-9414-45b65974b51b"}],"resourceTypes":[{"resourceType":"accounts","locations":["Global","Australia
+        East","Brazil South","West US","West US 2","West Europe","North Europe","Southeast
+        Asia","East Asia","West Central US","South Central US","East US","East US
+        2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"operations","locations":["Global","Australia
         East","Brazil South","West US","West US 2","West Europe","North Europe","Southeast
         Asia","East Asia","West Central US","South Central US","East US","East US
         2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations","locations":["Global","Australia
@@ -1534,13 +1608,13 @@ http_interactions:
         US","West US","Australia East","West Europe","North Europe","Southeast Asia","West
         Central US"],"apiVersions":["2016-03-30","2015-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataFactory","namespace":"Microsoft.DataFactory","resourceTypes":[{"resourceType":"dataFactories","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview","2014-04-01"]},{"resourceType":"factories","locations":["East
-        US"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
-        US"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
+        US","East US 2"],"apiVersions":["2017-09-01-preview","2017-03-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
+        US","East US 2"],"apiVersions":["2017-09-01-preview","2017-03-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
         Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"dataFactories/metricDefinitions","locations":["North
         Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"checkDataFactoryNameAvailability","locations":[],"apiVersions":["2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"checkAzureDataFactoryNameAvailability","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"dataFactorySchema","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"operations","locations":["West
-        US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeAnalytics","namespace":"Microsoft.DataLakeAnalytics","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US","North Europe","East US","West Central US"],"apiVersions":["2017-09-01-preview","2017-03-01-preview","2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeAnalytics","namespace":"Microsoft.DataLakeAnalytics","resourceTypes":[{"resourceType":"accounts","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/dataLakeStoreAccounts","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers","locations":["East
@@ -1589,11 +1663,12 @@ http_interactions:
         India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
         India","East Asia","East US 2","East US","Japan East","Japan West","North
         Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"checkProvisioningServiceNameAvailability","locations":[],"apiVersions":["2017-08-21-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
         US","North Europe","East Asia","East US","West Europe","Southeast Asia","Japan
         East","Japan West","Australia East","Australia Southeast","West US 2","West
         Central US","East US 2","Central US","UK South","UK West","South India","Central
-        India"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
+        India","Canada Central","Canada East"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"ProvisioningServices","locations":["East
+        US","West Europe","Southeast Asia"],"apiVersions":["2017-08-21-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
         East","Australia Southeast","Canada Central","Canada East","Central India","Central
         US","East Asia","East US","East US 2","Japan East","Japan West","North Central
         US","North Europe","South Central US","South India","Southeast Asia","West
@@ -1620,16 +1695,16 @@ http_interactions:
         US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"operations","locations":["Brazil
         South","East Asia","East US","Japan East","Japan West","North Central US","North
         Europe","South Central US","West Europe","West US","Southeast Asia","Central
-        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"topics","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operations","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topics","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operations","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","West
         US 2","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
@@ -1727,48 +1802,39 @@ http_interactions:
         Central US","West Europe","Southeast Asia","Japan East","East US 2","West
         Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"commitmentPlans","locations":["South
         Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
-        Central US","West US"],"apiVersions":["2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Media","namespace":"Microsoft.Media","authorization":{"applicationId":"374b2a64-3b6b-436b-934c-b820eacca870","roleDefinitionId":"aab70789-0cec-44b5-95d7-84b64c9487af"},"resourceTypes":[{"resourceType":"mediaservices","locations":["Japan
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningExperimentation","namespace":"Microsoft.MachineLearningExperimentation","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"accounts","locations":["Australia
+        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces","locations":["Australia
+        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces/projects","locations":["Australia
+        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningCompute","namespace":"Microsoft.MachineLearningCompute","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"376aa7d7-51a9-463d-bd4d-7e1691345612","managedByRoleDefinitionId":"91d00862-cf55-46a5-9dce-260bbd92ce25"},"resourceTypes":[{"resourceType":"operationalizationClusters","locations":["East
+        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"operations","locations":["East
+        US 2"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations","locations":["East
+        US 2"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["East
+        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningModelManagement","namespace":"Microsoft.MachineLearningModelManagement","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US 2","West Central US","Australia East"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"operations","locations":["West
+        Central US"],"apiVersions":["2017-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
+        Central US","West US"],"apiVersions":["2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01"]},{"resourceType":"offertypes","locations":["South
+        Central US","West US"],"apiVersions":["2015-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Media","namespace":"Microsoft.Media","authorization":{"applicationId":"374b2a64-3b6b-436b-934c-b820eacca870","roleDefinitionId":"aab70789-0cec-44b5-95d7-84b64c9487af"},"resourceTypes":[{"resourceType":"mediaservices","locations":["Japan
         West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
         US","West US","Australia East","Australia Southeast","Central US","Brazil
         South","Central India","West India","South India","South Central US","Canada
-        Central","Canada East","West Central US"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
+        Central","Canada East","West Central US"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
         Central US","North Central US","East US 2","West US","West Europe","North
         Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
         East","UK South","West India"],"apiVersions":["2016-01-29"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-01-29"]},{"resourceType":"locations/checkNameAvailability","locations":["South
         Central US","North Central US","East US 2","West US","West Europe","North
         Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
-        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"operations","locations":["East
+        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"capacities","locations":["West
+        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
+        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationresults","locations":["West
+        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
+        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"operations","locations":["East
         US 2"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Relay","namespace":"Microsoft.Relay","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US 2","West
         US","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
         India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2017-08-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkPolicyCompliance","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
@@ -1827,8 +1893,11 @@ http_interactions:
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","resourceTypes":[{"resourceType":"operations","locations":["West
-        Central US"],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
+        Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applianceDefinitions","locations":["West
+        Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"locations","locations":["West
+        Central US"],"apiVersions":["2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
+        Central US"],"apiVersions":["2017-09-01","2016-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","West Central US","Japan East","Japan West","Australia East","Australia
         Southeast"],"apiVersions":["2017-06-01","2017-05-15","2017-01-01","2016-10-01","2016-06-01","2015-03-15","2014-09-01"]},{"resourceType":"operations","locations":["West
@@ -1888,11 +1957,17 @@ http_interactions:
         US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RedisLabs.Memcached","namespace":"RedisLabs.Memcached","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-07-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RedisLabs.Redis","namespace":"RedisLabs.Redis","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-07-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RevAPM.MobileCDN","namespace":"RevAPM.MobileCDN","resourceTypes":[{"resourceType":"accounts","locations":["Central
         US","East US","East US 2","North Central US","South Central US","West US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
-        East","Australia Southeast"],"apiVersions":["2016-08-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-24","2016-08-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sendgrid.Email","namespace":"Sendgrid.Email","resourceTypes":[{"resourceType":"accounts","locations":["East
-        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
-        Central US","Central US","North Europe","West Europe","Japan East","Japan
-        West","Brazil South","Australia East","Australia Southeast","Canada Central","Canada
-        East","West Central US","West US 2","UK South","UK West"],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Signiant.Flight","namespace":"Signiant.Flight","resourceTypes":[{"resourceType":"accounts","locations":["East
+        East","Australia Southeast"],"apiVersions":["2016-08-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-24","2016-08-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sendgrid.Email","namespace":"Sendgrid.Email","resourceTypes":[{"resourceType":"accounts","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Signiant.Flight","namespace":"Signiant.Flight","resourceTypes":[{"resourceType":"accounts","locations":["East
         US","Central US","North Central US","South Central US","West US","North Europe","West
         Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast"],"apiVersions":["2015-06-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sparkpost.Basic","namespace":"Sparkpost.Basic","resourceTypes":[{"resourceType":"services","locations":["West
@@ -1909,7 +1984,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:31 GMT
+  recorded_at: Fri, 22 Sep 2017 21:43:10 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
@@ -1926,11 +2001,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NzMsIm5iZiI6MTUwNDY0MTU3MywiZXhwIjoxNTA0NjQ1NDczLCJhaW8iOiJZMkZnWUhBdHNEcjNuV3R0TWYvWmZTOFdyL1IvREFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUEFmTVdsUGZRa20yMnN5T0hNRVlBQSIsInZlciI6IjEuMCJ9.PKElQI3zgGjmUqPnsfHlnTHKsXgjuDYuwmKDoWIvH3KIGwHt7njKZTcz7Hpgj0EKEigFnYXd6egn-36s7XO93ebZdj2Z-dV3raQ3aFmNtSpUI1PFd1jyUi3fyzKAp5v-rNY1oUZ_BfkKkps0Gv_jEdEU21LR0-n_WInvwrJcKpXJOCqfFxbyfKsPBGw6WNPeT066nIqsIP6R9IwUovQqFL-iq6P32STALjR-DC_FRxAaa14KxQZeeaxMH_JDictjUOS9TvZNSJshne5NSFeSdFExFFqV73nhj5fRnqOwI7M6_T0h-HA70KZPkOUmFA2xh45IdXVDd90H0vLsh-5Bpw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyODcsIm5iZiI6MTUwNjExNjI4NywiZXhwIjoxNTA2MTIwMTg3LCJhaW8iOiJZMlZnWURBN2FjaFIvNVAvekU3TjI5dTc5V2VsQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiOTljNDktT0R4MDI3cGNKUmdEZ05BQSIsInZlciI6IjEuMCJ9.NVvVVwlnwXscLIZM4jdqDK2ouoMS2L5w7AjwjdDU2wodpK-G6FUfumZxjqKHGtihz2-o0Y6xbQBepjPMjIIiyASFXwHpAUJu4_yhjkeJPYTOVeoy-XCVDGUve-Lr4Mo10MKw1kK3jq3Fvoa8_YvcCAx9BkMTfbTjiTaBHtMKELmMSxoVHJGGXGyKQWPfL66ovHgwDUBo8XWmUeZ2J_msc0YeTMIkN30LYl456-UhmriXN2aggJZUHw8-4y7bhtCZeeXM6Wi6B1Duh0HKh8JZ4vea4mLk7Zu1yc3oCBNvsANa3Bgp7zQSZB4_WXI1in_6Phc52A4Myt_E9HodzFgRog
       Content-Length:
       - '42'
-      Host:
-      - management.azure.com
   response:
     status:
       code: 202
@@ -1945,34 +2018,34 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/35b10d2b-6aff-4ae1-ba1b-7e294bd0a6b7?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/d4f0e2cb-0af9-4476-8ce6-c34b5ee08e1f?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/35b10d2b-6aff-4ae1-ba1b-7e294bd0a6b7?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/d4f0e2cb-0af9-4476-8ce6-c34b5ee08e1f?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - 35b10d2b-6aff-4ae1-ba1b-7e294bd0a6b7
+      - d4f0e2cb-0af9-4476-8ce6-c34b5ee08e1f
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1184'
+      - '1169'
       X-Ms-Correlation-Request-Id:
-      - e9a38889-c5e1-44e1-9fe3-0a7e8e60ce2b
+      - 7f43fc9c-dcf8-45b7-a60b-dfdb6ac64de8
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200434Z:e9a38889-c5e1-44e1-9fe3-0a7e8e60ce2b
+      - WESTUS:20170922T214311Z:7f43fc9c-dcf8-45b7-a60b-dfdb6ac64de8
       Date:
-      - Tue, 05 Sep 2017 20:04:33 GMT
+      - Fri, 22 Sep 2017 21:43:11 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:31 GMT
+  recorded_at: Fri, 22 Sep 2017 21:43:11 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/35b10d2b-6aff-4ae1-ba1b-7e294bd0a6b7?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/d4f0e2cb-0af9-4476-8ce6-c34b5ee08e1f?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -1986,9 +2059,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NzMsIm5iZiI6MTUwNDY0MTU3MywiZXhwIjoxNTA0NjQ1NDczLCJhaW8iOiJZMkZnWUhBdHNEcjNuV3R0TWYvWmZTOFdyL1IvREFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUEFmTVdsUGZRa20yMnN5T0hNRVlBQSIsInZlciI6IjEuMCJ9.PKElQI3zgGjmUqPnsfHlnTHKsXgjuDYuwmKDoWIvH3KIGwHt7njKZTcz7Hpgj0EKEigFnYXd6egn-36s7XO93ebZdj2Z-dV3raQ3aFmNtSpUI1PFd1jyUi3fyzKAp5v-rNY1oUZ_BfkKkps0Gv_jEdEU21LR0-n_WInvwrJcKpXJOCqfFxbyfKsPBGw6WNPeT066nIqsIP6R9IwUovQqFL-iq6P32STALjR-DC_FRxAaa14KxQZeeaxMH_JDictjUOS9TvZNSJshne5NSFeSdFExFFqV73nhj5fRnqOwI7M6_T0h-HA70KZPkOUmFA2xh45IdXVDd90H0vLsh-5Bpw
-      Host:
-      - management.azure.com
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyODcsIm5iZiI6MTUwNjExNjI4NywiZXhwIjoxNTA2MTIwMTg3LCJhaW8iOiJZMlZnWURBN2FjaFIvNVAvekU3TjI5dTc5V2VsQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiOTljNDktT0R4MDI3cGNKUmdEZ05BQSIsInZlciI6IjEuMCJ9.NVvVVwlnwXscLIZM4jdqDK2ouoMS2L5w7AjwjdDU2wodpK-G6FUfumZxjqKHGtihz2-o0Y6xbQBepjPMjIIiyASFXwHpAUJu4_yhjkeJPYTOVeoy-XCVDGUve-Lr4Mo10MKw1kK3jq3Fvoa8_YvcCAx9BkMTfbTjiTaBHtMKELmMSxoVHJGGXGyKQWPfL66ovHgwDUBo8XWmUeZ2J_msc0YeTMIkN30LYl456-UhmriXN2aggJZUHw8-4y7bhtCZeeXM6Wi6B1Duh0HKh8JZ4vea4mLk7Zu1yc3oCBNvsANa3Bgp7zQSZB4_WXI1in_6Phc52A4Myt_E9HodzFgRog
   response:
     status:
       code: 200
@@ -2009,31 +2080,90 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - 8eaf2d0d-cc4f-4090-9bff-803caa227db3
+      - 3e8584c1-8166-48de-898b-0c59965b823a
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14987'
+      X-Ms-Correlation-Request-Id:
+      - 518a9fa5-e4fc-4c6d-902e-f79152e67de1
+      X-Ms-Routing-Request-Id:
+      - WESTUS:20170922T214312Z:518a9fa5-e4fc-4c6d-902e-f79152e67de1
+      Date:
+      - Fri, 22 Sep 2017 21:43:12 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"startTime\": \"2017-09-22T21:43:13.1794483+00:00\",\r\n  \"endTime\":
+        \"2017-09-22T21:43:13.3982845+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=bed63c44-b681-4b04-8749-15a1604dba88&sig=3DamxkhDnkQk5w7P9PiLUAVFolhGxatuoZwwZfq9%2Fq0%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"d4f0e2cb-0af9-4476-8ce6-c34b5ee08e1f\"\r\n}"
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 21:43:12 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/d4f0e2cb-0af9-4476-8ce6-c34b5ee08e1f?api-version=2017-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyODcsIm5iZiI6MTUwNjExNjI4NywiZXhwIjoxNTA2MTIwMTg3LCJhaW8iOiJZMlZnWURBN2FjaFIvNVAvekU3TjI5dTc5V2VsQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiOTljNDktT0R4MDI3cGNKUmdEZ05BQSIsInZlciI6IjEuMCJ9.NVvVVwlnwXscLIZM4jdqDK2ouoMS2L5w7AjwjdDU2wodpK-G6FUfumZxjqKHGtihz2-o0Y6xbQBepjPMjIIiyASFXwHpAUJu4_yhjkeJPYTOVeoy-XCVDGUve-Lr4Mo10MKw1kK3jq3Fvoa8_YvcCAx9BkMTfbTjiTaBHtMKELmMSxoVHJGGXGyKQWPfL66ovHgwDUBo8XWmUeZ2J_msc0YeTMIkN30LYl456-UhmriXN2aggJZUHw8-4y7bhtCZeeXM6Wi6B1Duh0HKh8JZ4vea4mLk7Zu1yc3oCBNvsANa3Bgp7zQSZB4_WXI1in_6Phc52A4Myt_E9HodzFgRog
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
+      X-Ms-Request-Id:
+      - 037bb834-cd91-4e84-98ab-56f7829a961e
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
       - '14922'
       X-Ms-Correlation-Request-Id:
-      - 638bc521-e558-440f-a1c7-97c7cd2e50a9
+      - 2a2ed3f6-f958-4e75-9ca2-31922bbd03f8
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200435Z:638bc521-e558-440f-a1c7-97c7cd2e50a9
+      - WESTUS:20170922T214313Z:2a2ed3f6-f958-4e75-9ca2-31922bbd03f8
       Date:
-      - Tue, 05 Sep 2017 20:04:35 GMT
+      - Fri, 22 Sep 2017 21:43:12 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-05T20:04:33.6966979+00:00\",\r\n  \"endTime\":
-        \"2017-09-05T20:04:33.9154397+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=b6140b12-0507-4d51-8c39-042b0afd1ba2&sig=TOsk4uQdm%2FuP2ADYXEWCOgO8261jMfTNidoZFRSIt18%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"35b10d2b-6aff-4ae1-ba1b-7e294bd0a6b7\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2017-09-22T21:43:13.1794483+00:00\",\r\n  \"endTime\":
+        \"2017-09-22T21:43:13.3982845+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=bed63c44-b681-4b04-8749-15a1604dba88&sig=3DamxkhDnkQk5w7P9PiLUAVFolhGxatuoZwwZfq9%2Fq0%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"d4f0e2cb-0af9-4476-8ce6-c34b5ee08e1f\"\r\n}"
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:31 GMT
+  recorded_at: Fri, 22 Sep 2017 21:43:13 GMT
 - request:
     method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=b6140b12-0507-4d51-8c39-042b0afd1ba2&sig=TOsk4uQdm/uP2ADYXEWCOgO8261jMfTNidoZFRSIt18=&sr=b&sv=2016-05-31
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=bed63c44-b681-4b04-8749-15a1604dba88&sig=3DamxkhDnkQk5w7P9PiLUAVFolhGxatuoZwwZfq9/q0=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2046,47 +2176,6 @@ http_interactions:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
       X-Ms-Range:
       - bytes=0-0
-      Host:
-      - md-t4jdgqqlgszp.blob.core.windows.net
-  response:
-    status:
-      code: 403
-      message: Server failed to authenticate the request. Make sure the value of Authorization
-        header is formed correctly including the signature.
-    headers:
-      Content-Length:
-      - '437'
-      Content-Type:
-      - application/xml
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Request-Id:
-      - abda70ad-001e-00a1-5982-266fb6000000
-      Date:
-      - Tue, 05 Sep 2017 20:04:35 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RXJyb3I+PENvZGU+QXV0aGVudGljYXRpb25GYWlsZWQ8L0NvZGU+PE1lc3NhZ2U+U2VydmVyIGZhaWxlZCB0byBhdXRoZW50aWNhdGUgdGhlIHJlcXVlc3QuIE1ha2Ugc3VyZSB0aGUgdmFsdWUgb2YgQXV0aG9yaXphdGlvbiBoZWFkZXIgaXMgZm9ybWVkIGNvcnJlY3RseSBpbmNsdWRpbmcgdGhlIHNpZ25hdHVyZS4KUmVxdWVzdElkOmFiZGE3MGFkLTAwMWUtMDBhMS01OTgyLTI2NmZiNjAwMDAwMApUaW1lOjIwMTctMDktMDVUMjA6MDQ6MzYuMTAxMTA4MFo8L01lc3NhZ2U+PEF1dGhlbnRpY2F0aW9uRXJyb3JEZXRhaWw+U0FTIGlkZW50aWZpZXIgY2Fubm90IGJlIGZvdW5kIGZvciBzcGVjaWZpZWQgc2lnbmVkIGlkZW50aWZpZXI8L0F1dGhlbnRpY2F0aW9uRXJyb3JEZXRhaWw+PC9FcnJvcj4=
-    http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:32 GMT
-- request:
-    method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=b6140b12-0507-4d51-8c39-042b0afd1ba2&sig=TOsk4uQdm/uP2ADYXEWCOgO8261jMfTNidoZFRSIt18=&sr=b&sv=2016-05-31
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      X-Ms-Range:
-      - bytes=0-0
-      Host:
-      - md-t4jdgqqlgszp.blob.core.windows.net
   response:
     status:
       code: 206
@@ -2107,7 +2196,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 18b0b981-001e-00a2-7382-266cb1000000
+      - ba85321c-001e-0066-29eb-331377000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2133,13 +2222,13 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Tue, 05 Sep 2017 20:04:35 GMT
+      - Fri, 22 Sep 2017 21:43:12 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         6w==
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:32 GMT
+  recorded_at: Fri, 22 Sep 2017 21:43:13 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/EndGetAccess?api-version=2017-03-30
@@ -2156,11 +2245,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NzMsIm5iZiI6MTUwNDY0MTU3MywiZXhwIjoxNTA0NjQ1NDczLCJhaW8iOiJZMkZnWUhBdHNEcjNuV3R0TWYvWmZTOFdyL1IvREFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUEFmTVdsUGZRa20yMnN5T0hNRVlBQSIsInZlciI6IjEuMCJ9.PKElQI3zgGjmUqPnsfHlnTHKsXgjuDYuwmKDoWIvH3KIGwHt7njKZTcz7Hpgj0EKEigFnYXd6egn-36s7XO93ebZdj2Z-dV3raQ3aFmNtSpUI1PFd1jyUi3fyzKAp5v-rNY1oUZ_BfkKkps0Gv_jEdEU21LR0-n_WInvwrJcKpXJOCqfFxbyfKsPBGw6WNPeT066nIqsIP6R9IwUovQqFL-iq6P32STALjR-DC_FRxAaa14KxQZeeaxMH_JDictjUOS9TvZNSJshne5NSFeSdFExFFqV73nhj5fRnqOwI7M6_T0h-HA70KZPkOUmFA2xh45IdXVDd90H0vLsh-5Bpw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyODcsIm5iZiI6MTUwNjExNjI4NywiZXhwIjoxNTA2MTIwMTg3LCJhaW8iOiJZMlZnWURBN2FjaFIvNVAvekU3TjI5dTc5V2VsQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiOTljNDktT0R4MDI3cGNKUmdEZ05BQSIsInZlciI6IjEuMCJ9.NVvVVwlnwXscLIZM4jdqDK2ouoMS2L5w7AjwjdDU2wodpK-G6FUfumZxjqKHGtihz2-o0Y6xbQBepjPMjIIiyASFXwHpAUJu4_yhjkeJPYTOVeoy-XCVDGUve-Lr4Mo10MKw1kK3jq3Fvoa8_YvcCAx9BkMTfbTjiTaBHtMKELmMSxoVHJGGXGyKQWPfL66ovHgwDUBo8XWmUeZ2J_msc0YeTMIkN30LYl456-UhmriXN2aggJZUHw8-4y7bhtCZeeXM6Wi6B1Duh0HKh8JZ4vea4mLk7Zu1yc3oCBNvsANa3Bgp7zQSZB4_WXI1in_6Phc52A4Myt_E9HodzFgRog
       Content-Length:
       - '0'
-      Host:
-      - management.azure.com
   response:
     status:
       code: 202
@@ -2175,31 +2262,31 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/d4243ea6-9f47-4879-91dc-a0bc3116d30f?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/f3cf3587-ff3f-4f9f-8683-005466036707?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/d4243ea6-9f47-4879-91dc-a0bc3116d30f?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/f3cf3587-ff3f-4f9f-8683-005466036707?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - d4243ea6-9f47-4879-91dc-a0bc3116d30f
+      - f3cf3587-ff3f-4f9f-8683-005466036707
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1190'
+      - '1181'
       X-Ms-Correlation-Request-Id:
-      - 7484f4b7-20d1-436b-a96a-683569796632
+      - 9e5326b6-2d2e-4268-8981-da75f51594ac
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200435Z:7484f4b7-20d1-436b-a96a-683569796632
+      - WESTUS:20170922T214314Z:9e5326b6-2d2e-4268-8981-da75f51594ac
       Date:
-      - Tue, 05 Sep 2017 20:04:35 GMT
+      - Fri, 22 Sep 2017 21:43:13 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:32 GMT
+  recorded_at: Fri, 22 Sep 2017 21:43:14 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
@@ -2216,11 +2303,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NzMsIm5iZiI6MTUwNDY0MTU3MywiZXhwIjoxNTA0NjQ1NDczLCJhaW8iOiJZMkZnWUhBdHNEcjNuV3R0TWYvWmZTOFdyL1IvREFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUEFmTVdsUGZRa20yMnN5T0hNRVlBQSIsInZlciI6IjEuMCJ9.PKElQI3zgGjmUqPnsfHlnTHKsXgjuDYuwmKDoWIvH3KIGwHt7njKZTcz7Hpgj0EKEigFnYXd6egn-36s7XO93ebZdj2Z-dV3raQ3aFmNtSpUI1PFd1jyUi3fyzKAp5v-rNY1oUZ_BfkKkps0Gv_jEdEU21LR0-n_WInvwrJcKpXJOCqfFxbyfKsPBGw6WNPeT066nIqsIP6R9IwUovQqFL-iq6P32STALjR-DC_FRxAaa14KxQZeeaxMH_JDictjUOS9TvZNSJshne5NSFeSdFExFFqV73nhj5fRnqOwI7M6_T0h-HA70KZPkOUmFA2xh45IdXVDd90H0vLsh-5Bpw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyODcsIm5iZiI6MTUwNjExNjI4NywiZXhwIjoxNTA2MTIwMTg3LCJhaW8iOiJZMlZnWURBN2FjaFIvNVAvekU3TjI5dTc5V2VsQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiOTljNDktT0R4MDI3cGNKUmdEZ05BQSIsInZlciI6IjEuMCJ9.NVvVVwlnwXscLIZM4jdqDK2ouoMS2L5w7AjwjdDU2wodpK-G6FUfumZxjqKHGtihz2-o0Y6xbQBepjPMjIIiyASFXwHpAUJu4_yhjkeJPYTOVeoy-XCVDGUve-Lr4Mo10MKw1kK3jq3Fvoa8_YvcCAx9BkMTfbTjiTaBHtMKELmMSxoVHJGGXGyKQWPfL66ovHgwDUBo8XWmUeZ2J_msc0YeTMIkN30LYl456-UhmriXN2aggJZUHw8-4y7bhtCZeeXM6Wi6B1Duh0HKh8JZ4vea4mLk7Zu1yc3oCBNvsANa3Bgp7zQSZB4_WXI1in_6Phc52A4Myt_E9HodzFgRog
       Content-Length:
       - '42'
-      Host:
-      - management.azure.com
   response:
     status:
       code: 202
@@ -2235,34 +2320,34 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/386575a5-53a4-4e57-b8e9-6e654a42b0a3?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/a485b41f-641a-45fe-bc32-dc394255b4a7?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/386575a5-53a4-4e57-b8e9-6e654a42b0a3?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/a485b41f-641a-45fe-bc32-dc394255b4a7?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - 386575a5-53a4-4e57-b8e9-6e654a42b0a3
+      - a485b41f-641a-45fe-bc32-dc394255b4a7
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1180'
+      - '1179'
       X-Ms-Correlation-Request-Id:
-      - 1c609c2e-26d8-4f47-833e-b80ce276c967
+      - 19a48a4c-5b7e-4df7-a783-969823993b2a
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200436Z:1c609c2e-26d8-4f47-833e-b80ce276c967
+      - WESTUS:20170922T214315Z:19a48a4c-5b7e-4df7-a783-969823993b2a
       Date:
-      - Tue, 05 Sep 2017 20:04:35 GMT
+      - Fri, 22 Sep 2017 21:43:14 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:32 GMT
+  recorded_at: Fri, 22 Sep 2017 21:43:15 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/386575a5-53a4-4e57-b8e9-6e654a42b0a3?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/a485b41f-641a-45fe-bc32-dc394255b4a7?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -2276,9 +2361,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NzMsIm5iZiI6MTUwNDY0MTU3MywiZXhwIjoxNTA0NjQ1NDczLCJhaW8iOiJZMkZnWUhBdHNEcjNuV3R0TWYvWmZTOFdyL1IvREFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUEFmTVdsUGZRa20yMnN5T0hNRVlBQSIsInZlciI6IjEuMCJ9.PKElQI3zgGjmUqPnsfHlnTHKsXgjuDYuwmKDoWIvH3KIGwHt7njKZTcz7Hpgj0EKEigFnYXd6egn-36s7XO93ebZdj2Z-dV3raQ3aFmNtSpUI1PFd1jyUi3fyzKAp5v-rNY1oUZ_BfkKkps0Gv_jEdEU21LR0-n_WInvwrJcKpXJOCqfFxbyfKsPBGw6WNPeT066nIqsIP6R9IwUovQqFL-iq6P32STALjR-DC_FRxAaa14KxQZeeaxMH_JDictjUOS9TvZNSJshne5NSFeSdFExFFqV73nhj5fRnqOwI7M6_T0h-HA70KZPkOUmFA2xh45IdXVDd90H0vLsh-5Bpw
-      Host:
-      - management.azure.com
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyODcsIm5iZiI6MTUwNjExNjI4NywiZXhwIjoxNTA2MTIwMTg3LCJhaW8iOiJZMlZnWURBN2FjaFIvNVAvekU3TjI5dTc5V2VsQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiOTljNDktT0R4MDI3cGNKUmdEZ05BQSIsInZlciI6IjEuMCJ9.NVvVVwlnwXscLIZM4jdqDK2ouoMS2L5w7AjwjdDU2wodpK-G6FUfumZxjqKHGtihz2-o0Y6xbQBepjPMjIIiyASFXwHpAUJu4_yhjkeJPYTOVeoy-XCVDGUve-Lr4Mo10MKw1kK3jq3Fvoa8_YvcCAx9BkMTfbTjiTaBHtMKELmMSxoVHJGGXGyKQWPfL66ovHgwDUBo8XWmUeZ2J_msc0YeTMIkN30LYl456-UhmriXN2aggJZUHw8-4y7bhtCZeeXM6Wi6B1Duh0HKh8JZ4vea4mLk7Zu1yc3oCBNvsANa3Bgp7zQSZB4_WXI1in_6Phc52A4Myt_E9HodzFgRog
   response:
     status:
       code: 200
@@ -2299,31 +2382,90 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - 77b4e2c5-3480-4baa-a555-7590845ebd46
+      - eabcf23e-a468-4187-b66b-8c2d3e217802
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14944'
+      - '14997'
       X-Ms-Correlation-Request-Id:
-      - fc4ebcc1-6e5b-4bed-a021-e9678781c1d7
+      - 34cdb2cc-4957-43ed-a19b-81447e969a65
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200436Z:fc4ebcc1-6e5b-4bed-a021-e9678781c1d7
+      - WESTUS:20170922T214315Z:34cdb2cc-4957-43ed-a19b-81447e969a65
       Date:
-      - Tue, 05 Sep 2017 20:04:36 GMT
+      - Fri, 22 Sep 2017 21:43:14 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-05T20:04:35.1082175+00:00\",\r\n  \"endTime\":
-        \"2017-09-05T20:04:35.3269719+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=087c260f-cdfe-4824-81c6-674d83f49e5a&sig=TMK6yjd4mMU%2BPYT%2FkLb42LH7xw7MOb8wY7pox7GkhkM%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"386575a5-53a4-4e57-b8e9-6e654a42b0a3\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2017-09-22T21:43:16.5958805+00:00\",\r\n  \"endTime\":
+        \"2017-09-22T21:43:16.8146963+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=7b2557de-903d-42d0-a8ec-c039e9e90e7e&sig=tgvF5VWb1fZkIH5AqMebKhIgNFeUdPuI5tYBCGfI%2FUU%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"a485b41f-641a-45fe-bc32-dc394255b4a7\"\r\n}"
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:33 GMT
+  recorded_at: Fri, 22 Sep 2017 21:43:15 GMT
 - request:
     method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=087c260f-cdfe-4824-81c6-674d83f49e5a&sig=TMK6yjd4mMU%2BPYT/kLb42LH7xw7MOb8wY7pox7GkhkM=&sr=b&sv=2016-05-31
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/a485b41f-641a-45fe-bc32-dc394255b4a7?api-version=2017-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyODcsIm5iZiI6MTUwNjExNjI4NywiZXhwIjoxNTA2MTIwMTg3LCJhaW8iOiJZMlZnWURBN2FjaFIvNVAvekU3TjI5dTc5V2VsQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiOTljNDktT0R4MDI3cGNKUmdEZ05BQSIsInZlciI6IjEuMCJ9.NVvVVwlnwXscLIZM4jdqDK2ouoMS2L5w7AjwjdDU2wodpK-G6FUfumZxjqKHGtihz2-o0Y6xbQBepjPMjIIiyASFXwHpAUJu4_yhjkeJPYTOVeoy-XCVDGUve-Lr4Mo10MKw1kK3jq3Fvoa8_YvcCAx9BkMTfbTjiTaBHtMKELmMSxoVHJGGXGyKQWPfL66ovHgwDUBo8XWmUeZ2J_msc0YeTMIkN30LYl456-UhmriXN2aggJZUHw8-4y7bhtCZeeXM6Wi6B1Duh0HKh8JZ4vea4mLk7Zu1yc3oCBNvsANa3Bgp7zQSZB4_WXI1in_6Phc52A4Myt_E9HodzFgRog
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
+      X-Ms-Request-Id:
+      - b4cb41e0-e998-4344-8884-97773cf45e70
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14910'
+      X-Ms-Correlation-Request-Id:
+      - 0625275f-c736-4b74-93a2-758917eeef6f
+      X-Ms-Routing-Request-Id:
+      - WESTUS:20170922T214316Z:0625275f-c736-4b74-93a2-758917eeef6f
+      Date:
+      - Fri, 22 Sep 2017 21:43:15 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"startTime\": \"2017-09-22T21:43:16.5958805+00:00\",\r\n  \"endTime\":
+        \"2017-09-22T21:43:16.8146963+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=7b2557de-903d-42d0-a8ec-c039e9e90e7e&sig=tgvF5VWb1fZkIH5AqMebKhIgNFeUdPuI5tYBCGfI%2FUU%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"a485b41f-641a-45fe-bc32-dc394255b4a7\"\r\n}"
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 21:43:16 GMT
+- request:
+    method: get
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=7b2557de-903d-42d0-a8ec-c039e9e90e7e&sig=tgvF5VWb1fZkIH5AqMebKhIgNFeUdPuI5tYBCGfI/UU=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2336,8 +2478,6 @@ http_interactions:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
       X-Ms-Range:
       - bytes=440-443
-      Host:
-      - md-t4jdgqqlgszp.blob.core.windows.net
   response:
     status:
       code: 206
@@ -2358,7 +2498,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - df4ceac9-001e-00fd-0f82-269e4f000000
+      - 653e129b-001e-00a4-1ceb-339bc9000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2384,13 +2524,13 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Tue, 05 Sep 2017 20:04:36 GMT
+      - Fri, 22 Sep 2017 21:43:16 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         U5MJAA==
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:33 GMT
+  recorded_at: Fri, 22 Sep 2017 21:43:16 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/EndGetAccess?api-version=2017-03-30
@@ -2407,11 +2547,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NzMsIm5iZiI6MTUwNDY0MTU3MywiZXhwIjoxNTA0NjQ1NDczLCJhaW8iOiJZMkZnWUhBdHNEcjNuV3R0TWYvWmZTOFdyL1IvREFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUEFmTVdsUGZRa20yMnN5T0hNRVlBQSIsInZlciI6IjEuMCJ9.PKElQI3zgGjmUqPnsfHlnTHKsXgjuDYuwmKDoWIvH3KIGwHt7njKZTcz7Hpgj0EKEigFnYXd6egn-36s7XO93ebZdj2Z-dV3raQ3aFmNtSpUI1PFd1jyUi3fyzKAp5v-rNY1oUZ_BfkKkps0Gv_jEdEU21LR0-n_WInvwrJcKpXJOCqfFxbyfKsPBGw6WNPeT066nIqsIP6R9IwUovQqFL-iq6P32STALjR-DC_FRxAaa14KxQZeeaxMH_JDictjUOS9TvZNSJshne5NSFeSdFExFFqV73nhj5fRnqOwI7M6_T0h-HA70KZPkOUmFA2xh45IdXVDd90H0vLsh-5Bpw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyODcsIm5iZiI6MTUwNjExNjI4NywiZXhwIjoxNTA2MTIwMTg3LCJhaW8iOiJZMlZnWURBN2FjaFIvNVAvekU3TjI5dTc5V2VsQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiOTljNDktT0R4MDI3cGNKUmdEZ05BQSIsInZlciI6IjEuMCJ9.NVvVVwlnwXscLIZM4jdqDK2ouoMS2L5w7AjwjdDU2wodpK-G6FUfumZxjqKHGtihz2-o0Y6xbQBepjPMjIIiyASFXwHpAUJu4_yhjkeJPYTOVeoy-XCVDGUve-Lr4Mo10MKw1kK3jq3Fvoa8_YvcCAx9BkMTfbTjiTaBHtMKELmMSxoVHJGGXGyKQWPfL66ovHgwDUBo8XWmUeZ2J_msc0YeTMIkN30LYl456-UhmriXN2aggJZUHw8-4y7bhtCZeeXM6Wi6B1Duh0HKh8JZ4vea4mLk7Zu1yc3oCBNvsANa3Bgp7zQSZB4_WXI1in_6Phc52A4Myt_E9HodzFgRog
       Content-Length:
       - '0'
-      Host:
-      - management.azure.com
   response:
     status:
       code: 202
@@ -2426,29 +2564,29 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/3526fa3a-3727-4ee5-a78c-fb9a2f6fc38f?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/0b374339-5ac4-4899-b11a-9a3c420ebf2d?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/3526fa3a-3727-4ee5-a78c-fb9a2f6fc38f?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/0b374339-5ac4-4899-b11a-9a3c420ebf2d?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - 3526fa3a-3727-4ee5-a78c-fb9a2f6fc38f
+      - 0b374339-5ac4-4899-b11a-9a3c420ebf2d
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1189'
+      - '1176'
       X-Ms-Correlation-Request-Id:
-      - 92e5d961-0545-4bec-97d0-492389b19245
+      - 6ac9ad5d-f77f-43cc-a772-d751e9f3e2e7
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200436Z:92e5d961-0545-4bec-97d0-492389b19245
+      - WESTUS:20170922T214317Z:6ac9ad5d-f77f-43cc-a772-d751e9f3e2e7
       Date:
-      - Tue, 05 Sep 2017 20:04:36 GMT
+      - Fri, 22 Sep 2017 21:43:16 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:33 GMT
+  recorded_at: Fri, 22 Sep 2017 21:43:17 GMT
 recorded_with: VCR 3.0.3

--- a/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_partType-1.yml
+++ b/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_partType-1.yml
@@ -17,8 +17,6 @@ http_interactions:
       - '186'
       Content-Type:
       - application/x-www-form-urlencoded
-      Host:
-      - login.microsoftonline.com
   response:
     status:
       code: 200
@@ -39,25 +37,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - a19bdd48-e6b7-494d-8a3f-4f72742e1f00
+      - def8d403-4f59-4754-ae4f-4363f3df0a00
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAAA9kTklhVy7SJTGAzR-p1BctARKPSf3wF5ohHWa5kD6WO1sMxnAUy4DbQRA973E27_91DIRD3TViixWSXi5wO2ietRuYk25cVkSx6bvvDS-3xFmy-3FyeKnlJcRz0Xb7rEnoBa9Tnb7HON2tgSXrWhsrKHOCAB06YXXdG7PhGGwU8Vhf8gZV6RCtQS5O30CuZIgAA;
+      - esctx=AQABAAAAAAABlDrqfEFlSaui6xnRjX5EDQ4x8Ke0WUTufcjKtoqrvq09B_EuuwcpqVfcZXNwP5ge2CObDYhbGp8r8ZdiDq36LCtEW-PBDieMr65GWFsStFCjdw0Bo7AZkXSnv3qVQnc83pGqq2BlOhHvp6YiVsJ69iaXLwtV407ZknJ34_kWVGgLvE9-3O1YFNL1LnS638EgAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=007; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=004; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Tue, 05 Sep 2017 20:04:43 GMT
+      - Fri, 22 Sep 2017 21:42:39 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1504645485","not_before":"1504641585","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1ODUsIm5iZiI6MTUwNDY0MTU4NSwiZXhwIjoxNTA0NjQ1NDg1LCJhaW8iOiJZMkZnWUpDNU9QVjlpZXowa29BN1ZndHFsTklFQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiU04yYm9iZm1UVW1LUDA5eWRDNGZBQSIsInZlciI6IjEuMCJ9.FMnRDaNClITFOgNWGzeF_DW5NXwfhSMEcq-7VFUdKnlENKVpA6z0fmaPmEIk9be1WlfHdzCy21xfhbluZ9omK8TVlKLg0PFRlOi3jBqTEgsQyRnim-j0b_0E4REBiEV7fk8E6cGI7yWBZGirJypjWghm86U-VlLqEblb5JyYdNp5_S_58j1nHStQlBbGjNrYk_g30fnL0Y8QUPsmlsZS5IQjQyZgBNtNczeKRHXm36ob_JbWaF8JvpZhq6WYpKJA6oAf33HBJOMvMmWEnyJg7FbHCdbNWdPHCLTb19cvjXQ7iQNcd6gtw3hgp4Rcuh-PGUucjahoO1dtuOOTeg03lw"}'
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1506120160","not_before":"1506116260","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNjAsIm5iZiI6MTUwNjExNjI2MCwiZXhwIjoxNTA2MTIwMTYwLCJhaW8iOiJZMlZnWU5paE9LMDd2L1MyZGlDWHpkSkRPaXdUQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQTlUNDNsbFBWRWV1VDBOajg5OEtBQSIsInZlciI6IjEuMCJ9.m2q1UV9vV03MzAANTYje3G1TeuvrUD7j9xF9RFAZ5K8Zpn8tCFh_-CIuO8uYfW2iT7Dlf1wuo4SO_wd3QIEwibwUzO6Kvx8QfsYAguRT1SJ9c5wjNpPMn5fUsF9ekp2w8naEvHBnxZAaX_6in8ZrOt5lXh2Dye14W65OFYNHV6kHvbVIl70LTnkqkgQsPeKjuVfhFjBvYX6otE_QHiM7PH8IXaadkD4Hk7EIityoza6HM32SHGs2_TNlUKC3vNm_O1ovfa-3NxjyMH94QUIzn0pfoYTskhE3yyLLinP2mDW5sqNEBKrJMlJ7JAZNNMmAO9lIZxOfhOrN-WJuyVSuqg"}'
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:45 GMT
+  recorded_at: Fri, 22 Sep 2017 21:42:39 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -74,9 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1ODUsIm5iZiI6MTUwNDY0MTU4NSwiZXhwIjoxNTA0NjQ1NDg1LCJhaW8iOiJZMkZnWUpDNU9QVjlpZXowa29BN1ZndHFsTklFQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiU04yYm9iZm1UVW1LUDA5eWRDNGZBQSIsInZlciI6IjEuMCJ9.FMnRDaNClITFOgNWGzeF_DW5NXwfhSMEcq-7VFUdKnlENKVpA6z0fmaPmEIk9be1WlfHdzCy21xfhbluZ9omK8TVlKLg0PFRlOi3jBqTEgsQyRnim-j0b_0E4REBiEV7fk8E6cGI7yWBZGirJypjWghm86U-VlLqEblb5JyYdNp5_S_58j1nHStQlBbGjNrYk_g30fnL0Y8QUPsmlsZS5IQjQyZgBNtNczeKRHXm36ob_JbWaF8JvpZhq6WYpKJA6oAf33HBJOMvMmWEnyJg7FbHCdbNWdPHCLTb19cvjXQ7iQNcd6gtw3hgp4Rcuh-PGUucjahoO1dtuOOTeg03lw
-      Host:
-      - management.azure.com
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNjAsIm5iZiI6MTUwNjExNjI2MCwiZXhwIjoxNTA2MTIwMTYwLCJhaW8iOiJZMlZnWU5paE9LMDd2L1MyZGlDWHpkSkRPaXdUQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQTlUNDNsbFBWRWV1VDBOajg5OEtBQSIsInZlciI6IjEuMCJ9.m2q1UV9vV03MzAANTYje3G1TeuvrUD7j9xF9RFAZ5K8Zpn8tCFh_-CIuO8uYfW2iT7Dlf1wuo4SO_wd3QIEwibwUzO6Kvx8QfsYAguRT1SJ9c5wjNpPMn5fUsF9ekp2w8naEvHBnxZAaX_6in8ZrOt5lXh2Dye14W65OFYNHV6kHvbVIl70LTnkqkgQsPeKjuVfhFjBvYX6otE_QHiM7PH8IXaadkD4Hk7EIityoza6HM32SHGs2_TNlUKC3vNm_O1ovfa-3NxjyMH94QUIzn0pfoYTskhE3yyLLinP2mDW5sqNEBKrJMlJ7JAZNNMmAO9lIZxOfhOrN-WJuyVSuqg
   response:
     status:
       code: 200
@@ -95,23 +91,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14998'
+      - '14999'
       X-Ms-Request-Id:
-      - 883bd33e-553a-4058-b1d4-38875a003bce
+      - e375a0e9-5d78-4a9e-bf05-276e81aaf80d
       X-Ms-Correlation-Request-Id:
-      - 883bd33e-553a-4058-b1d4-38875a003bce
+      - e375a0e9-5d78-4a9e-bf05-276e81aaf80d
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200445Z:883bd33e-553a-4058-b1d4-38875a003bce
+      - WESTUS:20170922T214241Z:e375a0e9-5d78-4a9e-bf05-276e81aaf80d
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 05 Sep 2017 20:04:44 GMT
+      - Fri, 22 Sep 2017 21:42:40 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:45 GMT
+  recorded_at: Fri, 22 Sep 2017 21:42:40 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/azure_subscription_id/providers?api-version=2015-01-01
@@ -128,9 +124,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1ODUsIm5iZiI6MTUwNDY0MTU4NSwiZXhwIjoxNTA0NjQ1NDg1LCJhaW8iOiJZMkZnWUpDNU9QVjlpZXowa29BN1ZndHFsTklFQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiU04yYm9iZm1UVW1LUDA5eWRDNGZBQSIsInZlciI6IjEuMCJ9.FMnRDaNClITFOgNWGzeF_DW5NXwfhSMEcq-7VFUdKnlENKVpA6z0fmaPmEIk9be1WlfHdzCy21xfhbluZ9omK8TVlKLg0PFRlOi3jBqTEgsQyRnim-j0b_0E4REBiEV7fk8E6cGI7yWBZGirJypjWghm86U-VlLqEblb5JyYdNp5_S_58j1nHStQlBbGjNrYk_g30fnL0Y8QUPsmlsZS5IQjQyZgBNtNczeKRHXm36ob_JbWaF8JvpZhq6WYpKJA6oAf33HBJOMvMmWEnyJg7FbHCdbNWdPHCLTb19cvjXQ7iQNcd6gtw3hgp4Rcuh-PGUucjahoO1dtuOOTeg03lw
-      Host:
-      - management.azure.com
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNjAsIm5iZiI6MTUwNjExNjI2MCwiZXhwIjoxNTA2MTIwMTYwLCJhaW8iOiJZMlZnWU5paE9LMDd2L1MyZGlDWHpkSkRPaXdUQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQTlUNDNsbFBWRWV1VDBOajg5OEtBQSIsInZlciI6IjEuMCJ9.m2q1UV9vV03MzAANTYje3G1TeuvrUD7j9xF9RFAZ5K8Zpn8tCFh_-CIuO8uYfW2iT7Dlf1wuo4SO_wd3QIEwibwUzO6Kvx8QfsYAguRT1SJ9c5wjNpPMn5fUsF9ekp2w8naEvHBnxZAaX_6in8ZrOt5lXh2Dye14W65OFYNHV6kHvbVIl70LTnkqkgQsPeKjuVfhFjBvYX6otE_QHiM7PH8IXaadkD4Hk7EIityoza6HM32SHGs2_TNlUKC3vNm_O1ovfa-3NxjyMH94QUIzn0pfoYTskhE3yyLLinP2mDW5sqNEBKrJMlJ7JAZNNMmAO9lIZxOfhOrN-WJuyVSuqg
   response:
     status:
       code: 200
@@ -147,22 +141,42 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14941'
+      - '14910'
       X-Ms-Request-Id:
-      - 739d21e5-6879-45a9-9da9-be96fb64ae7a
+      - 3149d3ca-4142-4c98-8971-3ddeac6facd4
       X-Ms-Correlation-Request-Id:
-      - 739d21e5-6879-45a9-9da9-be96fb64ae7a
+      - 3149d3ca-4142-4c98-8971-3ddeac6facd4
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200446Z:739d21e5-6879-45a9-9da9-be96fb64ae7a
+      - WESTUS:20170922T214242Z:3149d3ca-4142-4c98-8971-3ddeac6facd4
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 05 Sep 2017 20:04:46 GMT
+      - Fri, 22 Sep 2017 21:42:41 GMT
       Content-Length:
-      - '243687'
+      - '254785'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
+      string: '{"value":[{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"operations","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","North Central
         US","South Central US","West Central US","West US","West US 2","Canada Central","Canada
         East","North Europe","West Europe","UK South","UK West","East Asia","Southeast
@@ -437,7 +451,7 @@ http_interactions:
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
         Central US","West US 2","South India","Central India","West India","Canada
-        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
+        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
         East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
@@ -466,7 +480,7 @@ http_interactions:
         Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"}],"resourceTypes":[{"resourceType":"components","locations":["East
         US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
         US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01","2014-04-01"]},{"resourceType":"queries","locations":["East
-        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"alertrules","locations":["West
+        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
@@ -542,7 +556,7 @@ http_interactions:
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorization":{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorizations":[{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},{"applicationId":"7c33bfcb-8d33-48d6-8e60-dc6404003489","roleDefinitionId":"ad6261e4-fa9a-4642-aa5f-104f1b67e9e3"},{"applicationId":"1e3e4475-288f-4018-a376-df66fd7fac5f","roleDefinitionId":"1d538b69-3d87-4e56-8ff8-25786fd48261"},{"applicationId":"a0be0c72-870e-46f0-9c49-c98333a996f7","roleDefinitionId":"7ce22727-ffce-45a9-930c-ddb2e56fa131"}],"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -552,7 +566,7 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -567,7 +581,8 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
+        Central US"],"apiVersions":["2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -577,7 +592,12 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -597,7 +617,7 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -612,7 +632,7 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -622,7 +642,31 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
         East","UK South","Central India","Canada Central"],"apiVersions":["2017-04-26-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"]},{"resourceType":"workspaces/dataSources","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
@@ -641,17 +685,17 @@ http_interactions:
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"consoles","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/consoles","locations":["West
+        East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"consoles","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/consoles","locations":["West
         US","East US","Central India","North Europe","West Europe","South Central
-        US","Southeast Asia"],"apiVersions":["2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
+        US","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
         US","East US","Central India","North Europe","West Europe","South Central
-        US","Southeast Asia"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
+        US","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","Canada Central","Canada East","West Central US","West US 2","UK South","UK
         West","Korea Central","Korea South"],"apiVersions":["2017-07-01","2016-12-01","2016-08-10","2016-06-01","2016-05-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"operations","locations":["Southeast
-        Asia"],"apiVersions":["2016-08-10","2016-06-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01"]},{"resourceType":"locations/backupStatus","locations":["West
+        Asia"],"apiVersions":["2016-08-10","2016-06-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01","2016-06-01"]},{"resourceType":"locations/backupStatus","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
@@ -687,6 +731,7 @@ http_interactions:
         Central US","Central US","North Europe","West Europe","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada Central","Canada East"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"pricings","locations":["Central
+        US","East US"],"apiVersions":["2017-08-01-preview"]},{"resourceType":"securityContacts","locations":["Central
         US","East US"],"apiVersions":["2017-08-01-preview"]},{"resourceType":"workspaceSettings","locations":["Central
         US","East US"],"apiVersions":["2017-08-01-preview"]},{"resourceType":"complianceResults","locations":["Central
         US","East US"],"apiVersions":["2017-08-01"]},{"resourceType":"policies","locations":["Central
@@ -703,6 +748,8 @@ http_interactions:
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatusesSummaries","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/alerts","locations":["Central
         US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/tasks","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"externalSecuritySolutions","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/externalSecuritySolutions","locations":["Central
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.SiteRecovery","namespace":"Microsoft.SiteRecovery","authorization":{"applicationId":"b8340c3b-9267-498f-b21a-15d5547fd85e","roleDefinitionId":"8A00C8EA-8F1B-45A7-8F64-F4CC61EEE9B6"},"resourceTypes":[{"resourceType":"SiteRecoveryVault","locations":["East
         US","West US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","Australia East","Australia Southeast","Brazil South","North
@@ -722,7 +769,7 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -842,7 +889,22 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/databases/transparentDataEncryption","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -1077,6 +1139,26 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
         US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
@@ -1307,6 +1389,11 @@ http_interactions:
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"customApis","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
         East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/managedApis","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
@@ -1358,23 +1445,8 @@ http_interactions:
         US","North Europe","Japan West","Japan East","East Asia","West Europe","East
         US","Southeast Asia","Central US"],"apiVersions":["2016-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Lombiq.DotNest","namespace":"Lombiq.DotNest","resourceTypes":[{"resourceType":"sites","locations":["East
         US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Mailjet.Email","namespace":"Mailjet.Email","resourceTypes":[{"resourceType":"services","locations":["West
-        US"],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
-        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]},{"resourceType":"diagnosticSettings","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"addsservices","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"configuration","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"operations","locations":["West
@@ -1498,8 +1570,10 @@ http_interactions:
         Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
         Central US","Central US","North Europe","West Europe","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","West
-        India","South India"],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CognitiveServices","namespace":"Microsoft.CognitiveServices","authorizations":[{"applicationId":"7d312290-28c8-473c-a0ed-8e53749b6d6d","roleDefinitionId":"5cb87f79-a7c3-4a95-9414-45b65974b51b"}],"resourceTypes":[{"resourceType":"accounts","locations":["Global","West
-        US","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"operations","locations":["Global","Australia
+        India","South India"],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CognitiveServices","namespace":"Microsoft.CognitiveServices","authorizations":[{"applicationId":"7d312290-28c8-473c-a0ed-8e53749b6d6d","roleDefinitionId":"5cb87f79-a7c3-4a95-9414-45b65974b51b"}],"resourceTypes":[{"resourceType":"accounts","locations":["Global","Australia
+        East","Brazil South","West US","West US 2","West Europe","North Europe","Southeast
+        Asia","East Asia","West Central US","South Central US","East US","East US
+        2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"operations","locations":["Global","Australia
         East","Brazil South","West US","West US 2","West Europe","North Europe","Southeast
         Asia","East Asia","West Central US","South Central US","East US","East US
         2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations","locations":["Global","Australia
@@ -1534,13 +1608,13 @@ http_interactions:
         US","West US","Australia East","West Europe","North Europe","Southeast Asia","West
         Central US"],"apiVersions":["2016-03-30","2015-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataFactory","namespace":"Microsoft.DataFactory","resourceTypes":[{"resourceType":"dataFactories","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview","2014-04-01"]},{"resourceType":"factories","locations":["East
-        US"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
-        US"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
+        US","East US 2"],"apiVersions":["2017-09-01-preview","2017-03-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
+        US","East US 2"],"apiVersions":["2017-09-01-preview","2017-03-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
         Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"dataFactories/metricDefinitions","locations":["North
         Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"checkDataFactoryNameAvailability","locations":[],"apiVersions":["2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"checkAzureDataFactoryNameAvailability","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"dataFactorySchema","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"operations","locations":["West
-        US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeAnalytics","namespace":"Microsoft.DataLakeAnalytics","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US","North Europe","East US","West Central US"],"apiVersions":["2017-09-01-preview","2017-03-01-preview","2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeAnalytics","namespace":"Microsoft.DataLakeAnalytics","resourceTypes":[{"resourceType":"accounts","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/dataLakeStoreAccounts","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers","locations":["East
@@ -1589,11 +1663,12 @@ http_interactions:
         India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
         India","East Asia","East US 2","East US","Japan East","Japan West","North
         Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"checkProvisioningServiceNameAvailability","locations":[],"apiVersions":["2017-08-21-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
         US","North Europe","East Asia","East US","West Europe","Southeast Asia","Japan
         East","Japan West","Australia East","Australia Southeast","West US 2","West
         Central US","East US 2","Central US","UK South","UK West","South India","Central
-        India"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
+        India","Canada Central","Canada East"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"ProvisioningServices","locations":["East
+        US","West Europe","Southeast Asia"],"apiVersions":["2017-08-21-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
         East","Australia Southeast","Canada Central","Canada East","Central India","Central
         US","East Asia","East US","East US 2","Japan East","Japan West","North Central
         US","North Europe","South Central US","South India","Southeast Asia","West
@@ -1620,16 +1695,16 @@ http_interactions:
         US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"operations","locations":["Brazil
         South","East Asia","East US","Japan East","Japan West","North Central US","North
         Europe","South Central US","West Europe","West US","Southeast Asia","Central
-        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"topics","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operations","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topics","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operations","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","West
         US 2","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
@@ -1727,48 +1802,39 @@ http_interactions:
         Central US","West Europe","Southeast Asia","Japan East","East US 2","West
         Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"commitmentPlans","locations":["South
         Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
-        Central US","West US"],"apiVersions":["2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Media","namespace":"Microsoft.Media","authorization":{"applicationId":"374b2a64-3b6b-436b-934c-b820eacca870","roleDefinitionId":"aab70789-0cec-44b5-95d7-84b64c9487af"},"resourceTypes":[{"resourceType":"mediaservices","locations":["Japan
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningExperimentation","namespace":"Microsoft.MachineLearningExperimentation","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"accounts","locations":["Australia
+        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces","locations":["Australia
+        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces/projects","locations":["Australia
+        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningCompute","namespace":"Microsoft.MachineLearningCompute","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"376aa7d7-51a9-463d-bd4d-7e1691345612","managedByRoleDefinitionId":"91d00862-cf55-46a5-9dce-260bbd92ce25"},"resourceTypes":[{"resourceType":"operationalizationClusters","locations":["East
+        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"operations","locations":["East
+        US 2"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations","locations":["East
+        US 2"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["East
+        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningModelManagement","namespace":"Microsoft.MachineLearningModelManagement","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US 2","West Central US","Australia East"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"operations","locations":["West
+        Central US"],"apiVersions":["2017-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
+        Central US","West US"],"apiVersions":["2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01"]},{"resourceType":"offertypes","locations":["South
+        Central US","West US"],"apiVersions":["2015-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Media","namespace":"Microsoft.Media","authorization":{"applicationId":"374b2a64-3b6b-436b-934c-b820eacca870","roleDefinitionId":"aab70789-0cec-44b5-95d7-84b64c9487af"},"resourceTypes":[{"resourceType":"mediaservices","locations":["Japan
         West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
         US","West US","Australia East","Australia Southeast","Central US","Brazil
         South","Central India","West India","South India","South Central US","Canada
-        Central","Canada East","West Central US"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
+        Central","Canada East","West Central US"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
         Central US","North Central US","East US 2","West US","West Europe","North
         Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
         East","UK South","West India"],"apiVersions":["2016-01-29"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-01-29"]},{"resourceType":"locations/checkNameAvailability","locations":["South
         Central US","North Central US","East US 2","West US","West Europe","North
         Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
-        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"operations","locations":["East
+        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"capacities","locations":["West
+        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
+        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationresults","locations":["West
+        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
+        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"operations","locations":["East
         US 2"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Relay","namespace":"Microsoft.Relay","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US 2","West
         US","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
         India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2017-08-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkPolicyCompliance","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
@@ -1827,8 +1893,11 @@ http_interactions:
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","resourceTypes":[{"resourceType":"operations","locations":["West
-        Central US"],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
+        Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applianceDefinitions","locations":["West
+        Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"locations","locations":["West
+        Central US"],"apiVersions":["2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
+        Central US"],"apiVersions":["2017-09-01","2016-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","West Central US","Japan East","Japan West","Australia East","Australia
         Southeast"],"apiVersions":["2017-06-01","2017-05-15","2017-01-01","2016-10-01","2016-06-01","2015-03-15","2014-09-01"]},{"resourceType":"operations","locations":["West
@@ -1888,11 +1957,17 @@ http_interactions:
         US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RedisLabs.Memcached","namespace":"RedisLabs.Memcached","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-07-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RedisLabs.Redis","namespace":"RedisLabs.Redis","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-07-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RevAPM.MobileCDN","namespace":"RevAPM.MobileCDN","resourceTypes":[{"resourceType":"accounts","locations":["Central
         US","East US","East US 2","North Central US","South Central US","West US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
-        East","Australia Southeast"],"apiVersions":["2016-08-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-24","2016-08-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sendgrid.Email","namespace":"Sendgrid.Email","resourceTypes":[{"resourceType":"accounts","locations":["East
-        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
-        Central US","Central US","North Europe","West Europe","Japan East","Japan
-        West","Brazil South","Australia East","Australia Southeast","Canada Central","Canada
-        East","West Central US","West US 2","UK South","UK West"],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Signiant.Flight","namespace":"Signiant.Flight","resourceTypes":[{"resourceType":"accounts","locations":["East
+        East","Australia Southeast"],"apiVersions":["2016-08-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-24","2016-08-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sendgrid.Email","namespace":"Sendgrid.Email","resourceTypes":[{"resourceType":"accounts","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Signiant.Flight","namespace":"Signiant.Flight","resourceTypes":[{"resourceType":"accounts","locations":["East
         US","Central US","North Central US","South Central US","West US","North Europe","West
         Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast"],"apiVersions":["2015-06-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sparkpost.Basic","namespace":"Sparkpost.Basic","resourceTypes":[{"resourceType":"services","locations":["West
@@ -1909,7 +1984,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:46 GMT
+  recorded_at: Fri, 22 Sep 2017 21:42:41 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
@@ -1926,11 +2001,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1ODUsIm5iZiI6MTUwNDY0MTU4NSwiZXhwIjoxNTA0NjQ1NDg1LCJhaW8iOiJZMkZnWUpDNU9QVjlpZXowa29BN1ZndHFsTklFQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiU04yYm9iZm1UVW1LUDA5eWRDNGZBQSIsInZlciI6IjEuMCJ9.FMnRDaNClITFOgNWGzeF_DW5NXwfhSMEcq-7VFUdKnlENKVpA6z0fmaPmEIk9be1WlfHdzCy21xfhbluZ9omK8TVlKLg0PFRlOi3jBqTEgsQyRnim-j0b_0E4REBiEV7fk8E6cGI7yWBZGirJypjWghm86U-VlLqEblb5JyYdNp5_S_58j1nHStQlBbGjNrYk_g30fnL0Y8QUPsmlsZS5IQjQyZgBNtNczeKRHXm36ob_JbWaF8JvpZhq6WYpKJA6oAf33HBJOMvMmWEnyJg7FbHCdbNWdPHCLTb19cvjXQ7iQNcd6gtw3hgp4Rcuh-PGUucjahoO1dtuOOTeg03lw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNjAsIm5iZiI6MTUwNjExNjI2MCwiZXhwIjoxNTA2MTIwMTYwLCJhaW8iOiJZMlZnWU5paE9LMDd2L1MyZGlDWHpkSkRPaXdUQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQTlUNDNsbFBWRWV1VDBOajg5OEtBQSIsInZlciI6IjEuMCJ9.m2q1UV9vV03MzAANTYje3G1TeuvrUD7j9xF9RFAZ5K8Zpn8tCFh_-CIuO8uYfW2iT7Dlf1wuo4SO_wd3QIEwibwUzO6Kvx8QfsYAguRT1SJ9c5wjNpPMn5fUsF9ekp2w8naEvHBnxZAaX_6in8ZrOt5lXh2Dye14W65OFYNHV6kHvbVIl70LTnkqkgQsPeKjuVfhFjBvYX6otE_QHiM7PH8IXaadkD4Hk7EIityoza6HM32SHGs2_TNlUKC3vNm_O1ovfa-3NxjyMH94QUIzn0pfoYTskhE3yyLLinP2mDW5sqNEBKrJMlJ7JAZNNMmAO9lIZxOfhOrN-WJuyVSuqg
       Content-Length:
       - '42'
-      Host:
-      - management.azure.com
   response:
     status:
       code: 202
@@ -1945,34 +2018,34 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/525c00dd-3f00-4fe1-99e4-df9b02e81e4f?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/0986cdcd-5eef-4095-bb43-6a02f9e20e6a?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/525c00dd-3f00-4fe1-99e4-df9b02e81e4f?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/0986cdcd-5eef-4095-bb43-6a02f9e20e6a?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - 525c00dd-3f00-4fe1-99e4-df9b02e81e4f
+      - 0986cdcd-5eef-4095-bb43-6a02f9e20e6a
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
       - '1182'
       X-Ms-Correlation-Request-Id:
-      - '08ab90ee-8721-4ce4-a929-2a662e96e6b7'
+      - 03442526-fc5c-40c7-9a9e-772fa23e7505
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200447Z:08ab90ee-8721-4ce4-a929-2a662e96e6b7
+      - WESTUS:20170922T214243Z:03442526-fc5c-40c7-9a9e-772fa23e7505
       Date:
-      - Tue, 05 Sep 2017 20:04:46 GMT
+      - Fri, 22 Sep 2017 21:42:42 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:47 GMT
+  recorded_at: Fri, 22 Sep 2017 21:42:42 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/525c00dd-3f00-4fe1-99e4-df9b02e81e4f?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/0986cdcd-5eef-4095-bb43-6a02f9e20e6a?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -1986,9 +2059,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1ODUsIm5iZiI6MTUwNDY0MTU4NSwiZXhwIjoxNTA0NjQ1NDg1LCJhaW8iOiJZMkZnWUpDNU9QVjlpZXowa29BN1ZndHFsTklFQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiU04yYm9iZm1UVW1LUDA5eWRDNGZBQSIsInZlciI6IjEuMCJ9.FMnRDaNClITFOgNWGzeF_DW5NXwfhSMEcq-7VFUdKnlENKVpA6z0fmaPmEIk9be1WlfHdzCy21xfhbluZ9omK8TVlKLg0PFRlOi3jBqTEgsQyRnim-j0b_0E4REBiEV7fk8E6cGI7yWBZGirJypjWghm86U-VlLqEblb5JyYdNp5_S_58j1nHStQlBbGjNrYk_g30fnL0Y8QUPsmlsZS5IQjQyZgBNtNczeKRHXm36ob_JbWaF8JvpZhq6WYpKJA6oAf33HBJOMvMmWEnyJg7FbHCdbNWdPHCLTb19cvjXQ7iQNcd6gtw3hgp4Rcuh-PGUucjahoO1dtuOOTeg03lw
-      Host:
-      - management.azure.com
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNjAsIm5iZiI6MTUwNjExNjI2MCwiZXhwIjoxNTA2MTIwMTYwLCJhaW8iOiJZMlZnWU5paE9LMDd2L1MyZGlDWHpkSkRPaXdUQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQTlUNDNsbFBWRWV1VDBOajg5OEtBQSIsInZlciI6IjEuMCJ9.m2q1UV9vV03MzAANTYje3G1TeuvrUD7j9xF9RFAZ5K8Zpn8tCFh_-CIuO8uYfW2iT7Dlf1wuo4SO_wd3QIEwibwUzO6Kvx8QfsYAguRT1SJ9c5wjNpPMn5fUsF9ekp2w8naEvHBnxZAaX_6in8ZrOt5lXh2Dye14W65OFYNHV6kHvbVIl70LTnkqkgQsPeKjuVfhFjBvYX6otE_QHiM7PH8IXaadkD4Hk7EIityoza6HM32SHGs2_TNlUKC3vNm_O1ovfa-3NxjyMH94QUIzn0pfoYTskhE3yyLLinP2mDW5sqNEBKrJMlJ7JAZNNMmAO9lIZxOfhOrN-WJuyVSuqg
   response:
     status:
       code: 200
@@ -2009,31 +2080,90 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - 4bfa01be-545e-4dff-857e-18d053bceb53
+      - 468eb1fc-e6ea-45e1-bf61-fbf5e452bb41
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14924'
+      - '14926'
       X-Ms-Correlation-Request-Id:
-      - 21c75de2-9f7c-4572-b11d-4a9e865a9960
+      - 0133504e-717f-4345-977e-367b087adae7
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200447Z:21c75de2-9f7c-4572-b11d-4a9e865a9960
+      - WESTUS:20170922T214244Z:0133504e-717f-4345-977e-367b087adae7
       Date:
-      - Tue, 05 Sep 2017 20:04:47 GMT
+      - Fri, 22 Sep 2017 21:42:44 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-05T20:04:46.0689681+00:00\",\r\n  \"endTime\":
-        \"2017-09-05T20:04:46.3038177+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=0d385516-d4bd-4591-b5e2-cad147eddb17&sig=r8yPzMO4cDJP9mtGeNz86deTtv1PE%2FHZIYSag7JeMbA%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"525c00dd-3f00-4fe1-99e4-df9b02e81e4f\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2017-09-22T21:42:44.89792+00:00\",\r\n  \"endTime\":
+        \"2017-09-22T21:42:45.1792464+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=83a4d5f7-2772-4029-b547-3a574d4dc490&sig=er68jdNDqqqTnvcREHFmi%2FkrydxsFoYWdMVjU6A6DaM%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"0986cdcd-5eef-4095-bb43-6a02f9e20e6a\"\r\n}"
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:47 GMT
+  recorded_at: Fri, 22 Sep 2017 21:42:43 GMT
 - request:
     method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=0d385516-d4bd-4591-b5e2-cad147eddb17&sig=r8yPzMO4cDJP9mtGeNz86deTtv1PE/HZIYSag7JeMbA=&sr=b&sv=2016-05-31
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/0986cdcd-5eef-4095-bb43-6a02f9e20e6a?api-version=2017-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNjAsIm5iZiI6MTUwNjExNjI2MCwiZXhwIjoxNTA2MTIwMTYwLCJhaW8iOiJZMlZnWU5paE9LMDd2L1MyZGlDWHpkSkRPaXdUQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQTlUNDNsbFBWRWV1VDBOajg5OEtBQSIsInZlciI6IjEuMCJ9.m2q1UV9vV03MzAANTYje3G1TeuvrUD7j9xF9RFAZ5K8Zpn8tCFh_-CIuO8uYfW2iT7Dlf1wuo4SO_wd3QIEwibwUzO6Kvx8QfsYAguRT1SJ9c5wjNpPMn5fUsF9ekp2w8naEvHBnxZAaX_6in8ZrOt5lXh2Dye14W65OFYNHV6kHvbVIl70LTnkqkgQsPeKjuVfhFjBvYX6otE_QHiM7PH8IXaadkD4Hk7EIityoza6HM32SHGs2_TNlUKC3vNm_O1ovfa-3NxjyMH94QUIzn0pfoYTskhE3yyLLinP2mDW5sqNEBKrJMlJ7JAZNNMmAO9lIZxOfhOrN-WJuyVSuqg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
+      X-Ms-Request-Id:
+      - 9f7a6fcf-030a-4934-a879-531411e897a9
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14913'
+      X-Ms-Correlation-Request-Id:
+      - 03d42cd9-6458-4c88-8472-3f8a422dd590
+      X-Ms-Routing-Request-Id:
+      - WESTUS:20170922T214245Z:03d42cd9-6458-4c88-8472-3f8a422dd590
+      Date:
+      - Fri, 22 Sep 2017 21:42:44 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"startTime\": \"2017-09-22T21:42:44.89792+00:00\",\r\n  \"endTime\":
+        \"2017-09-22T21:42:45.1792464+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=83a4d5f7-2772-4029-b547-3a574d4dc490&sig=er68jdNDqqqTnvcREHFmi%2FkrydxsFoYWdMVjU6A6DaM%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"0986cdcd-5eef-4095-bb43-6a02f9e20e6a\"\r\n}"
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 21:42:44 GMT
+- request:
+    method: get
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=83a4d5f7-2772-4029-b547-3a574d4dc490&sig=er68jdNDqqqTnvcREHFmi/krydxsFoYWdMVjU6A6DaM=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2046,8 +2176,6 @@ http_interactions:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
       X-Ms-Range:
       - bytes=0-0
-      Host:
-      - md-t4jdgqqlgszp.blob.core.windows.net
   response:
     status:
       code: 206
@@ -2068,7 +2196,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 2f2860c5-001e-00e6-0e82-26b0dd000000
+      - 9322e1bf-001e-00b7-6deb-33ae28000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2094,13 +2222,13 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Tue, 05 Sep 2017 20:04:46 GMT
+      - Fri, 22 Sep 2017 21:42:45 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         6w==
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:47 GMT
+  recorded_at: Fri, 22 Sep 2017 21:42:44 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/EndGetAccess?api-version=2017-03-30
@@ -2117,11 +2245,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1ODUsIm5iZiI6MTUwNDY0MTU4NSwiZXhwIjoxNTA0NjQ1NDg1LCJhaW8iOiJZMkZnWUpDNU9QVjlpZXowa29BN1ZndHFsTklFQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiU04yYm9iZm1UVW1LUDA5eWRDNGZBQSIsInZlciI6IjEuMCJ9.FMnRDaNClITFOgNWGzeF_DW5NXwfhSMEcq-7VFUdKnlENKVpA6z0fmaPmEIk9be1WlfHdzCy21xfhbluZ9omK8TVlKLg0PFRlOi3jBqTEgsQyRnim-j0b_0E4REBiEV7fk8E6cGI7yWBZGirJypjWghm86U-VlLqEblb5JyYdNp5_S_58j1nHStQlBbGjNrYk_g30fnL0Y8QUPsmlsZS5IQjQyZgBNtNczeKRHXm36ob_JbWaF8JvpZhq6WYpKJA6oAf33HBJOMvMmWEnyJg7FbHCdbNWdPHCLTb19cvjXQ7iQNcd6gtw3hgp4Rcuh-PGUucjahoO1dtuOOTeg03lw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNjAsIm5iZiI6MTUwNjExNjI2MCwiZXhwIjoxNTA2MTIwMTYwLCJhaW8iOiJZMlZnWU5paE9LMDd2L1MyZGlDWHpkSkRPaXdUQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQTlUNDNsbFBWRWV1VDBOajg5OEtBQSIsInZlciI6IjEuMCJ9.m2q1UV9vV03MzAANTYje3G1TeuvrUD7j9xF9RFAZ5K8Zpn8tCFh_-CIuO8uYfW2iT7Dlf1wuo4SO_wd3QIEwibwUzO6Kvx8QfsYAguRT1SJ9c5wjNpPMn5fUsF9ekp2w8naEvHBnxZAaX_6in8ZrOt5lXh2Dye14W65OFYNHV6kHvbVIl70LTnkqkgQsPeKjuVfhFjBvYX6otE_QHiM7PH8IXaadkD4Hk7EIityoza6HM32SHGs2_TNlUKC3vNm_O1ovfa-3NxjyMH94QUIzn0pfoYTskhE3yyLLinP2mDW5sqNEBKrJMlJ7JAZNNMmAO9lIZxOfhOrN-WJuyVSuqg
       Content-Length:
       - '0'
-      Host:
-      - management.azure.com
   response:
     status:
       code: 202
@@ -2136,31 +2262,31 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/b1fb065c-bc2c-415f-87d1-9ae8c7181505?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/b3433cf7-06eb-4249-931e-878afc3f6f29?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/b1fb065c-bc2c-415f-87d1-9ae8c7181505?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/b3433cf7-06eb-4249-931e-878afc3f6f29?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - b1fb065c-bc2c-415f-87d1-9ae8c7181505
+      - b3433cf7-06eb-4249-931e-878afc3f6f29
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1187'
+      - '1186'
       X-Ms-Correlation-Request-Id:
-      - c41a3cba-c9c9-47bb-bcd6-819f33e2de59
+      - d5f3551f-fdd2-4dd4-9e3c-716b47f166c5
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200448Z:c41a3cba-c9c9-47bb-bcd6-819f33e2de59
+      - WESTUS:20170922T214246Z:d5f3551f-fdd2-4dd4-9e3c-716b47f166c5
       Date:
-      - Tue, 05 Sep 2017 20:04:47 GMT
+      - Fri, 22 Sep 2017 21:42:45 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:48 GMT
+  recorded_at: Fri, 22 Sep 2017 21:42:45 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
@@ -2177,11 +2303,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1ODUsIm5iZiI6MTUwNDY0MTU4NSwiZXhwIjoxNTA0NjQ1NDg1LCJhaW8iOiJZMkZnWUpDNU9QVjlpZXowa29BN1ZndHFsTklFQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiU04yYm9iZm1UVW1LUDA5eWRDNGZBQSIsInZlciI6IjEuMCJ9.FMnRDaNClITFOgNWGzeF_DW5NXwfhSMEcq-7VFUdKnlENKVpA6z0fmaPmEIk9be1WlfHdzCy21xfhbluZ9omK8TVlKLg0PFRlOi3jBqTEgsQyRnim-j0b_0E4REBiEV7fk8E6cGI7yWBZGirJypjWghm86U-VlLqEblb5JyYdNp5_S_58j1nHStQlBbGjNrYk_g30fnL0Y8QUPsmlsZS5IQjQyZgBNtNczeKRHXm36ob_JbWaF8JvpZhq6WYpKJA6oAf33HBJOMvMmWEnyJg7FbHCdbNWdPHCLTb19cvjXQ7iQNcd6gtw3hgp4Rcuh-PGUucjahoO1dtuOOTeg03lw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNjAsIm5iZiI6MTUwNjExNjI2MCwiZXhwIjoxNTA2MTIwMTYwLCJhaW8iOiJZMlZnWU5paE9LMDd2L1MyZGlDWHpkSkRPaXdUQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQTlUNDNsbFBWRWV1VDBOajg5OEtBQSIsInZlciI6IjEuMCJ9.m2q1UV9vV03MzAANTYje3G1TeuvrUD7j9xF9RFAZ5K8Zpn8tCFh_-CIuO8uYfW2iT7Dlf1wuo4SO_wd3QIEwibwUzO6Kvx8QfsYAguRT1SJ9c5wjNpPMn5fUsF9ekp2w8naEvHBnxZAaX_6in8ZrOt5lXh2Dye14W65OFYNHV6kHvbVIl70LTnkqkgQsPeKjuVfhFjBvYX6otE_QHiM7PH8IXaadkD4Hk7EIityoza6HM32SHGs2_TNlUKC3vNm_O1ovfa-3NxjyMH94QUIzn0pfoYTskhE3yyLLinP2mDW5sqNEBKrJMlJ7JAZNNMmAO9lIZxOfhOrN-WJuyVSuqg
       Content-Length:
       - '42'
-      Host:
-      - management.azure.com
   response:
     status:
       code: 202
@@ -2196,34 +2320,34 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/103514af-4498-45d2-92f7-dce04b3251df?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/c914d124-bb8b-418a-9bf9-362923fe7e22?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/103514af-4498-45d2-92f7-dce04b3251df?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/c914d124-bb8b-418a-9bf9-362923fe7e22?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - 103514af-4498-45d2-92f7-dce04b3251df
+      - c914d124-bb8b-418a-9bf9-362923fe7e22
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1178'
+      - '1176'
       X-Ms-Correlation-Request-Id:
-      - 61be4256-9b32-4415-891b-d08fd802fd2b
+      - 3a311246-e451-44fe-a941-f7d51ea655b1
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200448Z:61be4256-9b32-4415-891b-d08fd802fd2b
+      - WESTUS:20170922T214247Z:3a311246-e451-44fe-a941-f7d51ea655b1
       Date:
-      - Tue, 05 Sep 2017 20:04:47 GMT
+      - Fri, 22 Sep 2017 21:42:47 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:48 GMT
+  recorded_at: Fri, 22 Sep 2017 21:42:46 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/103514af-4498-45d2-92f7-dce04b3251df?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/c914d124-bb8b-418a-9bf9-362923fe7e22?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -2237,9 +2361,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1ODUsIm5iZiI6MTUwNDY0MTU4NSwiZXhwIjoxNTA0NjQ1NDg1LCJhaW8iOiJZMkZnWUpDNU9QVjlpZXowa29BN1ZndHFsTklFQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiU04yYm9iZm1UVW1LUDA5eWRDNGZBQSIsInZlciI6IjEuMCJ9.FMnRDaNClITFOgNWGzeF_DW5NXwfhSMEcq-7VFUdKnlENKVpA6z0fmaPmEIk9be1WlfHdzCy21xfhbluZ9omK8TVlKLg0PFRlOi3jBqTEgsQyRnim-j0b_0E4REBiEV7fk8E6cGI7yWBZGirJypjWghm86U-VlLqEblb5JyYdNp5_S_58j1nHStQlBbGjNrYk_g30fnL0Y8QUPsmlsZS5IQjQyZgBNtNczeKRHXm36ob_JbWaF8JvpZhq6WYpKJA6oAf33HBJOMvMmWEnyJg7FbHCdbNWdPHCLTb19cvjXQ7iQNcd6gtw3hgp4Rcuh-PGUucjahoO1dtuOOTeg03lw
-      Host:
-      - management.azure.com
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNjAsIm5iZiI6MTUwNjExNjI2MCwiZXhwIjoxNTA2MTIwMTYwLCJhaW8iOiJZMlZnWU5paE9LMDd2L1MyZGlDWHpkSkRPaXdUQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQTlUNDNsbFBWRWV1VDBOajg5OEtBQSIsInZlciI6IjEuMCJ9.m2q1UV9vV03MzAANTYje3G1TeuvrUD7j9xF9RFAZ5K8Zpn8tCFh_-CIuO8uYfW2iT7Dlf1wuo4SO_wd3QIEwibwUzO6Kvx8QfsYAguRT1SJ9c5wjNpPMn5fUsF9ekp2w8naEvHBnxZAaX_6in8ZrOt5lXh2Dye14W65OFYNHV6kHvbVIl70LTnkqkgQsPeKjuVfhFjBvYX6otE_QHiM7PH8IXaadkD4Hk7EIityoza6HM32SHGs2_TNlUKC3vNm_O1ovfa-3NxjyMH94QUIzn0pfoYTskhE3yyLLinP2mDW5sqNEBKrJMlJ7JAZNNMmAO9lIZxOfhOrN-WJuyVSuqg
   response:
     status:
       code: 200
@@ -2260,31 +2382,90 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - fc986a28-5907-4d65-be89-2a533c46e66b
+      - 585238b8-e5d3-402e-951f-ad8ee05ba47b
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14939'
+      - '14920'
       X-Ms-Correlation-Request-Id:
-      - 134b5c5b-c123-4946-bfc8-a95895868376
+      - e468966c-9130-4888-8af9-db3f72642d31
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200448Z:134b5c5b-c123-4946-bfc8-a95895868376
+      - WESTUS:20170922T214248Z:e468966c-9130-4888-8af9-db3f72642d31
       Date:
-      - Tue, 05 Sep 2017 20:04:48 GMT
+      - Fri, 22 Sep 2017 21:42:48 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-05T20:04:47.2121108+00:00\",\r\n  \"endTime\":
-        \"2017-09-05T20:04:47.3683367+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=eda07bf5-408f-48d6-bba7-361d8c3a8559&sig=MmAn4Wp6IVvZB9RTqU5nSMBdwqHE%2Bv2mWFF5a1SpwEM%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"103514af-4498-45d2-92f7-dce04b3251df\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2017-09-22T21:42:48.8051957+00:00\",\r\n  \"endTime\":
+        \"2017-09-22T21:42:49.0396021+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=ab501310-d397-4adf-b778-d27a19582557&sig=dqsfJkC8TUHkcbZ14QtUHFpL0fzH3%2BnBN8dg6EcX9bM%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"c914d124-bb8b-418a-9bf9-362923fe7e22\"\r\n}"
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:48 GMT
+  recorded_at: Fri, 22 Sep 2017 21:42:47 GMT
 - request:
     method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=eda07bf5-408f-48d6-bba7-361d8c3a8559&sig=MmAn4Wp6IVvZB9RTqU5nSMBdwqHE%2Bv2mWFF5a1SpwEM=&sr=b&sv=2016-05-31
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/c914d124-bb8b-418a-9bf9-362923fe7e22?api-version=2017-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNjAsIm5iZiI6MTUwNjExNjI2MCwiZXhwIjoxNTA2MTIwMTYwLCJhaW8iOiJZMlZnWU5paE9LMDd2L1MyZGlDWHpkSkRPaXdUQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQTlUNDNsbFBWRWV1VDBOajg5OEtBQSIsInZlciI6IjEuMCJ9.m2q1UV9vV03MzAANTYje3G1TeuvrUD7j9xF9RFAZ5K8Zpn8tCFh_-CIuO8uYfW2iT7Dlf1wuo4SO_wd3QIEwibwUzO6Kvx8QfsYAguRT1SJ9c5wjNpPMn5fUsF9ekp2w8naEvHBnxZAaX_6in8ZrOt5lXh2Dye14W65OFYNHV6kHvbVIl70LTnkqkgQsPeKjuVfhFjBvYX6otE_QHiM7PH8IXaadkD4Hk7EIityoza6HM32SHGs2_TNlUKC3vNm_O1ovfa-3NxjyMH94QUIzn0pfoYTskhE3yyLLinP2mDW5sqNEBKrJMlJ7JAZNNMmAO9lIZxOfhOrN-WJuyVSuqg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
+      X-Ms-Request-Id:
+      - cac2ca4f-dcb0-48b4-9bb9-0d2792a718a1
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14928'
+      X-Ms-Correlation-Request-Id:
+      - 254d62dd-60bd-4242-906f-ba77b868f5a8
+      X-Ms-Routing-Request-Id:
+      - WESTUS:20170922T214248Z:254d62dd-60bd-4242-906f-ba77b868f5a8
+      Date:
+      - Fri, 22 Sep 2017 21:42:48 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"startTime\": \"2017-09-22T21:42:48.8051957+00:00\",\r\n  \"endTime\":
+        \"2017-09-22T21:42:49.0396021+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=ab501310-d397-4adf-b778-d27a19582557&sig=dqsfJkC8TUHkcbZ14QtUHFpL0fzH3%2BnBN8dg6EcX9bM%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"c914d124-bb8b-418a-9bf9-362923fe7e22\"\r\n}"
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 21:42:47 GMT
+- request:
+    method: get
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=ab501310-d397-4adf-b778-d27a19582557&sig=dqsfJkC8TUHkcbZ14QtUHFpL0fzH3%2BnBN8dg6EcX9bM=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2297,8 +2478,6 @@ http_interactions:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
       X-Ms-Range:
       - bytes=440-443
-      Host:
-      - md-t4jdgqqlgszp.blob.core.windows.net
   response:
     status:
       code: 206
@@ -2319,7 +2498,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 0a8fd215-001e-013c-2282-2653a3000000
+      - 98f1a379-001e-0033-79eb-33f800000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2345,13 +2524,13 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Tue, 05 Sep 2017 20:04:46 GMT
+      - Fri, 22 Sep 2017 21:42:48 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         U5MJAA==
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:48 GMT
+  recorded_at: Fri, 22 Sep 2017 21:42:48 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/EndGetAccess?api-version=2017-03-30
@@ -2368,11 +2547,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1ODUsIm5iZiI6MTUwNDY0MTU4NSwiZXhwIjoxNTA0NjQ1NDg1LCJhaW8iOiJZMkZnWUpDNU9QVjlpZXowa29BN1ZndHFsTklFQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiU04yYm9iZm1UVW1LUDA5eWRDNGZBQSIsInZlciI6IjEuMCJ9.FMnRDaNClITFOgNWGzeF_DW5NXwfhSMEcq-7VFUdKnlENKVpA6z0fmaPmEIk9be1WlfHdzCy21xfhbluZ9omK8TVlKLg0PFRlOi3jBqTEgsQyRnim-j0b_0E4REBiEV7fk8E6cGI7yWBZGirJypjWghm86U-VlLqEblb5JyYdNp5_S_58j1nHStQlBbGjNrYk_g30fnL0Y8QUPsmlsZS5IQjQyZgBNtNczeKRHXm36ob_JbWaF8JvpZhq6WYpKJA6oAf33HBJOMvMmWEnyJg7FbHCdbNWdPHCLTb19cvjXQ7iQNcd6gtw3hgp4Rcuh-PGUucjahoO1dtuOOTeg03lw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNjAsIm5iZiI6MTUwNjExNjI2MCwiZXhwIjoxNTA2MTIwMTYwLCJhaW8iOiJZMlZnWU5paE9LMDd2L1MyZGlDWHpkSkRPaXdUQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQTlUNDNsbFBWRWV1VDBOajg5OEtBQSIsInZlciI6IjEuMCJ9.m2q1UV9vV03MzAANTYje3G1TeuvrUD7j9xF9RFAZ5K8Zpn8tCFh_-CIuO8uYfW2iT7Dlf1wuo4SO_wd3QIEwibwUzO6Kvx8QfsYAguRT1SJ9c5wjNpPMn5fUsF9ekp2w8naEvHBnxZAaX_6in8ZrOt5lXh2Dye14W65OFYNHV6kHvbVIl70LTnkqkgQsPeKjuVfhFjBvYX6otE_QHiM7PH8IXaadkD4Hk7EIityoza6HM32SHGs2_TNlUKC3vNm_O1ovfa-3NxjyMH94QUIzn0pfoYTskhE3yyLLinP2mDW5sqNEBKrJMlJ7JAZNNMmAO9lIZxOfhOrN-WJuyVSuqg
       Content-Length:
       - '0'
-      Host:
-      - management.azure.com
   response:
     status:
       code: 202
@@ -2387,29 +2564,29 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/df043d4d-4c70-468a-9c53-861da2b161cc?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/3d4d29af-3d3a-4ff7-9d77-e634eee5771d?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/df043d4d-4c70-468a-9c53-861da2b161cc?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/3d4d29af-3d3a-4ff7-9d77-e634eee5771d?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - df043d4d-4c70-468a-9c53-861da2b161cc
+      - 3d4d29af-3d3a-4ff7-9d77-e634eee5771d
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1189'
+      - '1199'
       X-Ms-Correlation-Request-Id:
-      - 15c09afd-5b7a-44f4-8df6-b1e65b94084a
+      - 83214645-3636-4804-bc40-65172941c47b
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200449Z:15c09afd-5b7a-44f4-8df6-b1e65b94084a
+      - WESTUS:20170922T214250Z:83214645-3636-4804-bc40-65172941c47b
       Date:
-      - Tue, 05 Sep 2017 20:04:48 GMT
+      - Fri, 22 Sep 2017 21:42:49 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:49 GMT
+  recorded_at: Fri, 22 Sep 2017 21:42:49 GMT
 recorded_with: VCR 3.0.3

--- a/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_size-1.yml
+++ b/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_size-1.yml
@@ -17,8 +17,6 @@ http_interactions:
       - '186'
       Content-Type:
       - application/x-www-form-urlencoded
-      Host:
-      - login.microsoftonline.com
   response:
     status:
       code: 200
@@ -39,25 +37,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - ba9a9ded-f3f8-4676-96ec-ce5a8f891e00
+      - e6faef01-1a89-4a57-a0a9-33b348810c00
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAAA9kTklhVy7SJTGAzR-p1BcQXMCtHdbyj8QEe_XKSK4juFzkp9Bwr2MXq9I8uOj7v0O-L3xUX0gU5FY1NzpMGA4eJAUTgzlokwuqPQ5ygz4kwqMPLudAZeUYdlZ87ey37X11Kdh8HGafVrOIatlSuvXTDTZN7KitMzuWeWCVTllLH7jPV98l3MlsEzJoKsD8XkgAA;
+      - esctx=AQABAAAAAAABlDrqfEFlSaui6xnRjX5EgoZSs1Hrzd4Foo49Rqc2sZC_0GRF_4s5c-lRCHhS6MjRGuVUaTkA9VmS8xN1_2GxfkQKeP-p3WiZ7isFdO0gXjW2nUNJ3Md3cZ38wk9M8EyquQfdy-wLn1cR5ucxuIJ2GwVBwCTDc34yQ7MLw9Hw7V9djv6QqSbHkU78_mpU6UUgAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
       - x-ms-gateway-slice=007; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Tue, 05 Sep 2017 20:04:21 GMT
+      - Fri, 22 Sep 2017 21:42:31 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1504645462","not_before":"1504641562","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NjIsIm5iZiI6MTUwNDY0MTU2MiwiZXhwIjoxNTA0NjQ1NDYyLCJhaW8iOiJZMkZnWUtoM2VQM3Q5dDIraWVxR3AyMU8vejR3RlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiN1oyYXV2anpka2FXN001YWo0a2VBQSIsInZlciI6IjEuMCJ9.rqANytszMqCZTWjs_0cHWBNyWPPba-u-48XYLvlOo9IXf5ld3_MSknmz7QTWq1xXq97Zl_8dS-I8aFEVVwZIFFGw89FSQyxCOFdpzpj0zehB-ZNnd91LGvmTxX9DMriRM3UV4rsXjvRr5TfGHmdVP3ZCB5tGqv3Tvi_1dSenX2lfn6sjXERmgGArmg3FahEOdSVd0zunSuYruDNTRw1uk3uNWkZ7KzdvQ871el2UHaeTLlIcB_RJWXeIsNnh5jtonkF3Kp5zETLjRBVfLbKJyN9H1xmNHFMtstW8pkGeylljIRp_T0ACdJXACXeDevy1LkWmujyacIdMMUo7xJ_ZVQ"}'
+      string: '{"token_type":"Bearer","expires_in":"3600","ext_expires_in":"0","expires_on":"1506120151","not_before":"1506116251","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNTEsIm5iZiI6MTUwNjExNjI1MSwiZXhwIjoxNTA2MTIwMTUxLCJhaW8iOiJZMlZnWUxnV3ZNR2haN3JqaENYWDZqZFBmcVp3RlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQWVfNjVva2FWMHFncVRPelNJRU1BQSIsInZlciI6IjEuMCJ9.yzoeDCrqx6h9nl-b6GtfmDyJbotu_2GBJu-ip3XG01YchUdtta9kywHCIj3lJYb4R5vXZEQPNg9M0bpMuy_rjlMLEWMcFxFU8iocbWvIm1JHj67MsPUQn-01Rl6sIvWrHA_qiKjv4RzfIECHmA6lY9zxpjLywyLjvlC8_zyME4-3AHUoy0felmuv7nWwCUXS4UhWtQkwNzNv5jIoBUb3hWFa5S-GNkgsrUwPgu0S-Y6AfGM58eXZgmPLCJwHrkXQiDcbc7qpncDb06snvYrQVwNHYXKe0QIlAmDEB4kaqJmrPyTRky_GCV63g5lfionsieQSEaKMl4xqchA0MGu36w"}'
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:20 GMT
+  recorded_at: Fri, 22 Sep 2017 21:42:30 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -74,9 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NjIsIm5iZiI6MTUwNDY0MTU2MiwiZXhwIjoxNTA0NjQ1NDYyLCJhaW8iOiJZMkZnWUtoM2VQM3Q5dDIraWVxR3AyMU8vejR3RlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiN1oyYXV2anpka2FXN001YWo0a2VBQSIsInZlciI6IjEuMCJ9.rqANytszMqCZTWjs_0cHWBNyWPPba-u-48XYLvlOo9IXf5ld3_MSknmz7QTWq1xXq97Zl_8dS-I8aFEVVwZIFFGw89FSQyxCOFdpzpj0zehB-ZNnd91LGvmTxX9DMriRM3UV4rsXjvRr5TfGHmdVP3ZCB5tGqv3Tvi_1dSenX2lfn6sjXERmgGArmg3FahEOdSVd0zunSuYruDNTRw1uk3uNWkZ7KzdvQ871el2UHaeTLlIcB_RJWXeIsNnh5jtonkF3Kp5zETLjRBVfLbKJyN9H1xmNHFMtstW8pkGeylljIRp_T0ACdJXACXeDevy1LkWmujyacIdMMUo7xJ_ZVQ
-      Host:
-      - management.azure.com
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNTEsIm5iZiI6MTUwNjExNjI1MSwiZXhwIjoxNTA2MTIwMTUxLCJhaW8iOiJZMlZnWUxnV3ZNR2haN3JqaENYWDZqZFBmcVp3RlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQWVfNjVva2FWMHFncVRPelNJRU1BQSIsInZlciI6IjEuMCJ9.yzoeDCrqx6h9nl-b6GtfmDyJbotu_2GBJu-ip3XG01YchUdtta9kywHCIj3lJYb4R5vXZEQPNg9M0bpMuy_rjlMLEWMcFxFU8iocbWvIm1JHj67MsPUQn-01Rl6sIvWrHA_qiKjv4RzfIECHmA6lY9zxpjLywyLjvlC8_zyME4-3AHUoy0felmuv7nWwCUXS4UhWtQkwNzNv5jIoBUb3hWFa5S-GNkgsrUwPgu0S-Y6AfGM58eXZgmPLCJwHrkXQiDcbc7qpncDb06snvYrQVwNHYXKe0QIlAmDEB4kaqJmrPyTRky_GCV63g5lfionsieQSEaKMl4xqchA0MGu36w
   response:
     status:
       code: 200
@@ -95,23 +91,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14996'
+      - '14999'
       X-Ms-Request-Id:
-      - c9ca22b4-abec-4b9c-89d9-f2c9f7dc1c9f
+      - 73523c6c-9895-4aaf-9a88-8d0a559a3a11
       X-Ms-Correlation-Request-Id:
-      - c9ca22b4-abec-4b9c-89d9-f2c9f7dc1c9f
+      - 73523c6c-9895-4aaf-9a88-8d0a559a3a11
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200423Z:c9ca22b4-abec-4b9c-89d9-f2c9f7dc1c9f
+      - WESTUS:20170922T214232Z:73523c6c-9895-4aaf-9a88-8d0a559a3a11
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 05 Sep 2017 20:04:22 GMT
+      - Fri, 22 Sep 2017 21:42:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:20 GMT
+  recorded_at: Fri, 22 Sep 2017 21:42:31 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/azure_subscription_id/providers?api-version=2015-01-01
@@ -128,9 +124,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NjIsIm5iZiI6MTUwNDY0MTU2MiwiZXhwIjoxNTA0NjQ1NDYyLCJhaW8iOiJZMkZnWUtoM2VQM3Q5dDIraWVxR3AyMU8vejR3RlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiN1oyYXV2anpka2FXN001YWo0a2VBQSIsInZlciI6IjEuMCJ9.rqANytszMqCZTWjs_0cHWBNyWPPba-u-48XYLvlOo9IXf5ld3_MSknmz7QTWq1xXq97Zl_8dS-I8aFEVVwZIFFGw89FSQyxCOFdpzpj0zehB-ZNnd91LGvmTxX9DMriRM3UV4rsXjvRr5TfGHmdVP3ZCB5tGqv3Tvi_1dSenX2lfn6sjXERmgGArmg3FahEOdSVd0zunSuYruDNTRw1uk3uNWkZ7KzdvQ871el2UHaeTLlIcB_RJWXeIsNnh5jtonkF3Kp5zETLjRBVfLbKJyN9H1xmNHFMtstW8pkGeylljIRp_T0ACdJXACXeDevy1LkWmujyacIdMMUo7xJ_ZVQ
-      Host:
-      - management.azure.com
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNTEsIm5iZiI6MTUwNjExNjI1MSwiZXhwIjoxNTA2MTIwMTUxLCJhaW8iOiJZMlZnWUxnV3ZNR2haN3JqaENYWDZqZFBmcVp3RlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQWVfNjVva2FWMHFncVRPelNJRU1BQSIsInZlciI6IjEuMCJ9.yzoeDCrqx6h9nl-b6GtfmDyJbotu_2GBJu-ip3XG01YchUdtta9kywHCIj3lJYb4R5vXZEQPNg9M0bpMuy_rjlMLEWMcFxFU8iocbWvIm1JHj67MsPUQn-01Rl6sIvWrHA_qiKjv4RzfIECHmA6lY9zxpjLywyLjvlC8_zyME4-3AHUoy0felmuv7nWwCUXS4UhWtQkwNzNv5jIoBUb3hWFa5S-GNkgsrUwPgu0S-Y6AfGM58eXZgmPLCJwHrkXQiDcbc7qpncDb06snvYrQVwNHYXKe0QIlAmDEB4kaqJmrPyTRky_GCV63g5lfionsieQSEaKMl4xqchA0MGu36w
   response:
     status:
       code: 200
@@ -147,22 +141,42 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14948'
+      - '14920'
       X-Ms-Request-Id:
-      - 1be37181-035b-49f3-8fd1-ee4a12932c75
+      - f04f34eb-8319-4006-9c04-5733b2147987
       X-Ms-Correlation-Request-Id:
-      - 1be37181-035b-49f3-8fd1-ee4a12932c75
+      - f04f34eb-8319-4006-9c04-5733b2147987
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200424Z:1be37181-035b-49f3-8fd1-ee4a12932c75
+      - WESTUS:20170922T214233Z:f04f34eb-8319-4006-9c04-5733b2147987
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 05 Sep 2017 20:04:23 GMT
+      - Fri, 22 Sep 2017 21:42:33 GMT
       Content-Length:
-      - '243687'
+      - '254785'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
+      string: '{"value":[{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"operations","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","North Central
         US","South Central US","West Central US","West US","West US 2","Canada Central","Canada
         East","North Europe","West Europe","UK South","UK West","East Asia","Southeast
@@ -437,7 +451,7 @@ http_interactions:
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
         Central US","West US 2","South India","Central India","West India","Canada
-        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
+        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
         East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
@@ -466,7 +480,7 @@ http_interactions:
         Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"}],"resourceTypes":[{"resourceType":"components","locations":["East
         US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
         US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01","2014-04-01"]},{"resourceType":"queries","locations":["East
-        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"alertrules","locations":["West
+        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
@@ -542,7 +556,7 @@ http_interactions:
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorization":{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorizations":[{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},{"applicationId":"7c33bfcb-8d33-48d6-8e60-dc6404003489","roleDefinitionId":"ad6261e4-fa9a-4642-aa5f-104f1b67e9e3"},{"applicationId":"1e3e4475-288f-4018-a376-df66fd7fac5f","roleDefinitionId":"1d538b69-3d87-4e56-8ff8-25786fd48261"},{"applicationId":"a0be0c72-870e-46f0-9c49-c98333a996f7","roleDefinitionId":"7ce22727-ffce-45a9-930c-ddb2e56fa131"}],"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -552,7 +566,7 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -567,7 +581,8 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
+        Central US"],"apiVersions":["2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -577,7 +592,12 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -597,7 +617,7 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -612,7 +632,7 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -622,7 +642,31 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
         East","UK South","Central India","Canada Central"],"apiVersions":["2017-04-26-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"]},{"resourceType":"workspaces/dataSources","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
@@ -641,17 +685,17 @@ http_interactions:
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"consoles","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/consoles","locations":["West
+        East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"consoles","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/consoles","locations":["West
         US","East US","Central India","North Europe","West Europe","South Central
-        US","Southeast Asia"],"apiVersions":["2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
+        US","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
         US","East US","Central India","North Europe","West Europe","South Central
-        US","Southeast Asia"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
+        US","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","Canada Central","Canada East","West Central US","West US 2","UK South","UK
         West","Korea Central","Korea South"],"apiVersions":["2017-07-01","2016-12-01","2016-08-10","2016-06-01","2016-05-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"operations","locations":["Southeast
-        Asia"],"apiVersions":["2016-08-10","2016-06-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01"]},{"resourceType":"locations/backupStatus","locations":["West
+        Asia"],"apiVersions":["2016-08-10","2016-06-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01","2016-06-01"]},{"resourceType":"locations/backupStatus","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
@@ -687,6 +731,7 @@ http_interactions:
         Central US","Central US","North Europe","West Europe","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada Central","Canada East"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"pricings","locations":["Central
+        US","East US"],"apiVersions":["2017-08-01-preview"]},{"resourceType":"securityContacts","locations":["Central
         US","East US"],"apiVersions":["2017-08-01-preview"]},{"resourceType":"workspaceSettings","locations":["Central
         US","East US"],"apiVersions":["2017-08-01-preview"]},{"resourceType":"complianceResults","locations":["Central
         US","East US"],"apiVersions":["2017-08-01"]},{"resourceType":"policies","locations":["Central
@@ -703,6 +748,8 @@ http_interactions:
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatusesSummaries","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/alerts","locations":["Central
         US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/tasks","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"externalSecuritySolutions","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/externalSecuritySolutions","locations":["Central
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.SiteRecovery","namespace":"Microsoft.SiteRecovery","authorization":{"applicationId":"b8340c3b-9267-498f-b21a-15d5547fd85e","roleDefinitionId":"8A00C8EA-8F1B-45A7-8F64-F4CC61EEE9B6"},"resourceTypes":[{"resourceType":"SiteRecoveryVault","locations":["East
         US","West US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","Australia East","Australia Southeast","Brazil South","North
@@ -722,7 +769,7 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -842,7 +889,22 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/databases/transparentDataEncryption","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -1077,6 +1139,26 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
         US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
@@ -1307,6 +1389,11 @@ http_interactions:
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"customApis","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
         East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/managedApis","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
@@ -1358,23 +1445,8 @@ http_interactions:
         US","North Europe","Japan West","Japan East","East Asia","West Europe","East
         US","Southeast Asia","Central US"],"apiVersions":["2016-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Lombiq.DotNest","namespace":"Lombiq.DotNest","resourceTypes":[{"resourceType":"sites","locations":["East
         US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Mailjet.Email","namespace":"Mailjet.Email","resourceTypes":[{"resourceType":"services","locations":["West
-        US"],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
-        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]},{"resourceType":"diagnosticSettings","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"addsservices","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"configuration","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"operations","locations":["West
@@ -1498,8 +1570,10 @@ http_interactions:
         Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
         Central US","Central US","North Europe","West Europe","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","West
-        India","South India"],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CognitiveServices","namespace":"Microsoft.CognitiveServices","authorizations":[{"applicationId":"7d312290-28c8-473c-a0ed-8e53749b6d6d","roleDefinitionId":"5cb87f79-a7c3-4a95-9414-45b65974b51b"}],"resourceTypes":[{"resourceType":"accounts","locations":["Global","West
-        US","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"operations","locations":["Global","Australia
+        India","South India"],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CognitiveServices","namespace":"Microsoft.CognitiveServices","authorizations":[{"applicationId":"7d312290-28c8-473c-a0ed-8e53749b6d6d","roleDefinitionId":"5cb87f79-a7c3-4a95-9414-45b65974b51b"}],"resourceTypes":[{"resourceType":"accounts","locations":["Global","Australia
+        East","Brazil South","West US","West US 2","West Europe","North Europe","Southeast
+        Asia","East Asia","West Central US","South Central US","East US","East US
+        2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"operations","locations":["Global","Australia
         East","Brazil South","West US","West US 2","West Europe","North Europe","Southeast
         Asia","East Asia","West Central US","South Central US","East US","East US
         2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations","locations":["Global","Australia
@@ -1534,13 +1608,13 @@ http_interactions:
         US","West US","Australia East","West Europe","North Europe","Southeast Asia","West
         Central US"],"apiVersions":["2016-03-30","2015-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataFactory","namespace":"Microsoft.DataFactory","resourceTypes":[{"resourceType":"dataFactories","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview","2014-04-01"]},{"resourceType":"factories","locations":["East
-        US"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
-        US"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
+        US","East US 2"],"apiVersions":["2017-09-01-preview","2017-03-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
+        US","East US 2"],"apiVersions":["2017-09-01-preview","2017-03-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
         Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"dataFactories/metricDefinitions","locations":["North
         Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"checkDataFactoryNameAvailability","locations":[],"apiVersions":["2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"checkAzureDataFactoryNameAvailability","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"dataFactorySchema","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"operations","locations":["West
-        US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeAnalytics","namespace":"Microsoft.DataLakeAnalytics","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US","North Europe","East US","West Central US"],"apiVersions":["2017-09-01-preview","2017-03-01-preview","2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeAnalytics","namespace":"Microsoft.DataLakeAnalytics","resourceTypes":[{"resourceType":"accounts","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/dataLakeStoreAccounts","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers","locations":["East
@@ -1589,11 +1663,12 @@ http_interactions:
         India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
         India","East Asia","East US 2","East US","Japan East","Japan West","North
         Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"checkProvisioningServiceNameAvailability","locations":[],"apiVersions":["2017-08-21-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
         US","North Europe","East Asia","East US","West Europe","Southeast Asia","Japan
         East","Japan West","Australia East","Australia Southeast","West US 2","West
         Central US","East US 2","Central US","UK South","UK West","South India","Central
-        India"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
+        India","Canada Central","Canada East"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"ProvisioningServices","locations":["East
+        US","West Europe","Southeast Asia"],"apiVersions":["2017-08-21-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
         East","Australia Southeast","Canada Central","Canada East","Central India","Central
         US","East Asia","East US","East US 2","Japan East","Japan West","North Central
         US","North Europe","South Central US","South India","Southeast Asia","West
@@ -1620,16 +1695,16 @@ http_interactions:
         US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"operations","locations":["Brazil
         South","East Asia","East US","Japan East","Japan West","North Central US","North
         Europe","South Central US","West Europe","West US","Southeast Asia","Central
-        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"topics","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operations","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topics","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operations","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","West
         US 2","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
@@ -1727,48 +1802,39 @@ http_interactions:
         Central US","West Europe","Southeast Asia","Japan East","East US 2","West
         Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"commitmentPlans","locations":["South
         Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
-        Central US","West US"],"apiVersions":["2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Media","namespace":"Microsoft.Media","authorization":{"applicationId":"374b2a64-3b6b-436b-934c-b820eacca870","roleDefinitionId":"aab70789-0cec-44b5-95d7-84b64c9487af"},"resourceTypes":[{"resourceType":"mediaservices","locations":["Japan
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningExperimentation","namespace":"Microsoft.MachineLearningExperimentation","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"accounts","locations":["Australia
+        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces","locations":["Australia
+        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces/projects","locations":["Australia
+        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningCompute","namespace":"Microsoft.MachineLearningCompute","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"376aa7d7-51a9-463d-bd4d-7e1691345612","managedByRoleDefinitionId":"91d00862-cf55-46a5-9dce-260bbd92ce25"},"resourceTypes":[{"resourceType":"operationalizationClusters","locations":["East
+        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"operations","locations":["East
+        US 2"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations","locations":["East
+        US 2"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["East
+        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningModelManagement","namespace":"Microsoft.MachineLearningModelManagement","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US 2","West Central US","Australia East"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"operations","locations":["West
+        Central US"],"apiVersions":["2017-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
+        Central US","West US"],"apiVersions":["2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01"]},{"resourceType":"offertypes","locations":["South
+        Central US","West US"],"apiVersions":["2015-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Media","namespace":"Microsoft.Media","authorization":{"applicationId":"374b2a64-3b6b-436b-934c-b820eacca870","roleDefinitionId":"aab70789-0cec-44b5-95d7-84b64c9487af"},"resourceTypes":[{"resourceType":"mediaservices","locations":["Japan
         West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
         US","West US","Australia East","Australia Southeast","Central US","Brazil
         South","Central India","West India","South India","South Central US","Canada
-        Central","Canada East","West Central US"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
+        Central","Canada East","West Central US"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
         Central US","North Central US","East US 2","West US","West Europe","North
         Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
         East","UK South","West India"],"apiVersions":["2016-01-29"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-01-29"]},{"resourceType":"locations/checkNameAvailability","locations":["South
         Central US","North Central US","East US 2","West US","West Europe","North
         Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
-        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"operations","locations":["East
+        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"capacities","locations":["West
+        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
+        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationresults","locations":["West
+        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
+        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"operations","locations":["East
         US 2"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Relay","namespace":"Microsoft.Relay","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US 2","West
         US","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
         India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2017-08-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkPolicyCompliance","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
@@ -1827,8 +1893,11 @@ http_interactions:
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","resourceTypes":[{"resourceType":"operations","locations":["West
-        Central US"],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
+        Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applianceDefinitions","locations":["West
+        Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"locations","locations":["West
+        Central US"],"apiVersions":["2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
+        Central US"],"apiVersions":["2017-09-01","2016-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","West Central US","Japan East","Japan West","Australia East","Australia
         Southeast"],"apiVersions":["2017-06-01","2017-05-15","2017-01-01","2016-10-01","2016-06-01","2015-03-15","2014-09-01"]},{"resourceType":"operations","locations":["West
@@ -1888,11 +1957,17 @@ http_interactions:
         US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RedisLabs.Memcached","namespace":"RedisLabs.Memcached","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-07-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RedisLabs.Redis","namespace":"RedisLabs.Redis","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-07-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RevAPM.MobileCDN","namespace":"RevAPM.MobileCDN","resourceTypes":[{"resourceType":"accounts","locations":["Central
         US","East US","East US 2","North Central US","South Central US","West US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
-        East","Australia Southeast"],"apiVersions":["2016-08-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-24","2016-08-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sendgrid.Email","namespace":"Sendgrid.Email","resourceTypes":[{"resourceType":"accounts","locations":["East
-        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
-        Central US","Central US","North Europe","West Europe","Japan East","Japan
-        West","Brazil South","Australia East","Australia Southeast","Canada Central","Canada
-        East","West Central US","West US 2","UK South","UK West"],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Signiant.Flight","namespace":"Signiant.Flight","resourceTypes":[{"resourceType":"accounts","locations":["East
+        East","Australia Southeast"],"apiVersions":["2016-08-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-24","2016-08-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sendgrid.Email","namespace":"Sendgrid.Email","resourceTypes":[{"resourceType":"accounts","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Signiant.Flight","namespace":"Signiant.Flight","resourceTypes":[{"resourceType":"accounts","locations":["East
         US","Central US","North Central US","South Central US","West US","North Europe","West
         Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast"],"apiVersions":["2015-06-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sparkpost.Basic","namespace":"Sparkpost.Basic","resourceTypes":[{"resourceType":"services","locations":["West
@@ -1909,7 +1984,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:21 GMT
+  recorded_at: Fri, 22 Sep 2017 21:42:32 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
@@ -1926,11 +2001,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NjIsIm5iZiI6MTUwNDY0MTU2MiwiZXhwIjoxNTA0NjQ1NDYyLCJhaW8iOiJZMkZnWUtoM2VQM3Q5dDIraWVxR3AyMU8vejR3RlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiN1oyYXV2anpka2FXN001YWo0a2VBQSIsInZlciI6IjEuMCJ9.rqANytszMqCZTWjs_0cHWBNyWPPba-u-48XYLvlOo9IXf5ld3_MSknmz7QTWq1xXq97Zl_8dS-I8aFEVVwZIFFGw89FSQyxCOFdpzpj0zehB-ZNnd91LGvmTxX9DMriRM3UV4rsXjvRr5TfGHmdVP3ZCB5tGqv3Tvi_1dSenX2lfn6sjXERmgGArmg3FahEOdSVd0zunSuYruDNTRw1uk3uNWkZ7KzdvQ871el2UHaeTLlIcB_RJWXeIsNnh5jtonkF3Kp5zETLjRBVfLbKJyN9H1xmNHFMtstW8pkGeylljIRp_T0ACdJXACXeDevy1LkWmujyacIdMMUo7xJ_ZVQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNTEsIm5iZiI6MTUwNjExNjI1MSwiZXhwIjoxNTA2MTIwMTUxLCJhaW8iOiJZMlZnWUxnV3ZNR2haN3JqaENYWDZqZFBmcVp3RlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQWVfNjVva2FWMHFncVRPelNJRU1BQSIsInZlciI6IjEuMCJ9.yzoeDCrqx6h9nl-b6GtfmDyJbotu_2GBJu-ip3XG01YchUdtta9kywHCIj3lJYb4R5vXZEQPNg9M0bpMuy_rjlMLEWMcFxFU8iocbWvIm1JHj67MsPUQn-01Rl6sIvWrHA_qiKjv4RzfIECHmA6lY9zxpjLywyLjvlC8_zyME4-3AHUoy0felmuv7nWwCUXS4UhWtQkwNzNv5jIoBUb3hWFa5S-GNkgsrUwPgu0S-Y6AfGM58eXZgmPLCJwHrkXQiDcbc7qpncDb06snvYrQVwNHYXKe0QIlAmDEB4kaqJmrPyTRky_GCV63g5lfionsieQSEaKMl4xqchA0MGu36w
       Content-Length:
       - '42'
-      Host:
-      - management.azure.com
   response:
     status:
       code: 202
@@ -1945,34 +2018,34 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/67fb0f39-d862-4792-80b8-4d0feb8d28ec?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/4a0c2863-3b65-416f-b65a-3a178db4140c?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/67fb0f39-d862-4792-80b8-4d0feb8d28ec?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/4a0c2863-3b65-416f-b65a-3a178db4140c?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - 67fb0f39-d862-4792-80b8-4d0feb8d28ec
+      - 4a0c2863-3b65-416f-b65a-3a178db4140c
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1194'
+      - '1185'
       X-Ms-Correlation-Request-Id:
-      - 550ae060-70e2-4e2e-8900-a83475525cfd
+      - 31a56b3f-6742-44a1-948e-8022efc8eadd
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200424Z:550ae060-70e2-4e2e-8900-a83475525cfd
+      - WESTUS:20170922T214234Z:31a56b3f-6742-44a1-948e-8022efc8eadd
       Date:
-      - Tue, 05 Sep 2017 20:04:24 GMT
+      - Fri, 22 Sep 2017 21:42:34 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:22 GMT
+  recorded_at: Fri, 22 Sep 2017 21:42:33 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/67fb0f39-d862-4792-80b8-4d0feb8d28ec?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/4a0c2863-3b65-416f-b65a-3a178db4140c?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -1986,9 +2059,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NjIsIm5iZiI6MTUwNDY0MTU2MiwiZXhwIjoxNTA0NjQ1NDYyLCJhaW8iOiJZMkZnWUtoM2VQM3Q5dDIraWVxR3AyMU8vejR3RlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiN1oyYXV2anpka2FXN001YWo0a2VBQSIsInZlciI6IjEuMCJ9.rqANytszMqCZTWjs_0cHWBNyWPPba-u-48XYLvlOo9IXf5ld3_MSknmz7QTWq1xXq97Zl_8dS-I8aFEVVwZIFFGw89FSQyxCOFdpzpj0zehB-ZNnd91LGvmTxX9DMriRM3UV4rsXjvRr5TfGHmdVP3ZCB5tGqv3Tvi_1dSenX2lfn6sjXERmgGArmg3FahEOdSVd0zunSuYruDNTRw1uk3uNWkZ7KzdvQ871el2UHaeTLlIcB_RJWXeIsNnh5jtonkF3Kp5zETLjRBVfLbKJyN9H1xmNHFMtstW8pkGeylljIRp_T0ACdJXACXeDevy1LkWmujyacIdMMUo7xJ_ZVQ
-      Host:
-      - management.azure.com
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNTEsIm5iZiI6MTUwNjExNjI1MSwiZXhwIjoxNTA2MTIwMTUxLCJhaW8iOiJZMlZnWUxnV3ZNR2haN3JqaENYWDZqZFBmcVp3RlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQWVfNjVva2FWMHFncVRPelNJRU1BQSIsInZlciI6IjEuMCJ9.yzoeDCrqx6h9nl-b6GtfmDyJbotu_2GBJu-ip3XG01YchUdtta9kywHCIj3lJYb4R5vXZEQPNg9M0bpMuy_rjlMLEWMcFxFU8iocbWvIm1JHj67MsPUQn-01Rl6sIvWrHA_qiKjv4RzfIECHmA6lY9zxpjLywyLjvlC8_zyME4-3AHUoy0felmuv7nWwCUXS4UhWtQkwNzNv5jIoBUb3hWFa5S-GNkgsrUwPgu0S-Y6AfGM58eXZgmPLCJwHrkXQiDcbc7qpncDb06snvYrQVwNHYXKe0QIlAmDEB4kaqJmrPyTRky_GCV63g5lfionsieQSEaKMl4xqchA0MGu36w
   response:
     status:
       code: 200
@@ -2009,31 +2080,90 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - 034c95b0-df95-40e3-83bb-3b89e2576679
+      - eef11316-2ad5-4ff7-a8cb-cc9a836a6a69
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14913'
       X-Ms-Correlation-Request-Id:
-      - 76f16eea-b8d9-4465-9880-0cfb427075cf
+      - 4cbeb191-cdc4-4114-974f-fd25a5718bb6
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200425Z:76f16eea-b8d9-4465-9880-0cfb427075cf
+      - WESTUS:20170922T214235Z:4cbeb191-cdc4-4114-974f-fd25a5718bb6
       Date:
-      - Tue, 05 Sep 2017 20:04:24 GMT
+      - Fri, 22 Sep 2017 21:42:34 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-05T20:04:23.6086826+00:00\",\r\n  \"endTime\":
-        \"2017-09-05T20:04:23.8117968+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=69778812-5d85-431e-99ca-742ba2cafecc&sig=%2FMzAGcNfJT7IDhfdQfE06leSefkUIcCCPTRw%2B3LFSY8%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"67fb0f39-d862-4792-80b8-4d0feb8d28ec\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2017-09-22T21:42:35.8383046+00:00\",\r\n  \"endTime\":
+        \"2017-09-22T21:42:36.0570674+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=ea7f51ca-94cc-4b22-a944-7d1201dce37e&sig=XABfazFRzmWVlCzOZJVLNDF%2BCgQtDUE1J9y9YqJaZAg%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"4a0c2863-3b65-416f-b65a-3a178db4140c\"\r\n}"
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:22 GMT
+  recorded_at: Fri, 22 Sep 2017 21:42:34 GMT
 - request:
     method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=69778812-5d85-431e-99ca-742ba2cafecc&sig=/MzAGcNfJT7IDhfdQfE06leSefkUIcCCPTRw%2B3LFSY8=&sr=b&sv=2016-05-31
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/4a0c2863-3b65-416f-b65a-3a178db4140c?api-version=2017-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNTEsIm5iZiI6MTUwNjExNjI1MSwiZXhwIjoxNTA2MTIwMTUxLCJhaW8iOiJZMlZnWUxnV3ZNR2haN3JqaENYWDZqZFBmcVp3RlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQWVfNjVva2FWMHFncVRPelNJRU1BQSIsInZlciI6IjEuMCJ9.yzoeDCrqx6h9nl-b6GtfmDyJbotu_2GBJu-ip3XG01YchUdtta9kywHCIj3lJYb4R5vXZEQPNg9M0bpMuy_rjlMLEWMcFxFU8iocbWvIm1JHj67MsPUQn-01Rl6sIvWrHA_qiKjv4RzfIECHmA6lY9zxpjLywyLjvlC8_zyME4-3AHUoy0felmuv7nWwCUXS4UhWtQkwNzNv5jIoBUb3hWFa5S-GNkgsrUwPgu0S-Y6AfGM58eXZgmPLCJwHrkXQiDcbc7qpncDb06snvYrQVwNHYXKe0QIlAmDEB4kaqJmrPyTRky_GCV63g5lfionsieQSEaKMl4xqchA0MGu36w
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
+      X-Ms-Request-Id:
+      - f18c5793-071a-46fc-94ca-382fc78d61fa
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14923'
+      X-Ms-Correlation-Request-Id:
+      - aac6c222-5dbc-48a7-864e-93e84d18a1cf
+      X-Ms-Routing-Request-Id:
+      - WESTUS:20170922T214235Z:aac6c222-5dbc-48a7-864e-93e84d18a1cf
+      Date:
+      - Fri, 22 Sep 2017 21:42:35 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"startTime\": \"2017-09-22T21:42:35.8383046+00:00\",\r\n  \"endTime\":
+        \"2017-09-22T21:42:36.0570674+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=ea7f51ca-94cc-4b22-a944-7d1201dce37e&sig=XABfazFRzmWVlCzOZJVLNDF%2BCgQtDUE1J9y9YqJaZAg%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"4a0c2863-3b65-416f-b65a-3a178db4140c\"\r\n}"
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 21:42:34 GMT
+- request:
+    method: get
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=ea7f51ca-94cc-4b22-a944-7d1201dce37e&sig=XABfazFRzmWVlCzOZJVLNDF%2BCgQtDUE1J9y9YqJaZAg=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2046,8 +2176,6 @@ http_interactions:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
       X-Ms-Range:
       - bytes=0-0
-      Host:
-      - md-t4jdgqqlgszp.blob.core.windows.net
   response:
     status:
       code: 206
@@ -2068,7 +2196,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 7870848a-001e-0045-3782-267cbc000000
+      - b1326ac1-001e-00bf-55eb-33b55b000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2094,13 +2222,13 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Tue, 05 Sep 2017 20:04:24 GMT
+      - Fri, 22 Sep 2017 21:42:35 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         6w==
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:22 GMT
+  recorded_at: Fri, 22 Sep 2017 21:42:35 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/EndGetAccess?api-version=2017-03-30
@@ -2117,11 +2245,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NjIsIm5iZiI6MTUwNDY0MTU2MiwiZXhwIjoxNTA0NjQ1NDYyLCJhaW8iOiJZMkZnWUtoM2VQM3Q5dDIraWVxR3AyMU8vejR3RlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiN1oyYXV2anpka2FXN001YWo0a2VBQSIsInZlciI6IjEuMCJ9.rqANytszMqCZTWjs_0cHWBNyWPPba-u-48XYLvlOo9IXf5ld3_MSknmz7QTWq1xXq97Zl_8dS-I8aFEVVwZIFFGw89FSQyxCOFdpzpj0zehB-ZNnd91LGvmTxX9DMriRM3UV4rsXjvRr5TfGHmdVP3ZCB5tGqv3Tvi_1dSenX2lfn6sjXERmgGArmg3FahEOdSVd0zunSuYruDNTRw1uk3uNWkZ7KzdvQ871el2UHaeTLlIcB_RJWXeIsNnh5jtonkF3Kp5zETLjRBVfLbKJyN9H1xmNHFMtstW8pkGeylljIRp_T0ACdJXACXeDevy1LkWmujyacIdMMUo7xJ_ZVQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNTEsIm5iZiI6MTUwNjExNjI1MSwiZXhwIjoxNTA2MTIwMTUxLCJhaW8iOiJZMlZnWUxnV3ZNR2haN3JqaENYWDZqZFBmcVp3RlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQWVfNjVva2FWMHFncVRPelNJRU1BQSIsInZlciI6IjEuMCJ9.yzoeDCrqx6h9nl-b6GtfmDyJbotu_2GBJu-ip3XG01YchUdtta9kywHCIj3lJYb4R5vXZEQPNg9M0bpMuy_rjlMLEWMcFxFU8iocbWvIm1JHj67MsPUQn-01Rl6sIvWrHA_qiKjv4RzfIECHmA6lY9zxpjLywyLjvlC8_zyME4-3AHUoy0felmuv7nWwCUXS4UhWtQkwNzNv5jIoBUb3hWFa5S-GNkgsrUwPgu0S-Y6AfGM58eXZgmPLCJwHrkXQiDcbc7qpncDb06snvYrQVwNHYXKe0QIlAmDEB4kaqJmrPyTRky_GCV63g5lfionsieQSEaKMl4xqchA0MGu36w
       Content-Length:
       - '0'
-      Host:
-      - management.azure.com
   response:
     status:
       code: 202
@@ -2136,31 +2262,31 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/5a41c623-76c1-462e-b378-2c058e34cf0b?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/1410599e-84ce-4711-b867-3cbf4e36754f?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/5a41c623-76c1-462e-b378-2c058e34cf0b?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/1410599e-84ce-4711-b867-3cbf4e36754f?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - 5a41c623-76c1-462e-b378-2c058e34cf0b
+      - 1410599e-84ce-4711-b867-3cbf4e36754f
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1189'
+      - '1183'
       X-Ms-Correlation-Request-Id:
-      - 820b2e89-fc3b-45de-8de7-7e7756b61aa4
+      - 5188bf09-9e1d-495b-95d9-9c6ef7eedca4
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200425Z:820b2e89-fc3b-45de-8de7-7e7756b61aa4
+      - WESTUS:20170922T214236Z:5188bf09-9e1d-495b-95d9-9c6ef7eedca4
       Date:
-      - Tue, 05 Sep 2017 20:04:25 GMT
+      - Fri, 22 Sep 2017 21:42:36 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:23 GMT
+  recorded_at: Fri, 22 Sep 2017 21:42:35 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
@@ -2177,11 +2303,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NjIsIm5iZiI6MTUwNDY0MTU2MiwiZXhwIjoxNTA0NjQ1NDYyLCJhaW8iOiJZMkZnWUtoM2VQM3Q5dDIraWVxR3AyMU8vejR3RlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiN1oyYXV2anpka2FXN001YWo0a2VBQSIsInZlciI6IjEuMCJ9.rqANytszMqCZTWjs_0cHWBNyWPPba-u-48XYLvlOo9IXf5ld3_MSknmz7QTWq1xXq97Zl_8dS-I8aFEVVwZIFFGw89FSQyxCOFdpzpj0zehB-ZNnd91LGvmTxX9DMriRM3UV4rsXjvRr5TfGHmdVP3ZCB5tGqv3Tvi_1dSenX2lfn6sjXERmgGArmg3FahEOdSVd0zunSuYruDNTRw1uk3uNWkZ7KzdvQ871el2UHaeTLlIcB_RJWXeIsNnh5jtonkF3Kp5zETLjRBVfLbKJyN9H1xmNHFMtstW8pkGeylljIRp_T0ACdJXACXeDevy1LkWmujyacIdMMUo7xJ_ZVQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNTEsIm5iZiI6MTUwNjExNjI1MSwiZXhwIjoxNTA2MTIwMTUxLCJhaW8iOiJZMlZnWUxnV3ZNR2haN3JqaENYWDZqZFBmcVp3RlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQWVfNjVva2FWMHFncVRPelNJRU1BQSIsInZlciI6IjEuMCJ9.yzoeDCrqx6h9nl-b6GtfmDyJbotu_2GBJu-ip3XG01YchUdtta9kywHCIj3lJYb4R5vXZEQPNg9M0bpMuy_rjlMLEWMcFxFU8iocbWvIm1JHj67MsPUQn-01Rl6sIvWrHA_qiKjv4RzfIECHmA6lY9zxpjLywyLjvlC8_zyME4-3AHUoy0felmuv7nWwCUXS4UhWtQkwNzNv5jIoBUb3hWFa5S-GNkgsrUwPgu0S-Y6AfGM58eXZgmPLCJwHrkXQiDcbc7qpncDb06snvYrQVwNHYXKe0QIlAmDEB4kaqJmrPyTRky_GCV63g5lfionsieQSEaKMl4xqchA0MGu36w
       Content-Length:
       - '42'
-      Host:
-      - management.azure.com
   response:
     status:
       code: 202
@@ -2196,34 +2320,34 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/ed8018e0-6e7c-4948-9159-3de68578f7a2?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/16e4e359-1754-41ab-bd6e-b62ac7bf805e?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/ed8018e0-6e7c-4948-9159-3de68578f7a2?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/16e4e359-1754-41ab-bd6e-b62ac7bf805e?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - ed8018e0-6e7c-4948-9159-3de68578f7a2
+      - 16e4e359-1754-41ab-bd6e-b62ac7bf805e
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1185'
+      - '1183'
       X-Ms-Correlation-Request-Id:
-      - 9dc6e558-abbe-44f6-a063-a2b4b7838635
+      - 10063a85-2416-4699-8112-8e354f43726f
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200425Z:9dc6e558-abbe-44f6-a063-a2b4b7838635
+      - WESTUS:20170922T214237Z:10063a85-2416-4699-8112-8e354f43726f
       Date:
-      - Tue, 05 Sep 2017 20:04:24 GMT
+      - Fri, 22 Sep 2017 21:42:36 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:23 GMT
+  recorded_at: Fri, 22 Sep 2017 21:42:36 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/ed8018e0-6e7c-4948-9159-3de68578f7a2?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/16e4e359-1754-41ab-bd6e-b62ac7bf805e?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -2237,9 +2361,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NjIsIm5iZiI6MTUwNDY0MTU2MiwiZXhwIjoxNTA0NjQ1NDYyLCJhaW8iOiJZMkZnWUtoM2VQM3Q5dDIraWVxR3AyMU8vejR3RlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiN1oyYXV2anpka2FXN001YWo0a2VBQSIsInZlciI6IjEuMCJ9.rqANytszMqCZTWjs_0cHWBNyWPPba-u-48XYLvlOo9IXf5ld3_MSknmz7QTWq1xXq97Zl_8dS-I8aFEVVwZIFFGw89FSQyxCOFdpzpj0zehB-ZNnd91LGvmTxX9DMriRM3UV4rsXjvRr5TfGHmdVP3ZCB5tGqv3Tvi_1dSenX2lfn6sjXERmgGArmg3FahEOdSVd0zunSuYruDNTRw1uk3uNWkZ7KzdvQ871el2UHaeTLlIcB_RJWXeIsNnh5jtonkF3Kp5zETLjRBVfLbKJyN9H1xmNHFMtstW8pkGeylljIRp_T0ACdJXACXeDevy1LkWmujyacIdMMUo7xJ_ZVQ
-      Host:
-      - management.azure.com
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNTEsIm5iZiI6MTUwNjExNjI1MSwiZXhwIjoxNTA2MTIwMTUxLCJhaW8iOiJZMlZnWUxnV3ZNR2haN3JqaENYWDZqZFBmcVp3RlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQWVfNjVva2FWMHFncVRPelNJRU1BQSIsInZlciI6IjEuMCJ9.yzoeDCrqx6h9nl-b6GtfmDyJbotu_2GBJu-ip3XG01YchUdtta9kywHCIj3lJYb4R5vXZEQPNg9M0bpMuy_rjlMLEWMcFxFU8iocbWvIm1JHj67MsPUQn-01Rl6sIvWrHA_qiKjv4RzfIECHmA6lY9zxpjLywyLjvlC8_zyME4-3AHUoy0felmuv7nWwCUXS4UhWtQkwNzNv5jIoBUb3hWFa5S-GNkgsrUwPgu0S-Y6AfGM58eXZgmPLCJwHrkXQiDcbc7qpncDb06snvYrQVwNHYXKe0QIlAmDEB4kaqJmrPyTRky_GCV63g5lfionsieQSEaKMl4xqchA0MGu36w
   response:
     status:
       code: 200
@@ -2260,31 +2382,90 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - 892f25d3-7d06-4eab-a8a8-cff341fd0315
+      - a1a64b8e-0a5e-4d4f-b42c-c313b69fd055
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14950'
+      - '14928'
       X-Ms-Correlation-Request-Id:
-      - bf6f43f3-3aee-4960-8a75-f67ec2118edf
+      - d3ff3779-7b7a-42dc-84f3-59899702e675
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200426Z:bf6f43f3-3aee-4960-8a75-f67ec2118edf
+      - WESTUS:20170922T214238Z:d3ff3779-7b7a-42dc-84f3-59899702e675
       Date:
-      - Tue, 05 Sep 2017 20:04:25 GMT
+      - Fri, 22 Sep 2017 21:42:37 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-05T20:04:24.5995416+00:00\",\r\n  \"endTime\":
-        \"2017-09-05T20:04:24.7719839+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=f417f74d-8d52-4b61-80fe-53acd3f820f1&sig=dLYNi1R88aNHltKEFZDEbu%2B7berg%2ByBB0%2BhwmVIe4Ls%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"ed8018e0-6e7c-4948-9159-3de68578f7a2\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2017-09-22T21:42:38.7452672+00:00\",\r\n  \"endTime\":
+        \"2017-09-22T21:42:38.9640627+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=ecd23b31-3157-4872-9b2d-bed4826624f0&sig=iulVige61e9ofaQPJbKxWQQJIrQIp7787w1Q25UfWyw%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"16e4e359-1754-41ab-bd6e-b62ac7bf805e\"\r\n}"
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:23 GMT
+  recorded_at: Fri, 22 Sep 2017 21:42:37 GMT
 - request:
     method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=f417f74d-8d52-4b61-80fe-53acd3f820f1&sig=dLYNi1R88aNHltKEFZDEbu%2B7berg%2ByBB0%2BhwmVIe4Ls=&sr=b&sv=2016-05-31
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/16e4e359-1754-41ab-bd6e-b62ac7bf805e?api-version=2017-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNTEsIm5iZiI6MTUwNjExNjI1MSwiZXhwIjoxNTA2MTIwMTUxLCJhaW8iOiJZMlZnWUxnV3ZNR2haN3JqaENYWDZqZFBmcVp3RlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQWVfNjVva2FWMHFncVRPelNJRU1BQSIsInZlciI6IjEuMCJ9.yzoeDCrqx6h9nl-b6GtfmDyJbotu_2GBJu-ip3XG01YchUdtta9kywHCIj3lJYb4R5vXZEQPNg9M0bpMuy_rjlMLEWMcFxFU8iocbWvIm1JHj67MsPUQn-01Rl6sIvWrHA_qiKjv4RzfIECHmA6lY9zxpjLywyLjvlC8_zyME4-3AHUoy0felmuv7nWwCUXS4UhWtQkwNzNv5jIoBUb3hWFa5S-GNkgsrUwPgu0S-Y6AfGM58eXZgmPLCJwHrkXQiDcbc7qpncDb06snvYrQVwNHYXKe0QIlAmDEB4kaqJmrPyTRky_GCV63g5lfionsieQSEaKMl4xqchA0MGu36w
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
+      X-Ms-Request-Id:
+      - 38d8ea10-b71e-44c8-a354-96228b7a1e82
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14939'
+      X-Ms-Correlation-Request-Id:
+      - 072fad29-5aab-4597-9bc2-d84ac7cbdbee
+      X-Ms-Routing-Request-Id:
+      - WESTUS:20170922T214238Z:072fad29-5aab-4597-9bc2-d84ac7cbdbee
+      Date:
+      - Fri, 22 Sep 2017 21:42:38 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"startTime\": \"2017-09-22T21:42:38.7452672+00:00\",\r\n  \"endTime\":
+        \"2017-09-22T21:42:38.9640627+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=ecd23b31-3157-4872-9b2d-bed4826624f0&sig=iulVige61e9ofaQPJbKxWQQJIrQIp7787w1Q25UfWyw%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"16e4e359-1754-41ab-bd6e-b62ac7bf805e\"\r\n}"
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 21:42:38 GMT
+- request:
+    method: get
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=ecd23b31-3157-4872-9b2d-bed4826624f0&sig=iulVige61e9ofaQPJbKxWQQJIrQIp7787w1Q25UfWyw=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2297,8 +2478,6 @@ http_interactions:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
       X-Ms-Range:
       - bytes=440-443
-      Host:
-      - md-t4jdgqqlgszp.blob.core.windows.net
   response:
     status:
       code: 206
@@ -2319,7 +2498,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - c8892220-001e-003e-3882-26170c000000
+      - 1ffd947e-001e-010a-25eb-33fef1000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2345,13 +2524,13 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Tue, 05 Sep 2017 20:04:25 GMT
+      - Fri, 22 Sep 2017 21:42:38 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         U5MJAA==
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:23 GMT
+  recorded_at: Fri, 22 Sep 2017 21:42:38 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/EndGetAccess?api-version=2017-03-30
@@ -2368,11 +2547,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NjIsIm5iZiI6MTUwNDY0MTU2MiwiZXhwIjoxNTA0NjQ1NDYyLCJhaW8iOiJZMkZnWUtoM2VQM3Q5dDIraWVxR3AyMU8vejR3RlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiN1oyYXV2anpka2FXN001YWo0a2VBQSIsInZlciI6IjEuMCJ9.rqANytszMqCZTWjs_0cHWBNyWPPba-u-48XYLvlOo9IXf5ld3_MSknmz7QTWq1xXq97Zl_8dS-I8aFEVVwZIFFGw89FSQyxCOFdpzpj0zehB-ZNnd91LGvmTxX9DMriRM3UV4rsXjvRr5TfGHmdVP3ZCB5tGqv3Tvi_1dSenX2lfn6sjXERmgGArmg3FahEOdSVd0zunSuYruDNTRw1uk3uNWkZ7KzdvQ871el2UHaeTLlIcB_RJWXeIsNnh5jtonkF3Kp5zETLjRBVfLbKJyN9H1xmNHFMtstW8pkGeylljIRp_T0ACdJXACXeDevy1LkWmujyacIdMMUo7xJ_ZVQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNTEsIm5iZiI6MTUwNjExNjI1MSwiZXhwIjoxNTA2MTIwMTUxLCJhaW8iOiJZMlZnWUxnV3ZNR2haN3JqaENYWDZqZFBmcVp3RlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQWVfNjVva2FWMHFncVRPelNJRU1BQSIsInZlciI6IjEuMCJ9.yzoeDCrqx6h9nl-b6GtfmDyJbotu_2GBJu-ip3XG01YchUdtta9kywHCIj3lJYb4R5vXZEQPNg9M0bpMuy_rjlMLEWMcFxFU8iocbWvIm1JHj67MsPUQn-01Rl6sIvWrHA_qiKjv4RzfIECHmA6lY9zxpjLywyLjvlC8_zyME4-3AHUoy0felmuv7nWwCUXS4UhWtQkwNzNv5jIoBUb3hWFa5S-GNkgsrUwPgu0S-Y6AfGM58eXZgmPLCJwHrkXQiDcbc7qpncDb06snvYrQVwNHYXKe0QIlAmDEB4kaqJmrPyTRky_GCV63g5lfionsieQSEaKMl4xqchA0MGu36w
       Content-Length:
       - '0'
-      Host:
-      - management.azure.com
   response:
     status:
       code: 202
@@ -2387,29 +2564,29 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/d86ab3a5-7d13-41bb-aa40-3df29a35b784?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/239777ed-b55a-4216-ae05-deae75ec3404?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/d86ab3a5-7d13-41bb-aa40-3df29a35b784?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/239777ed-b55a-4216-ae05-deae75ec3404?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - d86ab3a5-7d13-41bb-aa40-3df29a35b784
+      - 239777ed-b55a-4216-ae05-deae75ec3404
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1193'
+      - '1185'
       X-Ms-Correlation-Request-Id:
-      - cd84830b-d5b6-4191-b77d-cf2e02eb4c51
+      - 7c80fd65-86f4-48b4-978d-e3f1800557a5
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200426Z:cd84830b-d5b6-4191-b77d-cf2e02eb4c51
+      - WESTUS:20170922T214239Z:7c80fd65-86f4-48b4-978d-e3f1800557a5
       Date:
-      - Tue, 05 Sep 2017 20:04:26 GMT
+      - Fri, 22 Sep 2017 21:42:39 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:23 GMT
+  recorded_at: Fri, 22 Sep 2017 21:42:39 GMT
 recorded_with: VCR 3.0.3

--- a/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_startByteAddr-1.yml
+++ b/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_startByteAddr-1.yml
@@ -17,8 +17,6 @@ http_interactions:
       - '186'
       Content-Type:
       - application/x-www-form-urlencoded
-      Host:
-      - login.microsoftonline.com
   response:
     status:
       code: 200
@@ -39,25 +37,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 9a5d2224-6b54-4706-96ad-af364e122000
+      - 48f95e2d-d869-4fe7-8c36-f13c0f0a0d00
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAAA9kTklhVy7SJTGAzR-p1BcEkUGhFYBEefsaCU4z9pu7L1FNxMV8ref6AXY_MhzpLgITD2Es8nHicu9h5KNBS120eejUu_Q0lF4PWb0out62xqAK7DJiy2FZGXuBlasHSBuCddoiyHki4HT3YXfiFMpPVjHtIvRdRsKRrRZtQPma2OFFQa--jzzW048c4VgSzggAA;
+      - esctx=AQABAAAAAAABlDrqfEFlSaui6xnRjX5EwYQxHm0G_qE03nz-XmxlFNDp4oqMZOIr4gb2JPCJ3egC57SGsnb2kVyx18N444Aup3nF3av7UvGhiu6ZU0U2jZtNiT6ib96uHGDpgbMfVK_UDksNX--DLS2S3JatRfzBc_k0ANMv_ctMuzZ9H8DBFTqbyONlYgREUlHm_Nwjx6kgAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=003; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=008; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Tue, 05 Sep 2017 20:04:05 GMT
+      - Fri, 22 Sep 2017 21:42:07 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3600","ext_expires_in":"0","expires_on":"1504645445","not_before":"1504641545","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NDUsIm5iZiI6MTUwNDY0MTU0NSwiZXhwIjoxNTA0NjQ1NDQ1LCJhaW8iOiJZMkZnWURqQkhiTHk3OWFuc3hqNnkwU3NHRzIyQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSkNKZG1sUnJCa2VXcmE4MlRoSWdBQSIsInZlciI6IjEuMCJ9.y1cEoYSbK51hrI6ozDjUEBLzjBfpj23wDp8PADEwf5H92Q1fCREM6Om0WYOc_A5us-i-wL3wzPvX-V62XM0tuu_5K6hND7JqIdwHCB75I11kKgP1B1V1g5kOBKPH_5ZiRqe5glGYya4qHrWpWq7czmDOmzrLHH3F3bGpOToW7ip73p_Vjn1a4rleD8cxlkKIPEH-Hi18TMxP9G4OB5h6YK3re9zM2dvVcmB3dPT9s0mxd1LJh0TqvTigi6LmMrCsdXIM_nv0ZRx1lad26J5d8sre1bkle7ymKnIdOYtOc2d4eT84QnSwy77M1KBvQA7J39Eq_tBrLgdZDH9uh0eClg"}'
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1506120127","not_before":"1506116227","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMjcsIm5iZiI6MTUwNjExNjIyNywiZXhwIjoxNTA2MTIwMTI3LCJhaW8iOiJZMlZnWU5pV0pXUHdMc2ZWM2ZoSVFWajJIT3N5QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTFY3NVNHblk1MC1NTnZFOER3b05BQSIsInZlciI6IjEuMCJ9.qvqsibTj97Wje7DCzUZsV0avjdDT3jRuYQaaD4f6Zx9Nw6quJKnQDC-ifyJGTzLH38kpVmfLEZhClnR-HC2Y7nFMt_MEgpSrE1kOx9ZC3tbRPCp053tqyehRMpwIDaSQaulpJEL2SW-a3uR_4twj7Tck7yGwaA0jT9rV1kEARjo3g-A5P4fVwmf7vhMI-3u4QcBSrxN0JsYO5OufKAiXaECbT1aBUKACVMQzQjhu5w2RJLpS45vFL9y-H8VboQC3XB92D4wGvsYEh1APnSXBPvOpvGt72M-ob_uFHh4q7opWMyKUpDccB7mWtALp3MNCWeTfxyx9misbaWEzPnEhoQ"}'
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:05 GMT
+  recorded_at: Fri, 22 Sep 2017 21:42:06 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -74,9 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NDUsIm5iZiI6MTUwNDY0MTU0NSwiZXhwIjoxNTA0NjQ1NDQ1LCJhaW8iOiJZMkZnWURqQkhiTHk3OWFuc3hqNnkwU3NHRzIyQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSkNKZG1sUnJCa2VXcmE4MlRoSWdBQSIsInZlciI6IjEuMCJ9.y1cEoYSbK51hrI6ozDjUEBLzjBfpj23wDp8PADEwf5H92Q1fCREM6Om0WYOc_A5us-i-wL3wzPvX-V62XM0tuu_5K6hND7JqIdwHCB75I11kKgP1B1V1g5kOBKPH_5ZiRqe5glGYya4qHrWpWq7czmDOmzrLHH3F3bGpOToW7ip73p_Vjn1a4rleD8cxlkKIPEH-Hi18TMxP9G4OB5h6YK3re9zM2dvVcmB3dPT9s0mxd1LJh0TqvTigi6LmMrCsdXIM_nv0ZRx1lad26J5d8sre1bkle7ymKnIdOYtOc2d4eT84QnSwy77M1KBvQA7J39Eq_tBrLgdZDH9uh0eClg
-      Host:
-      - management.azure.com
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMjcsIm5iZiI6MTUwNjExNjIyNywiZXhwIjoxNTA2MTIwMTI3LCJhaW8iOiJZMlZnWU5pV0pXUHdMc2ZWM2ZoSVFWajJIT3N5QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTFY3NVNHblk1MC1NTnZFOER3b05BQSIsInZlciI6IjEuMCJ9.qvqsibTj97Wje7DCzUZsV0avjdDT3jRuYQaaD4f6Zx9Nw6quJKnQDC-ifyJGTzLH38kpVmfLEZhClnR-HC2Y7nFMt_MEgpSrE1kOx9ZC3tbRPCp053tqyehRMpwIDaSQaulpJEL2SW-a3uR_4twj7Tck7yGwaA0jT9rV1kEARjo3g-A5P4fVwmf7vhMI-3u4QcBSrxN0JsYO5OufKAiXaECbT1aBUKACVMQzQjhu5w2RJLpS45vFL9y-H8VboQC3XB92D4wGvsYEh1APnSXBPvOpvGt72M-ob_uFHh4q7opWMyKUpDccB7mWtALp3MNCWeTfxyx9misbaWEzPnEhoQ
   response:
     status:
       code: 200
@@ -95,23 +91,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14997'
+      - '14999'
       X-Ms-Request-Id:
-      - 8cdc79a5-06fb-492f-a981-fe1786780d6e
+      - 5205dab7-0047-42cc-a95f-84bf16dfc828
       X-Ms-Correlation-Request-Id:
-      - 8cdc79a5-06fb-492f-a981-fe1786780d6e
+      - 5205dab7-0047-42cc-a95f-84bf16dfc828
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200406Z:8cdc79a5-06fb-492f-a981-fe1786780d6e
+      - WESTUS:20170922T214207Z:5205dab7-0047-42cc-a95f-84bf16dfc828
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 05 Sep 2017 20:04:06 GMT
+      - Fri, 22 Sep 2017 21:42:07 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:05 GMT
+  recorded_at: Fri, 22 Sep 2017 21:42:06 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/azure_subscription_id/providers?api-version=2015-01-01
@@ -128,9 +124,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NDUsIm5iZiI6MTUwNDY0MTU0NSwiZXhwIjoxNTA0NjQ1NDQ1LCJhaW8iOiJZMkZnWURqQkhiTHk3OWFuc3hqNnkwU3NHRzIyQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSkNKZG1sUnJCa2VXcmE4MlRoSWdBQSIsInZlciI6IjEuMCJ9.y1cEoYSbK51hrI6ozDjUEBLzjBfpj23wDp8PADEwf5H92Q1fCREM6Om0WYOc_A5us-i-wL3wzPvX-V62XM0tuu_5K6hND7JqIdwHCB75I11kKgP1B1V1g5kOBKPH_5ZiRqe5glGYya4qHrWpWq7czmDOmzrLHH3F3bGpOToW7ip73p_Vjn1a4rleD8cxlkKIPEH-Hi18TMxP9G4OB5h6YK3re9zM2dvVcmB3dPT9s0mxd1LJh0TqvTigi6LmMrCsdXIM_nv0ZRx1lad26J5d8sre1bkle7ymKnIdOYtOc2d4eT84QnSwy77M1KBvQA7J39Eq_tBrLgdZDH9uh0eClg
-      Host:
-      - management.azure.com
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMjcsIm5iZiI6MTUwNjExNjIyNywiZXhwIjoxNTA2MTIwMTI3LCJhaW8iOiJZMlZnWU5pV0pXUHdMc2ZWM2ZoSVFWajJIT3N5QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTFY3NVNHblk1MC1NTnZFOER3b05BQSIsInZlciI6IjEuMCJ9.qvqsibTj97Wje7DCzUZsV0avjdDT3jRuYQaaD4f6Zx9Nw6quJKnQDC-ifyJGTzLH38kpVmfLEZhClnR-HC2Y7nFMt_MEgpSrE1kOx9ZC3tbRPCp053tqyehRMpwIDaSQaulpJEL2SW-a3uR_4twj7Tck7yGwaA0jT9rV1kEARjo3g-A5P4fVwmf7vhMI-3u4QcBSrxN0JsYO5OufKAiXaECbT1aBUKACVMQzQjhu5w2RJLpS45vFL9y-H8VboQC3XB92D4wGvsYEh1APnSXBPvOpvGt72M-ob_uFHh4q7opWMyKUpDccB7mWtALp3MNCWeTfxyx9misbaWEzPnEhoQ
   response:
     status:
       code: 200
@@ -147,22 +141,42 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14987'
+      - '14930'
       X-Ms-Request-Id:
-      - 2b16c36a-ff8e-4079-b446-69598719055a
+      - df750db1-3f19-4aea-9baf-094e814f1664
       X-Ms-Correlation-Request-Id:
-      - 2b16c36a-ff8e-4079-b446-69598719055a
+      - df750db1-3f19-4aea-9baf-094e814f1664
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200407Z:2b16c36a-ff8e-4079-b446-69598719055a
+      - WESTUS:20170922T214209Z:df750db1-3f19-4aea-9baf-094e814f1664
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 05 Sep 2017 20:04:07 GMT
+      - Fri, 22 Sep 2017 21:42:08 GMT
       Content-Length:
-      - '243687'
+      - '254785'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
+      string: '{"value":[{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"operations","locations":["West
+        US","Central US","East US","South Central US","West Europe","North Europe","East
+        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
+        Central US","North Central US","Japan East","Japan West","Brazil South","Central
+        India","South India","West India","Canada Central","Canada East","West US
+        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","North Central
         US","South Central US","West Central US","West US","West US 2","Canada Central","Canada
         East","North Europe","West Europe","UK South","UK West","East Asia","Southeast
@@ -437,7 +451,7 @@ http_interactions:
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
         Central US","West US 2","South India","Central India","West India","Canada
-        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
+        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
         East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
@@ -466,7 +480,7 @@ http_interactions:
         Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"}],"resourceTypes":[{"resourceType":"components","locations":["East
         US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
         US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01","2014-04-01"]},{"resourceType":"queries","locations":["East
-        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"alertrules","locations":["West
+        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
@@ -542,7 +556,7 @@ http_interactions:
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorization":{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorizations":[{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},{"applicationId":"7c33bfcb-8d33-48d6-8e60-dc6404003489","roleDefinitionId":"ad6261e4-fa9a-4642-aa5f-104f1b67e9e3"},{"applicationId":"1e3e4475-288f-4018-a376-df66fd7fac5f","roleDefinitionId":"1d538b69-3d87-4e56-8ff8-25786fd48261"},{"applicationId":"a0be0c72-870e-46f0-9c49-c98333a996f7","roleDefinitionId":"7ce22727-ffce-45a9-930c-ddb2e56fa131"}],"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -552,7 +566,7 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -567,7 +581,8 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
+        Central US"],"apiVersions":["2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -577,7 +592,12 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -597,7 +617,7 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -612,7 +632,7 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -622,7 +642,31 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","North
+        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
+        South","Japan East","Japan West","North Europe","West Europe","Central India","South
+        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
         East","UK South","Central India","Canada Central"],"apiVersions":["2017-04-26-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"]},{"resourceType":"workspaces/dataSources","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
@@ -641,17 +685,17 @@ http_interactions:
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"consoles","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/consoles","locations":["West
+        East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"consoles","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/consoles","locations":["West
         US","East US","Central India","North Europe","West Europe","South Central
-        US","Southeast Asia"],"apiVersions":["2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
+        US","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
         US","East US","Central India","North Europe","West Europe","South Central
-        US","Southeast Asia"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
+        US","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","Canada Central","Canada East","West Central US","West US 2","UK South","UK
         West","Korea Central","Korea South"],"apiVersions":["2017-07-01","2016-12-01","2016-08-10","2016-06-01","2016-05-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"operations","locations":["Southeast
-        Asia"],"apiVersions":["2016-08-10","2016-06-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01"]},{"resourceType":"locations/backupStatus","locations":["West
+        Asia"],"apiVersions":["2016-08-10","2016-06-01","2015-12-15","2015-12-10","2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01","2016-06-01"]},{"resourceType":"locations/backupStatus","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
@@ -687,6 +731,7 @@ http_interactions:
         Central US","Central US","North Europe","West Europe","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada Central","Canada East"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"pricings","locations":["Central
+        US","East US"],"apiVersions":["2017-08-01-preview"]},{"resourceType":"securityContacts","locations":["Central
         US","East US"],"apiVersions":["2017-08-01-preview"]},{"resourceType":"workspaceSettings","locations":["Central
         US","East US"],"apiVersions":["2017-08-01-preview"]},{"resourceType":"complianceResults","locations":["Central
         US","East US"],"apiVersions":["2017-08-01"]},{"resourceType":"policies","locations":["Central
@@ -703,6 +748,8 @@ http_interactions:
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatusesSummaries","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/alerts","locations":["Central
         US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/tasks","locations":["Central
+        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"externalSecuritySolutions","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/externalSecuritySolutions","locations":["Central
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.SiteRecovery","namespace":"Microsoft.SiteRecovery","authorization":{"applicationId":"b8340c3b-9267-498f-b21a-15d5547fd85e","roleDefinitionId":"8A00C8EA-8F1B-45A7-8F64-F4CC61EEE9B6"},"resourceTypes":[{"resourceType":"SiteRecoveryVault","locations":["East
         US","West US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","Australia East","Australia Southeast","Brazil South","North
@@ -722,7 +769,7 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -842,7 +889,22 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/databases/transparentDataEncryption","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -1077,6 +1139,26 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
         US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
@@ -1307,6 +1389,11 @@ http_interactions:
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"customApis","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
         East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/managedApis","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
@@ -1358,23 +1445,8 @@ http_interactions:
         US","North Europe","Japan West","Japan East","East Asia","West Europe","East
         US","Southeast Asia","Central US"],"apiVersions":["2016-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Lombiq.DotNest","namespace":"Lombiq.DotNest","resourceTypes":[{"resourceType":"sites","locations":["East
         US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Mailjet.Email","namespace":"Mailjet.Email","resourceTypes":[{"resourceType":"services","locations":["West
-        US"],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
-        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]},{"resourceType":"diagnosticSettings","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
+        US"],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"addsservices","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"configuration","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"operations","locations":["West
@@ -1498,8 +1570,10 @@ http_interactions:
         Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
         Central US","Central US","North Europe","West Europe","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","West
-        India","South India"],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CognitiveServices","namespace":"Microsoft.CognitiveServices","authorizations":[{"applicationId":"7d312290-28c8-473c-a0ed-8e53749b6d6d","roleDefinitionId":"5cb87f79-a7c3-4a95-9414-45b65974b51b"}],"resourceTypes":[{"resourceType":"accounts","locations":["Global","West
-        US","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"operations","locations":["Global","Australia
+        India","South India"],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CognitiveServices","namespace":"Microsoft.CognitiveServices","authorizations":[{"applicationId":"7d312290-28c8-473c-a0ed-8e53749b6d6d","roleDefinitionId":"5cb87f79-a7c3-4a95-9414-45b65974b51b"}],"resourceTypes":[{"resourceType":"accounts","locations":["Global","Australia
+        East","Brazil South","West US","West US 2","West Europe","North Europe","Southeast
+        Asia","East Asia","West Central US","South Central US","East US","East US
+        2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"operations","locations":["Global","Australia
         East","Brazil South","West US","West US 2","West Europe","North Europe","Southeast
         Asia","East Asia","West Central US","South Central US","East US","East US
         2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations","locations":["Global","Australia
@@ -1534,13 +1608,13 @@ http_interactions:
         US","West US","Australia East","West Europe","North Europe","Southeast Asia","West
         Central US"],"apiVersions":["2016-03-30","2015-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataFactory","namespace":"Microsoft.DataFactory","resourceTypes":[{"resourceType":"dataFactories","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview","2014-04-01"]},{"resourceType":"factories","locations":["East
-        US"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
-        US"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
+        US","East US 2"],"apiVersions":["2017-09-01-preview","2017-03-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
+        US","East US 2"],"apiVersions":["2017-09-01-preview","2017-03-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
         Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"dataFactories/metricDefinitions","locations":["North
         Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"checkDataFactoryNameAvailability","locations":[],"apiVersions":["2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"checkAzureDataFactoryNameAvailability","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"dataFactorySchema","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"operations","locations":["West
-        US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeAnalytics","namespace":"Microsoft.DataLakeAnalytics","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US","North Europe","East US","West Central US"],"apiVersions":["2017-09-01-preview","2017-03-01-preview","2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeAnalytics","namespace":"Microsoft.DataLakeAnalytics","resourceTypes":[{"resourceType":"accounts","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/dataLakeStoreAccounts","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers","locations":["East
@@ -1589,11 +1663,12 @@ http_interactions:
         India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
         India","East Asia","East US 2","East US","Japan East","Japan West","North
         Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
+        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"checkProvisioningServiceNameAvailability","locations":[],"apiVersions":["2017-08-21-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
         US","North Europe","East Asia","East US","West Europe","Southeast Asia","Japan
         East","Japan West","Australia East","Australia Southeast","West US 2","West
         Central US","East US 2","Central US","UK South","UK West","South India","Central
-        India"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
+        India","Canada Central","Canada East"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"ProvisioningServices","locations":["East
+        US","West Europe","Southeast Asia"],"apiVersions":["2017-08-21-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
         East","Australia Southeast","Canada Central","Canada East","Central India","Central
         US","East Asia","East US","East US 2","Japan East","Japan West","North Central
         US","North Europe","South Central US","South India","Southeast Asia","West
@@ -1620,16 +1695,16 @@ http_interactions:
         US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"operations","locations":["Brazil
         South","East Asia","East US","Japan East","Japan West","North Central US","North
         Europe","South Central US","West Europe","West US","Southeast Asia","Central
-        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"topics","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operations","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topics","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operations","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
+        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","West
         US 2","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
@@ -1727,48 +1802,39 @@ http_interactions:
         Central US","West Europe","Southeast Asia","Japan East","East US 2","West
         Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"commitmentPlans","locations":["South
         Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
-        Central US","West US"],"apiVersions":["2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Media","namespace":"Microsoft.Media","authorization":{"applicationId":"374b2a64-3b6b-436b-934c-b820eacca870","roleDefinitionId":"aab70789-0cec-44b5-95d7-84b64c9487af"},"resourceTypes":[{"resourceType":"mediaservices","locations":["Japan
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningExperimentation","namespace":"Microsoft.MachineLearningExperimentation","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"accounts","locations":["Australia
+        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces","locations":["Australia
+        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces/projects","locations":["Australia
+        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningCompute","namespace":"Microsoft.MachineLearningCompute","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"376aa7d7-51a9-463d-bd4d-7e1691345612","managedByRoleDefinitionId":"91d00862-cf55-46a5-9dce-260bbd92ce25"},"resourceTypes":[{"resourceType":"operationalizationClusters","locations":["East
+        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"operations","locations":["East
+        US 2"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations","locations":["East
+        US 2"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["East
+        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningModelManagement","namespace":"Microsoft.MachineLearningModelManagement","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US 2","West Central US","Australia East"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"operations","locations":["West
+        Central US"],"apiVersions":["2017-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
+        Central US","West US"],"apiVersions":["2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01"]},{"resourceType":"offertypes","locations":["South
+        Central US","West US"],"apiVersions":["2015-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Media","namespace":"Microsoft.Media","authorization":{"applicationId":"374b2a64-3b6b-436b-934c-b820eacca870","roleDefinitionId":"aab70789-0cec-44b5-95d7-84b64c9487af"},"resourceTypes":[{"resourceType":"mediaservices","locations":["Japan
         West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
         US","West US","Australia East","Australia Southeast","Central US","Brazil
         South","Central India","West India","South India","South Central US","Canada
-        Central","Canada East","West Central US"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
+        Central","Canada East","West Central US"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
         Central US","North Central US","East US 2","West US","West Europe","North
         Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
         East","UK South","West India"],"apiVersions":["2016-01-29"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-01-29"]},{"resourceType":"locations/checkNameAvailability","locations":["South
         Central US","North Central US","East US 2","West US","West Europe","North
         Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
-        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"operations","locations":["East
+        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"capacities","locations":["West
+        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
+        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationresults","locations":["West
+        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
+        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"operations","locations":["East
         US 2"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Relay","namespace":"Microsoft.Relay","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US 2","West
         US","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
         India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2017-08-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkPolicyCompliance","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
@@ -1827,8 +1893,11 @@ http_interactions:
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","resourceTypes":[{"resourceType":"operations","locations":["West
-        Central US"],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
+        Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applianceDefinitions","locations":["West
+        Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"locations","locations":["West
+        Central US"],"apiVersions":["2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
+        Central US"],"apiVersions":["2017-09-01","2016-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","West Central US","Japan East","Japan West","Australia East","Australia
         Southeast"],"apiVersions":["2017-06-01","2017-05-15","2017-01-01","2016-10-01","2016-06-01","2015-03-15","2014-09-01"]},{"resourceType":"operations","locations":["West
@@ -1888,11 +1957,17 @@ http_interactions:
         US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RedisLabs.Memcached","namespace":"RedisLabs.Memcached","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-07-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RedisLabs.Redis","namespace":"RedisLabs.Redis","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2016-07-10"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/RevAPM.MobileCDN","namespace":"RevAPM.MobileCDN","resourceTypes":[{"resourceType":"accounts","locations":["Central
         US","East US","East US 2","North Central US","South Central US","West US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
-        East","Australia Southeast"],"apiVersions":["2016-08-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-24","2016-08-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sendgrid.Email","namespace":"Sendgrid.Email","resourceTypes":[{"resourceType":"accounts","locations":["East
-        Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
-        Central US","Central US","North Europe","West Europe","Japan East","Japan
-        West","Brazil South","Australia East","Australia Southeast","Canada Central","Canada
-        East","West Central US","West US 2","UK South","UK West"],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Signiant.Flight","namespace":"Signiant.Flight","resourceTypes":[{"resourceType":"accounts","locations":["East
+        East","Australia Southeast"],"apiVersions":["2016-08-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-24","2016-08-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sendgrid.Email","namespace":"Sendgrid.Email","resourceTypes":[{"resourceType":"accounts","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Signiant.Flight","namespace":"Signiant.Flight","resourceTypes":[{"resourceType":"accounts","locations":["East
         US","Central US","North Central US","South Central US","West US","North Europe","West
         Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast"],"apiVersions":["2015-06-29"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-29"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-29"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Sparkpost.Basic","namespace":"Sparkpost.Basic","resourceTypes":[{"resourceType":"services","locations":["West
@@ -1909,7 +1984,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:06 GMT
+  recorded_at: Fri, 22 Sep 2017 21:42:08 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
@@ -1926,11 +2001,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NDUsIm5iZiI6MTUwNDY0MTU0NSwiZXhwIjoxNTA0NjQ1NDQ1LCJhaW8iOiJZMkZnWURqQkhiTHk3OWFuc3hqNnkwU3NHRzIyQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSkNKZG1sUnJCa2VXcmE4MlRoSWdBQSIsInZlciI6IjEuMCJ9.y1cEoYSbK51hrI6ozDjUEBLzjBfpj23wDp8PADEwf5H92Q1fCREM6Om0WYOc_A5us-i-wL3wzPvX-V62XM0tuu_5K6hND7JqIdwHCB75I11kKgP1B1V1g5kOBKPH_5ZiRqe5glGYya4qHrWpWq7czmDOmzrLHH3F3bGpOToW7ip73p_Vjn1a4rleD8cxlkKIPEH-Hi18TMxP9G4OB5h6YK3re9zM2dvVcmB3dPT9s0mxd1LJh0TqvTigi6LmMrCsdXIM_nv0ZRx1lad26J5d8sre1bkle7ymKnIdOYtOc2d4eT84QnSwy77M1KBvQA7J39Eq_tBrLgdZDH9uh0eClg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMjcsIm5iZiI6MTUwNjExNjIyNywiZXhwIjoxNTA2MTIwMTI3LCJhaW8iOiJZMlZnWU5pV0pXUHdMc2ZWM2ZoSVFWajJIT3N5QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTFY3NVNHblk1MC1NTnZFOER3b05BQSIsInZlciI6IjEuMCJ9.qvqsibTj97Wje7DCzUZsV0avjdDT3jRuYQaaD4f6Zx9Nw6quJKnQDC-ifyJGTzLH38kpVmfLEZhClnR-HC2Y7nFMt_MEgpSrE1kOx9ZC3tbRPCp053tqyehRMpwIDaSQaulpJEL2SW-a3uR_4twj7Tck7yGwaA0jT9rV1kEARjo3g-A5P4fVwmf7vhMI-3u4QcBSrxN0JsYO5OufKAiXaECbT1aBUKACVMQzQjhu5w2RJLpS45vFL9y-H8VboQC3XB92D4wGvsYEh1APnSXBPvOpvGt72M-ob_uFHh4q7opWMyKUpDccB7mWtALp3MNCWeTfxyx9misbaWEzPnEhoQ
       Content-Length:
       - '42'
-      Host:
-      - management.azure.com
   response:
     status:
       code: 202
@@ -1945,34 +2018,34 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/38ba8448-a222-4ba8-a807-f55218277e14?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/41bcee67-68a7-4667-8f73-fd109c9041c5?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/38ba8448-a222-4ba8-a807-f55218277e14?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/41bcee67-68a7-4667-8f73-fd109c9041c5?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - 38ba8448-a222-4ba8-a807-f55218277e14
+      - 41bcee67-68a7-4667-8f73-fd109c9041c5
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1198'
+      - '1178'
       X-Ms-Correlation-Request-Id:
-      - 5811cfc2-a32d-4952-b56e-2082d2e479d3
+      - 93553c50-6cc9-4a9c-8d08-fb453d07384e
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200407Z:5811cfc2-a32d-4952-b56e-2082d2e479d3
+      - WESTUS:20170922T214210Z:93553c50-6cc9-4a9c-8d08-fb453d07384e
       Date:
-      - Tue, 05 Sep 2017 20:04:07 GMT
+      - Fri, 22 Sep 2017 21:42:09 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:06 GMT
+  recorded_at: Fri, 22 Sep 2017 21:42:09 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/38ba8448-a222-4ba8-a807-f55218277e14?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/41bcee67-68a7-4667-8f73-fd109c9041c5?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -1986,9 +2059,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NDUsIm5iZiI6MTUwNDY0MTU0NSwiZXhwIjoxNTA0NjQ1NDQ1LCJhaW8iOiJZMkZnWURqQkhiTHk3OWFuc3hqNnkwU3NHRzIyQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSkNKZG1sUnJCa2VXcmE4MlRoSWdBQSIsInZlciI6IjEuMCJ9.y1cEoYSbK51hrI6ozDjUEBLzjBfpj23wDp8PADEwf5H92Q1fCREM6Om0WYOc_A5us-i-wL3wzPvX-V62XM0tuu_5K6hND7JqIdwHCB75I11kKgP1B1V1g5kOBKPH_5ZiRqe5glGYya4qHrWpWq7czmDOmzrLHH3F3bGpOToW7ip73p_Vjn1a4rleD8cxlkKIPEH-Hi18TMxP9G4OB5h6YK3re9zM2dvVcmB3dPT9s0mxd1LJh0TqvTigi6LmMrCsdXIM_nv0ZRx1lad26J5d8sre1bkle7ymKnIdOYtOc2d4eT84QnSwy77M1KBvQA7J39Eq_tBrLgdZDH9uh0eClg
-      Host:
-      - management.azure.com
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMjcsIm5iZiI6MTUwNjExNjIyNywiZXhwIjoxNTA2MTIwMTI3LCJhaW8iOiJZMlZnWU5pV0pXUHdMc2ZWM2ZoSVFWajJIT3N5QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTFY3NVNHblk1MC1NTnZFOER3b05BQSIsInZlciI6IjEuMCJ9.qvqsibTj97Wje7DCzUZsV0avjdDT3jRuYQaaD4f6Zx9Nw6quJKnQDC-ifyJGTzLH38kpVmfLEZhClnR-HC2Y7nFMt_MEgpSrE1kOx9ZC3tbRPCp053tqyehRMpwIDaSQaulpJEL2SW-a3uR_4twj7Tck7yGwaA0jT9rV1kEARjo3g-A5P4fVwmf7vhMI-3u4QcBSrxN0JsYO5OufKAiXaECbT1aBUKACVMQzQjhu5w2RJLpS45vFL9y-H8VboQC3XB92D4wGvsYEh1APnSXBPvOpvGt72M-ob_uFHh4q7opWMyKUpDccB7mWtALp3MNCWeTfxyx9misbaWEzPnEhoQ
   response:
     status:
       code: 200
@@ -2009,31 +2080,90 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - 7626173a-695b-4a17-ad3b-0d5d5511f7f8
+      - a415e4a1-d042-464d-8517-220046eb0bd5
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14926'
+      - '14929'
       X-Ms-Correlation-Request-Id:
-      - cc514064-eebf-4f39-8684-3696ecf1f0fb
+      - b6d2b3dd-d323-4f0f-ade0-5b527ee3e2bb
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200408Z:cc514064-eebf-4f39-8684-3696ecf1f0fb
+      - WESTUS:20170922T214211Z:b6d2b3dd-d323-4f0f-ade0-5b527ee3e2bb
       Date:
-      - Tue, 05 Sep 2017 20:04:08 GMT
+      - Fri, 22 Sep 2017 21:42:11 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-05T20:04:06.5553708+00:00\",\r\n  \"endTime\":
-        \"2017-09-05T20:04:06.7429031+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=bb386318-17f2-4ebf-83c3-27cf09ca68cb&sig=mhRsHUol7jNLOCqFR2vWBL6rSRStvt6ZxYtyPBvbhxs%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"38ba8448-a222-4ba8-a807-f55218277e14\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2017-09-22T21:42:12.1094742+00:00\",\r\n  \"endTime\":
+        \"2017-09-22T21:42:12.2501206+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=c33ab88c-087e-436b-a3d6-433b3af6e71f&sig=unMkh%2Buv5JQPB7i4OLpcRekonXIKQ6kSH2%2FZU084k4c%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"41bcee67-68a7-4667-8f73-fd109c9041c5\"\r\n}"
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:07 GMT
+  recorded_at: Fri, 22 Sep 2017 21:42:10 GMT
 - request:
     method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=bb386318-17f2-4ebf-83c3-27cf09ca68cb&sig=mhRsHUol7jNLOCqFR2vWBL6rSRStvt6ZxYtyPBvbhxs=&sr=b&sv=2016-05-31
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/41bcee67-68a7-4667-8f73-fd109c9041c5?api-version=2017-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMjcsIm5iZiI6MTUwNjExNjIyNywiZXhwIjoxNTA2MTIwMTI3LCJhaW8iOiJZMlZnWU5pV0pXUHdMc2ZWM2ZoSVFWajJIT3N5QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTFY3NVNHblk1MC1NTnZFOER3b05BQSIsInZlciI6IjEuMCJ9.qvqsibTj97Wje7DCzUZsV0avjdDT3jRuYQaaD4f6Zx9Nw6quJKnQDC-ifyJGTzLH38kpVmfLEZhClnR-HC2Y7nFMt_MEgpSrE1kOx9ZC3tbRPCp053tqyehRMpwIDaSQaulpJEL2SW-a3uR_4twj7Tck7yGwaA0jT9rV1kEARjo3g-A5P4fVwmf7vhMI-3u4QcBSrxN0JsYO5OufKAiXaECbT1aBUKACVMQzQjhu5w2RJLpS45vFL9y-H8VboQC3XB92D4wGvsYEh1APnSXBPvOpvGt72M-ob_uFHh4q7opWMyKUpDccB7mWtALp3MNCWeTfxyx9misbaWEzPnEhoQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
+      X-Ms-Request-Id:
+      - 990ffa35-f0b9-4789-a1db-2681493779e5
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14921'
+      X-Ms-Correlation-Request-Id:
+      - 230e63cc-5381-421a-9c25-ddc7f327d898
+      X-Ms-Routing-Request-Id:
+      - WESTUS:20170922T214212Z:230e63cc-5381-421a-9c25-ddc7f327d898
+      Date:
+      - Fri, 22 Sep 2017 21:42:11 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"startTime\": \"2017-09-22T21:42:12.1094742+00:00\",\r\n  \"endTime\":
+        \"2017-09-22T21:42:12.2501206+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=c33ab88c-087e-436b-a3d6-433b3af6e71f&sig=unMkh%2Buv5JQPB7i4OLpcRekonXIKQ6kSH2%2FZU084k4c%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"41bcee67-68a7-4667-8f73-fd109c9041c5\"\r\n}"
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 21:42:11 GMT
+- request:
+    method: get
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=c33ab88c-087e-436b-a3d6-433b3af6e71f&sig=unMkh%2Buv5JQPB7i4OLpcRekonXIKQ6kSH2/ZU084k4c=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2046,8 +2176,6 @@ http_interactions:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
       X-Ms-Range:
       - bytes=0-0
-      Host:
-      - md-t4jdgqqlgszp.blob.core.windows.net
   response:
     status:
       code: 206
@@ -2068,7 +2196,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 2e875b03-001e-004e-2882-2664c8000000
+      - f4c3fe69-001e-00a1-2beb-336fb6000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2094,13 +2222,13 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Tue, 05 Sep 2017 20:04:08 GMT
+      - Fri, 22 Sep 2017 21:42:11 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         6w==
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:07 GMT
+  recorded_at: Fri, 22 Sep 2017 21:42:11 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/EndGetAccess?api-version=2017-03-30
@@ -2117,11 +2245,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NDUsIm5iZiI6MTUwNDY0MTU0NSwiZXhwIjoxNTA0NjQ1NDQ1LCJhaW8iOiJZMkZnWURqQkhiTHk3OWFuc3hqNnkwU3NHRzIyQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSkNKZG1sUnJCa2VXcmE4MlRoSWdBQSIsInZlciI6IjEuMCJ9.y1cEoYSbK51hrI6ozDjUEBLzjBfpj23wDp8PADEwf5H92Q1fCREM6Om0WYOc_A5us-i-wL3wzPvX-V62XM0tuu_5K6hND7JqIdwHCB75I11kKgP1B1V1g5kOBKPH_5ZiRqe5glGYya4qHrWpWq7czmDOmzrLHH3F3bGpOToW7ip73p_Vjn1a4rleD8cxlkKIPEH-Hi18TMxP9G4OB5h6YK3re9zM2dvVcmB3dPT9s0mxd1LJh0TqvTigi6LmMrCsdXIM_nv0ZRx1lad26J5d8sre1bkle7ymKnIdOYtOc2d4eT84QnSwy77M1KBvQA7J39Eq_tBrLgdZDH9uh0eClg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMjcsIm5iZiI6MTUwNjExNjIyNywiZXhwIjoxNTA2MTIwMTI3LCJhaW8iOiJZMlZnWU5pV0pXUHdMc2ZWM2ZoSVFWajJIT3N5QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTFY3NVNHblk1MC1NTnZFOER3b05BQSIsInZlciI6IjEuMCJ9.qvqsibTj97Wje7DCzUZsV0avjdDT3jRuYQaaD4f6Zx9Nw6quJKnQDC-ifyJGTzLH38kpVmfLEZhClnR-HC2Y7nFMt_MEgpSrE1kOx9ZC3tbRPCp053tqyehRMpwIDaSQaulpJEL2SW-a3uR_4twj7Tck7yGwaA0jT9rV1kEARjo3g-A5P4fVwmf7vhMI-3u4QcBSrxN0JsYO5OufKAiXaECbT1aBUKACVMQzQjhu5w2RJLpS45vFL9y-H8VboQC3XB92D4wGvsYEh1APnSXBPvOpvGt72M-ob_uFHh4q7opWMyKUpDccB7mWtALp3MNCWeTfxyx9misbaWEzPnEhoQ
       Content-Length:
       - '0'
-      Host:
-      - management.azure.com
   response:
     status:
       code: 202
@@ -2136,31 +2262,31 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/9b2f4c5e-c0ad-4c3b-89f3-df898f7dcf63?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/ef0e785e-1355-457e-a735-bb73e38aa4cb?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/9b2f4c5e-c0ad-4c3b-89f3-df898f7dcf63?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/ef0e785e-1355-457e-a735-bb73e38aa4cb?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - 9b2f4c5e-c0ad-4c3b-89f3-df898f7dcf63
+      - ef0e785e-1355-457e-a735-bb73e38aa4cb
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
       - '1183'
       X-Ms-Correlation-Request-Id:
-      - 9db7aa8c-1ccd-4c05-ae62-afcc74f470c8
+      - d9cd58c8-6a1a-4ea1-ba4b-207b7788bd60
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200408Z:9db7aa8c-1ccd-4c05-ae62-afcc74f470c8
+      - WESTUS:20170922T214213Z:d9cd58c8-6a1a-4ea1-ba4b-207b7788bd60
       Date:
-      - Tue, 05 Sep 2017 20:04:08 GMT
+      - Fri, 22 Sep 2017 21:42:13 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:07 GMT
+  recorded_at: Fri, 22 Sep 2017 21:42:12 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
@@ -2177,11 +2303,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NDUsIm5iZiI6MTUwNDY0MTU0NSwiZXhwIjoxNTA0NjQ1NDQ1LCJhaW8iOiJZMkZnWURqQkhiTHk3OWFuc3hqNnkwU3NHRzIyQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSkNKZG1sUnJCa2VXcmE4MlRoSWdBQSIsInZlciI6IjEuMCJ9.y1cEoYSbK51hrI6ozDjUEBLzjBfpj23wDp8PADEwf5H92Q1fCREM6Om0WYOc_A5us-i-wL3wzPvX-V62XM0tuu_5K6hND7JqIdwHCB75I11kKgP1B1V1g5kOBKPH_5ZiRqe5glGYya4qHrWpWq7czmDOmzrLHH3F3bGpOToW7ip73p_Vjn1a4rleD8cxlkKIPEH-Hi18TMxP9G4OB5h6YK3re9zM2dvVcmB3dPT9s0mxd1LJh0TqvTigi6LmMrCsdXIM_nv0ZRx1lad26J5d8sre1bkle7ymKnIdOYtOc2d4eT84QnSwy77M1KBvQA7J39Eq_tBrLgdZDH9uh0eClg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMjcsIm5iZiI6MTUwNjExNjIyNywiZXhwIjoxNTA2MTIwMTI3LCJhaW8iOiJZMlZnWU5pV0pXUHdMc2ZWM2ZoSVFWajJIT3N5QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTFY3NVNHblk1MC1NTnZFOER3b05BQSIsInZlciI6IjEuMCJ9.qvqsibTj97Wje7DCzUZsV0avjdDT3jRuYQaaD4f6Zx9Nw6quJKnQDC-ifyJGTzLH38kpVmfLEZhClnR-HC2Y7nFMt_MEgpSrE1kOx9ZC3tbRPCp053tqyehRMpwIDaSQaulpJEL2SW-a3uR_4twj7Tck7yGwaA0jT9rV1kEARjo3g-A5P4fVwmf7vhMI-3u4QcBSrxN0JsYO5OufKAiXaECbT1aBUKACVMQzQjhu5w2RJLpS45vFL9y-H8VboQC3XB92D4wGvsYEh1APnSXBPvOpvGt72M-ob_uFHh4q7opWMyKUpDccB7mWtALp3MNCWeTfxyx9misbaWEzPnEhoQ
       Content-Length:
       - '42'
-      Host:
-      - management.azure.com
   response:
     status:
       code: 202
@@ -2196,34 +2320,34 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/89ab4ac6-ce9c-4d9b-a21a-c8f496cb55d1?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/e7e667ba-efe5-4973-bfe6-79ad0dfc239e?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/89ab4ac6-ce9c-4d9b-a21a-c8f496cb55d1?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/e7e667ba-efe5-4973-bfe6-79ad0dfc239e?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - 89ab4ac6-ce9c-4d9b-a21a-c8f496cb55d1
+      - e7e667ba-efe5-4973-bfe6-79ad0dfc239e
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1185'
+      - '1186'
       X-Ms-Correlation-Request-Id:
-      - ddc34381-7e6d-472e-b0f4-e77647bc8fd8
+      - c28c8945-dfeb-4174-9b33-3222a422ff86
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200408Z:ddc34381-7e6d-472e-b0f4-e77647bc8fd8
+      - WESTUS:20170922T214214Z:c28c8945-dfeb-4174-9b33-3222a422ff86
       Date:
-      - Tue, 05 Sep 2017 20:04:08 GMT
+      - Fri, 22 Sep 2017 21:42:13 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:08 GMT
+  recorded_at: Fri, 22 Sep 2017 21:42:13 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/89ab4ac6-ce9c-4d9b-a21a-c8f496cb55d1?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/e7e667ba-efe5-4973-bfe6-79ad0dfc239e?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -2237,9 +2361,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NDUsIm5iZiI6MTUwNDY0MTU0NSwiZXhwIjoxNTA0NjQ1NDQ1LCJhaW8iOiJZMkZnWURqQkhiTHk3OWFuc3hqNnkwU3NHRzIyQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSkNKZG1sUnJCa2VXcmE4MlRoSWdBQSIsInZlciI6IjEuMCJ9.y1cEoYSbK51hrI6ozDjUEBLzjBfpj23wDp8PADEwf5H92Q1fCREM6Om0WYOc_A5us-i-wL3wzPvX-V62XM0tuu_5K6hND7JqIdwHCB75I11kKgP1B1V1g5kOBKPH_5ZiRqe5glGYya4qHrWpWq7czmDOmzrLHH3F3bGpOToW7ip73p_Vjn1a4rleD8cxlkKIPEH-Hi18TMxP9G4OB5h6YK3re9zM2dvVcmB3dPT9s0mxd1LJh0TqvTigi6LmMrCsdXIM_nv0ZRx1lad26J5d8sre1bkle7ymKnIdOYtOc2d4eT84QnSwy77M1KBvQA7J39Eq_tBrLgdZDH9uh0eClg
-      Host:
-      - management.azure.com
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMjcsIm5iZiI6MTUwNjExNjIyNywiZXhwIjoxNTA2MTIwMTI3LCJhaW8iOiJZMlZnWU5pV0pXUHdMc2ZWM2ZoSVFWajJIT3N5QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTFY3NVNHblk1MC1NTnZFOER3b05BQSIsInZlciI6IjEuMCJ9.qvqsibTj97Wje7DCzUZsV0avjdDT3jRuYQaaD4f6Zx9Nw6quJKnQDC-ifyJGTzLH38kpVmfLEZhClnR-HC2Y7nFMt_MEgpSrE1kOx9ZC3tbRPCp053tqyehRMpwIDaSQaulpJEL2SW-a3uR_4twj7Tck7yGwaA0jT9rV1kEARjo3g-A5P4fVwmf7vhMI-3u4QcBSrxN0JsYO5OufKAiXaECbT1aBUKACVMQzQjhu5w2RJLpS45vFL9y-H8VboQC3XB92D4wGvsYEh1APnSXBPvOpvGt72M-ob_uFHh4q7opWMyKUpDccB7mWtALp3MNCWeTfxyx9misbaWEzPnEhoQ
   response:
     status:
       code: 200
@@ -2260,31 +2382,90 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - 89eba848-593b-4dee-ba80-f990ff7edf1c
+      - ab554cb7-1d31-44c1-b392-24f9b729105f
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14944'
+      - '14914'
       X-Ms-Correlation-Request-Id:
-      - 72fc0a68-c7d4-4cd6-a779-8403b4ce0917
+      - 8842d634-0ccf-4c5a-bd4d-03dc6fe203c4
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200409Z:72fc0a68-c7d4-4cd6-a779-8403b4ce0917
+      - WESTUS:20170922T214214Z:8842d634-0ccf-4c5a-bd4d-03dc6fe203c4
       Date:
-      - Tue, 05 Sep 2017 20:04:09 GMT
+      - Fri, 22 Sep 2017 21:42:14 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-05T20:04:07.6991909+00:00\",\r\n  \"endTime\":
-        \"2017-09-05T20:04:07.8710728+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=7708623c-6ccb-4614-9880-32ad719af22f&sig=ol8IBrfskfohHZ5jlYjvJHkiF6pz8bDj1cvcmxs8xms%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"89ab4ac6-ce9c-4d9b-a21a-c8f496cb55d1\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2017-09-22T21:42:15.5009669+00:00\",\r\n  \"endTime\":
+        \"2017-09-22T21:42:15.7041218+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=ced7963c-2fba-4a05-84e2-fba42eed5327&sig=uzaOefZdnSRaa3jJHLmnqb2LFx8GZ0aqBzQw9z6cLoI%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"e7e667ba-efe5-4973-bfe6-79ad0dfc239e\"\r\n}"
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:08 GMT
+  recorded_at: Fri, 22 Sep 2017 21:42:14 GMT
 - request:
     method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=7708623c-6ccb-4614-9880-32ad719af22f&sig=ol8IBrfskfohHZ5jlYjvJHkiF6pz8bDj1cvcmxs8xms=&sr=b&sv=2016-05-31
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/e7e667ba-efe5-4973-bfe6-79ad0dfc239e?api-version=2017-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMjcsIm5iZiI6MTUwNjExNjIyNywiZXhwIjoxNTA2MTIwMTI3LCJhaW8iOiJZMlZnWU5pV0pXUHdMc2ZWM2ZoSVFWajJIT3N5QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTFY3NVNHblk1MC1NTnZFOER3b05BQSIsInZlciI6IjEuMCJ9.qvqsibTj97Wje7DCzUZsV0avjdDT3jRuYQaaD4f6Zx9Nw6quJKnQDC-ifyJGTzLH38kpVmfLEZhClnR-HC2Y7nFMt_MEgpSrE1kOx9ZC3tbRPCp053tqyehRMpwIDaSQaulpJEL2SW-a3uR_4twj7Tck7yGwaA0jT9rV1kEARjo3g-A5P4fVwmf7vhMI-3u4QcBSrxN0JsYO5OufKAiXaECbT1aBUKACVMQzQjhu5w2RJLpS45vFL9y-H8VboQC3XB92D4wGvsYEh1APnSXBPvOpvGt72M-ob_uFHh4q7opWMyKUpDccB7mWtALp3MNCWeTfxyx9misbaWEzPnEhoQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
+      X-Ms-Request-Id:
+      - e723ac75-d2af-4493-bdcb-1ac98ed61e0d
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14924'
+      X-Ms-Correlation-Request-Id:
+      - a12079a4-9317-4c4b-9161-d84ea56be7a7
+      X-Ms-Routing-Request-Id:
+      - WESTUS:20170922T214215Z:a12079a4-9317-4c4b-9161-d84ea56be7a7
+      Date:
+      - Fri, 22 Sep 2017 21:42:15 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"startTime\": \"2017-09-22T21:42:15.5009669+00:00\",\r\n  \"endTime\":
+        \"2017-09-22T21:42:15.7041218+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=ced7963c-2fba-4a05-84e2-fba42eed5327&sig=uzaOefZdnSRaa3jJHLmnqb2LFx8GZ0aqBzQw9z6cLoI%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"e7e667ba-efe5-4973-bfe6-79ad0dfc239e\"\r\n}"
+    http_version: 
+  recorded_at: Fri, 22 Sep 2017 21:42:14 GMT
+- request:
+    method: get
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=ced7963c-2fba-4a05-84e2-fba42eed5327&sig=uzaOefZdnSRaa3jJHLmnqb2LFx8GZ0aqBzQw9z6cLoI=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2297,8 +2478,6 @@ http_interactions:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
       X-Ms-Range:
       - bytes=440-443
-      Host:
-      - md-t4jdgqqlgszp.blob.core.windows.net
   response:
     status:
       code: 206
@@ -2319,7 +2498,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - a6723fd8-001e-0020-6282-26cde1000000
+      - fe4eebbd-001e-0009-32eb-33bba3000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2345,13 +2524,13 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Tue, 05 Sep 2017 20:04:08 GMT
+      - Fri, 22 Sep 2017 21:42:15 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         U5MJAA==
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:08 GMT
+  recorded_at: Fri, 22 Sep 2017 21:42:15 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/EndGetAccess?api-version=2017-03-30
@@ -2368,11 +2547,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDQ2NDE1NDUsIm5iZiI6MTUwNDY0MTU0NSwiZXhwIjoxNTA0NjQ1NDQ1LCJhaW8iOiJZMkZnWURqQkhiTHk3OWFuc3hqNnkwU3NHRzIyQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSkNKZG1sUnJCa2VXcmE4MlRoSWdBQSIsInZlciI6IjEuMCJ9.y1cEoYSbK51hrI6ozDjUEBLzjBfpj23wDp8PADEwf5H92Q1fCREM6Om0WYOc_A5us-i-wL3wzPvX-V62XM0tuu_5K6hND7JqIdwHCB75I11kKgP1B1V1g5kOBKPH_5ZiRqe5glGYya4qHrWpWq7czmDOmzrLHH3F3bGpOToW7ip73p_Vjn1a4rleD8cxlkKIPEH-Hi18TMxP9G4OB5h6YK3re9zM2dvVcmB3dPT9s0mxd1LJh0TqvTigi6LmMrCsdXIM_nv0ZRx1lad26J5d8sre1bkle7ymKnIdOYtOc2d4eT84QnSwy77M1KBvQA7J39Eq_tBrLgdZDH9uh0eClg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMjcsIm5iZiI6MTUwNjExNjIyNywiZXhwIjoxNTA2MTIwMTI3LCJhaW8iOiJZMlZnWU5pV0pXUHdMc2ZWM2ZoSVFWajJIT3N5QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTFY3NVNHblk1MC1NTnZFOER3b05BQSIsInZlciI6IjEuMCJ9.qvqsibTj97Wje7DCzUZsV0avjdDT3jRuYQaaD4f6Zx9Nw6quJKnQDC-ifyJGTzLH38kpVmfLEZhClnR-HC2Y7nFMt_MEgpSrE1kOx9ZC3tbRPCp053tqyehRMpwIDaSQaulpJEL2SW-a3uR_4twj7Tck7yGwaA0jT9rV1kEARjo3g-A5P4fVwmf7vhMI-3u4QcBSrxN0JsYO5OufKAiXaECbT1aBUKACVMQzQjhu5w2RJLpS45vFL9y-H8VboQC3XB92D4wGvsYEh1APnSXBPvOpvGt72M-ob_uFHh4q7opWMyKUpDccB7mWtALp3MNCWeTfxyx9misbaWEzPnEhoQ
       Content-Length:
       - '0'
-      Host:
-      - management.azure.com
   response:
     status:
       code: 202
@@ -2387,29 +2564,29 @@ http_interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/15452a3a-ab7b-422c-9891-28135f44bf08?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/3dcdfaac-a7a4-49d4-a900-eb161cef6bbf?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/15452a3a-ab7b-422c-9891-28135f44bf08?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/3dcdfaac-a7a4-49d4-a900-eb161cef6bbf?api-version=2017-03-30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358032842089313
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
       X-Ms-Request-Id:
-      - 15452a3a-ab7b-422c-9891-28135f44bf08
+      - 3dcdfaac-a7a4-49d4-a900-eb161cef6bbf
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1183'
+      - '1184'
       X-Ms-Correlation-Request-Id:
-      - 528ae836-e4e6-4839-a0f8-4ce1923c7bd9
+      - 2f902528-a7fc-432d-8926-7da697f119ac
       X-Ms-Routing-Request-Id:
-      - EASTUS:20170905T200409Z:528ae836-e4e6-4839-a0f8-4ce1923c7bd9
+      - WESTUS:20170922T214216Z:2f902528-a7fc-432d-8926-7da697f119ac
       Date:
-      - Tue, 05 Sep 2017 20:04:08 GMT
+      - Fri, 22 Sep 2017 21:42:16 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 05 Sep 2017 20:04:08 GMT
+  recorded_at: Fri, 22 Sep 2017 21:42:16 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
In support of BZ https://bugzilla.redhat.com/show_bug.cgi?id=1488967 we added PR
https://github.com/ManageIQ/manageiq-smartstate/pull/29 but failed to bump
the gem version.  This does the needful.

@roliveri please review, merge, and push out the gem.  Then we have to stick it in the Gemfile again unfortunately.