### PR TITLE
Fix require since miq-file extension is removed

### DIFF
--- a/lib/metadata/util/win32/system_path_win.rb
+++ b/lib/metadata/util/win32/system_path_win.rb
@@ -1,4 +1,3 @@
-require 'util/extensions/miq-file'
 require 'enumerator'
 
 module Win32


### PR DESCRIPTION
@roliveri @agrare Please review.

I missed this because the file doesn't use any of the miq-file methods, and I didn't catch it when grepping for the removed methods.  Looks like we should have removed it when we removed File.normalize.