### PR TITLE
Remove Log4r in favor of Logger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,8 @@
 /spec/reports/
 /tmp/
 
+/log/
+*.log
+
 # rspec failure tracking
 .rspec_status
-
-# Log files generated from running test:miq_disk
-mdfs*.log

--- a/lib/MiqVm/MiqLocalVm.rb
+++ b/lib/MiqVm/MiqLocalVm.rb
@@ -23,20 +23,9 @@ class MiqLocalVm < MiqVm
 end # class MiqVm
 
 if __FILE__ == $0
-
-  require 'rubygems'
-  require 'log4r'
-
-  class ConsoleFormatter < Log4r::Formatter
-    def format(event)
-      (event.data.kind_of?(String) ? event.data : event.data.inspect)
-    end
-  end
-
-  toplog = Log4r::Logger.new 'toplog'
-  Log4r::StderrOutputter.new('err_console', :level => Log4r::DEBUG, :formatter => ConsoleFormatter)
-  toplog.add 'err_console'
-  $log = toplog if $log.nil?
+  require 'logger'
+  $log = Logger.new(STDERR)
+  $log.level = Logger::DEBUG
 
   vm = MiqLocalVm.new
 

--- a/lib/MiqVm/MiqVm.rb
+++ b/lib/MiqVm/MiqVm.rb
@@ -207,7 +207,6 @@ class MiqVm
 end # class MiqVm
 
 if __FILE__ == $0
-  require 'log4r'
   require 'metadata/util/win32/boot_info_win'
 
   # vmDir = File.join(ENV.fetch("HOME", '.'), 'VMs')
@@ -217,16 +216,9 @@ if __FILE__ == $0
   targetLv = "rpolv2"
   rootLv = "LogVol00"
 
-  class ConsoleFormatter < Log4r::Formatter
-    def format(event)
-      (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-    end
-  end
-
-  toplog = Log4r::Logger.new 'toplog'
-  Log4r::StderrOutputter.new('err_console', :level => Log4r::DEBUG, :formatter => ConsoleFormatter)
-  toplog.add 'err_console'
-  $log = toplog if $log.nil?
+  require 'logger'
+  $log = Logger.new(STDERR)
+  $log.level = Logger::DEBUG
 
   #
   # *** Test start

--- a/lib/MiqVm/test/camcorder_fleece_test.rb
+++ b/lib/MiqVm/test/camcorder_fleece_test.rb
@@ -1,19 +1,11 @@
 require 'manageiq-gems-pending'
 require 'openssl' # Required for 'Digest' in camcorder (< Ruby 2.1)
 require 'camcorder'
-require 'log4r'
 require 'MiqVm/MiqVm'
 
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-
-toplog = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level => Log4r::DEBUG, :formatter => ConsoleFormatter)
-toplog.add 'err_console'
-$log = toplog if $log.nil?
+require 'logger'
+$log = Logger.new(STDERR)
+$log.level = Logger::DEBUG
 
 #
 # Path to RAW disk image.

--- a/lib/MiqVm/test/localVm.rb
+++ b/lib/MiqVm/test/localVm.rb
@@ -1,17 +1,10 @@
 require 'manageiq-gems-pending'
 require 'ostruct'
-require 'log4r'
 require 'MiqVm/MiqVm'
 
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-
-$log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level => Log4r::DEBUG, :formatter => ConsoleFormatter)
-$log.add 'err_console'
+require 'logger'
+$log = Logger.new(STDERR)
+$log.level = Logger::DEBUG
 
 VHD = raise "Please define VHD"
 diskid    = "ide0:0"

--- a/lib/MiqVm/test/partitionAlignmentCheck.rb
+++ b/lib/MiqVm/test/partitionAlignmentCheck.rb
@@ -1,19 +1,10 @@
 require 'manageiq-gems-pending'
 require 'ostruct'
-require 'log4r'
 require 'MiqVm/MiqVm'
 require 'VmwareWebService/MiqVim'
 
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-
-toplog = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level => Log4r::INFO, :formatter => ConsoleFormatter)
-toplog.add 'err_console'
-$vim_log = $log = toplog if $log.nil?
+require 'logger'
+$vim_log = $log = Logger.new(STDERR)
 
 SERVER        = raise "please define SERVER"
 USERNAME      = raise "please define USERNAME"

