### PR TITLE
Changes a non-fatal error message to be reported info log level

### DIFF
--- a/lib/fs/MiqFS/modules/Ext4.rb
+++ b/lib/fs/MiqFS/modules/Ext4.rb
@@ -5,6 +5,8 @@ require 'fs/ext4/superblock'
 require 'fs/ext4/directory_entry'
 require 'fs/ext4/directory'
 
+require 'fs/MiqFsError'
+
 # Ext4 file system interface to MiqFS.
 module Ext4
   # Default directory cache size.
@@ -225,6 +227,10 @@ module Ext4
     begin
       dirObj = ifs_getDir(dir, miqfs)
       dirEnt = dirObj.nil? ? nil : dirObj.findEntry(fname)
+
+    rescue DirectoryNotFound => err
+      dirEnt = nil
+
     rescue RuntimeError => err
       $log.error err.message.to_s if $log
       dirEnt = nil
@@ -268,7 +274,7 @@ module Ext4
     names.shift
 
     dir = ifs_getDirR(names, miqfs)
-    raise "Directory '#{p}' not found" if dir.nil?
+    raise DirectoryNotFound, p if dir.nil?
     dir
   end
 

--- a/lib/fs/MiqFS/modules/Ext4.rb
+++ b/lib/fs/MiqFS/modules/Ext4.rb
@@ -228,7 +228,7 @@ module Ext4
       dirObj = ifs_getDir(dir, miqfs)
       dirEnt = dirObj.nil? ? nil : dirObj.findEntry(fname)
 
-    rescue DirectoryNotFound => err
+    rescue MiqFsDirectoryNotFound => err
       dirEnt = nil
 
     rescue RuntimeError => err
@@ -274,7 +274,7 @@ module Ext4
     names.shift
 
     dir = ifs_getDirR(names, miqfs)
-    raise DirectoryNotFound, p if dir.nil?
+    raise MiqFsDirectoryNotFound, p if dir.nil?
     dir
   end
 

--- a/lib/fs/MiqFsError.rb
+++ b/lib/fs/MiqFsError.rb
@@ -1,0 +1,11 @@
+class MiqFsError < RuntimeError
+end
+
+class DirectoryNotFound < MiqFsError
+  attr_accessor :dir
+
+  def initialize(dir)
+    super
+    @dir = dir
+  end
+end

--- a/lib/fs/MiqFsError.rb
+++ b/lib/fs/MiqFsError.rb
@@ -1,7 +1,7 @@
 class MiqFsError < RuntimeError
 end
 
-class DirectoryNotFound < MiqFsError
+class MiqFsDirectoryNotFound < MiqFsError
   attr_accessor :dir
 
   def initialize(dir)


### PR DESCRIPTION
Missing parent directories in EXT4 getfile module will no longer report
an error (inappropriate when checking for file existance, etc)