### PR TITLE
Move miq-file extension from gems/pending

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in manageiq-smartstate.gemspec
 gemspec
 
-gem "manageiq-gems-pending", :git => "https://github.com/ManageIQ/manageiq-gems-pending", :branch => "master"
+gem "manageiq-gems-pending", :git => "https://github.com/ManageIQ/manageiq-gems-pending.git", :branch => "master"
 
-# Modified gems for gems-pending.  Setting sources here since they are git references
+# Modified gems for vmware_web_service.  Setting sources here since they are git references
 gem "handsoap", "~>0.2.5", :require => false, :git => "https://github.com/ManageIQ/handsoap.git", :tag => "v0.2.5-5"

--- a/lib/manageiq/smartstate.rb
+++ b/lib/manageiq/smartstate.rb
@@ -1,7 +1,3 @@
 require "manageiq/smartstate/version"
 
-module ManageIQ
-  module Smartstate
-    # Your code goes here...
-  end
-end
+require "manageiq/smartstate/util"

--- a/lib/manageiq/smartstate/util.rb
+++ b/lib/manageiq/smartstate/util.rb
@@ -1,0 +1,34 @@
+require 'uri'
+require 'util/MiqSockUtil'
+require 'addressable'
+
+module ManageIQ
+  module Smartstate
+    module Util
+      def self.path_to_uri(file, hostname = nil)
+        hostname ||= MiqSockUtil.getFullyQualifiedDomainName
+        file = Addressable::URI.encode(file.tr('\\', '/'))
+
+        begin
+          URI::Generic.build(
+            :scheme => 'file',
+            :host   => hostname,
+            :path   => "/#{file}"
+          ).to_s
+        rescue URI::InvalidComponentError # Punt on Windows volume names, etc
+          "file://#{hostname}/#{file}"
+        end
+      end
+
+      def self.uri_to_local_path(uri_path)
+        # Detect and return UNC paths
+        return URI.decode(uri_path) if uri_path[0, 2] == '//'
+        local = URI.decode(URI.parse(uri_path).path)
+        return local[1..-1] if local[2, 1] == ':'
+        return local
+      rescue
+        return uri_path
+      end
+    end
+  end
+end

--- a/lib/manageiq/smartstate/util.rb
+++ b/lib/manageiq/smartstate/util.rb
@@ -1,23 +1,13 @@
 require 'uri'
-require 'util/MiqSockUtil'
 require 'addressable'
 
 module ManageIQ
   module Smartstate
     module Util
       def self.path_to_uri(file, hostname = nil)
-        hostname ||= MiqSockUtil.getFullyQualifiedDomainName
         file = Addressable::URI.encode(file.tr('\\', '/'))
-
-        begin
-          URI::Generic.build(
-            :scheme => 'file',
-            :host   => hostname,
-            :path   => "/#{file}"
-          ).to_s
-        rescue URI::InvalidComponentError # Punt on Windows volume names, etc
-          "file://#{hostname}/#{file}"
-        end
+        hostname = URI::Generic.build(:host => hostname).host if hostname # ensure IPv6 hostnames
+        "file://#{hostname}/#{file}"
       end
 
       def self.uri_to_local_path(uri_path)

--- a/manageiq-smartstate.gemspec
+++ b/manageiq-smartstate.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "linux_block_device", "~>0.2.1"
   spec.add_dependency "memory_buffer",      ">=0.1.0"
   spec.add_dependency "rufus-lru",          "~>1.0.3"
+  spec.add_dependency "sys-uname",          "~>1.0.1"
   spec.add_dependency "vmware_web_service", "~>0.2.0"
 
   spec.add_development_dependency "bundler"

--- a/manageiq-smartstate.gemspec
+++ b/manageiq-smartstate.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "addressable",        "~> 2.4"
   spec.add_dependency "azure-armrest"
   spec.add_dependency "binary_struct",      "~> 2.1"
   spec.add_dependency "iniparse"

--- a/spec/manageiq/smartstate/util_spec.rb
+++ b/spec/manageiq/smartstate/util_spec.rb
@@ -1,0 +1,50 @@
+describe ManageIQ::Smartstate::Util do
+  describe '#path_to_uri' do
+    it 'is defined and returns a string' do
+      expect(described_class.path_to_uri('foo')).to be_kind_of(String)
+    end
+
+    it 'returns the expected result' do
+      expect(described_class.path_to_uri('foo')).to eql("file:///foo")
+      expect(described_class.path_to_uri('foo/bar')).to eql("file:///foo/bar")
+      expect(described_class.path_to_uri('foo/bar-stuff')).to eql("file:///foo/bar-stuff")
+      expect(described_class.path_to_uri('foo/C:/bar')).to eql("file:///foo/C:/bar")
+      expect(described_class.path_to_uri('foo/[bar]')).to eql("file:///foo/%5Bbar%5D")
+    end
+
+    it 'accepts an optional hostname and returns the expected result' do
+      hostname = 'lab.example.com'
+
+      expect(described_class.path_to_uri('foo', hostname)).to eql("file://#{hostname}/foo")
+      expect(described_class.path_to_uri('foo/bar', hostname)).to eql("file://#{hostname}/foo/bar")
+      expect(described_class.path_to_uri('foo/bar-stuff', hostname)).to eql("file://#{hostname}/foo/bar-stuff")
+      expect(described_class.path_to_uri('foo/C:/bar', hostname)).to eql("file://#{hostname}/foo/C:/bar")
+      expect(described_class.path_to_uri('foo/[bar]', hostname)).to eql("file://#{hostname}/foo/%5Bbar%5D")
+    end
+
+    it 'handles an IPv6 hostname as expected' do
+      hostname = '::1'
+
+      expect(described_class.path_to_uri('foo', hostname)).to eql("file://[#{hostname}]/foo")
+    end
+
+    it 'handles a UNC path as expected' do
+      hostname = "lab.example.com"
+      file = "//foo/bar/baz"
+
+      expect(described_class.path_to_uri(file, hostname)).to eql("file://#{hostname}/#{file}")
+    end
+
+    it 'handles a volume name as expected' do
+      hostname = "lab.example.com"
+      file = "///?/Volume{xxx-yyy-42zzz-1111-222233334444}/"
+      encoded_file = URI.encode(file)
+
+      expect(described_class.path_to_uri(file, hostname)).to eql("file://#{hostname}/#{encoded_file}")
+    end
+
+    it 'requires at least one argument' do
+      expect { described_class.path_to_uri }.to raise_error(ArgumentError)
+    end
+  end
+end


### PR DESCRIPTION
@roliveri @agrare Please review.

This extension is only used by a few manageiq-providers-*/.../scanning.rb code and a few places in manageiq-smartstate itself, so the plan is to remove it from gems/pending and let it live here directly.  After this is merged I plan to change all of the callers to this method, and then I can remove the extension (and hopefully the reference to manageiq-gems-pending 🤞 )


Some notes, the original code is here for comparison... https://github.com/ManageIQ/manageiq-gems-pending/blob/17ba45c6a0ed881c056ac3d707ed91df309f1d40/lib/gems/pending/util/extensions/miq-file.rb
The last commit removes the call to MiqSockUtil (so we can further remove manageiq-gems-pending.  That is the commit that needs review, but luckily all of the specs pass before/after, so I'm confident.