### PR TITLE
Replace old File.normalize with expand_path and tr

### DIFF
--- a/lib/metadata/util/win32/system_path_win.rb
+++ b/lib/metadata/util/win32/system_path_win.rb
@@ -31,7 +31,7 @@ module Win32
       # If we are not passed a fs handle return the %systemRoot% from the environment
       if fs.nil?
         raise(MiqException::MiqVmMountError, "System root not available through environment variables.") if ENV["SystemRoot"].nil?
-        return File.normalize(ENV["SystemRoot"])
+        return File.expand_path(ENV["SystemRoot"].tr('\\', '/'))
       end
 
       # Use the boot.ini file to get the starting path to the Windows folder


### PR DESCRIPTION
File.normalize was removed in https://github.com/ManageIQ/manageiq-gems-pending/pull/245
but this caller was missed, replace it with a simple expand_path and
tr('\\', '/').