### PR TITLE
Fix Resource Group Object Issue with Smartstate on Azure Blob Disk Instances

### DIFF
--- a/lib/MiqVm/miq_azure_vm.rb
+++ b/lib/MiqVm/miq_azure_vm.rb
@@ -8,7 +8,7 @@ class MiqAzureVm < MiqVm
     @azure_handle   = azure_handle
     @uri            = nil
     @disk_name      = nil
-    @resource_group = args[:resource_group]
+    @resource_group = args[:resource_group]&.name
     @managed_image  = args[:managed_image]
 
     raise ArgumentError, "MiqAzureVm: missing required arg :name" unless (@name = args[:name])
@@ -17,7 +17,7 @@ class MiqAzureVm < MiqVm
       @uri = args[:image_uri]
     elsif args[:managed_image]
       @disk_name = args[:managed_image]
-    elsif args[:resource_group] && args[:name]
+    elsif @resource_group
       vm_obj = vm_svc.get(@name, @resource_group)
       os_disk = vm_obj.properties.storage_profile.os_disk
       if vm_obj.managed_disk?


### PR DESCRIPTION
Azure Blob Disk instances have an issue caused by a previous fix for Managed Images
back-ported to Fine.  This issue is only in Gaprindashvili and Master.
An older modification to the Azure provider changed the ResourceGroup
from a string to an object and this is a result of that change.

This fixes BZ https://bugzilla.redhat.com/show_bug.cgi?id=1507977.
This should be back-ported to Gaprindashvili but NOT to Fine, which does not have the issue.
In order to do this we need to make sure that the Gemfile for manageiq-providers-azure contains the correct version of the manageiq-smartstate gem after this change is pushed out.

@roliveri @hsong-rh please review and merge.