### PR TITLE
Force Bundler 1.15.4 on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ language: ruby
 rvm:
   - 2.3.1
   - 2.4.2
-before_install: gem install bundler -v 1.14.4
+before_install:
+  - rvm @global do gem uninstall bundler -a -x
+  - rvm @global do gem install bundler -v 1.15.4
 after_script: bundle exec codeclimate-test-reporter
 notifications:
   webhooks:


### PR DESCRIPTION
There appears to be a regression of some sort with the new bundler
version, causing azure-armrest to be pulled in as an ancient 0.0.3
version which causes builds to fail. Pulling this back to the last known
good version of Bundler before investigating.

cc/ @blomquisg @jrafanie