### PR TITLE
Use the Smartstate Snapshot Name Built by the Provider

### DIFF
--- a/lib/MiqVm/miq_azure_vm.rb
+++ b/lib/MiqVm/miq_azure_vm.rb
@@ -23,15 +23,8 @@ class MiqAzureVm < MiqVm
       if vm_obj.managed_disk?
         #
         # Use the Smartstate SNAPSHOT Added by the Provider
-        # If the provider didn't pass the name in then it is running older code that built
-        # the old name - use that instead
         #
-        if args[:snapshot]
-          @disk_name = args[:snapshot]
-        else
-          @disk_name = os_disk.name + "__EVM__SSA__SNAPSHOT"
-          $log.warn("MiqAzureVm: missing required snapshot arg: using old name #{@disk_name}")
-        end
+        raise ArgumentError, "MiqAzureVm: missing required arg :snapshot for Managed Disk" unless (@disk_name = args[:snapshot])
       else
         #
         # Non-Managed Disk Snapshot handling

--- a/lib/MiqVm/miq_azure_vm.rb
+++ b/lib/MiqVm/miq_azure_vm.rb
@@ -22,9 +22,16 @@ class MiqAzureVm < MiqVm
       os_disk = vm_obj.properties.storage_profile.os_disk
       if vm_obj.managed_disk?
         #
-        # Use the EVM SNAPSHOT Added by the Provider
+        # Use the Smartstate SNAPSHOT Added by the Provider
+        # If the provider didn't pass the name in then it is running older code that built
+        # the old name - use that instead
         #
-        @disk_name = os_disk.name + "__EVM__SSA__SNAPSHOT"
+        if args[:snapshot]
+          @disk_name = args[:snapshot]
+        else
+          @disk_name = os_disk.name + "__EVM__SSA__SNAPSHOT"
+          $log.warn("MiqAzureVm: missing required snapshot arg: using old name #{@disk_name}")
+        end
       else
         #
         # Non-Managed Disk Snapshot handling


### PR DESCRIPTION
Since there is an 80 character limit on the length of the snapshot name
constructed for managed disks use the name set by the Azure provider.

This is one of two PRs required to fix https://bugzilla.redhat.com/show_bug.cgi?id=1508577.
The other will be against the Azure provider repo.

This change is required upstream, for Fine, and for Gaprindashvili.  Once this gem is
pushed out the Gemfile for the Azure provider will be updated in all three places.

@roliveri @hsong-rh please review and merge.  This PR should be merged asap since the
The Azure Provider PR is https://github.com/ManageIQ/manageiq-providers-azure/pull/157.
has already been merged.