--- a/lib/MiqVm/test/remoteVm.rb
+++ b/lib/MiqVm/test/remoteVm.rb
@@ -1,14 +1,10 @@
 require 'manageiq-gems-pending'
 require 'ostruct'
-require 'log4r'
 require 'MiqVm/MiqVm'
 require 'VMwareWebService/MiqVim'
 
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
+require 'logger'
+$vim_log = $log = Logger.new(STDERR)
 
 SERVER        = raise "please define SERVER"
 PORT          = 443
@@ -16,11 +12,6 @@ DOMAIN        = raise "please define DOMAIN"
 USERNAME      = raise "please define USERNAME"
 PASSWORD      = raise "please define PASSWORD"
 TARGET_VM     = raise "please define TARGET_VM"
-
-toplog = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level => Log4r::INFO, :formatter => ConsoleFormatter)
-toplog.add 'err_console'
-$vim_log = $log = toplog if $log.nil?
 
 vim = MiqVim.new(SERVER, USERNAME, PASSWORD)
 

--- a/lib/MiqVm/test/rhevmNfsTest.rb
+++ b/lib/MiqVm/test/rhevmNfsTest.rb
@@ -3,20 +3,12 @@
 #
 
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'ostruct'
 require 'MiqVm/MiqVm'
 
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-
-toplog = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level => Log4r::DEBUG, :formatter => ConsoleFormatter)
-toplog.add 'err_console'
-$log = toplog if $log.nil?
+require 'logger'
+$log = Logger.new(STDERR)
+$log.level = Logger::DEBUG
 
 DDIR = "/mnt/vm/7fd0b9b2-e362-11e2-97b7-001a4aa8fcea/rhev/data-center/773f2ddf-7765-42fc-85d6-673b718541cd/aa7e70e5-40d0-43e2-a605-92ce6ba652a8/images/19449cf8-1905-4b8a-b45a-e845a693a3df"
 BASE_FILE = "#{DDIR}/903306be-f676-4005-a813-daa6d7a6c33f"

--- a/lib/MiqVm/test/rhevmNfsTest2.rb
+++ b/lib/MiqVm/test/rhevmNfsTest2.rb
@@ -3,20 +3,12 @@
 #
 
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'ostruct'
 require 'MiqVm/MiqVm'
 
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-
-toplog = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level => Log4r::DEBUG, :formatter => ConsoleFormatter)
-toplog.add 'err_console'
-$log = toplog if $log.nil?
+require 'logger'
+$log = Logger.new(STDERR)
+$log.level = Logger::DEBUG
 
 DDIR = "/mnt/vm/7fd0b9b2-e362-11e2-97b7-001a4aa8fcea/rhev/data-center/773f2ddf-7765-42fc-85d6-673b718541cd/aa7e70e5-40d0-43e2-a605-92ce6ba652a8/images/19449cf8-1905-4b8a-b45a-e845a693a3df"
 BASE_FILE = "#{DDIR}/903306be-f676-4005-a813-daa6d7a6c33f"

--- a/lib/MiqVm/test/rhevmTest.rb
+++ b/lib/MiqVm/test/rhevmTest.rb
@@ -1,5 +1,4 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'ostruct'
 require 'MiqVm/MiqVm'
 require 'ovirt'
@@ -13,16 +12,9 @@ RHEVM_USERNAME      = raise "please define RHEVM_USERNAME"
 RHEVM_PASSWORD      = raise "please define RHEVM_PASSWORD"
 VM_NAME             = raise "please define VM_NAME"
 
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-
-toplog = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level => Log4r::DEBUG, :formatter => ConsoleFormatter)
-toplog.add 'err_console'
-$log = toplog if $log.nil?
+require 'logger'
+$log = Logger.new(STDERR)
+$log.level = Logger::DEBUG
 
 begin
 

--- a/lib/Scvmm/test/miq_hyperv_disk_test.rb
+++ b/lib/Scvmm/test/miq_hyperv_disk_test.rb
@@ -1,20 +1,10 @@
 require 'manageiq-gems-pending'
 require 'rubygems'
-require 'log4r'
 require 'Scvmm/miq_hyperv_disk'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-
-$log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level => Log4r::DEBUG, :formatter => ConsoleFormatter)
-$log.add 'err_console'
+require 'logger'
+$log = Logger.new(STDERR)
+$log.level = Logger::DEBUG
 
 HOST = raise "Please define SERVERNAME"
 PORT = raise "Please define PORT"

