### PR TITLE
Use latest Bundler (1.16.0+)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ language: ruby
 rvm:
   - 2.3.1
   - 2.4.2
-before_install:
-  - rvm @global do gem uninstall bundler -a -x
-  - rvm @global do gem install bundler -v 1.15.4
 after_script: bundle exec codeclimate-test-reporter
 notifications:
   webhooks:

--- a/manageiq-smartstate.gemspec
+++ b/manageiq-smartstate.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "azure-armrest"
+  spec.add_dependency "azure-armrest",      "~> 0.9"
   spec.add_dependency "binary_struct",      "~> 2.1"
   spec.add_dependency "iniparse"
   spec.add_dependency "linux_block_device", "~>0.2.1"


### PR DESCRIPTION
A regression was found in Bundler 1.16.0 that caused us to force an old version; the problem disappears with specifying a minimum dependency requirement on azure-armrest which arguably we should be doing anyway.  Thus, let's do that and go back to using what Travis gives us and not keep this baggage.

Links:
* https://github.com/ManageIQ/manageiq-smartstate/pull/42
* https://github.com/bundler/bundler/issues/6139