### PR TITLE
Don't assume xml node for software in the Registry has attributes

### DIFF
--- a/lib/metadata/util/win32/Win32Software.rb
+++ b/lib/metadata/util/win32/Win32Software.rb
@@ -142,7 +142,7 @@ module MiqWin32
           attrs.delete(:description2) if attrs[:description] || attrs[:description2].blank?
           attrs[:description] = attrs.delete(:description2) if attrs[:description2]
 
-          attrs.merge!(:name => e.attributes[:keyname], :vendor => "Microsoft Corporation", :installed_on => @patch_install_dates[e.attributes[:keyname]])
+          attrs.merge!(:name => e.attributes[:keyname], :vendor => "Microsoft Corporation", :installed_on => @patch_install_dates[e.attributes[:keyname]]) unless e.attributes.nil? || e.attributes[:keyname].nil?
           @patches << attrs
         end
       end
@@ -152,6 +152,7 @@ module MiqWin32
       if reg_node
         hotfix = {}
         reg_node.each_element do |e|
+          next if e.attributes.nil? || e.attributes[:keyname].nil?
           if e.attributes[:keyname][0, 8] == 'Package_'
             # Expected pattern: Package_for_KBxxx_RTM~xxxx
             

--- a/lib/metadata/util/win32/Win32Software.rb
+++ b/lib/metadata/util/win32/Win32Software.rb
@@ -134,17 +134,15 @@ module MiqWin32
 
       # Get the patches (Win2000, Win2003, WinXP)
       reg_node = MIQRexml.findRegElement("HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Hotfix", reg_doc.root)
-      if reg_node
-        reg_node.each_element_with_attribute(:keyname) do |e|
-          attrs = XmlFind.decode(e, HOTFIX_MAPPING)
+      reg_node&.each_element_with_attribute(:keyname) do |e|
+        attrs = XmlFind.decode(e, HOTFIX_MAPPING)
 
-          # Check both descriptions and take the first one with a value
-          attrs.delete(:description2) if attrs[:description] || attrs[:description2].blank?
-          attrs[:description] = attrs.delete(:description2) if attrs[:description2]
+        # Check both descriptions and take the first one with a value
+        attrs.delete(:description2) if attrs[:description] || attrs[:description2].blank?
+        attrs[:description] = attrs.delete(:description2) if attrs[:description2]
 
-          attrs.merge!(:name => e.attributes[:keyname], :vendor => "Microsoft Corporation", :installed_on => @patch_install_dates[e.attributes[:keyname]]) unless e.attributes.nil? || e.attributes[:keyname].nil?
-          @patches << attrs
-        end
+        attrs.merge!(:name => e.attributes[:keyname], :vendor => "Microsoft Corporation", :installed_on => @patch_install_dates[e.attributes[:keyname]]) unless e.attributes.nil? || e.attributes[:keyname].nil?
+        @patches << attrs
       end
 
       # Get the patches (Vista, Win2008, Windows 7)


### PR DESCRIPTION
XML nodes for the software attributes in the registry may be nil and should
be checked prior to using them.  This has resulted in exceptions during SSA processing.
This fixes an issue in BZ https://bugzilla.redhat.com/show_bug.cgi?id=1490488.  We have seen issues where the Applications and/or HotFixes (Patches) are missing in windows instances/vms in different providers.  This should fix several of those cases.
This should be back ported to both Fine and Gaprindashvili (by way of Gemfile updates)

@roliveri @hsong-rh please review.  Thanks.