--- a/lib/Scvmm/test/miq_scvmm_vm_ssa_info_test.rb
+++ b/lib/Scvmm/test/miq_scvmm_vm_ssa_info_test.rb
@@ -1,20 +1,10 @@
 require 'manageiq-gems-pending'
 require 'rubygems'
-require 'log4r'
 require 'Scvmm/miq_scvmm_vm_ssa_info'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-
-$log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level => Log4r::DEBUG, :formatter => ConsoleFormatter)
-$log.add 'err_console'
+require 'logger'
+$log = Logger.new(STDERR)
+$log.level = Logger::DEBUG
 
 HOST = raise "Please define SERVERNAME"
 PORT = raise "Please define PORT"

--- a/lib/VmLocalDiskAccess/test/localCfg.rb
+++ b/lib/VmLocalDiskAccess/test/localCfg.rb
@@ -1,4 +1,3 @@
-require 'log4r'
 require 'util/miq-xml'
 require 'util/runcmd'
 require 'metadata/VmConfig/VmConfig'
@@ -44,18 +43,9 @@ module MiqNativeMountManager
 end # module MiqNativeMountManager
 
 if __FILE__ == $0
-  #
-  # Formatter to output log messages to the console.
-  #
-  class ConsoleFormatter < Log4r::Formatter
-    def format(event)
-      (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-    end
-  end
-  $log = Log4r::Logger.new 'toplog'
-  $log.level = Log4r::DEBUG
-  Log4r::StderrOutputter.new('err_console', :formatter => ConsoleFormatter)
-  $log.add 'err_console'
+  require 'logger'
+  $log = Logger.new(STDERR)
+  $log.level = Logger::DEBUG
 
   puts "Log debug?: #{$log.debug?}"
 

--- a/lib/VolumeManager/MiqLdm.rb
+++ b/lib/VolumeManager/MiqLdm.rb
@@ -443,22 +443,12 @@ if __FILE__ == $0
   $: << File.join(SD, "../disk")
 
   require 'rubygems'
-  require 'log4r'
   require 'ostruct'
   require 'MiqDisk'
 
-  #
-  # Formatter to output log messages to the console.
-  #
-  class ConsoleFormatter < Log4r::Formatter
-    def format(event)
-      (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-    end
-  end
-  $log = Log4r::Logger.new 'toplog'
-  $log.level = Log4r::DEBUG
-  Log4r::StderrOutputter.new('err_console', :formatter => ConsoleFormatter)
-  $log.add 'err_console'
+  require 'logger'
+  $log = Logger.new(STDERR)
+  $log.level = Logger::DEBUG
 
   # DISK = "/Volumes/WDpassport/Virtual Machines/cn071vcce130/cn071vcce130_3.vmdk"
   # DISK = "/Volumes/WDpassport/Virtual Machines/cn071vcce130/cn071vcce130.vmdk"

--- a/lib/VolumeManager/test/blockDevTest.rb
+++ b/lib/VolumeManager/test/blockDevTest.rb
@@ -1,20 +1,12 @@
 require 'manageiq-gems-pending'
 require 'ostruct'
-require 'log4r'
 
 require 'disk/MiqDisk'
 require 'VolumeManager/MiqVolumeManager'
 
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-
-toplog = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level => Log4r::DEBUG, :formatter => ConsoleFormatter)
-toplog.add 'err_console'
-$vim_log = $log = toplog if $log.nil?
+require 'logger'
+$vim_log = $log = Logger.new(STDERR)
+$log.level = Logger::DEBUG
 
 begin
 

--- a/lib/VolumeManager/test/ldm.rb
+++ b/lib/VolumeManager/test/ldm.rb
@@ -1,5 +1,4 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'ostruct'
 require 'more_core_extensions/core_ext/object/blank'
 require 'metadata/VmConfig/VmConfig'
@@ -11,15 +10,9 @@ require 'VMwareWebService/MiqVimBroker'
 SRC_VM = raise "please define"
 vmCfg = "/Volumes/WDpassport/Virtual Machines/MIQAppliance-win2008x86/Win2008x86.vmx"
 
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$log = Log4r::Logger.new 'toplog'
-$log.level = Log4r::DEBUG
-Log4r::StderrOutputter.new('err_console', :formatter => ConsoleFormatter)
-$log.add 'err_console'
+require 'logger'
+$log = Logger.new(STDERR)
+$log.level = Logger::DEBUG
 
 vm = nil
 vim = nil

--- a/lib/disk/camcorder_test.rb
+++ b/lib/disk/camcorder_test.rb
@@ -1,22 +1,12 @@
 require 'openssl' # Required for 'Digest' in camcorder (< Ruby 2.1)?
 require 'camcorder'
-require 'log4r'
 require 'ostruct'
 require 'disk/MiqDisk'
 require 'disk/modules/MiqLargeFile'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$log = Log4r::Logger.new 'toplog'
-$log.level = Log4r::DEBUG
-Log4r::StderrOutputter.new('err_console', :formatter => ConsoleFormatter)
-$log.add 'err_console'
+require 'logger'
+$log = Logger.new(STDERR)
+$log.level = Logger::DEBUG
 
 #
 # Path to RAW disk image.

--- a/lib/disk/test.rb
+++ b/lib/disk/test.rb
@@ -1,20 +1,10 @@
 begin
-  require 'log4r'
   require 'ostruct'
   require 'disk/MiqDisk'
 
-  #
-  # Formatter to output log messages to the console.
-  #
-  class ConsoleFormatter < Log4r::Formatter
-    def format(event)
-      (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-    end
-  end
-  $log = Log4r::Logger.new 'toplog'
-  $log.level = Log4r::DEBUG
-  Log4r::StderrOutputter.new('err_console', :formatter => ConsoleFormatter)
-  $log.add 'err_console'
+  require 'logger'
+  $log = Logger.new(STDERR)
+  $log.level = Logger::DEBUG
 
   diskInfo = OpenStruct.new
   diskInfo.rawDisk = true

--- a/lib/fs/MetakitFS/test/MkSelectFiles.rb
+++ b/lib/fs/MetakitFS/test/MkSelectFiles.rb
@@ -1,22 +1,12 @@
-require 'log4r'
 require 'fs/MiqFsUtil'
 require 'fs/MiqFS/MiqFS'
 require 'fs/MetakitFS/MetakitFS'
 require 'fs/MiqFS/modules/LocalFS'
 
-#
-# Formatter to output log messages to the console.
-#
-$stderr.sync = true
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    t = Time.now
-    "#{t.hour}:#{t.min}:#{t.sec}: " + (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level => Log4r::DEBUG, :formatter => ConsoleFormatter)
-$log.add 'err_console'
+require 'logger'
+STDERR.sync = true
+$log = Logger.new(STDERR)
+$log.level = Logger::DEBUG
 
 dobj = OpenStruct.new
 dobj.mkfile = ARGV[1]

--- a/lib/fs/MetakitFS/test/mk2vmdk.rb
+++ b/lib/fs/MetakitFS/test/mk2vmdk.rb
@@ -1,22 +1,12 @@
-require 'log4r'
 require 'ostruct'
 require 'disk/MiqDisk'
 
 VMDK  = "/Volumes/WDpassport/Virtual Machines/Red Hat Linux.vmwarevm/payload2.vmdk"
 MKFILE  = "rawmkfs"
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$log = Log4r::Logger.new 'toplog'
-$log.level = Log4r::DEBUG
-Log4r::StderrOutputter.new('err_console', :formatter => ConsoleFormatter)
-$log.add 'err_console'
+require 'logger'
+$log = Logger.new(STDERR)
+$log.level = Logger::DEBUG
 
 diskInfo = OpenStruct.new
 diskInfo.mountMode = "rw"

--- a/lib/fs/MiqNativeMountManager.rb
+++ b/lib/fs/MiqNativeMountManager.rb
@@ -1,4 +1,3 @@
-require 'log4r'
 require 'metadata/VmConfig/GetNativeCfg'
 require 'VolumeManager/MiqNativeVolumeManager'
 require 'fs/MiqMountManager'
@@ -13,18 +12,9 @@ module MiqNativeMountManager
 end # module MiqNativeMountManager
 
 if __FILE__ == $0
-  #
-  # Formatter to output log messages to the console.
-  #
-  class ConsoleFormatter < Log4r::Formatter
-    def format(event)
-      (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-    end
-  end
-  $log = Log4r::Logger.new 'toplog'
-  $log.level = Log4r::DEBUG
-  Log4r::StderrOutputter.new('err_console', :formatter => ConsoleFormatter)
-  $log.add 'err_console'
+  require 'logger'
+  $log = Logger.new(STDERR)
+  $log.level = Logger::DEBUG
 
   puts "Log debug?: #{$log.debug?}"
 

--- a/lib/fs/test/camcorder_fs_test.rb
+++ b/lib/fs/test/camcorder_fs_test.rb
@@ -1,24 +1,14 @@
 require 'manageiq-gems-pending'
 require 'openssl' # Required for 'Digest' in camcorder (< Ruby 2.1)
 require 'camcorder'
-require 'log4r'
 require 'ostruct'
 require 'disk/MiqDisk'
 require 'fs/MiqFS/MiqFS'
 require 'disk/modules/MiqLargeFile'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$log = Log4r::Logger.new 'toplog'
-$log.level = Log4r::DEBUG
-Log4r::StderrOutputter.new('err_console', :formatter => ConsoleFormatter)
-$log.add 'err_console'
+require 'logger'
+$log = Logger.new(STDERR)
+$log.level = Logger::DEBUG
 
 #
 # Path to RAW disk image.

--- a/lib/fs/test/copyTest.rb
+++ b/lib/fs/test/copyTest.rb
@@ -1,4 +1,3 @@
-require 'log4r'
 require 'ostruct'
 require 'fs/MiqFS/MiqFS'
 require 'fs/MiqFsUtil'
@@ -9,20 +8,11 @@ SRC_DIR = "../../../.."
 DST_DIR = "copy_dst"
 MK_FILE = "mkfs"
 
-#
-# Formatter to output log messages to the console.
-#
-$stderr.sync = true
-$stdout.sync = true
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    t = Time.now
-    "#{t.hour}:#{t.min}:#{t.sec}: " + (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level => Log4r::DEBUG, :formatter => ConsoleFormatter)
-$log.add 'err_console'
+require 'logger'
+STDOUT.sync = true
+STDERR.sync = true
+$log = Logger.new(STDERR)
+$log.level = Logger::DEBUG
 
 #
 # First, copy files from the local filesystem to another directory in the local filesystem.

--- a/lib/fs/test/fsTest.rb
+++ b/lib/fs/test/fsTest.rb
@@ -1,21 +1,11 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'ostruct'
 require 'disk/MiqDisk'
 require 'fs/MiqFS/MiqFS'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$log = Log4r::Logger.new 'toplog'
-$log.level = Log4r::DEBUG
-Log4r::StderrOutputter.new('err_console', :formatter => ConsoleFormatter)
-$log.add 'err_console'
+require 'logger'
+$log = Logger.new(STDERR)
+$log.level = Logger::DEBUG
 
 #
 # Path to RAW disk image.

--- a/lib/fs/test/updateTest.rb
+++ b/lib/fs/test/updateTest.rb
@@ -1,4 +1,3 @@
-require 'log4r'
 require 'ostruct'
 
 require 'fs/MiqFS/MiqFS'
@@ -12,20 +11,11 @@ REF_DIR   = "copy_dst_ref"
 MK_FILE   = "mkfs"
 MK_FILE_NC  = "mkfs_nc"
 
-#
-# Formatter to output log messages to the console.
-#
-$stderr.sync = true
-$stdout.sync = true
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    t = Time.now
-    "#{t.hour}:#{t.min}:#{t.sec}: " + (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level => Log4r::DEBUG, :formatter => ConsoleFormatter)
-$log.add 'err_console'
+require 'logger'
+STDOUT.sync = true
+STDERR.sync = true
+$log = Logger.new(STDERR)
+$log.level = Logger::DEBUG
 
 fromFs  = MiqFS.new(LocalFS, nil)
 toFs  = MiqFS.new(LocalFS, nil)

--- a/lib/metadata/MIQExtract/MIQExtract.rb
+++ b/lib/metadata/MIQExtract/MIQExtract.rb
@@ -1,7 +1,6 @@
 require 'MiqVm/MiqVm'
 require 'metadata/util/md5deep'
 require 'util/miq-xml'
-require 'util/miq-logger'
 require 'ostruct'
 require 'metadata/util/win32/Win32Accounts'
 require 'metadata/util/win32/Win32Software'

--- a/lib/metadata/MIQExtract/test/extractTest.rb
+++ b/lib/metadata/MIQExtract/test/extractTest.rb
@@ -1,21 +1,13 @@
 require 'metadata/MIQExtract/MIQExtract'
-require 'log4r'
 require 'MiqVm/MiqVm'
 
 # vmDir = "v:"
 vmDir = File.join(ENV.fetch("HOME", '.'), 'VMs')
 puts "vmDir = #{vmDir}"
 
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-
-toplog = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level => Log4r::ERROR, :formatter => ConsoleFormatter)
-toplog.add 'err_console'
-$log = toplog if $log.nil?
+require 'logger'
+$log = Logger.new(STDERR)
+$log.level = Logger::ERROR
 
 #
 # *** Test start

--- a/lib/metadata/MIQExtract/test/full_extract_test.rb
+++ b/lib/metadata/MIQExtract/test/full_extract_test.rb
@@ -1,9 +1,7 @@
-require 'util/miq-logger'
 require 'tempfile'
-include Log4r
 
-$log = MIQLogger.get_log(nil, __FILE__)
-$log.level = INFO
+require 'logger'
+$log = Logger.new(File.expand_path("../../../../log/#{File.basename(__FILE__, ".*")}.log", __dir__))
 
 require 'metadata/MIQExtract/MIQExtract'
 require 'util/miq-process'
@@ -39,7 +37,7 @@ begin
 
     $log.warn "Fleece for [#{c}] completed [#{Time.now - stf}]"
 
-    $log.summary "[#{c}] extract return xml of type [#{xml.class}]" if xml
+    $log.info "[#{c}] extract return xml of type [#{xml.class}]" if xml
     File.open(Tempfile.new("extract_#{c}.xml"), "w") { |f| xml.write(f, 2) } if xml
   end
   $log.info "******************** Memory    : [#{MiqProcess.processInfo.inspect}] ********************"

--- a/lib/metadata/ScanProfile/ScanProfilesBase.rb
+++ b/lib/metadata/ScanProfile/ScanProfilesBase.rb
@@ -1,5 +1,4 @@
 require 'util/miq-xml'
-require 'util/miq-logger'
 
 class ScanProfilesBase
   def self.get_class(type, from)

--- a/lib/metadata/VmConfig/test/GetVMwareCfgTest.rb
+++ b/lib/metadata/VmConfig/test/GetVMwareCfgTest.rb
@@ -1,9 +1,9 @@
 # Only run if we are calling this script directly
-require 'util/miq-logger'
 require 'metadata/VmConfig/VmConfig'
 require 'metadata/MIQExtract/MIQExtract'
-$log = MIQLogger.get_log(nil, __FILE__)
-$log.level = Log4r::DEBUG
+
+$log = Logger.new("#{File.basename(__FILE__, ".*")}.log")
+$log.level = Logger::DEBUG
 
 vmNames = []
 # vmNames << "//miq-websvr1/scratch2/vmimages/VMware/DHCP Server/Windows Server 2003 Standard Edition.vmx"

--- a/lib/metadata/linux/LinuxUsers.rb
+++ b/lib/metadata/linux/LinuxUsers.rb
@@ -249,22 +249,14 @@ module MiqLinux
 end # module MiqLinux
 
 if __FILE__ == $0
-  require 'log4r'
   require 'MiqVm/MiqVm'
 
   vmDir = File.join(ENV.fetch("HOME", '.'), 'VMs')
   puts "vmDir = #{vmDir}"
 
-  class ConsoleFormatter < Log4r::Formatter
-    def format(event)
-      (event.data.kind_of?(String) ? event.data : event.data.inspect)
-    end
-  end
-
-  toplog = Log4r::Logger.new 'toplog'
-  Log4r::StderrOutputter.new('err_console', :level => Log4r::ERROR, :formatter => ConsoleFormatter)
-  toplog.add 'err_console'
-  $log = toplog if $log.nil?
+  require 'logger'
+  $log = Logger.new(STDERR)
+  $log.level = Logger::ERROR
 
   #
   # *** Test start

--- a/lib/metadata/util/md5deep.rb
+++ b/lib/metadata/util/md5deep.rb
@@ -233,10 +233,9 @@ end
 if __FILE__ == $0
   # if 1
   require 'MiqVm/MiqVm'
-  require 'util/miq-logger'
 
-  $log = MIQLogger.get_log(nil, __FILE__)
-  $log.level = Log4r::INFO
+  require 'logger'
+  $log = Logger.new("#{File.basename(__FILE__, ".*")}.log")
 
   startTime = Time.now
 

--- a/lib/metadata/util/win32/Win32Accounts.rb
+++ b/lib/metadata/util/win32/Win32Accounts.rb
@@ -1,7 +1,6 @@
 # encoding: US-ASCII
 
 require 'util/miq-xml'
-require 'util/miq-logger'
 require 'enumerator'
 
 module MiqWin32

--- a/lib/metadata/util/win32/Win32Services.rb
+++ b/lib/metadata/util/win32/Win32Services.rb
@@ -1,5 +1,4 @@
 require 'util/miq-xml'
-require 'util/miq-logger'
 require 'util/xml/xml_utils'
 require 'util/xml/xml_hash'
 

--- a/lib/metadata/util/win32/Win32Software.rb
+++ b/lib/metadata/util/win32/Win32Software.rb
@@ -1,6 +1,5 @@
 require 'util/xml/xml_utils'
 require 'util/miq-xml'
-require 'util/miq-logger'
 require 'metadata/util/win32/peheader'
 
 module MiqWin32

--- a/lib/metadata/util/win32/Win32System.rb
+++ b/lib/metadata/util/win32/Win32System.rb
@@ -1,6 +1,5 @@
 require 'util/xml/xml_utils'
 require 'util/miq-xml'
-require 'util/miq-logger'
 
 module MiqWin32
   class System

--- a/test/DiskTestCommon/tc_MiqLargeFile.rb
+++ b/test/DiskTestCommon/tc_MiqLargeFile.rb
@@ -18,18 +18,6 @@ module DiskTestCommon
     SIZE_4GB = 0x0000000100000000
     SIZE_5GB = 0x0000000140000000
 
-    def setup
-      #     unless $log
-      #       require 'util/miq-logger'
-      #
-      #       # Setup console logging
-      #       $log = MIQLogger.get_log(nil, nil)
-      #     end
-    end
-
-    def teardown
-    end
-
     def test_open
       params = [FILE_1MB, FILE_1GB, FILE_4GB, FILE_5GB]
 

--- a/test/extract/tc_registry.rb
+++ b/test/extract/tc_registry.rb
@@ -14,14 +14,6 @@ module Extract
     ]
 
     def setup
-      unless $log
-        require 'util/miq-logger'
-
-        # Setup console logging
-        $log = MIQLogger.get_log(nil, nil)
-        $log.level = WARN
-      end
-
       @vm = nil
     end
 

--- a/test/ts_extract.rb
+++ b/test/ts_extract.rb
@@ -1,10 +1,9 @@
 require_relative './test_helper'
 
-require 'util/miq-logger'
-
 # Setup console logging
-$log = MIQLogger.get_log(nil, nil)
-$log.level = Log4r::WARN
+require 'logger'
+$log = Logger.new(File.expand_path("../log/ts_extract.log", __dir__))
+$log.level = Logger::DEBUG
 
 require_relative 'extract/tc_versioninfo.rb'
 require_relative 'extract/tc_md5deep.rb'

--- a/test/ts_mdfs.rb
+++ b/test/ts_mdfs.rb
@@ -19,13 +19,9 @@ miq_test_fat32      = true
 miq_test_ntfs       = true
 miq_test_ext3       = true
 
-if $log.nil?
-  puts "Initializing log"
-  require 'util/miq-logger'
-  include Log4r
-  $log = MIQLogger.get_log(nil, 'mdfs.log')
-  $log.outputters.delete(Outputter.stdout)
-end
+require 'logger'
+$log = Logger.new(File.expand_path("../log/ts_mdfs.log", __dir__))
+$log.level = Logger::DEBUG
 
 # MiqLargeFile tests.
 if miq_test_largefile


### PR DESCRIPTION
Built on top of #38 (since #38 has a removal of Log4r as well).

All usages in this PR happen to be in files named test, in a test directory, or in a `if __FILE__ == $0` section

This is the last usages of Log4r, and after this the dependency can be removed from manageiq-gems-pending.

@roliveri Please review
cc @bdunne @chessbyte 