### PR TITLE
Managed Disk Read Semantics Change

### DIFF
--- a/lib/disk/modules/AzureDiskCommon.rb
+++ b/lib/disk/modules/AzureDiskCommon.rb
@@ -85,16 +85,7 @@ module AzureDiskCommon
       options[:date] = @snapshot if @snapshot
       ret = @storage_acct.get_blob_raw(@container, @blob, key, options)
     else
-      retries = 0
-      begin
-        ret = managed_disk.read(options)
-      rescue Azure::Armrest::ForbiddenException => err
-        raise err if retries > 0
-        $log.warn("#{@class}: blob_read: #{err}: acquiring new SAS URL")
-        @managed_disk = nil
-        retries += 1
-        retry
-      end
+      ret = managed_disk.read(options)
     end
 
     @reads += 1

--- a/lib/disk/modules/AzureManagedDisk.rb
+++ b/lib/disk/modules/AzureManagedDisk.rb
@@ -48,7 +48,7 @@ module AzureManagedDisk
         :start_byte => 0,
         :length     => 1
       }
-      data = @storage_disk_svc.get_blob_raw(@disk_name, @resource_group, options)
+      data = managed_disk.read(options)
       data.headers
     end
   end

--- a/manageiq-smartstate.gemspec
+++ b/manageiq-smartstate.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "azure-armrest",      "~> 0.9"
+  spec.add_dependency "azure-armrest",      "~> 0.9.5"
   spec.add_dependency "binary_struct",      "~> 2.1"
   spec.add_dependency "iniparse"
   spec.add_dependency "linux_block_device", "~>0.2.1"

--- a/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_blockSize-1.yml
+++ b/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_blockSize-1.yml
@@ -17,6 +17,8 @@ http_interactions:
       - '186'
       Content-Type:
       - application/x-www-form-urlencoded
+      Host:
+      - login.microsoftonline.com
   response:
     status:
       code: 200
@@ -37,25 +39,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 76a57ce7-1d66-437f-84c4-918643290e00
+      - 57351c97-53fa-4483-bed8-f24eeb3e1100
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAAABlDrqfEFlSaui6xnRjX5Eg3WbAgOT4RyVyqPfg63eN3w3DA2o2E7ceIvUjXpkFdzthQ38xhbPqBe0sTXAIsPoaLA3WTtgARnZq6LBINLOYGOysineaBWH2jRcHKcJgBLjxnJcrG6stdos6xTRTWZS7BMXJpH56ILLXFTVwyX9Z4xHQ9TvSBhBLMeo82cwXFggAA;
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzajaYEuRxwjN2z8Xg74a--f0TAGBUGoayPooOENBQFDleUfUFHWH_1GxfML7PPrBzE38baRIVsd9-FmBcHlglpoqoISqbjYDEYZXOIAZqdx2X5bD2YnRJFZjTlZzQlu6Xal12G7piqI2ojaWJIgSXuKF1rgyEVtQTmSd3Z1pPIrwgAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=005; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=003; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Fri, 22 Sep 2017 21:43:18 GMT
+      - Tue, 23 Jan 2018 20:06:49 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1506120198","not_before":"1506116298","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyOTgsIm5iZiI6MTUwNjExNjI5OCwiZXhwIjoxNTA2MTIwMTk4LCJhaW8iOiJZMlZnWVBpYkdpZTFMU0JhNkUvbm8rMWF5cWRXQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTN5bGRtWWRmME9FeEpHR1F5a09BQSIsInZlciI6IjEuMCJ9.GXfU7XOKtiFTBk1pmTywNCCfzOXXoOfOiww3yywW6Ukwzy3_nMl-h1y9gCia2FHM5GqUnV530zFq_glFJtlMzRFfDxRC_SCmdNrrUtI025PnBxiPBy43kvGugxRdlzDwtxuWeJc0MjZha9lM5I3tBjGQTKYGyCF4rrXnijh-pFPopigaPbUeB0k0joA30JSnYUWDV6LhKYzBtlUrn8rhz4xpuLlRL7sMvHOWbZpTT_XOLL_6Dd9lcdGPCW2TadXlUTvlQMQM3r4KX6dfARWt96SltdoAwjLxFGi6fk5VYIFPtdZihzYQO3IWKsFNiM3S5KSoJxGHl0_OKp11fkmHGw"}'
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1516741612","not_before":"1516737712","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3MTIsIm5iZiI6MTUxNjczNzcxMiwiZXhwIjoxNTE2NzQxNjEyLCJhaW8iOiJZMk5nWU5pM2dmVzIwemZWVjVlMGVscW1hNml0QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibHh3MVZfcFRnMFMtMlBKTzZ6NFJBQSIsInZlciI6IjEuMCJ9.W4bjxEKCoeWaAXXkoq9PkzuPHpMUL17KOemH5oBCOHsUc-0oYPFZEfTxT5FCh69lsrTP2FgzkGyWpvQEQ7gSKmNqNaKBKw4QWbqB-aOyTBleqBn5uV1L4xXiVdDtGOVjDaE_4sbZ_tXWp1AQMtajpbRKmMPVnlBH8avQCUrCwN_C7YfkY5rcmq8rZbd_9j-Febq0-m4IPK2-N6Rz0CANglovksI1nSmUIfu1zm90U2ey0GsU60ExrRjZskjhAPPdrIesEmzuJb_zAgP5hIKWALX8Nc1-4BYWpHPizsAB8DhjchuUavB6sJg8SThAWrWECw9C_Fb5eStoPrmrJlnKhg"}'
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:43:18 GMT
+  recorded_at: Tue, 23 Jan 2018 20:06:52 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -72,7 +74,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyOTgsIm5iZiI6MTUwNjExNjI5OCwiZXhwIjoxNTA2MTIwMTk4LCJhaW8iOiJZMlZnWVBpYkdpZTFMU0JhNkUvbm8rMWF5cWRXQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTN5bGRtWWRmME9FeEpHR1F5a09BQSIsInZlciI6IjEuMCJ9.GXfU7XOKtiFTBk1pmTywNCCfzOXXoOfOiww3yywW6Ukwzy3_nMl-h1y9gCia2FHM5GqUnV530zFq_glFJtlMzRFfDxRC_SCmdNrrUtI025PnBxiPBy43kvGugxRdlzDwtxuWeJc0MjZha9lM5I3tBjGQTKYGyCF4rrXnijh-pFPopigaPbUeB0k0joA30JSnYUWDV6LhKYzBtlUrn8rhz4xpuLlRL7sMvHOWbZpTT_XOLL_6Dd9lcdGPCW2TadXlUTvlQMQM3r4KX6dfARWt96SltdoAwjLxFGi6fk5VYIFPtdZihzYQO3IWKsFNiM3S5KSoJxGHl0_OKp11fkmHGw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3MTIsIm5iZiI6MTUxNjczNzcxMiwiZXhwIjoxNTE2NzQxNjEyLCJhaW8iOiJZMk5nWU5pM2dmVzIwemZWVjVlMGVscW1hNml0QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibHh3MVZfcFRnMFMtMlBKTzZ6NFJBQSIsInZlciI6IjEuMCJ9.W4bjxEKCoeWaAXXkoq9PkzuPHpMUL17KOemH5oBCOHsUc-0oYPFZEfTxT5FCh69lsrTP2FgzkGyWpvQEQ7gSKmNqNaKBKw4QWbqB-aOyTBleqBn5uV1L4xXiVdDtGOVjDaE_4sbZ_tXWp1AQMtajpbRKmMPVnlBH8avQCUrCwN_C7YfkY5rcmq8rZbd_9j-Febq0-m4IPK2-N6Rz0CANglovksI1nSmUIfu1zm90U2ey0GsU60ExrRjZskjhAPPdrIesEmzuJb_zAgP5hIKWALX8Nc1-4BYWpHPizsAB8DhjchuUavB6sJg8SThAWrWECw9C_Fb5eStoPrmrJlnKhg
+      Host:
+      - management.azure.com
   response:
     status:
       code: 200
@@ -93,21 +97,22 @@ http_interactions:
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
       - '14999'
       X-Ms-Request-Id:
-      - dbddeb53-848f-4a05-b877-188eeb28608c
+      - 51c44af4-1d47-4df7-a225-27855839fd84
       X-Ms-Correlation-Request-Id:
-      - dbddeb53-848f-4a05-b877-188eeb28608c
+      - 51c44af4-1d47-4df7-a225-27855839fd84
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214318Z:dbddeb53-848f-4a05-b877-188eeb28608c
+      - WESTUS:20180123T200653Z:51c44af4-1d47-4df7-a225-27855839fd84
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 22 Sep 2017 21:43:18 GMT
+      - Tue, 23 Jan 2018 20:06:52 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
-        Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
+      string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
+        Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
+        Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:43:18 GMT
+  recorded_at: Tue, 23 Jan 2018 20:06:53 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/azure_subscription_id/providers?api-version=2015-01-01
@@ -124,7 +129,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyOTgsIm5iZiI6MTUwNjExNjI5OCwiZXhwIjoxNTA2MTIwMTk4LCJhaW8iOiJZMlZnWVBpYkdpZTFMU0JhNkUvbm8rMWF5cWRXQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTN5bGRtWWRmME9FeEpHR1F5a09BQSIsInZlciI6IjEuMCJ9.GXfU7XOKtiFTBk1pmTywNCCfzOXXoOfOiww3yywW6Ukwzy3_nMl-h1y9gCia2FHM5GqUnV530zFq_glFJtlMzRFfDxRC_SCmdNrrUtI025PnBxiPBy43kvGugxRdlzDwtxuWeJc0MjZha9lM5I3tBjGQTKYGyCF4rrXnijh-pFPopigaPbUeB0k0joA30JSnYUWDV6LhKYzBtlUrn8rhz4xpuLlRL7sMvHOWbZpTT_XOLL_6Dd9lcdGPCW2TadXlUTvlQMQM3r4KX6dfARWt96SltdoAwjLxFGi6fk5VYIFPtdZihzYQO3IWKsFNiM3S5KSoJxGHl0_OKp11fkmHGw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3MTIsIm5iZiI6MTUxNjczNzcxMiwiZXhwIjoxNTE2NzQxNjEyLCJhaW8iOiJZMk5nWU5pM2dmVzIwemZWVjVlMGVscW1hNml0QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibHh3MVZfcFRnMFMtMlBKTzZ6NFJBQSIsInZlciI6IjEuMCJ9.W4bjxEKCoeWaAXXkoq9PkzuPHpMUL17KOemH5oBCOHsUc-0oYPFZEfTxT5FCh69lsrTP2FgzkGyWpvQEQ7gSKmNqNaKBKw4QWbqB-aOyTBleqBn5uV1L4xXiVdDtGOVjDaE_4sbZ_tXWp1AQMtajpbRKmMPVnlBH8avQCUrCwN_C7YfkY5rcmq8rZbd_9j-Febq0-m4IPK2-N6Rz0CANglovksI1nSmUIfu1zm90U2ey0GsU60ExrRjZskjhAPPdrIesEmzuJb_zAgP5hIKWALX8Nc1-4BYWpHPizsAB8DhjchuUavB6sJg8SThAWrWECw9C_Fb5eStoPrmrJlnKhg
+      Host:
+      - management.azure.com
   response:
     status:
       code: 200
@@ -141,19 +148,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14924'
+      - '14852'
       X-Ms-Request-Id:
-      - 71e85ebf-c450-4f0d-863e-655d6920c4f1
+      - 327a88a3-29b2-4829-9db6-27b5c5bb4662
       X-Ms-Correlation-Request-Id:
-      - 71e85ebf-c450-4f0d-863e-655d6920c4f1
+      - 327a88a3-29b2-4829-9db6-27b5c5bb4662
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214319Z:71e85ebf-c450-4f0d-863e-655d6920c4f1
+      - WESTUS:20180123T200654Z:327a88a3-29b2-4829-9db6-27b5c5bb4662
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 22 Sep 2017 21:43:19 GMT
+      - Tue, 23 Jan 2018 20:06:53 GMT
       Content-Length:
-      - '254785'
+      - '293551'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
@@ -176,7 +183,7 @@ http_interactions:
         Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
         Central US","North Central US","Japan East","Japan West","Brazil South","Central
         India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
+        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-04-19","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-04-19","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-04-19","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-04-19","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","North Central
         US","South Central US","West Central US","West US","West US 2","Canada Central","Canada
         East","North Europe","West Europe","UK South","UK West","East Asia","Southeast
@@ -184,20 +191,26 @@ http_interactions:
         India","South India","West India"],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"validateServiceName","locations":[],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"checkServiceNameAvailability","locations":[],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"reportFeedback","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"checkFeedbackRequired","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Automation","namespace":"Microsoft.Automation","authorizations":[{"applicationId":"fc75330b-179d-49af-87dd-3b1acf6827fa","roleDefinitionId":"95fd5de3-d071-4362-92bf-cf341c1de832"}],"resourceTypes":[{"resourceType":"automationAccounts","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
         South","UK South","West Central US","North Europe","Canada Central","Australia
-        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/runbooks","locations":["Japan
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/runbooks","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
         South","UK South","West Central US","North Europe","Canada Central","Australia
-        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/configurations","locations":["Japan
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/configurations","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","North
-        Central US","Brazil South","UK South","West Central US","Central India","Australia
-        Southeast","Canada Central","North Europe"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/webhooks","locations":["Japan
+        Central US","Korea Central","East US","West US 2","Brazil South","UK South","West
+        Central US","Central India","Australia Southeast","Canada Central","North
+        Europe"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/webhooks","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
         South","UK South","West Central US","North Europe","Canada Central","Australia
-        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"operations","locations":["South
-        Central US"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/softwareUpdateConfigurations","locations":["Japan
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"operations","locations":["South
+        Central US"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/softwareUpdateConfigurations","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
         South","UK South","West Central US","North Europe","Canada Central","Australia
-        Southeast","Central India"],"apiVersions":["2017-05-15-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Backup","namespace":"Microsoft.Backup","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"BackupVault","locations":["West
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview"]},{"resourceType":"automationAccounts/jobs","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
+        South","UK South","West Central US","North Europe","Canada Central","Australia
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureActiveDirectory","namespace":"Microsoft.AzureActiveDirectory","resourceTypes":[{"resourceType":"b2cDirectories","locations":["Global","United
+        States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]},{"resourceType":"operations","locations":["Global","United
+        States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]}],"registrationState":"Unregistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Backup","namespace":"Microsoft.Backup","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"BackupVault","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
@@ -206,22 +219,22 @@ http_interactions:
         Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
         West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
         East","South India","Central India","Canada Central","Canada East","UK South","UK
-        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01","2015-07-01","2014-05-01-privatepreview"]},{"resourceType":"operations","locations":["West
+        West","West Central US","West US 2"],"apiVersions":["2017-09-01","2017-05-01","2017-01-01","2015-12-01","2015-09-01","2015-07-01","2014-05-01-privatepreview"]},{"resourceType":"operations","locations":["West
         Europe","East US","East US 2","West US","North Central US","Brazil South","North
         Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
         West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
         East","South India","Central India","Canada Central","Canada East","UK South","UK
-        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations/quotas","locations":["West
+        West","West Central US","West US 2"],"apiVersions":["2017-09-01","2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01","2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations/quotas","locations":["West
         Europe","East US","East US 2","West US","North Central US","Brazil South","North
         Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
         West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
         East","South India","Central India","Canada Central","Canada East","UK South","UK
-        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]}],"registrationState":"Unregistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicCompute","namespace":"Microsoft.ClassicCompute","resourceTypes":[{"resourceType":"domainNames","locations":["East
+        West","West Central US","West US 2"],"apiVersions":["2017-09-01","2017-05-01","2017-01-01","2015-12-01","2015-09-01"]}],"registrationState":"Unregistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicCompute","namespace":"Microsoft.ClassicCompute","resourceTypes":[{"resourceType":"domainNames","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
@@ -256,7 +269,7 @@ http_interactions:
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -296,92 +309,92 @@ http_interactions:
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30"]},{"resourceType":"locations/usages","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations/usages","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
+        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
@@ -411,76 +424,138 @@ http_interactions:
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
+        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
         US","East US","South Central US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
         Central","Central US","East US 2","North Central US","West Central US","West
-        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/webhooks","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/ping","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/getCallbackConfig","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/listEvents","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"locations","locations":["South
-        Central US","East US","West US","Central US","East US 2","North Central US","West
-        Central US","West US 2","Brazil South","Canada East","Canada Central","West
-        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
-        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"locations/operationResults","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/GetCredentials","locations":["West
+        US 2"],"apiVersions":["2017-10-01","2017-03-01"]},{"resourceType":"registries/replications","locations":["South
+        Central US","West Central US","East US","West Europe","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/webhooks","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/webhooks/ping","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/webhooks/getCallbackConfig","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/webhooks/listEvents","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"locations/operationResults","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/GetCredentials","locations":["West
         US","East US","South Central US","West Europe"],"apiVersions":["2016-06-27-preview"]},{"resourceType":"registries/listCredentials","locations":["South
         Central US","East US","West US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
         Central","Central US","East US 2","North Central US","West Central US","West
-        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/regenerateCredential","locations":["South
+        US 2"],"apiVersions":["2017-10-01","2017-03-01"]},{"resourceType":"registries/regenerateCredential","locations":["South
         Central US","West US","East US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
         Central","Central US","East US 2","North Central US","West Central US","West
-        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/listUsages","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/regenerateCredentials","locations":["West
+        US 2"],"apiVersions":["2017-10-01","2017-03-01"]},{"resourceType":"registries/listUsages","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/regenerateCredentials","locations":["West
         US","East US","South Central US","West Europe"],"apiVersions":["2016-06-27-preview"]},{"resourceType":"checkNameAvailability","locations":["South
         Central US","East US","West US","Central US","East US 2","North Central US","West
         Central US","West US 2","Brazil South","Canada East","Canada Central","West
         Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
-        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview","2017-03-01","2016-06-27-preview"]},{"resourceType":"operations","locations":["South
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-10-01","2017-06-01-preview","2017-03-01","2016-06-27-preview"]},{"resourceType":"operations","locations":["South
         Central US","East US","West US","Central US","East US 2","North Central US","West
         Central US","West US 2","Brazil South","Canada East","Canada Central","West
         Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
-        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview","2017-03-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerService","namespace":"Microsoft.ContainerService","authorization":{"applicationId":"7319c514-987d-4e9b-ac3d-d38c4f427f4c","roleDefinitionId":"1b4a0c7f-2217-416f-acfa-cf73452fdc1c"},"resourceTypes":[{"resourceType":"containerServices","locations":["Japan
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-10-01","2017-06-01-preview","2017-03-01"]},{"resourceType":"locations","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-10-01","2017-06-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerService","namespace":"Microsoft.ContainerService","authorization":{"applicationId":"7319c514-987d-4e9b-ac3d-d38c4f427f4c","roleDefinitionId":"1b4a0c7f-2217-416f-acfa-cf73452fdc1c","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"containerServices","locations":["Japan
         East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
         Central US","West US 2","South India","Central India","West India","Canada
-        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
+        East","Canada Central","Korea South","Korea Central"],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"managedClusters","locations":["East
+        US","West Europe","Central US","Canada Central","Canada East"],"apiVersions":["2017-08-31"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
         East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
         Central US","West US 2","South India","Central India","West India","Canada
-        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DevTestLab","namespace":"Microsoft.DevTestLab","authorization":{"applicationId":"1a14be2a-e903-4cec-99cf-b2e209259a0f","roleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525"},"resourceTypes":[{"resourceType":"labs","locations":["West
+        East","Canada Central","Korea South","Korea Central"],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/orchestrators","locations":["UK
+        West","West US 2","East US","West Europe","Central US"],"apiVersions":["2017-09-30"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DevTestLab","namespace":"Microsoft.DevTestLab","authorization":{"applicationId":"1a14be2a-e903-4cec-99cf-b2e209259a0f","roleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525","managedByRoleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525"},"resourceTypes":[{"resourceType":"labs","locations":["West
         Central US","Japan East","West US","Australia Southeast","Canada Central","Central
         India","Central US","East Asia","Korea Central","North Europe","South Central
-        US","UK West","Australia East","Brazil South","Canada East","East US","East
-        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        US","UK West","West India","Australia East","Brazil South","Canada East","East
+        US","East US 2","Japan West","Korea South","North Central US","South India","Southeast
         Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"schedules","locations":["West
         Central US","Japan East","West US","Australia Southeast","Canada Central","Central
         India","Central US","East Asia","Korea Central","North Europe","South Central
-        US","UK West","Australia East","Brazil South","Canada East","East US","East
-        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        US","UK West","West India","Australia East","Brazil South","Canada East","East
+        US","East US 2","Japan West","Korea South","North Central US","South India","Southeast
         Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"labs/virtualMachines","locations":["West
         Central US","Japan East","West US","Australia Southeast","Canada Central","Central
         India","Central US","East Asia","Korea Central","North Europe","South Central
-        US","UK West","Australia East","Brazil South","Canada East","East US","East
-        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        US","UK West","West India","Australia East","Brazil South","Canada East","East
+        US","East US 2","Japan West","Korea South","North Central US","South India","Southeast
         Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"labs/serviceRunners","locations":["Central
         US","East US 2","South Central US"],"apiVersions":["2017-04-26-preview","2016-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"locations/operations","locations":["West
         Central US","Japan East","West US","Australia Southeast","Canada Central","Central
         India","Central US","East Asia","Korea Central","North Europe","South Central
-        US","UK West","Australia East","Brazil South","Canada East","East US","East
-        US 2","Japan West","Korea South","North Central US","South India","Southeast
-        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"}],"resourceTypes":[{"resourceType":"components","locations":["East
-        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
-        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01","2014-04-01"]},{"resourceType":"queries","locations":["East
-        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
+        US","UK West","West India","Australia East","Brazil South","Canada East","East
+        US","East US 2","Japan West","Korea South","North Central US","South India","Southeast
+        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","authorizations":[{"applicationId":"57c0fc58-a83a-41d0-8ae9-08952659bdfd","roleDefinitionId":"FFFD5CF5-FFD3-4B24-B0E2-0715ADD4C282"}],"resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"databaseAccountNames","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"operationResults","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"},{"applicationId":"f5c26e74-f226-4ae8-85f0-b4af0080ac9e","roleDefinitionId":"529d7ae6-e892-4d43-809d-8547aeb90643"}],"resourceTypes":[{"resourceType":"components","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2015-05-01","2014-08-01","2014-04-01"]},{"resourceType":"queries","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"components/pricingPlans","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"migrateToNewPricingModel","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"rollbackToLegacyPricingModel","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"listMigrationdate","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
@@ -516,7 +591,7 @@ http_interactions:
         West","North Central US","South Central US","East US 2","Canada East","Canada
         Central","Central US","Australia East","Australia Southeast","Brazil South","South
         India","Central India","West India","North Europe","West US 2","West Central
-        US","Korea South","Korea Central","UK South","UK West","Global"],"apiVersions":["2017-05-01-preview","2016-03-01","2015-07-01"]},{"resourceType":"logDefinitions","locations":["West
+        US","Korea South","Korea Central","UK South","UK West","Global"],"apiVersions":["2017-09-01-preview","2017-05-01-preview","2016-03-01","2015-07-01"]},{"resourceType":"logDefinitions","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
@@ -526,7 +601,7 @@ http_interactions:
         West","North Central US","South Central US","East US 2","Canada East","Canada
         Central","Central US","Australia East","Australia Southeast","Brazil South","South
         India","Central India","West India","North Europe","West US 2","West Central
-        US","Korea South","Korea Central","UK South","UK West"],"apiVersions":["2017-05-01-preview","2016-09-01","2016-06-01"]},{"resourceType":"actiongroups","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]},{"resourceType":"activityLogAlerts","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.KeyVault","namespace":"Microsoft.KeyVault","resourceTypes":[{"resourceType":"vaults","locations":["North
+        US","Korea South","Korea Central","UK South","UK West"],"apiVersions":["2017-09-01-preview","2017-05-01-preview","2016-09-01","2016-06-01"]},{"resourceType":"actiongroups","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]},{"resourceType":"activityLogAlerts","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.KeyVault","namespace":"Microsoft.KeyVault","resourceTypes":[{"resourceType":"vaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
@@ -556,126 +631,153 @@ http_interactions:
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorizations":[{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},{"applicationId":"7c33bfcb-8d33-48d6-8e60-dc6404003489","roleDefinitionId":"ad6261e4-fa9a-4642-aa5f-104f1b67e9e3"},{"applicationId":"1e3e4475-288f-4018-a376-df66fd7fac5f","roleDefinitionId":"1d538b69-3d87-4e56-8ff8-25786fd48261"},{"applicationId":"a0be0c72-870e-46f0-9c49-c98333a996f7","roleDefinitionId":"7ce22727-ffce-45a9-930c-ddb2e56fa131"}],"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","West Central US"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"operations","locations":["South
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations","locations":["South
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operations","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"commitmentPlans","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"Registering"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorizations":[{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},{"applicationId":"7c33bfcb-8d33-48d6-8e60-dc6404003489","roleDefinitionId":"ad6261e4-fa9a-4642-aa5f-104f1b67e9e3"},{"applicationId":"1e3e4475-288f-4018-a376-df66fd7fac5f","roleDefinitionId":"1d538b69-3d87-4e56-8ff8-25786fd48261"},{"applicationId":"a0be0c72-870e-46f0-9c49-c98333a996f7","roleDefinitionId":"7ce22727-ffce-45a9-930c-ddb2e56fa131"}],"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
-        Central US"],"apiVersions":["2017-09-01"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
-        East","UK South","Central India","Canada Central"],"apiVersions":["2017-04-26-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"]},{"resourceType":"workspaces/dataSources","locations":["East
+        East","UK South","Central India","Canada Central"],"apiVersions":["2017-04-26-preview","2017-03-15-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"]},{"resourceType":"workspaces/query","locations":["West
+        Central US","Australia Southeast","West Europe","East US","Southeast Asia","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2017-10-01"]},{"resourceType":"workspaces/dataSources","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
         East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"storageInsightConfigs","locations":[],"apiVersions":["2014-10-10"]},{"resourceType":"workspaces/linkedServices","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
         East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"linkTargets","locations":["East
         US"],"apiVersions":["2015-03-20"]},{"resourceType":"operations","locations":[],"apiVersions":["2014-11-10"]},{"resourceType":"devices","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationsManagement","namespace":"Microsoft.OperationsManagement","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"aa249101-6816-4966-aafa-08175d795f14"},"resourceTypes":[{"resourceType":"solutions","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
-        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Portal","namespace":"Microsoft.Portal","resourceTypes":[{"resourceType":"dashboards","locations":["Central
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"managementconfigurations","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"managementassociations","locations":[],"apiVersions":["2015-11-01-preview"]},{"resourceType":"views","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2017-08-21-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Portal","namespace":"Microsoft.Portal","resourceTypes":[{"resourceType":"dashboards","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
@@ -687,9 +789,9 @@ http_interactions:
         East","West India","South India","Central India","Canada Central","Canada
         East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"consoles","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/consoles","locations":["West
         US","East US","Central India","North Europe","West Europe","South Central
-        US","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
+        US","Southeast Asia","East US 2","Central US"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
         US","East US","Central India","North Europe","West Europe","South Central
-        US","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
+        US","Southeast Asia","East US 2","Central US"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
@@ -710,7 +812,17 @@ http_interactions:
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ResourceHealth","namespace":"Microsoft.ResourceHealth","authorization":{"applicationId":"8bdebf23-c0fe-4187-a378-717ad86f6a53","roleDefinitionId":"cc026344-c8b1-4561-83ba-59eba84b27cc"},"resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2017-07-01","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"notifications","locations":["Australia
+        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]},{"resourceType":"locations/backupValidateFeatures","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-07-01"]},{"resourceType":"locations/backupPreValidateProtection","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-07-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ResourceHealth","namespace":"Microsoft.ResourceHealth","authorization":{"applicationId":"8bdebf23-c0fe-4187-a378-717ad86f6a53","roleDefinitionId":"cc026344-c8b1-4561-83ba-59eba84b27cc"},"resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2017-07-01","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"notifications","locations":["Australia
         Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Security","namespace":"Microsoft.Security","authorization":{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatuses","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/virtualMachines","locations":["Central
@@ -743,10 +855,14 @@ http_interactions:
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securitySolutionsReferenceData","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/securitySolutionsReferenceData","locations":["Central
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"jitNetworkAccessPolicies","locations":["Central
-        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/jitNetworkAccessPolicies","locations":["Central
-        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations","locations":["Central
+        US","East US","North Europe","West Europe","UK South","UK West","West Central
+        US","West US 2"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/jitNetworkAccessPolicies","locations":["Central
+        US","East US","North Europe","West Europe","UK South","UK West","West Central
+        US","West US 2"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatusesSummaries","locations":["Central
-        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/alerts","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"applicationWhitelistings","locations":["Central
+        US","East US","West Central US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/applicationWhitelistings","locations":["Central
+        US","West Central US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/alerts","locations":["Central
         US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/tasks","locations":["Central
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"externalSecuritySolutions","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/externalSecuritySolutions","locations":["Central
@@ -769,7 +885,17 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/databaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/databaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -814,7 +940,7 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01","2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -829,7 +955,7 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -859,12 +985,17 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/geoBackupPolicies","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -879,12 +1010,12 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/firewallrules","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/backupLongTermRetentionPolicies","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -999,6 +1130,16 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
         US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
@@ -1034,7 +1175,22 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -1144,7 +1300,47 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -1159,7 +1355,17 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/administratorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -1179,52 +1385,52 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorization":{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorizations":[{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},{"applicationId":"e406a681-f3d4-42a8-90b6-c2b029497af1"}],"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
         US","West US","West Europe","North Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","South India","Central
@@ -1234,7 +1440,19 @@ http_interactions:
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Web","namespace":"Microsoft.Web","authorization":{"applicationId":"abfa0a7c-a6b6-4736-8310-5855508787cd","roleDefinitionId":"f47ed98b-b063-4a5b-9e10-4b9b44fa7735"},"resourceTypes":[{"resourceType":"sites/extensions","locations":["South
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/project","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/extension","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"checkNameAvailability","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Web","namespace":"Microsoft.Web","authorization":{"applicationId":"abfa0a7c-a6b6-4736-8310-5855508787cd","roleDefinitionId":"f47ed98b-b063-4a5b-9e10-4b9b44fa7735"},"resourceTypes":[{"resourceType":"sites/extensions","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
         South","West US","East US","Japan West","Japan East","East Asia","East US
         2","North Central US","Central US","Brazil South","Australia East","Australia
@@ -1339,7 +1557,7 @@ http_interactions:
         South","West US","East US","Japan West","Japan East","East Asia","East US
         2","North Central US","Central US","Brazil South","Australia East","Australia
         Southeast","West India","Central India","South India","Canada Central","Canada
-        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms/workers","locations":["South
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms/workers","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
         South","West US","East US","Japan West","Japan East","East Asia","East US
         2","North Central US","Central US","Brazil South","Australia East","Australia
@@ -1394,7 +1612,17 @@ http_interactions:
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","West US 2","West Central US","Canada Central","Canada
-        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/managedApis","locations":["North
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/listWsdlInterfaces","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/extractApiDefinitionFromWsdl","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/managedApis","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
@@ -1445,8 +1673,11 @@ http_interactions:
         US","North Europe","Japan West","Japan East","East Asia","West Europe","East
         US","Southeast Asia","Central US"],"apiVersions":["2016-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Lombiq.DotNest","namespace":"Lombiq.DotNest","resourceTypes":[{"resourceType":"sites","locations":["East
         US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Mailjet.Email","namespace":"Mailjet.Email","resourceTypes":[{"resourceType":"services","locations":["West
-        US"],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
-        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
+        US","West Europe"],"apiVersions":["2017-10-01","2017-02-03"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-10-01","2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-10-01","2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]},{"resourceType":"diagnosticSettings","locations":[],"apiVersions":["2017-04-01"]},{"resourceType":"diagnosticSettingsCategories","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Addons","namespace":"Microsoft.Addons","authorization":{"applicationId":"24d3987b-be4a-48e0-a3e7-11c186f39e41","roleDefinitionId":"8004BAAB-A4CB-4981-8571-F7E44D039D93"},"resourceTypes":[{"resourceType":"supportProviders","locations":["West
+        Central US","South Central US","East US","West Europe"],"apiVersions":["2017-05-15"]},{"resourceType":"operations","locations":["West
+        Central US","South Central US","East US","West Europe"],"apiVersions":["2017-05-15"]},{"resourceType":"operationResults","locations":["West
+        Central US","South Central US","East US","West Europe"],"apiVersions":["2017-05-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"addsservices","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"configuration","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"operations","locations":["West
@@ -1456,51 +1687,45 @@ http_interactions:
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"servicehealthmetrics","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"logs","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"anonymousapiusers","locations":["West
-        US"],"apiVersions":["2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AnalysisServices","namespace":"Microsoft.AnalysisServices","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"servers","locations":["West
+        US"],"apiVersions":["2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AlertsManagement","namespace":"Microsoft.AlertsManagement","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-11-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AnalysisServices","namespace":"Microsoft.AnalysisServices","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"servers","locations":["West
         US","North Europe","South Central US","West Europe","West Central US","Southeast
         Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
-        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/checkNameAvailability","locations":["West
+        Southeast","Japan East","UK South","West India","West US 2","East US"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"locations/checkNameAvailability","locations":["West
         US","North Europe","South Central US","West Europe","West Central US","Southeast
         Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
-        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationresults","locations":["West
+        Southeast","Japan East","UK South","West India","West US 2","East US"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationresults","locations":["West
         US","North Europe","South Central US","West Europe","West Central US","Southeast
         Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
-        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationstatuses","locations":["West
+        Southeast","Japan East","UK South","West India","West US 2","East US"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationstatuses","locations":["West
         US","North Europe","South Central US","West Europe","West Central US","Southeast
         Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
-        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"operations","locations":["East
-        US 2","West Central US"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AppService","namespace":"Microsoft.AppService","authorization":{"applicationId":"dee7ba80-6a55-4f3b-a86c-746a9231ae49","roleDefinitionId":"6715d172-49c4-46f6-bb21-60512a8689dc"},"resourceTypes":[{"resourceType":"apiapps","locations":["East
-        US","West US","South Central US","North Europe","East Asia","Japan East","West
-        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
-        South","East US 2","Australia Southeast","Australia East","West India","South
-        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"appIdentities","locations":["East
-        US","West US","South Central US","North Europe","East Asia","Japan East","West
-        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
-        South","East US 2","Australia Southeast","Australia East","West India","South
-        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"gateways","locations":["East
-        US","West US","South Central US","North Europe","East Asia","Japan East","West
-        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
-        South","East US 2","Australia Southeast","Australia East","West India","South
-        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"deploymenttemplates","locations":[],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Authorization","namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"roleDefinitions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"classicAdministrators","locations":[],"apiVersions":["2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"permissions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"locks","locations":[],"apiVersions":["2017-04-01","2016-09-01","2015-06-01","2015-05-01-preview","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-01-01","2014-10-01-preview","2014-06-01"]},{"resourceType":"policyDefinitions","locations":[],"apiVersions":["2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"policySetDefinitions","locations":[],"apiVersions":["2017-06-01-preview"]},{"resourceType":"policyAssignments","locations":[],"apiVersions":["2017-06-01-preview","2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"providerOperations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01-preview","2015-07-01"]},{"resourceType":"elevateAccess","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureActiveDirectory","namespace":"Microsoft.AzureActiveDirectory","resourceTypes":[{"resourceType":"b2cDirectories","locations":["Global","United
-        States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureStack","namespace":"Microsoft.AzureStack","resourceTypes":[{"resourceType":"operations","locations":["Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations","locations":["West
+        Southeast","Japan East","UK South","West India","West US 2","East US"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"operations","locations":["East
+        US 2","West Central US","West US 2"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Authorization","namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[],"apiVersions":["2017-10-01-preview","2017-09-01","2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"roleDefinitions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"classicAdministrators","locations":[],"apiVersions":["2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"permissions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"locks","locations":[],"apiVersions":["2017-04-01","2016-09-01","2015-06-01","2015-05-01-preview","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-01-01","2014-10-01-preview","2014-06-01"]},{"resourceType":"policyDefinitions","locations":[],"apiVersions":["2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"policySetDefinitions","locations":[],"apiVersions":["2017-06-01-preview"]},{"resourceType":"policyAssignments","locations":[],"apiVersions":["2017-06-01-preview","2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"providerOperations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01-preview","2015-07-01"]},{"resourceType":"elevateAccess","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"checkAccess","locations":[],"apiVersions":["2017-10-01-preview","2017-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureStack","namespace":"Microsoft.AzureStack","resourceTypes":[{"resourceType":"operations","locations":["Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations","locations":["West
         Central US","Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations/products","locations":["West
-        Central US","Global"],"apiVersions":["2017-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Billing","namespace":"Microsoft.Billing","resourceTypes":[{"resourceType":"BillingPeriods","locations":["Central
+        Central US","Global"],"apiVersions":["2017-06-01","2016-01-01"]},{"resourceType":"registrations/customerSubscriptions","locations":["West
+        Central US","Global"],"apiVersions":["2017-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BatchAI","namespace":"Microsoft.BatchAI","authorization":{"applicationId":"9fcb3732-5f52-4135-8c08-9d4bbaf203ea","roleDefinitionId":"703B89C7-CE2C-431B-BDD8-FA34E39AF696","managedByRoleDefinitionId":"90B8E153-EBFF-4073-A95F-4DAD56B14C78"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"jobs","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"fileservers","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"operations","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01-preview"]},{"resourceType":"locations/operationresults","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Billing","namespace":"Microsoft.Billing","resourceTypes":[{"resourceType":"BillingPeriods","locations":["Central
         US"],"apiVersions":["2017-04-24-preview"]},{"resourceType":"Invoices","locations":["Central
         US"],"apiVersions":["2017-04-24-preview","2017-02-27-preview"]},{"resourceType":"operations","locations":["Central
         US"],"apiVersions":["2017-04-24-preview","2017-02-27-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BingMaps","namespace":"Microsoft.BingMaps","resourceTypes":[{"resourceType":"mapApis","locations":["West
         US"],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-18","2015-07-02"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BizTalkServices","namespace":"Microsoft.BizTalkServices","resourceTypes":[{"resourceType":"BizTalk","locations":["East
         US","West US","North Europe","West Europe","Southeast Asia","East Asia","North
-        Central US","Japan West","Japan East","South Central US"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Cache","namespace":"Microsoft.Cache","authorization":{"applicationId":"96231a05-34ce-4eb4-aa6a-70759cbb5e83","roleDefinitionId":"4f731528-ba85-45c7-acfb-cd0a9b3cf31b"},"resourceTypes":[{"resourceType":"Redis","locations":["North
+        Central US","Japan West","Japan East","South Central US"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BotService","namespace":"Microsoft.BotService","resourceTypes":[{"resourceType":"botServices","locations":["Global"],"apiVersions":["2017-12-01"]},{"resourceType":"checkNameAvailability","locations":["Global"],"apiVersions":["2017-12-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Cache","namespace":"Microsoft.Cache","authorization":{"applicationId":"96231a05-34ce-4eb4-aa6a-70759cbb5e83","roleDefinitionId":"4f731528-ba85-45c7-acfb-cd0a9b3cf31b"},"resourceTypes":[{"resourceType":"Redis","locations":["North
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","Canada Central","Canada East","UK South","UK West","West US 2","West
-        Central US","South India","Korea Central","Korea South"],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","South India","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","South India","Canada Central","Canada East","UK South","UK West","West
-        US 2","West Central US","Korea Central","Korea South"],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01"]},{"resourceType":"Redis/metricDefinitions","locations":["North
+        US 2","West Central US","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01"]},{"resourceType":"Redis/metricDefinitions","locations":["North
         Central US","South Central US","East US","East US 2","West US","Central US","East
         Asia","Southeast Asia","North Europe","West Europe","Japan East","Japan West","Brazil
         South","Australia Southeast","Australia East","Central India","West India","South
@@ -1514,59 +1739,59 @@ http_interactions:
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/origins","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/origins","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/customdomains","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/customdomains","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/originresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/originresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/customdomainresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/customdomainresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkResourceUsage","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkResourceUsage","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02"]},{"resourceType":"validateProbe","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02"]},{"resourceType":"validateProbe","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02"]},{"resourceType":"operations","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02"]},{"resourceType":"operations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"edgenodes","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"edgenodes","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CertificateRegistration","namespace":"Microsoft.CertificateRegistration","authorization":{"applicationId":"f3c21649-0979-4721-ac85-b0216b2cf413","roleDefinitionId":"933fba7e-2ed3-4da8-973d-8bd8298a9b40"},"resourceTypes":[{"resourceType":"certificateOrders","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"certificateOrders/certificates","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"validateCertificateRegistrationInformation","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicSubscription","namespace":"Microsoft.ClassicSubscription","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicInfrastructureMigrate","namespace":"Microsoft.ClassicInfrastructureMigrate","authorization":{"applicationId":"5e5abe2b-83cd-4786-826a-a05653ebb103","roleDefinitionId":"766c4d9b-ef83-4f73-8352-1450a506a69b"},"resourceTypes":[{"resourceType":"classicInfrastructureResources","locations":["East
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CertificateRegistration","namespace":"Microsoft.CertificateRegistration","authorization":{"applicationId":"f3c21649-0979-4721-ac85-b0216b2cf413","roleDefinitionId":"933fba7e-2ed3-4da8-973d-8bd8298a9b40"},"resourceTypes":[{"resourceType":"certificateOrders","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"certificateOrders/certificates","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"validateCertificateRegistrationInformation","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicSubscription","namespace":"Microsoft.ClassicSubscription","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-09-01","2017-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicInfrastructureMigrate","namespace":"Microsoft.ClassicInfrastructureMigrate","authorization":{"applicationId":"5e5abe2b-83cd-4786-826a-a05653ebb103","roleDefinitionId":"766c4d9b-ef83-4f73-8352-1450a506a69b"},"resourceTypes":[{"resourceType":"classicInfrastructureResources","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
         Central US","Central US","North Europe","West Europe","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","West
@@ -1584,8 +1809,9 @@ http_interactions:
         Asia","East Asia","West Central US","South Central US","East US","East US
         2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/updateAccountsCreationSettings","locations":["West
         US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/accountsCreationSettings","locations":["West
-        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2016-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Commerce","namespace":"Microsoft.Commerce","resourceTypes":[{"resourceType":"UsageAggregates","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]},{"resourceType":"RateCard","locations":[],"apiVersions":["2016-08-31-preview","2015-06-01-preview","2015-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Consumption","namespace":"Microsoft.Consumption","resourceTypes":[{"resourceType":"reservationsummaries","locations":[],"apiVersions":["2017-01-30"]},{"resourceType":"reservationdetails","locations":[],"apiVersions":["2017-01-30"]},{"resourceType":"UsageDetails","locations":[],"apiVersions":["2017-06-30-preview","2017-04-24-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-30-preview","2017-04-24-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","resourceTypes":[{"resourceType":"containerGroups","locations":["West
-        US","East US","West Europe"],"apiVersions":["2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
+        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2016-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Commerce","namespace":"Microsoft.Commerce","resourceTypes":[{"resourceType":"UsageAggregates","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]},{"resourceType":"RateCard","locations":[],"apiVersions":["2016-08-31-preview","2015-06-01-preview","2015-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Consumption","namespace":"Microsoft.Consumption","resourceTypes":[{"resourceType":"ReservationSummaries","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationTransactions","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"Balances","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"Pricesheets","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationDetails","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"Budgets","locations":[],"apiVersions":["2017-12-30-preview"]},{"resourceType":"Terms","locations":[],"apiVersions":["2017-12-30-preview"]},{"resourceType":"UsageDetails","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview","2017-04-24-preview"]},{"resourceType":"Operations","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview","2017-04-24-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","resourceTypes":[{"resourceType":"containerGroups","locations":["West
+        US","East US","West Europe","Southeast Asia"],"apiVersions":["2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US","East US","West Europe","Southeast Asia"],"apiVersions":["2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
         US"],"apiVersions":["2016-04-08"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CustomerInsights","namespace":"Microsoft.CustomerInsights","authorization":{"applicationId":"38c77d00-5fcb-4cce-9d93-af4738258e3c","roleDefinitionId":"E006F9C7-F333-477C-8AD6-1F3A9FE87F55"},"resourceTypes":[{"resourceType":"hubs","locations":["East
         US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/profiles","locations":["East
         US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/interactions","locations":["East
@@ -1608,8 +1834,8 @@ http_interactions:
         US","West US","Australia East","West Europe","North Europe","Southeast Asia","West
         Central US"],"apiVersions":["2016-03-30","2015-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataFactory","namespace":"Microsoft.DataFactory","resourceTypes":[{"resourceType":"dataFactories","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview","2014-04-01"]},{"resourceType":"factories","locations":["East
-        US","East US 2"],"apiVersions":["2017-09-01-preview","2017-03-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
-        US","East US 2"],"apiVersions":["2017-09-01-preview","2017-03-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
+        US","East US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
+        US","East US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
         Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"dataFactories/metricDefinitions","locations":["North
         Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"checkDataFactoryNameAvailability","locations":[],"apiVersions":["2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"checkAzureDataFactoryNameAvailability","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"dataFactorySchema","locations":["West
@@ -1621,69 +1847,71 @@ http_interactions:
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers/listSasTokens","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeStore","namespace":"Microsoft.DataLakeStore","authorization":{"applicationId":"e9f49c6b-5ce5-44c8-925d-015017e9f7ad","roleDefinitionId":"17eb9cca-f08a-4499-b2d3-852d175f614f"},"resourceTypes":[{"resourceType":"accounts","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/firewallRules","locations":["East
-        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","resourceTypes":[{"resourceType":"operations","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforPostgreSQL","namespace":"Microsoft.DBforPostgreSQL","resourceTypes":[{"resourceType":"operations","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"checkProvisioningServiceNameAvailability","locations":[],"apiVersions":["2017-08-21-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataMigration","namespace":"Microsoft.DataMigration","authorization":{"applicationId":"a4bad4aa-bf02-4631-9f78-a64ffdba8150","roleDefinitionId":"b831a21d-db98-4760-89cb-bef871952df1","managedByRoleDefinitionId":"6256fb55-9e59-4018-a9e1-76b11c0a4c89"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services/projects","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationStatuses","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforPostgreSQL","namespace":"Microsoft.DBforPostgreSQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"checkProvisioningServiceNameAvailability","locations":[],"apiVersions":["2017-11-15","2017-08-21-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
         US","North Europe","East Asia","East US","West Europe","Southeast Asia","Japan
         East","Japan West","Australia East","Australia Southeast","West US 2","West
         Central US","East US 2","Central US","UK South","UK West","South India","Central
-        India","Canada Central","Canada East"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"ProvisioningServices","locations":["East
-        US","West Europe","Southeast Asia"],"apiVersions":["2017-08-21-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
-        East","Australia Southeast","Canada Central","Canada East","Central India","Central
-        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
-        US","North Europe","South Central US","South India","Southeast Asia","West
-        Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"databaseAccountNames","locations":["Australia
-        East","Australia Southeast","Canada Central","Canada East","Central India","Central
-        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
-        US","North Europe","South Central US","South India","Southeast Asia","West
-        Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"operations","locations":["Australia
-        East","Australia Southeast","Canada Central","Canada East","Central India","Central
-        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
-        US","North Europe","South Central US","South India","Southeast Asia","West
-        Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DomainRegistration","namespace":"Microsoft.DomainRegistration","authorization":{"applicationId":"ea2f600a-4980-45b7-89bf-d34da487bda1","roleDefinitionId":"54d7f2e3-5040-48a7-ae90-eebf629cfa0b"},"resourceTypes":[{"resourceType":"domains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"domains/domainOwnershipIdentifiers","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"topLevelDomains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"checkDomainAvailability","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"listDomainRecommendations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"validateDomainRegistrationInformation","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"generateSsoRequest","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DynamicsLcs","namespace":"Microsoft.DynamicsLcs","resourceTypes":[{"resourceType":"lcsprojects","locations":["Brazil
+        India","Canada Central","Canada East","Brazil South","South Central US"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs/eventGridFilters","locations":["West
+        US","East US","West US 2","West Central US","East US 2","Central US"],"apiVersions":["2018-01-15-preview"]},{"resourceType":"ProvisioningServices","locations":["East
+        US","West US","West Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2017-11-15","2017-08-21-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DomainRegistration","namespace":"Microsoft.DomainRegistration","authorization":{"applicationId":"ea2f600a-4980-45b7-89bf-d34da487bda1","roleDefinitionId":"54d7f2e3-5040-48a7-ae90-eebf629cfa0b"},"resourceTypes":[{"resourceType":"domains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"domains/domainOwnershipIdentifiers","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"topLevelDomains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"checkDomainAvailability","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"listDomainRecommendations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"validateDomainRegistrationInformation","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"generateSsoRequest","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DynamicsLcs","namespace":"Microsoft.DynamicsLcs","resourceTypes":[{"resourceType":"lcsprojects","locations":["Brazil
         South","East Asia","East US","Japan East","Japan West","North Central US","North
         Europe","South Central US","West Europe","West US","Southeast Asia","Central
         US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"lcsprojects/connectors","locations":["Brazil
@@ -1695,21 +1923,21 @@ http_interactions:
         US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"operations","locations":["Brazil
         South","East Asia","East US","Japan East","Japan West","North Central US","North
         Europe","South Central US","West Europe","West US","Southeast Asia","Central
-        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topics","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operations","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topics","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operations","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","West
         US 2","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
         India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/consumergroups","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
         US","East US 2","West US","South Central US","Central US","Australia East","Australia
         Southeast","Central India","West Central US","West US 2","Canada East","Canada
         Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
@@ -1754,23 +1982,23 @@ http_interactions:
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations","locations":["Australia
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations/operationResults","locations":["Australia
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations/operationResults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"operations","locations":["Australia
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"operations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Logic","namespace":"Microsoft.Logic","authorization":{"applicationId":"7cd684f4-8a78-49b0-91ec-6a35d38739ba","roleDefinitionId":"cb3ef1fb-6e31-49e2-9d87-ed821053fe58"},"resourceTypes":[{"resourceType":"workflows","locations":["North
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.LocationBasedServices","namespace":"Microsoft.LocationBasedServices","resourceTypes":[{"resourceType":"accounts","locations":["Global"],"apiVersions":["2017-01-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Logic","namespace":"Microsoft.Logic","authorization":{"applicationId":"7cd684f4-8a78-49b0-91ec-6a35d38739ba","roleDefinitionId":"cb3ef1fb-6e31-49e2-9d87-ed821053fe58"},"resourceTypes":[{"resourceType":"workflows","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
@@ -1791,60 +2019,78 @@ http_interactions:
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada Central","Canada East","West US 2","West Central
-        US","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","West Central US"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"operations","locations":["South
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations","locations":["South
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operations","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"commitmentPlans","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningExperimentation","namespace":"Microsoft.MachineLearningExperimentation","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"accounts","locations":["Australia
-        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces","locations":["Australia
-        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces/projects","locations":["Australia
-        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningCompute","namespace":"Microsoft.MachineLearningCompute","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"376aa7d7-51a9-463d-bd4d-7e1691345612","managedByRoleDefinitionId":"91d00862-cf55-46a5-9dce-260bbd92ce25"},"resourceTypes":[{"resourceType":"operationalizationClusters","locations":["East
-        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"operations","locations":["East
+        US","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningExperimentation","namespace":"Microsoft.MachineLearningExperimentation","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"accounts","locations":["Australia
+        East","East US 2","West Central US","Southeast Asia","West Europe"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces","locations":["Australia
+        East","East US 2","West Central US","Southeast Asia","West Europe"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces/projects","locations":["Australia
+        East","East US 2","West Central US","Southeast Asia","West Europe"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"teamAccounts","locations":["Australia
+        East","West Central US","East US 2"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"teamAccounts/workspaces","locations":["Australia
+        East","West Central US","East US 2"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"teamAccounts/workspaces/projects","locations":["Australia
+        East","West Central US","East US 2"],"apiVersions":["2017-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningCompute","namespace":"Microsoft.MachineLearningCompute","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"376aa7d7-51a9-463d-bd4d-7e1691345612","managedByRoleDefinitionId":"91d00862-cf55-46a5-9dce-260bbd92ce25"},"resourceTypes":[{"resourceType":"operationalizationClusters","locations":["East
+        US 2","West Central US","Australia East","West Europe","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"operations","locations":["East
         US 2"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations","locations":["East
         US 2"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operations","locations":["East
-        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["East
-        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningModelManagement","namespace":"Microsoft.MachineLearningModelManagement","resourceTypes":[{"resourceType":"accounts","locations":["East
-        US 2","West Central US","Australia East"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"operations","locations":["West
-        Central US"],"apiVersions":["2017-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
+        US 2","West Central US","Australia East","West Europe","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["East
+        US 2","West Central US","Australia East","West Europe","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningModelManagement","namespace":"Microsoft.MachineLearningModelManagement","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US 2","West Central US","Australia East","West Europe","Southeast Asia"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"operations","locations":["West
+        Central US"],"apiVersions":["2017-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ManagedIdentity","namespace":"Microsoft.ManagedIdentity","resourceTypes":[{"resourceType":"Identities","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Brazil South","Central
+        India","West India","South India","Japan West","Japan East","East Asia","Southeast
+        Asia","Korea Central","Korea South","North Europe","West Europe","UK West","UK
+        South","Central US","North Central US","East US","East US 2","South Central
+        US","West US","West US 2","West Central US"],"apiVersions":["2015-08-31-PREVIEW"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Brazil South","Central
+        India","West India","South India","Japan West","Japan East","East Asia","Southeast
+        Asia","Korea Central","Korea South","North Europe","West Europe","UK West","UK
+        South","Central US","North Central US","East US","East US 2","South Central
+        US","West US","West US 2","West Central US"],"apiVersions":["2015-08-31-PREVIEW"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Management","namespace":"Microsoft.Management","authorization":{"applicationId":"f2c304cf-8e7e-4c3f-8164-16299ad9d272","roleDefinitionId":"c1cf3708-588a-4647-be7f-f400bbe214cf"},"resourceTypes":[{"resourceType":"resources","locations":[],"apiVersions":["2017-11-01-preview","2017-08-31-preview","2017-06-30-preview","2017-05-31-preview"]},{"resourceType":"managementGroups","locations":[],"apiVersions":["2017-11-01-preview","2017-08-31-preview","2017-06-30-preview","2017-05-31-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01-preview","2017-08-31-preview","2017-06-30-preview","2017-05-31-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceApps","namespace":"Microsoft.MarketplaceApps","resourceTypes":[{"resourceType":"classicDevServices","locations":["Northwest
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","Central US","North
+        Europe","West Europe","Japan East","Japan West","Brazil South","Australia
+        East","Australia Southeast","South India","Central India","Canada Central","Canada
+        East"],"apiVersions":["2017-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
         Central US","West US"],"apiVersions":["2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01"]},{"resourceType":"offertypes","locations":["South
         Central US","West US"],"apiVersions":["2015-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Media","namespace":"Microsoft.Media","authorization":{"applicationId":"374b2a64-3b6b-436b-934c-b820eacca870","roleDefinitionId":"aab70789-0cec-44b5-95d7-84b64c9487af"},"resourceTypes":[{"resourceType":"mediaservices","locations":["Japan
         West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
         US","West US","Australia East","Australia Southeast","Central US","Brazil
         South","Central India","West India","South India","South Central US","Canada
-        Central","Canada East","West Central US"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
+        Central","Canada East","West Central US","West US 2"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
+        Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"operations","locations":["West
+        Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
+        Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PolicyInsights","namespace":"Microsoft.PolicyInsights","authorization":{"applicationId":"1d78a85d-813d-46f0-b496-dd72f50a3ec0","roleDefinitionId":"63d2b225-4c34-4641-8768-21a1f7c68ce8"},"resourceTypes":[{"resourceType":"policyEvents","locations":[],"apiVersions":["2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"policyStates","locations":[],"apiVersions":["2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-17-preview","2017-08-09-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
         Central US","North Central US","East US 2","West US","West Europe","North
         Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
         East","UK South","West India"],"apiVersions":["2016-01-29"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-01-29"]},{"resourceType":"locations/checkNameAvailability","locations":["South
         Central US","North Central US","East US 2","West US","West Europe","North
         Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
-        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"capacities","locations":["West
-        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
-        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationresults","locations":["West
-        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
-        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"operations","locations":["East
-        US 2"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Relay","namespace":"Microsoft.Relay","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"capacities","locations":["Australia
+        Southeast","Brazil South","Canada Central","East Asia","East US","East US
+        2","West India","Japan East","West Central US","North Central US","North Europe","South
+        Central US","Southeast Asia","UK South","West Europe","West US","West US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":["Australia
+        Southeast","Brazil South","Canada Central","East Asia","East US","East US
+        2","West India","Japan East","West Central US","North Central US","North Europe","South
+        Central US","Southeast Asia","UK South","West Europe","West US","West US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationresults","locations":["Australia
+        Southeast","Brazil South","Canada Central","East Asia","East US","East US
+        2","West India","Japan East","West Central US","North Central US","North Europe","South
+        Central US","Southeast Asia","UK South","West Europe","West US","West US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["Australia
+        Southeast","Brazil South","Canada Central","East Asia","East US","East US
+        2","West India","Japan East","West Central US","North Central US","North Europe","South
+        Central US","Southeast Asia","UK South","West Europe","West US","West US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"operations","locations":["East
+        US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Relay","namespace":"Microsoft.Relay","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US 2","West
         US","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
         India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2017-08-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkPolicyCompliance","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/hybridconnections","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/hybridconnections/authorizationrules","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/wcfrelays","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/wcfrelays/authorizationrules","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkPolicyCompliance","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
         Central US","South Central US","North Europe","West Europe","East Asia","Southeast
         Asia","West US","East US","Japan West","Japan East","Brazil South","Central
         US","East US 2","Australia East","Australia Southeast","South India","Central
@@ -1868,12 +2114,12 @@ http_interactions:
         India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19","2015-02-28"]},{"resourceType":"checkServiceNameAvailability","locations":[],"apiVersions":["2015-02-28","2014-07-31-Preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2015-08-19"]},{"resourceType":"resourceHealthMetadata","locations":["West
         US","East US","North Europe","West Europe","Southeast Asia","East Asia","North
         Central US","South Central US","Japan West","Australia East","Brazil South","Central
-        India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","authorization":{"applicationId":"80a10ef9-8168-493d-abf9-3297c4ef6e3c","roleDefinitionId":"2b7763f7-bbe2-4e19-befe-28c79f1cf7f7"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US 2","West
         US","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
         India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"premiumMessagingRegions","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceFabric","namespace":"Microsoft.ServiceFabric","authorization":{"applicationId":"74cb6831-0dbb-4be1-8206-fd4df301cdc2","roleDefinitionId":"e55cc65f-6903-4917-b4ef-f8d4640b57f5"},"resourceTypes":[{"resourceType":"clusters","locations":["West
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/queues","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/queues/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/topics","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/topics/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/topics/subscriptions","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/topics/subscriptions/rules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"premiumMessagingRegions","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceFabric","namespace":"Microsoft.ServiceFabric","authorization":{"applicationId":"74cb6831-0dbb-4be1-8206-fd4df301cdc2","roleDefinitionId":"e55cc65f-6903-4917-b4ef-f8d4640b57f5"},"resourceTypes":[{"resourceType":"clusters","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
@@ -1887,17 +2133,43 @@ http_interactions:
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
-        India","West India","Central India","Brazil South","South Central US","Canada
-        Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
         Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
         Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applianceDefinitions","locations":["West
-        Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"locations","locations":["West
-        Central US"],"apiVersions":["2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
-        Central US"],"apiVersions":["2017-09-01","2016-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
+        Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applications","locations":["South
+        Central US","North Central US","West Central US","West US","West US 2","East
+        US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
+        Asia","Brazil South","Japan West","Japan East","Australia East","Australia
+        Southeast","South India","West India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
+        Central US","North Central US","West Central US","West US","West US 2","East
+        US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
+        Asia","Brazil South","Japan West","Japan East","Australia East","Australia
+        Southeast","South India","West India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
+        Central US"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
+        Central US","North Central US","West Central US","West US","West US 2","East
+        US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
+        Asia","Brazil South","Japan West","Japan East","Australia East","Australia
+        Southeast","South India","West India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/cloudEndpoints","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/serverEndpoints","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/registeredServers","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/workflows","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","West Central US","Japan East","Japan West","Australia East","Australia
         Southeast"],"apiVersions":["2017-06-01","2017-05-15","2017-01-01","2016-10-01","2016-06-01","2015-03-15","2014-09-01"]},{"resourceType":"operations","locations":["West
@@ -1928,23 +2200,11 @@ http_interactions:
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast"],"apiVersions":["2015-07-01-Preview","2015-03-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.TimeSeriesInsights","namespace":"Microsoft.TimeSeriesInsights","authorizations":[{"applicationId":"120d688d-1518-4cf7-bd38-182f158850b6","roleDefinitionId":"5a43abdf-bb87-42c4-9e56-1c24bf364150"}],"resourceTypes":[{"resourceType":"environments","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/eventsources","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/referenceDataSets","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/accessPolicies","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"operations","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
-        Central US","South Central US","East US","West US","Central US","North Europe","West
-        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
-        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/project","locations":["North
-        Central US","South Central US","East US","West US","Central US","North Europe","West
-        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
-        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/extension","locations":["North
-        Central US","South Central US","East US","West US","Central US","North Europe","West
-        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
-        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"checkNameAvailability","locations":["North
-        Central US","South Central US","East US","West US","Central US","North Europe","West
-        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
-        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Myget.PackageManagement","namespace":"Myget.PackageManagement","resourceTypes":[{"resourceType":"services","locations":["West
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]},{"resourceType":"environments/eventsources","locations":["East
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]},{"resourceType":"environments/referenceDataSets","locations":["East
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]},{"resourceType":"environments/accessPolicies","locations":["East
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]},{"resourceType":"operations","locations":["East
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Myget.PackageManagement","namespace":"Myget.PackageManagement","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/NewRelic.APM","namespace":"NewRelic.APM","authorization":{"allowedThirdPartyExtensions":[{"name":"NewRelic_AzurePortal_APM"}]},"resourceTypes":[{"resourceType":"accounts","locations":["North
         Central US","South Central US","West US","East US","North Europe","West Europe","Southeast
         Asia","East Asia","Japan East","Japan West"],"apiVersions":["2014-10-01","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/nuubit.nextgencdn","namespace":"nuubit.nextgencdn","resourceTypes":[{"resourceType":"accounts","locations":["East
@@ -1984,7 +2244,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:43:20 GMT
+  recorded_at: Tue, 23 Jan 2018 20:06:54 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
@@ -2001,9 +2261,11 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyOTgsIm5iZiI6MTUwNjExNjI5OCwiZXhwIjoxNTA2MTIwMTk4LCJhaW8iOiJZMlZnWVBpYkdpZTFMU0JhNkUvbm8rMWF5cWRXQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTN5bGRtWWRmME9FeEpHR1F5a09BQSIsInZlciI6IjEuMCJ9.GXfU7XOKtiFTBk1pmTywNCCfzOXXoOfOiww3yywW6Ukwzy3_nMl-h1y9gCia2FHM5GqUnV530zFq_glFJtlMzRFfDxRC_SCmdNrrUtI025PnBxiPBy43kvGugxRdlzDwtxuWeJc0MjZha9lM5I3tBjGQTKYGyCF4rrXnijh-pFPopigaPbUeB0k0joA30JSnYUWDV6LhKYzBtlUrn8rhz4xpuLlRL7sMvHOWbZpTT_XOLL_6Dd9lcdGPCW2TadXlUTvlQMQM3r4KX6dfARWt96SltdoAwjLxFGi6fk5VYIFPtdZihzYQO3IWKsFNiM3S5KSoJxGHl0_OKp11fkmHGw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3MTIsIm5iZiI6MTUxNjczNzcxMiwiZXhwIjoxNTE2NzQxNjEyLCJhaW8iOiJZMk5nWU5pM2dmVzIwemZWVjVlMGVscW1hNml0QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibHh3MVZfcFRnMFMtMlBKTzZ6NFJBQSIsInZlciI6IjEuMCJ9.W4bjxEKCoeWaAXXkoq9PkzuPHpMUL17KOemH5oBCOHsUc-0oYPFZEfTxT5FCh69lsrTP2FgzkGyWpvQEQ7gSKmNqNaKBKw4QWbqB-aOyTBleqBn5uV1L4xXiVdDtGOVjDaE_4sbZ_tXWp1AQMtajpbRKmMPVnlBH8avQCUrCwN_C7YfkY5rcmq8rZbd_9j-Febq0-m4IPK2-N6Rz0CANglovksI1nSmUIfu1zm90U2ey0GsU60ExrRjZskjhAPPdrIesEmzuJb_zAgP5hIKWALX8Nc1-4BYWpHPizsAB8DhjchuUavB6sJg8SThAWrWECw9C_Fb5eStoPrmrJlnKhg
       Content-Length:
       - '42'
+      Host:
+      - management.azure.com
   response:
     status:
       code: 202
@@ -2013,39 +2275,41 @@ http_interactions:
       - no-cache
       Pragma:
       - no-cache
-      Content-Length:
-      - '0'
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/ecf32a2f-c18d-4b1c-bc42-fc0f00cac50a?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/e50d6461-f96b-4a3e-9329-d4fe9d5dca51?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/ecf32a2f-c18d-4b1c-bc42-fc0f00cac50a?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/e50d6461-f96b-4a3e-9329-d4fe9d5dca51?api-version=2017-03-30
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/HighCostHydrate3Min;236,Microsoft.Compute/HighCostHydrate30Min;1163
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131599701143261070
       X-Ms-Request-Id:
-      - ecf32a2f-c18d-4b1c-bc42-fc0f00cac50a
+      - e50d6461-f96b-4a3e-9329-d4fe9d5dca51
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1181'
+      - '1162'
       X-Ms-Correlation-Request-Id:
-      - 44f31156-1555-4f42-8657-7bc65ba7e375
+      - b79fc451-e554-4581-baf2-eedd2aa7cd29
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214321Z:44f31156-1555-4f42-8657-7bc65ba7e375
+      - WESTUS:20180123T200655Z:b79fc451-e554-4581-baf2-eedd2aa7cd29
       Date:
-      - Fri, 22 Sep 2017 21:43:21 GMT
+      - Tue, 23 Jan 2018 20:06:54 GMT
+      Content-Length:
+      - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:43:21 GMT
+  recorded_at: Tue, 23 Jan 2018 20:06:55 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/ecf32a2f-c18d-4b1c-bc42-fc0f00cac50a?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/e50d6461-f96b-4a3e-9329-d4fe9d5dca51?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -2059,7 +2323,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyOTgsIm5iZiI6MTUwNjExNjI5OCwiZXhwIjoxNTA2MTIwMTk4LCJhaW8iOiJZMlZnWVBpYkdpZTFMU0JhNkUvbm8rMWF5cWRXQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTN5bGRtWWRmME9FeEpHR1F5a09BQSIsInZlciI6IjEuMCJ9.GXfU7XOKtiFTBk1pmTywNCCfzOXXoOfOiww3yywW6Ukwzy3_nMl-h1y9gCia2FHM5GqUnV530zFq_glFJtlMzRFfDxRC_SCmdNrrUtI025PnBxiPBy43kvGugxRdlzDwtxuWeJc0MjZha9lM5I3tBjGQTKYGyCF4rrXnijh-pFPopigaPbUeB0k0joA30JSnYUWDV6LhKYzBtlUrn8rhz4xpuLlRL7sMvHOWbZpTT_XOLL_6Dd9lcdGPCW2TadXlUTvlQMQM3r4KX6dfARWt96SltdoAwjLxFGi6fk5VYIFPtdZihzYQO3IWKsFNiM3S5KSoJxGHl0_OKp11fkmHGw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3MTIsIm5iZiI6MTUxNjczNzcxMiwiZXhwIjoxNTE2NzQxNjEyLCJhaW8iOiJZMk5nWU5pM2dmVzIwemZWVjVlMGVscW1hNml0QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibHh3MVZfcFRnMFMtMlBKTzZ6NFJBQSIsInZlciI6IjEuMCJ9.W4bjxEKCoeWaAXXkoq9PkzuPHpMUL17KOemH5oBCOHsUc-0oYPFZEfTxT5FCh69lsrTP2FgzkGyWpvQEQ7gSKmNqNaKBKw4QWbqB-aOyTBleqBn5uV1L4xXiVdDtGOVjDaE_4sbZ_tXWp1AQMtajpbRKmMPVnlBH8avQCUrCwN_C7YfkY5rcmq8rZbd_9j-Febq0-m4IPK2-N6Rz0CANglovksI1nSmUIfu1zm90U2ey0GsU60ExrRjZskjhAPPdrIesEmzuJb_zAgP5hIKWALX8Nc1-4BYWpHPizsAB8DhjchuUavB6sJg8SThAWrWECw9C_Fb5eStoPrmrJlnKhg
+      Host:
+      - management.azure.com
   response:
     status:
       code: 200
@@ -2077,34 +2343,36 @@ http_interactions:
       - "-1"
       Vary:
       - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/GetOperation3Min;49992,Microsoft.Compute/GetOperation30Min;249992
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131599701143261070
       X-Ms-Request-Id:
-      - 71a3c669-edcb-4d21-b9b6-d077cf5e2a4e
+      - 056b4b12-d452-4d82-a875-d9f6526e5e16
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14936'
+      - '14704'
       X-Ms-Correlation-Request-Id:
-      - bc66b0ee-bb61-4629-9835-40b8d70a7b3b
+      - d486991c-ba25-4717-b891-80ce283e7c9a
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214322Z:bc66b0ee-bb61-4629-9835-40b8d70a7b3b
+      - WESTUS:20180123T200656Z:d486991c-ba25-4717-b891-80ce283e7c9a
       Date:
-      - Fri, 22 Sep 2017 21:43:21 GMT
+      - Tue, 23 Jan 2018 20:06:55 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-22T21:43:22.6790953+00:00\",\r\n  \"endTime\":
-        \"2017-09-22T21:43:22.8510167+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=0e6847e5-43a4-4a22-9baf-6cbd6b92bcf9&sig=ZYWDMMESZruGP%2Bb82bh%2FtQUuwqM%2BKubYfgw6kUANajQ%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"ecf32a2f-c18d-4b1c-bc42-fc0f00cac50a\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2018-01-23T20:06:54.7008963+00:00\",\r\n  \"endTime\":
+        \"2018-01-23T20:06:54.9195997+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=5b50eecf-d522-443f-b208-c1540f6a8c67&sig=n2LtwFMC9lfTEsiCXwdgnpf8awQDScKcRVK%2BzvkkctA%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"e50d6461-f96b-4a3e-9329-d4fe9d5dca51\"\r\n}"
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:43:21 GMT
+  recorded_at: Tue, 23 Jan 2018 20:06:56 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/ecf32a2f-c18d-4b1c-bc42-fc0f00cac50a?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/e50d6461-f96b-4a3e-9329-d4fe9d5dca51?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -2118,7 +2386,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyOTgsIm5iZiI6MTUwNjExNjI5OCwiZXhwIjoxNTA2MTIwMTk4LCJhaW8iOiJZMlZnWVBpYkdpZTFMU0JhNkUvbm8rMWF5cWRXQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTN5bGRtWWRmME9FeEpHR1F5a09BQSIsInZlciI6IjEuMCJ9.GXfU7XOKtiFTBk1pmTywNCCfzOXXoOfOiww3yywW6Ukwzy3_nMl-h1y9gCia2FHM5GqUnV530zFq_glFJtlMzRFfDxRC_SCmdNrrUtI025PnBxiPBy43kvGugxRdlzDwtxuWeJc0MjZha9lM5I3tBjGQTKYGyCF4rrXnijh-pFPopigaPbUeB0k0joA30JSnYUWDV6LhKYzBtlUrn8rhz4xpuLlRL7sMvHOWbZpTT_XOLL_6Dd9lcdGPCW2TadXlUTvlQMQM3r4KX6dfARWt96SltdoAwjLxFGi6fk5VYIFPtdZihzYQO3IWKsFNiM3S5KSoJxGHl0_OKp11fkmHGw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3MTIsIm5iZiI6MTUxNjczNzcxMiwiZXhwIjoxNTE2NzQxNjEyLCJhaW8iOiJZMk5nWU5pM2dmVzIwemZWVjVlMGVscW1hNml0QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibHh3MVZfcFRnMFMtMlBKTzZ6NFJBQSIsInZlciI6IjEuMCJ9.W4bjxEKCoeWaAXXkoq9PkzuPHpMUL17KOemH5oBCOHsUc-0oYPFZEfTxT5FCh69lsrTP2FgzkGyWpvQEQ7gSKmNqNaKBKw4QWbqB-aOyTBleqBn5uV1L4xXiVdDtGOVjDaE_4sbZ_tXWp1AQMtajpbRKmMPVnlBH8avQCUrCwN_C7YfkY5rcmq8rZbd_9j-Febq0-m4IPK2-N6Rz0CANglovksI1nSmUIfu1zm90U2ey0GsU60ExrRjZskjhAPPdrIesEmzuJb_zAgP5hIKWALX8Nc1-4BYWpHPizsAB8DhjchuUavB6sJg8SThAWrWECw9C_Fb5eStoPrmrJlnKhg
+      Host:
+      - management.azure.com
   response:
     status:
       code: 200
@@ -2136,34 +2406,36 @@ http_interactions:
       - "-1"
       Vary:
       - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/GetOperation3Min;49991,Microsoft.Compute/GetOperation30Min;249991
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131599701143261070
       X-Ms-Request-Id:
-      - ec07f302-9c84-4e4a-8e1d-b5a023584dc8
+      - e1d013d6-e0ca-4a18-b1b9-37e9018ffb2c
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14917'
+      - '14862'
       X-Ms-Correlation-Request-Id:
-      - 1367ff81-60cd-4a08-aaaf-8c6041d15413
+      - a540c550-5271-44bf-b4b0-223ef6f6e746
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214322Z:1367ff81-60cd-4a08-aaaf-8c6041d15413
+      - WESTUS:20180123T200655Z:a540c550-5271-44bf-b4b0-223ef6f6e746
       Date:
-      - Fri, 22 Sep 2017 21:43:21 GMT
+      - Tue, 23 Jan 2018 20:06:55 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-22T21:43:22.6790953+00:00\",\r\n  \"endTime\":
-        \"2017-09-22T21:43:22.8510167+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=0e6847e5-43a4-4a22-9baf-6cbd6b92bcf9&sig=ZYWDMMESZruGP%2Bb82bh%2FtQUuwqM%2BKubYfgw6kUANajQ%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"ecf32a2f-c18d-4b1c-bc42-fc0f00cac50a\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2018-01-23T20:06:54.7008963+00:00\",\r\n  \"endTime\":
+        \"2018-01-23T20:06:54.9195997+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=5b50eecf-d522-443f-b208-c1540f6a8c67&sig=n2LtwFMC9lfTEsiCXwdgnpf8awQDScKcRVK%2BzvkkctA%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"e50d6461-f96b-4a3e-9329-d4fe9d5dca51\"\r\n}"
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:43:22 GMT
+  recorded_at: Tue, 23 Jan 2018 20:06:57 GMT
 - request:
     method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=0e6847e5-43a4-4a22-9baf-6cbd6b92bcf9&sig=ZYWDMMESZruGP%2Bb82bh/tQUuwqM%2BKubYfgw6kUANajQ=&sr=b&sv=2016-05-31
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=5b50eecf-d522-443f-b208-c1540f6a8c67&sig=n2LtwFMC9lfTEsiCXwdgnpf8awQDScKcRVK%2BzvkkctA=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2176,6 +2448,8 @@ http_interactions:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
       X-Ms-Range:
       - bytes=0-0
+      Host:
+      - md-t4jdgqqlgszp.blob.core.windows.net
   response:
     status:
       code: 206
@@ -2188,15 +2462,15 @@ http_interactions:
       Content-Range:
       - bytes 0-0/34359738880
       Last-Modified:
-      - Sat, 15 Jul 2017 14:23:07 GMT
+      - Tue, 23 Jan 2018 20:04:26 GMT
       Accept-Ranges:
       - bytes
       Etag:
-      - '"0x8D4CB8D039FC699"'
+      - '"0x8D5629C811B65EB"'
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - ac592393-001e-0118-07eb-33caed000000
+      - 526c8a3c-001e-0068-2c85-94ff7c000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2208,7 +2482,7 @@ http_interactions:
       X-Ms-Blob-Type:
       - PageBlob
       X-Ms-Blob-Sequence-Number:
-      - '20'
+      - '30'
       X-Ms-Copy-Id:
       - 30cedd78-548a-4fd8-967e-f8344f587e3c
       X-Ms-Copy-Source:
@@ -2222,250 +2496,16 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Fri, 22 Sep 2017 21:43:22 GMT
+      - Tue, 23 Jan 2018 20:06:55 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         6w==
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:43:22 GMT
-- request:
-    method: post
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/EndGetAccess?api-version=2017-03-30
-    body:
-      encoding: ASCII-8BIT
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyOTgsIm5iZiI6MTUwNjExNjI5OCwiZXhwIjoxNTA2MTIwMTk4LCJhaW8iOiJZMlZnWVBpYkdpZTFMU0JhNkUvbm8rMWF5cWRXQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTN5bGRtWWRmME9FeEpHR1F5a09BQSIsInZlciI6IjEuMCJ9.GXfU7XOKtiFTBk1pmTywNCCfzOXXoOfOiww3yywW6Ukwzy3_nMl-h1y9gCia2FHM5GqUnV530zFq_glFJtlMzRFfDxRC_SCmdNrrUtI025PnBxiPBy43kvGugxRdlzDwtxuWeJc0MjZha9lM5I3tBjGQTKYGyCF4rrXnijh-pFPopigaPbUeB0k0joA30JSnYUWDV6LhKYzBtlUrn8rhz4xpuLlRL7sMvHOWbZpTT_XOLL_6Dd9lcdGPCW2TadXlUTvlQMQM3r4KX6dfARWt96SltdoAwjLxFGi6fk5VYIFPtdZihzYQO3IWKsFNiM3S5KSoJxGHl0_OKp11fkmHGw
-      Content-Length:
-      - '0'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '0'
-      Expires:
-      - "-1"
-      Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/a7f4008f-d5ca-4c73-9934-f74338f5cea9?monitor=true&api-version=2017-03-30
-      Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/a7f4008f-d5ca-4c73-9934-f74338f5cea9?api-version=2017-03-30
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - a7f4008f-d5ca-4c73-9934-f74338f5cea9
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1184'
-      X-Ms-Correlation-Request-Id:
-      - cdf877f8-2f68-46de-8bf6-7b1f603136a6
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214323Z:cdf877f8-2f68-46de-8bf6-7b1f603136a6
-      Date:
-      - Fri, 22 Sep 2017 21:43:23 GMT
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:43:23 GMT
-- request:
-    method: post
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
-    body:
-      encoding: UTF-8
-      string: '{"access":"read","durationInSeconds":3600}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyOTgsIm5iZiI6MTUwNjExNjI5OCwiZXhwIjoxNTA2MTIwMTk4LCJhaW8iOiJZMlZnWVBpYkdpZTFMU0JhNkUvbm8rMWF5cWRXQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTN5bGRtWWRmME9FeEpHR1F5a09BQSIsInZlciI6IjEuMCJ9.GXfU7XOKtiFTBk1pmTywNCCfzOXXoOfOiww3yywW6Ukwzy3_nMl-h1y9gCia2FHM5GqUnV530zFq_glFJtlMzRFfDxRC_SCmdNrrUtI025PnBxiPBy43kvGugxRdlzDwtxuWeJc0MjZha9lM5I3tBjGQTKYGyCF4rrXnijh-pFPopigaPbUeB0k0joA30JSnYUWDV6LhKYzBtlUrn8rhz4xpuLlRL7sMvHOWbZpTT_XOLL_6Dd9lcdGPCW2TadXlUTvlQMQM3r4KX6dfARWt96SltdoAwjLxFGi6fk5VYIFPtdZihzYQO3IWKsFNiM3S5KSoJxGHl0_OKp11fkmHGw
-      Content-Length:
-      - '42'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '0'
-      Expires:
-      - "-1"
-      Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/d5303e2e-9f0c-42c0-8e92-41f1b947ce98?monitor=true&api-version=2017-03-30
-      Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/d5303e2e-9f0c-42c0-8e92-41f1b947ce98?api-version=2017-03-30
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - d5303e2e-9f0c-42c0-8e92-41f1b947ce98
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1181'
-      X-Ms-Correlation-Request-Id:
-      - d59d8d37-4f2b-41d1-9c39-09ad1b190e93
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214325Z:d59d8d37-4f2b-41d1-9c39-09ad1b190e93
-      Date:
-      - Fri, 22 Sep 2017 21:43:24 GMT
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:43:25 GMT
+  recorded_at: Tue, 23 Jan 2018 20:06:57 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/d5303e2e-9f0c-42c0-8e92-41f1b947ce98?api-version=2017-03-30
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyOTgsIm5iZiI6MTUwNjExNjI5OCwiZXhwIjoxNTA2MTIwMTk4LCJhaW8iOiJZMlZnWVBpYkdpZTFMU0JhNkUvbm8rMWF5cWRXQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTN5bGRtWWRmME9FeEpHR1F5a09BQSIsInZlciI6IjEuMCJ9.GXfU7XOKtiFTBk1pmTywNCCfzOXXoOfOiww3yywW6Ukwzy3_nMl-h1y9gCia2FHM5GqUnV530zFq_glFJtlMzRFfDxRC_SCmdNrrUtI025PnBxiPBy43kvGugxRdlzDwtxuWeJc0MjZha9lM5I3tBjGQTKYGyCF4rrXnijh-pFPopigaPbUeB0k0joA30JSnYUWDV6LhKYzBtlUrn8rhz4xpuLlRL7sMvHOWbZpTT_XOLL_6Dd9lcdGPCW2TadXlUTvlQMQM3r4KX6dfARWt96SltdoAwjLxFGi6fk5VYIFPtdZihzYQO3IWKsFNiM3S5KSoJxGHl0_OKp11fkmHGw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - 18fe3312-d435-48d6-95cf-1ea961fddb62
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14917'
-      X-Ms-Correlation-Request-Id:
-      - 1aa08855-cb1c-4d99-bb52-b43e362aa6e0
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214326Z:1aa08855-cb1c-4d99-bb52-b43e362aa6e0
-      Date:
-      - Fri, 22 Sep 2017 21:43:26 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-22T21:43:26.8087261+00:00\",\r\n  \"endTime\":
-        \"2017-09-22T21:43:26.9650264+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=dd9f1548-c7a2-4a92-b9a4-bdb1ba19c1f9&sig=3siCGhj9NYpe%2BKYdwiF%2Bh7Rce%2BnvAeHxpc4jITj9AvA%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"d5303e2e-9f0c-42c0-8e92-41f1b947ce98\"\r\n}"
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:43:26 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/d5303e2e-9f0c-42c0-8e92-41f1b947ce98?api-version=2017-03-30
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyOTgsIm5iZiI6MTUwNjExNjI5OCwiZXhwIjoxNTA2MTIwMTk4LCJhaW8iOiJZMlZnWVBpYkdpZTFMU0JhNkUvbm8rMWF5cWRXQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTN5bGRtWWRmME9FeEpHR1F5a09BQSIsInZlciI6IjEuMCJ9.GXfU7XOKtiFTBk1pmTywNCCfzOXXoOfOiww3yywW6Ukwzy3_nMl-h1y9gCia2FHM5GqUnV530zFq_glFJtlMzRFfDxRC_SCmdNrrUtI025PnBxiPBy43kvGugxRdlzDwtxuWeJc0MjZha9lM5I3tBjGQTKYGyCF4rrXnijh-pFPopigaPbUeB0k0joA30JSnYUWDV6LhKYzBtlUrn8rhz4xpuLlRL7sMvHOWbZpTT_XOLL_6Dd9lcdGPCW2TadXlUTvlQMQM3r4KX6dfARWt96SltdoAwjLxFGi6fk5VYIFPtdZihzYQO3IWKsFNiM3S5KSoJxGHl0_OKp11fkmHGw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - e860cfaa-43d8-4544-90e9-a660b25c9e68
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Correlation-Request-Id:
-      - 8194b7ae-d2af-45e6-b0e2-e09a8849e072
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214327Z:8194b7ae-d2af-45e6-b0e2-e09a8849e072
-      Date:
-      - Fri, 22 Sep 2017 21:43:26 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-22T21:43:26.8087261+00:00\",\r\n  \"endTime\":
-        \"2017-09-22T21:43:26.9650264+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=dd9f1548-c7a2-4a92-b9a4-bdb1ba19c1f9&sig=3siCGhj9NYpe%2BKYdwiF%2Bh7Rce%2BnvAeHxpc4jITj9AvA%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"d5303e2e-9f0c-42c0-8e92-41f1b947ce98\"\r\n}"
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:43:26 GMT
-- request:
-    method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=dd9f1548-c7a2-4a92-b9a4-bdb1ba19c1f9&sig=3siCGhj9NYpe%2BKYdwiF%2Bh7Rce%2BnvAeHxpc4jITj9AvA=&sr=b&sv=2016-05-31
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=5b50eecf-d522-443f-b208-c1540f6a8c67&sig=n2LtwFMC9lfTEsiCXwdgnpf8awQDScKcRVK%2BzvkkctA=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2478,6 +2518,8 @@ http_interactions:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
       X-Ms-Range:
       - bytes=440-443
+      Host:
+      - md-t4jdgqqlgszp.blob.core.windows.net
   response:
     status:
       code: 206
@@ -2490,15 +2532,15 @@ http_interactions:
       Content-Range:
       - bytes 440-443/34359738880
       Last-Modified:
-      - Sat, 15 Jul 2017 14:23:07 GMT
+      - Tue, 23 Jan 2018 20:04:26 GMT
       Accept-Ranges:
       - bytes
       Etag:
-      - '"0x8D4CB8D039FC699"'
+      - '"0x8D5629C811B65EB"'
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 19df09c1-001e-00d0-08eb-331d8f000000
+      - 7c07fdf1-001e-00d4-5085-94e80d000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2510,7 +2552,7 @@ http_interactions:
       X-Ms-Blob-Type:
       - PageBlob
       X-Ms-Blob-Sequence-Number:
-      - '20'
+      - '30'
       X-Ms-Copy-Id:
       - 30cedd78-548a-4fd8-967e-f8344f587e3c
       X-Ms-Copy-Source:
@@ -2524,69 +2566,11 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Fri, 22 Sep 2017 21:43:27 GMT
+      - Tue, 23 Jan 2018 20:06:57 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         U5MJAA==
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:43:27 GMT
-- request:
-    method: post
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/EndGetAccess?api-version=2017-03-30
-    body:
-      encoding: ASCII-8BIT
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyOTgsIm5iZiI6MTUwNjExNjI5OCwiZXhwIjoxNTA2MTIwMTk4LCJhaW8iOiJZMlZnWVBpYkdpZTFMU0JhNkUvbm8rMWF5cWRXQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTN5bGRtWWRmME9FeEpHR1F5a09BQSIsInZlciI6IjEuMCJ9.GXfU7XOKtiFTBk1pmTywNCCfzOXXoOfOiww3yywW6Ukwzy3_nMl-h1y9gCia2FHM5GqUnV530zFq_glFJtlMzRFfDxRC_SCmdNrrUtI025PnBxiPBy43kvGugxRdlzDwtxuWeJc0MjZha9lM5I3tBjGQTKYGyCF4rrXnijh-pFPopigaPbUeB0k0joA30JSnYUWDV6LhKYzBtlUrn8rhz4xpuLlRL7sMvHOWbZpTT_XOLL_6Dd9lcdGPCW2TadXlUTvlQMQM3r4KX6dfARWt96SltdoAwjLxFGi6fk5VYIFPtdZihzYQO3IWKsFNiM3S5KSoJxGHl0_OKp11fkmHGw
-      Content-Length:
-      - '0'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '0'
-      Expires:
-      - "-1"
-      Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/a8bc71ec-235f-4e1c-a974-93e139af1347?monitor=true&api-version=2017-03-30
-      Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/a8bc71ec-235f-4e1c-a974-93e139af1347?api-version=2017-03-30
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - a8bc71ec-235f-4e1c-a974-93e139af1347
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1184'
-      X-Ms-Correlation-Request-Id:
-      - 4ec9d408-0207-4f2e-bf2e-fb57fcd4b32c
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214328Z:4ec9d408-0207-4f2e-bf2e-fb57fcd4b32c
-      Date:
-      - Fri, 22 Sep 2017 21:43:27 GMT
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:43:27 GMT
+  recorded_at: Tue, 23 Jan 2018 20:06:57 GMT
 recorded_with: VCR 3.0.3

--- a/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_diskType-1.yml
+++ b/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_diskType-1.yml
@@ -17,6 +17,8 @@ http_interactions:
       - '186'
       Content-Type:
       - application/x-www-form-urlencoded
+      Host:
+      - login.microsoftonline.com
   response:
     status:
       code: 200
@@ -37,25 +39,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - c73edbde-235e-45f9-8f62-7b7798a40a00
+      - 45424ee2-3046-4ec8-8483-c9a087c61100
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAAABlDrqfEFlSaui6xnRjX5EZPGl2GfjW0Go6xkXR5q1iJrJh-w1VkWLg7up53muVZJCu0TimEdEV_4hlzxfKSKhemvES3r4S-_apBmdAAW5IHbj5lE5UB2-fyIdLoFrkBEdjwUaIQRW7b_0iiO-gHQh6dZA6Fs1cVZxwwckFaEWh-9r0oUCzh3vrbkZOnFwbukgAA;
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzYfo-2hHkKsBttdyt5nFVk8H7I5zW6r2yWhwdG5su6FUFOaPutBBbsDTkT6GTFXadHP_J2H6vqEGxXB1etSFwUcX0B7-T16HYL3e-kNoW8kYWNW4cyS2EP6zGofRGI29thcfQxMgUwPCXiK1Iww4TPir227duJAaYMJsnlR8TSXYgAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=006; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=004; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Fri, 22 Sep 2017 21:41:53 GMT
+      - Tue, 23 Jan 2018 20:06:36 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1506120114","not_before":"1506116214","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMTQsIm5iZiI6MTUwNjExNjIxNCwiZXhwIjoxNTA2MTIwMTE0LCJhaW8iOiJZMlZnWURoNkxlTFlueWZjdXhLM1AwbGxXakZ0Q3dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiM3RzLXgxNGotVVdQWW50M21LUUtBQSIsInZlciI6IjEuMCJ9.tNfZxYjnzlN9LDikmqxEQ9ZcfV9Yn8I3V3YgPPMCQLu3VgrgqT1_rVmxUL5elZ7234OpvauDuw7T2xQ1ea_cnqFrbD2iIEH3LeIndrF0vmL16m8SaE9Adbufc2txA0w0nKguQnS51reRhW196Cv_p_w7_KFjhOba6m9Xg6w2eAmeRZGVccg0Esjne3ymo09Hvq4cdUq-RfDoTuZk9Sm9QglJEcC9IIargAWz2A37cemo9amSIV1VQrz-UyCgbvXygTJXgMoix96kQ8FvsLtiNTjhsdoFC0jdytz3igNPoUEIJnflKEYUP9nYddgNqO95tJ4jns580aLjg_Yn_mnuTw"}'
+      string: '{"token_type":"Bearer","expires_in":"3600","ext_expires_in":"0","expires_on":"1516741595","not_before":"1516737695","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc2OTUsIm5iZiI6MTUxNjczNzY5NSwiZXhwIjoxNTE2NzQxNTk1LCJhaW8iOiJZMk5nWUhnbjkraHlncU9xK2lIZUw1OGpqdDdOQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNGs1Q1JVWXd5RTZFZzhtZ2g4WVJBQSIsInZlciI6IjEuMCJ9.nKuSlYhBpWZ4JicCfBpm7DuN4-ths2pQBH2TqUW_z9iKp3PVKoNtSHKIJBQ0pFeJDPN1qm_SRoxg3hw_r6B-TAE7g6M__z8C5VfRVLmhpgQvAkT2igsLsdzbVFf0WokGFq6XPtdycJOUBFL-tBC2STEH7wk152_qEYuhHea--oc1DOMmzYlZubBn34WHcOTBlDlXVkr6OiwuEXW8pOFwYA4MuZ_TixqpqUpWvwvO13yIZHX5h8dHmgKJaJGirButu_VWmaTfuOwhfF1huq1Vqy4WzTFuBsLBW_PW2sIRoMscVGplbeHwsW3TSHPy2W-_kYj6U3lZ2BOZl7a5AGgJBw"}'
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:41:53 GMT
+  recorded_at: Tue, 23 Jan 2018 20:06:35 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -72,7 +74,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMTQsIm5iZiI6MTUwNjExNjIxNCwiZXhwIjoxNTA2MTIwMTE0LCJhaW8iOiJZMlZnWURoNkxlTFlueWZjdXhLM1AwbGxXakZ0Q3dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiM3RzLXgxNGotVVdQWW50M21LUUtBQSIsInZlciI6IjEuMCJ9.tNfZxYjnzlN9LDikmqxEQ9ZcfV9Yn8I3V3YgPPMCQLu3VgrgqT1_rVmxUL5elZ7234OpvauDuw7T2xQ1ea_cnqFrbD2iIEH3LeIndrF0vmL16m8SaE9Adbufc2txA0w0nKguQnS51reRhW196Cv_p_w7_KFjhOba6m9Xg6w2eAmeRZGVccg0Esjne3ymo09Hvq4cdUq-RfDoTuZk9Sm9QglJEcC9IIargAWz2A37cemo9amSIV1VQrz-UyCgbvXygTJXgMoix96kQ8FvsLtiNTjhsdoFC0jdytz3igNPoUEIJnflKEYUP9nYddgNqO95tJ4jns580aLjg_Yn_mnuTw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc2OTUsIm5iZiI6MTUxNjczNzY5NSwiZXhwIjoxNTE2NzQxNTk1LCJhaW8iOiJZMk5nWUhnbjkraHlncU9xK2lIZUw1OGpqdDdOQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNGs1Q1JVWXd5RTZFZzhtZ2g4WVJBQSIsInZlciI6IjEuMCJ9.nKuSlYhBpWZ4JicCfBpm7DuN4-ths2pQBH2TqUW_z9iKp3PVKoNtSHKIJBQ0pFeJDPN1qm_SRoxg3hw_r6B-TAE7g6M__z8C5VfRVLmhpgQvAkT2igsLsdzbVFf0WokGFq6XPtdycJOUBFL-tBC2STEH7wk152_qEYuhHea--oc1DOMmzYlZubBn34WHcOTBlDlXVkr6OiwuEXW8pOFwYA4MuZ_TixqpqUpWvwvO13yIZHX5h8dHmgKJaJGirButu_VWmaTfuOwhfF1huq1Vqy4WzTFuBsLBW_PW2sIRoMscVGplbeHwsW3TSHPy2W-_kYj6U3lZ2BOZl7a5AGgJBw
+      Host:
+      - management.azure.com
   response:
     status:
       code: 200
@@ -93,21 +97,22 @@ http_interactions:
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
       - '14999'
       X-Ms-Request-Id:
-      - 872a2570-4e2d-4fac-93dc-824b0ae3cc0c
+      - 61c1a2cc-767d-4ab7-b888-e3702990582b
       X-Ms-Correlation-Request-Id:
-      - 872a2570-4e2d-4fac-93dc-824b0ae3cc0c
+      - 61c1a2cc-767d-4ab7-b888-e3702990582b
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214154Z:872a2570-4e2d-4fac-93dc-824b0ae3cc0c
+      - WESTUS:20180123T200636Z:61c1a2cc-767d-4ab7-b888-e3702990582b
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 22 Sep 2017 21:41:53 GMT
+      - Tue, 23 Jan 2018 20:06:35 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
-        Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
+      string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
+        Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
+        Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:41:54 GMT
+  recorded_at: Tue, 23 Jan 2018 20:06:36 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/azure_subscription_id/providers?api-version=2015-01-01
@@ -124,7 +129,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMTQsIm5iZiI6MTUwNjExNjIxNCwiZXhwIjoxNTA2MTIwMTE0LCJhaW8iOiJZMlZnWURoNkxlTFlueWZjdXhLM1AwbGxXakZ0Q3dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiM3RzLXgxNGotVVdQWW50M21LUUtBQSIsInZlciI6IjEuMCJ9.tNfZxYjnzlN9LDikmqxEQ9ZcfV9Yn8I3V3YgPPMCQLu3VgrgqT1_rVmxUL5elZ7234OpvauDuw7T2xQ1ea_cnqFrbD2iIEH3LeIndrF0vmL16m8SaE9Adbufc2txA0w0nKguQnS51reRhW196Cv_p_w7_KFjhOba6m9Xg6w2eAmeRZGVccg0Esjne3ymo09Hvq4cdUq-RfDoTuZk9Sm9QglJEcC9IIargAWz2A37cemo9amSIV1VQrz-UyCgbvXygTJXgMoix96kQ8FvsLtiNTjhsdoFC0jdytz3igNPoUEIJnflKEYUP9nYddgNqO95tJ4jns580aLjg_Yn_mnuTw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc2OTUsIm5iZiI6MTUxNjczNzY5NSwiZXhwIjoxNTE2NzQxNTk1LCJhaW8iOiJZMk5nWUhnbjkraHlncU9xK2lIZUw1OGpqdDdOQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNGs1Q1JVWXd5RTZFZzhtZ2g4WVJBQSIsInZlciI6IjEuMCJ9.nKuSlYhBpWZ4JicCfBpm7DuN4-ths2pQBH2TqUW_z9iKp3PVKoNtSHKIJBQ0pFeJDPN1qm_SRoxg3hw_r6B-TAE7g6M__z8C5VfRVLmhpgQvAkT2igsLsdzbVFf0WokGFq6XPtdycJOUBFL-tBC2STEH7wk152_qEYuhHea--oc1DOMmzYlZubBn34WHcOTBlDlXVkr6OiwuEXW8pOFwYA4MuZ_TixqpqUpWvwvO13yIZHX5h8dHmgKJaJGirButu_VWmaTfuOwhfF1huq1Vqy4WzTFuBsLBW_PW2sIRoMscVGplbeHwsW3TSHPy2W-_kYj6U3lZ2BOZl7a5AGgJBw
+      Host:
+      - management.azure.com
   response:
     status:
       code: 200
@@ -141,19 +148,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14930'
+      - '14873'
       X-Ms-Request-Id:
-      - 53685ca2-e45b-40ee-96ea-6a1c7d43abf0
+      - ff901edc-e4e6-4be2-b301-fb1a2b977e1d
       X-Ms-Correlation-Request-Id:
-      - 53685ca2-e45b-40ee-96ea-6a1c7d43abf0
+      - ff901edc-e4e6-4be2-b301-fb1a2b977e1d
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214156Z:53685ca2-e45b-40ee-96ea-6a1c7d43abf0
+      - WESTUS:20180123T200638Z:ff901edc-e4e6-4be2-b301-fb1a2b977e1d
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 22 Sep 2017 21:41:55 GMT
+      - Tue, 23 Jan 2018 20:06:37 GMT
       Content-Length:
-      - '254785'
+      - '293551'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
@@ -176,7 +183,7 @@ http_interactions:
         Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
         Central US","North Central US","Japan East","Japan West","Brazil South","Central
         India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
+        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-04-19","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-04-19","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-04-19","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-04-19","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","North Central
         US","South Central US","West Central US","West US","West US 2","Canada Central","Canada
         East","North Europe","West Europe","UK South","UK West","East Asia","Southeast
@@ -184,20 +191,26 @@ http_interactions:
         India","South India","West India"],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"validateServiceName","locations":[],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"checkServiceNameAvailability","locations":[],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"reportFeedback","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"checkFeedbackRequired","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Automation","namespace":"Microsoft.Automation","authorizations":[{"applicationId":"fc75330b-179d-49af-87dd-3b1acf6827fa","roleDefinitionId":"95fd5de3-d071-4362-92bf-cf341c1de832"}],"resourceTypes":[{"resourceType":"automationAccounts","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
         South","UK South","West Central US","North Europe","Canada Central","Australia
-        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/runbooks","locations":["Japan
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/runbooks","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
         South","UK South","West Central US","North Europe","Canada Central","Australia
-        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/configurations","locations":["Japan
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/configurations","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","North
-        Central US","Brazil South","UK South","West Central US","Central India","Australia
-        Southeast","Canada Central","North Europe"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/webhooks","locations":["Japan
+        Central US","Korea Central","East US","West US 2","Brazil South","UK South","West
+        Central US","Central India","Australia Southeast","Canada Central","North
+        Europe"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/webhooks","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
         South","UK South","West Central US","North Europe","Canada Central","Australia
-        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"operations","locations":["South
-        Central US"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/softwareUpdateConfigurations","locations":["Japan
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"operations","locations":["South
+        Central US"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/softwareUpdateConfigurations","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
         South","UK South","West Central US","North Europe","Canada Central","Australia
-        Southeast","Central India"],"apiVersions":["2017-05-15-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Backup","namespace":"Microsoft.Backup","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"BackupVault","locations":["West
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview"]},{"resourceType":"automationAccounts/jobs","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
+        South","UK South","West Central US","North Europe","Canada Central","Australia
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureActiveDirectory","namespace":"Microsoft.AzureActiveDirectory","resourceTypes":[{"resourceType":"b2cDirectories","locations":["Global","United
+        States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]},{"resourceType":"operations","locations":["Global","United
+        States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]}],"registrationState":"Unregistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Backup","namespace":"Microsoft.Backup","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"BackupVault","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
@@ -206,22 +219,22 @@ http_interactions:
         Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
         West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
         East","South India","Central India","Canada Central","Canada East","UK South","UK
-        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01","2015-07-01","2014-05-01-privatepreview"]},{"resourceType":"operations","locations":["West
+        West","West Central US","West US 2"],"apiVersions":["2017-09-01","2017-05-01","2017-01-01","2015-12-01","2015-09-01","2015-07-01","2014-05-01-privatepreview"]},{"resourceType":"operations","locations":["West
         Europe","East US","East US 2","West US","North Central US","Brazil South","North
         Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
         West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
         East","South India","Central India","Canada Central","Canada East","UK South","UK
-        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations/quotas","locations":["West
+        West","West Central US","West US 2"],"apiVersions":["2017-09-01","2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01","2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations/quotas","locations":["West
         Europe","East US","East US 2","West US","North Central US","Brazil South","North
         Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
         West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
         East","South India","Central India","Canada Central","Canada East","UK South","UK
-        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]}],"registrationState":"Unregistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicCompute","namespace":"Microsoft.ClassicCompute","resourceTypes":[{"resourceType":"domainNames","locations":["East
+        West","West Central US","West US 2"],"apiVersions":["2017-09-01","2017-05-01","2017-01-01","2015-12-01","2015-09-01"]}],"registrationState":"Unregistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicCompute","namespace":"Microsoft.ClassicCompute","resourceTypes":[{"resourceType":"domainNames","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
@@ -256,7 +269,7 @@ http_interactions:
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -296,92 +309,92 @@ http_interactions:
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30"]},{"resourceType":"locations/usages","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations/usages","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
+        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
@@ -411,76 +424,138 @@ http_interactions:
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
+        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
         US","East US","South Central US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
         Central","Central US","East US 2","North Central US","West Central US","West
-        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/webhooks","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/ping","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/getCallbackConfig","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/listEvents","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"locations","locations":["South
-        Central US","East US","West US","Central US","East US 2","North Central US","West
-        Central US","West US 2","Brazil South","Canada East","Canada Central","West
-        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
-        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"locations/operationResults","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/GetCredentials","locations":["West
+        US 2"],"apiVersions":["2017-10-01","2017-03-01"]},{"resourceType":"registries/replications","locations":["South
+        Central US","West Central US","East US","West Europe","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/webhooks","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/webhooks/ping","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/webhooks/getCallbackConfig","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/webhooks/listEvents","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"locations/operationResults","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/GetCredentials","locations":["West
         US","East US","South Central US","West Europe"],"apiVersions":["2016-06-27-preview"]},{"resourceType":"registries/listCredentials","locations":["South
         Central US","East US","West US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
         Central","Central US","East US 2","North Central US","West Central US","West
-        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/regenerateCredential","locations":["South
+        US 2"],"apiVersions":["2017-10-01","2017-03-01"]},{"resourceType":"registries/regenerateCredential","locations":["South
         Central US","West US","East US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
         Central","Central US","East US 2","North Central US","West Central US","West
-        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/listUsages","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/regenerateCredentials","locations":["West
+        US 2"],"apiVersions":["2017-10-01","2017-03-01"]},{"resourceType":"registries/listUsages","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/regenerateCredentials","locations":["West
         US","East US","South Central US","West Europe"],"apiVersions":["2016-06-27-preview"]},{"resourceType":"checkNameAvailability","locations":["South
         Central US","East US","West US","Central US","East US 2","North Central US","West
         Central US","West US 2","Brazil South","Canada East","Canada Central","West
         Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
-        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview","2017-03-01","2016-06-27-preview"]},{"resourceType":"operations","locations":["South
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-10-01","2017-06-01-preview","2017-03-01","2016-06-27-preview"]},{"resourceType":"operations","locations":["South
         Central US","East US","West US","Central US","East US 2","North Central US","West
         Central US","West US 2","Brazil South","Canada East","Canada Central","West
         Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
-        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview","2017-03-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerService","namespace":"Microsoft.ContainerService","authorization":{"applicationId":"7319c514-987d-4e9b-ac3d-d38c4f427f4c","roleDefinitionId":"1b4a0c7f-2217-416f-acfa-cf73452fdc1c"},"resourceTypes":[{"resourceType":"containerServices","locations":["Japan
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-10-01","2017-06-01-preview","2017-03-01"]},{"resourceType":"locations","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-10-01","2017-06-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerService","namespace":"Microsoft.ContainerService","authorization":{"applicationId":"7319c514-987d-4e9b-ac3d-d38c4f427f4c","roleDefinitionId":"1b4a0c7f-2217-416f-acfa-cf73452fdc1c","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"containerServices","locations":["Japan
         East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
         Central US","West US 2","South India","Central India","West India","Canada
-        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
+        East","Canada Central","Korea South","Korea Central"],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"managedClusters","locations":["East
+        US","West Europe","Central US","Canada Central","Canada East"],"apiVersions":["2017-08-31"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
         East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
         Central US","West US 2","South India","Central India","West India","Canada
-        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DevTestLab","namespace":"Microsoft.DevTestLab","authorization":{"applicationId":"1a14be2a-e903-4cec-99cf-b2e209259a0f","roleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525"},"resourceTypes":[{"resourceType":"labs","locations":["West
+        East","Canada Central","Korea South","Korea Central"],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/orchestrators","locations":["UK
+        West","West US 2","East US","West Europe","Central US"],"apiVersions":["2017-09-30"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DevTestLab","namespace":"Microsoft.DevTestLab","authorization":{"applicationId":"1a14be2a-e903-4cec-99cf-b2e209259a0f","roleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525","managedByRoleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525"},"resourceTypes":[{"resourceType":"labs","locations":["West
         Central US","Japan East","West US","Australia Southeast","Canada Central","Central
         India","Central US","East Asia","Korea Central","North Europe","South Central
-        US","UK West","Australia East","Brazil South","Canada East","East US","East
-        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        US","UK West","West India","Australia East","Brazil South","Canada East","East
+        US","East US 2","Japan West","Korea South","North Central US","South India","Southeast
         Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"schedules","locations":["West
         Central US","Japan East","West US","Australia Southeast","Canada Central","Central
         India","Central US","East Asia","Korea Central","North Europe","South Central
-        US","UK West","Australia East","Brazil South","Canada East","East US","East
-        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        US","UK West","West India","Australia East","Brazil South","Canada East","East
+        US","East US 2","Japan West","Korea South","North Central US","South India","Southeast
         Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"labs/virtualMachines","locations":["West
         Central US","Japan East","West US","Australia Southeast","Canada Central","Central
         India","Central US","East Asia","Korea Central","North Europe","South Central
-        US","UK West","Australia East","Brazil South","Canada East","East US","East
-        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        US","UK West","West India","Australia East","Brazil South","Canada East","East
+        US","East US 2","Japan West","Korea South","North Central US","South India","Southeast
         Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"labs/serviceRunners","locations":["Central
         US","East US 2","South Central US"],"apiVersions":["2017-04-26-preview","2016-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"locations/operations","locations":["West
         Central US","Japan East","West US","Australia Southeast","Canada Central","Central
         India","Central US","East Asia","Korea Central","North Europe","South Central
-        US","UK West","Australia East","Brazil South","Canada East","East US","East
-        US 2","Japan West","Korea South","North Central US","South India","Southeast
-        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"}],"resourceTypes":[{"resourceType":"components","locations":["East
-        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
-        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01","2014-04-01"]},{"resourceType":"queries","locations":["East
-        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
+        US","UK West","West India","Australia East","Brazil South","Canada East","East
+        US","East US 2","Japan West","Korea South","North Central US","South India","Southeast
+        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","authorizations":[{"applicationId":"57c0fc58-a83a-41d0-8ae9-08952659bdfd","roleDefinitionId":"FFFD5CF5-FFD3-4B24-B0E2-0715ADD4C282"}],"resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"databaseAccountNames","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"operationResults","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"},{"applicationId":"f5c26e74-f226-4ae8-85f0-b4af0080ac9e","roleDefinitionId":"529d7ae6-e892-4d43-809d-8547aeb90643"}],"resourceTypes":[{"resourceType":"components","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2015-05-01","2014-08-01","2014-04-01"]},{"resourceType":"queries","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"components/pricingPlans","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"migrateToNewPricingModel","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"rollbackToLegacyPricingModel","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"listMigrationdate","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
@@ -516,7 +591,7 @@ http_interactions:
         West","North Central US","South Central US","East US 2","Canada East","Canada
         Central","Central US","Australia East","Australia Southeast","Brazil South","South
         India","Central India","West India","North Europe","West US 2","West Central
-        US","Korea South","Korea Central","UK South","UK West","Global"],"apiVersions":["2017-05-01-preview","2016-03-01","2015-07-01"]},{"resourceType":"logDefinitions","locations":["West
+        US","Korea South","Korea Central","UK South","UK West","Global"],"apiVersions":["2017-09-01-preview","2017-05-01-preview","2016-03-01","2015-07-01"]},{"resourceType":"logDefinitions","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
@@ -526,7 +601,7 @@ http_interactions:
         West","North Central US","South Central US","East US 2","Canada East","Canada
         Central","Central US","Australia East","Australia Southeast","Brazil South","South
         India","Central India","West India","North Europe","West US 2","West Central
-        US","Korea South","Korea Central","UK South","UK West"],"apiVersions":["2017-05-01-preview","2016-09-01","2016-06-01"]},{"resourceType":"actiongroups","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]},{"resourceType":"activityLogAlerts","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.KeyVault","namespace":"Microsoft.KeyVault","resourceTypes":[{"resourceType":"vaults","locations":["North
+        US","Korea South","Korea Central","UK South","UK West"],"apiVersions":["2017-09-01-preview","2017-05-01-preview","2016-09-01","2016-06-01"]},{"resourceType":"actiongroups","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]},{"resourceType":"activityLogAlerts","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.KeyVault","namespace":"Microsoft.KeyVault","resourceTypes":[{"resourceType":"vaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
@@ -556,126 +631,153 @@ http_interactions:
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorizations":[{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},{"applicationId":"7c33bfcb-8d33-48d6-8e60-dc6404003489","roleDefinitionId":"ad6261e4-fa9a-4642-aa5f-104f1b67e9e3"},{"applicationId":"1e3e4475-288f-4018-a376-df66fd7fac5f","roleDefinitionId":"1d538b69-3d87-4e56-8ff8-25786fd48261"},{"applicationId":"a0be0c72-870e-46f0-9c49-c98333a996f7","roleDefinitionId":"7ce22727-ffce-45a9-930c-ddb2e56fa131"}],"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","West Central US"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"operations","locations":["South
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations","locations":["South
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operations","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"commitmentPlans","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"Registering"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorizations":[{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},{"applicationId":"7c33bfcb-8d33-48d6-8e60-dc6404003489","roleDefinitionId":"ad6261e4-fa9a-4642-aa5f-104f1b67e9e3"},{"applicationId":"1e3e4475-288f-4018-a376-df66fd7fac5f","roleDefinitionId":"1d538b69-3d87-4e56-8ff8-25786fd48261"},{"applicationId":"a0be0c72-870e-46f0-9c49-c98333a996f7","roleDefinitionId":"7ce22727-ffce-45a9-930c-ddb2e56fa131"}],"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
-        Central US"],"apiVersions":["2017-09-01"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
-        East","UK South","Central India","Canada Central"],"apiVersions":["2017-04-26-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"]},{"resourceType":"workspaces/dataSources","locations":["East
+        East","UK South","Central India","Canada Central"],"apiVersions":["2017-04-26-preview","2017-03-15-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"]},{"resourceType":"workspaces/query","locations":["West
+        Central US","Australia Southeast","West Europe","East US","Southeast Asia","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2017-10-01"]},{"resourceType":"workspaces/dataSources","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
         East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"storageInsightConfigs","locations":[],"apiVersions":["2014-10-10"]},{"resourceType":"workspaces/linkedServices","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
         East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"linkTargets","locations":["East
         US"],"apiVersions":["2015-03-20"]},{"resourceType":"operations","locations":[],"apiVersions":["2014-11-10"]},{"resourceType":"devices","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationsManagement","namespace":"Microsoft.OperationsManagement","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"aa249101-6816-4966-aafa-08175d795f14"},"resourceTypes":[{"resourceType":"solutions","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
-        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Portal","namespace":"Microsoft.Portal","resourceTypes":[{"resourceType":"dashboards","locations":["Central
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"managementconfigurations","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"managementassociations","locations":[],"apiVersions":["2015-11-01-preview"]},{"resourceType":"views","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2017-08-21-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Portal","namespace":"Microsoft.Portal","resourceTypes":[{"resourceType":"dashboards","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
@@ -687,9 +789,9 @@ http_interactions:
         East","West India","South India","Central India","Canada Central","Canada
         East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"consoles","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/consoles","locations":["West
         US","East US","Central India","North Europe","West Europe","South Central
-        US","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
+        US","Southeast Asia","East US 2","Central US"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
         US","East US","Central India","North Europe","West Europe","South Central
-        US","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
+        US","Southeast Asia","East US 2","Central US"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
@@ -710,7 +812,17 @@ http_interactions:
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ResourceHealth","namespace":"Microsoft.ResourceHealth","authorization":{"applicationId":"8bdebf23-c0fe-4187-a378-717ad86f6a53","roleDefinitionId":"cc026344-c8b1-4561-83ba-59eba84b27cc"},"resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2017-07-01","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"notifications","locations":["Australia
+        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]},{"resourceType":"locations/backupValidateFeatures","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-07-01"]},{"resourceType":"locations/backupPreValidateProtection","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-07-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ResourceHealth","namespace":"Microsoft.ResourceHealth","authorization":{"applicationId":"8bdebf23-c0fe-4187-a378-717ad86f6a53","roleDefinitionId":"cc026344-c8b1-4561-83ba-59eba84b27cc"},"resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2017-07-01","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"notifications","locations":["Australia
         Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Security","namespace":"Microsoft.Security","authorization":{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatuses","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/virtualMachines","locations":["Central
@@ -743,10 +855,14 @@ http_interactions:
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securitySolutionsReferenceData","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/securitySolutionsReferenceData","locations":["Central
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"jitNetworkAccessPolicies","locations":["Central
-        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/jitNetworkAccessPolicies","locations":["Central
-        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations","locations":["Central
+        US","East US","North Europe","West Europe","UK South","UK West","West Central
+        US","West US 2"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/jitNetworkAccessPolicies","locations":["Central
+        US","East US","North Europe","West Europe","UK South","UK West","West Central
+        US","West US 2"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatusesSummaries","locations":["Central
-        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/alerts","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"applicationWhitelistings","locations":["Central
+        US","East US","West Central US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/applicationWhitelistings","locations":["Central
+        US","West Central US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/alerts","locations":["Central
         US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/tasks","locations":["Central
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"externalSecuritySolutions","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/externalSecuritySolutions","locations":["Central
@@ -769,7 +885,17 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/databaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/databaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -814,7 +940,7 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01","2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -829,7 +955,7 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -859,12 +985,17 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/geoBackupPolicies","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -879,12 +1010,12 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/firewallrules","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/backupLongTermRetentionPolicies","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -999,6 +1130,16 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
         US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
@@ -1034,7 +1175,22 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -1144,7 +1300,47 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -1159,7 +1355,17 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/administratorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -1179,52 +1385,52 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorization":{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorizations":[{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},{"applicationId":"e406a681-f3d4-42a8-90b6-c2b029497af1"}],"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
         US","West US","West Europe","North Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","South India","Central
@@ -1234,7 +1440,19 @@ http_interactions:
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Web","namespace":"Microsoft.Web","authorization":{"applicationId":"abfa0a7c-a6b6-4736-8310-5855508787cd","roleDefinitionId":"f47ed98b-b063-4a5b-9e10-4b9b44fa7735"},"resourceTypes":[{"resourceType":"sites/extensions","locations":["South
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/project","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/extension","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"checkNameAvailability","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Web","namespace":"Microsoft.Web","authorization":{"applicationId":"abfa0a7c-a6b6-4736-8310-5855508787cd","roleDefinitionId":"f47ed98b-b063-4a5b-9e10-4b9b44fa7735"},"resourceTypes":[{"resourceType":"sites/extensions","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
         South","West US","East US","Japan West","Japan East","East Asia","East US
         2","North Central US","Central US","Brazil South","Australia East","Australia
@@ -1339,7 +1557,7 @@ http_interactions:
         South","West US","East US","Japan West","Japan East","East Asia","East US
         2","North Central US","Central US","Brazil South","Australia East","Australia
         Southeast","West India","Central India","South India","Canada Central","Canada
-        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms/workers","locations":["South
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms/workers","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
         South","West US","East US","Japan West","Japan East","East Asia","East US
         2","North Central US","Central US","Brazil South","Australia East","Australia
@@ -1394,7 +1612,17 @@ http_interactions:
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","West US 2","West Central US","Canada Central","Canada
-        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/managedApis","locations":["North
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/listWsdlInterfaces","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/extractApiDefinitionFromWsdl","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/managedApis","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
@@ -1445,8 +1673,11 @@ http_interactions:
         US","North Europe","Japan West","Japan East","East Asia","West Europe","East
         US","Southeast Asia","Central US"],"apiVersions":["2016-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Lombiq.DotNest","namespace":"Lombiq.DotNest","resourceTypes":[{"resourceType":"sites","locations":["East
         US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Mailjet.Email","namespace":"Mailjet.Email","resourceTypes":[{"resourceType":"services","locations":["West
-        US"],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
-        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
+        US","West Europe"],"apiVersions":["2017-10-01","2017-02-03"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-10-01","2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-10-01","2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]},{"resourceType":"diagnosticSettings","locations":[],"apiVersions":["2017-04-01"]},{"resourceType":"diagnosticSettingsCategories","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Addons","namespace":"Microsoft.Addons","authorization":{"applicationId":"24d3987b-be4a-48e0-a3e7-11c186f39e41","roleDefinitionId":"8004BAAB-A4CB-4981-8571-F7E44D039D93"},"resourceTypes":[{"resourceType":"supportProviders","locations":["West
+        Central US","South Central US","East US","West Europe"],"apiVersions":["2017-05-15"]},{"resourceType":"operations","locations":["West
+        Central US","South Central US","East US","West Europe"],"apiVersions":["2017-05-15"]},{"resourceType":"operationResults","locations":["West
+        Central US","South Central US","East US","West Europe"],"apiVersions":["2017-05-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"addsservices","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"configuration","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"operations","locations":["West
@@ -1456,51 +1687,45 @@ http_interactions:
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"servicehealthmetrics","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"logs","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"anonymousapiusers","locations":["West
-        US"],"apiVersions":["2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AnalysisServices","namespace":"Microsoft.AnalysisServices","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"servers","locations":["West
+        US"],"apiVersions":["2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AlertsManagement","namespace":"Microsoft.AlertsManagement","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-11-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AnalysisServices","namespace":"Microsoft.AnalysisServices","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"servers","locations":["West
         US","North Europe","South Central US","West Europe","West Central US","Southeast
         Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
-        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/checkNameAvailability","locations":["West
+        Southeast","Japan East","UK South","West India","West US 2","East US"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"locations/checkNameAvailability","locations":["West
         US","North Europe","South Central US","West Europe","West Central US","Southeast
         Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
-        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationresults","locations":["West
+        Southeast","Japan East","UK South","West India","West US 2","East US"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationresults","locations":["West
         US","North Europe","South Central US","West Europe","West Central US","Southeast
         Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
-        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationstatuses","locations":["West
+        Southeast","Japan East","UK South","West India","West US 2","East US"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationstatuses","locations":["West
         US","North Europe","South Central US","West Europe","West Central US","Southeast
         Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
-        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"operations","locations":["East
-        US 2","West Central US"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AppService","namespace":"Microsoft.AppService","authorization":{"applicationId":"dee7ba80-6a55-4f3b-a86c-746a9231ae49","roleDefinitionId":"6715d172-49c4-46f6-bb21-60512a8689dc"},"resourceTypes":[{"resourceType":"apiapps","locations":["East
-        US","West US","South Central US","North Europe","East Asia","Japan East","West
-        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
-        South","East US 2","Australia Southeast","Australia East","West India","South
-        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"appIdentities","locations":["East
-        US","West US","South Central US","North Europe","East Asia","Japan East","West
-        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
-        South","East US 2","Australia Southeast","Australia East","West India","South
-        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"gateways","locations":["East
-        US","West US","South Central US","North Europe","East Asia","Japan East","West
-        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
-        South","East US 2","Australia Southeast","Australia East","West India","South
-        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"deploymenttemplates","locations":[],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Authorization","namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"roleDefinitions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"classicAdministrators","locations":[],"apiVersions":["2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"permissions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"locks","locations":[],"apiVersions":["2017-04-01","2016-09-01","2015-06-01","2015-05-01-preview","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-01-01","2014-10-01-preview","2014-06-01"]},{"resourceType":"policyDefinitions","locations":[],"apiVersions":["2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"policySetDefinitions","locations":[],"apiVersions":["2017-06-01-preview"]},{"resourceType":"policyAssignments","locations":[],"apiVersions":["2017-06-01-preview","2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"providerOperations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01-preview","2015-07-01"]},{"resourceType":"elevateAccess","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureActiveDirectory","namespace":"Microsoft.AzureActiveDirectory","resourceTypes":[{"resourceType":"b2cDirectories","locations":["Global","United
-        States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureStack","namespace":"Microsoft.AzureStack","resourceTypes":[{"resourceType":"operations","locations":["Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations","locations":["West
+        Southeast","Japan East","UK South","West India","West US 2","East US"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"operations","locations":["East
+        US 2","West Central US","West US 2"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Authorization","namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[],"apiVersions":["2017-10-01-preview","2017-09-01","2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"roleDefinitions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"classicAdministrators","locations":[],"apiVersions":["2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"permissions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"locks","locations":[],"apiVersions":["2017-04-01","2016-09-01","2015-06-01","2015-05-01-preview","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-01-01","2014-10-01-preview","2014-06-01"]},{"resourceType":"policyDefinitions","locations":[],"apiVersions":["2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"policySetDefinitions","locations":[],"apiVersions":["2017-06-01-preview"]},{"resourceType":"policyAssignments","locations":[],"apiVersions":["2017-06-01-preview","2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"providerOperations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01-preview","2015-07-01"]},{"resourceType":"elevateAccess","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"checkAccess","locations":[],"apiVersions":["2017-10-01-preview","2017-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureStack","namespace":"Microsoft.AzureStack","resourceTypes":[{"resourceType":"operations","locations":["Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations","locations":["West
         Central US","Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations/products","locations":["West
-        Central US","Global"],"apiVersions":["2017-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Billing","namespace":"Microsoft.Billing","resourceTypes":[{"resourceType":"BillingPeriods","locations":["Central
+        Central US","Global"],"apiVersions":["2017-06-01","2016-01-01"]},{"resourceType":"registrations/customerSubscriptions","locations":["West
+        Central US","Global"],"apiVersions":["2017-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BatchAI","namespace":"Microsoft.BatchAI","authorization":{"applicationId":"9fcb3732-5f52-4135-8c08-9d4bbaf203ea","roleDefinitionId":"703B89C7-CE2C-431B-BDD8-FA34E39AF696","managedByRoleDefinitionId":"90B8E153-EBFF-4073-A95F-4DAD56B14C78"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"jobs","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"fileservers","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"operations","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01-preview"]},{"resourceType":"locations/operationresults","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Billing","namespace":"Microsoft.Billing","resourceTypes":[{"resourceType":"BillingPeriods","locations":["Central
         US"],"apiVersions":["2017-04-24-preview"]},{"resourceType":"Invoices","locations":["Central
         US"],"apiVersions":["2017-04-24-preview","2017-02-27-preview"]},{"resourceType":"operations","locations":["Central
         US"],"apiVersions":["2017-04-24-preview","2017-02-27-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BingMaps","namespace":"Microsoft.BingMaps","resourceTypes":[{"resourceType":"mapApis","locations":["West
         US"],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-18","2015-07-02"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BizTalkServices","namespace":"Microsoft.BizTalkServices","resourceTypes":[{"resourceType":"BizTalk","locations":["East
         US","West US","North Europe","West Europe","Southeast Asia","East Asia","North
-        Central US","Japan West","Japan East","South Central US"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Cache","namespace":"Microsoft.Cache","authorization":{"applicationId":"96231a05-34ce-4eb4-aa6a-70759cbb5e83","roleDefinitionId":"4f731528-ba85-45c7-acfb-cd0a9b3cf31b"},"resourceTypes":[{"resourceType":"Redis","locations":["North
+        Central US","Japan West","Japan East","South Central US"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BotService","namespace":"Microsoft.BotService","resourceTypes":[{"resourceType":"botServices","locations":["Global"],"apiVersions":["2017-12-01"]},{"resourceType":"checkNameAvailability","locations":["Global"],"apiVersions":["2017-12-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Cache","namespace":"Microsoft.Cache","authorization":{"applicationId":"96231a05-34ce-4eb4-aa6a-70759cbb5e83","roleDefinitionId":"4f731528-ba85-45c7-acfb-cd0a9b3cf31b"},"resourceTypes":[{"resourceType":"Redis","locations":["North
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","Canada Central","Canada East","UK South","UK West","West US 2","West
-        Central US","South India","Korea Central","Korea South"],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","South India","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","South India","Canada Central","Canada East","UK South","UK West","West
-        US 2","West Central US","Korea Central","Korea South"],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01"]},{"resourceType":"Redis/metricDefinitions","locations":["North
+        US 2","West Central US","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01"]},{"resourceType":"Redis/metricDefinitions","locations":["North
         Central US","South Central US","East US","East US 2","West US","Central US","East
         Asia","Southeast Asia","North Europe","West Europe","Japan East","Japan West","Brazil
         South","Australia Southeast","Australia East","Central India","West India","South
@@ -1514,59 +1739,59 @@ http_interactions:
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/origins","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/origins","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/customdomains","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/customdomains","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/originresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/originresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/customdomainresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/customdomainresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkResourceUsage","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkResourceUsage","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02"]},{"resourceType":"validateProbe","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02"]},{"resourceType":"validateProbe","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02"]},{"resourceType":"operations","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02"]},{"resourceType":"operations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"edgenodes","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"edgenodes","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CertificateRegistration","namespace":"Microsoft.CertificateRegistration","authorization":{"applicationId":"f3c21649-0979-4721-ac85-b0216b2cf413","roleDefinitionId":"933fba7e-2ed3-4da8-973d-8bd8298a9b40"},"resourceTypes":[{"resourceType":"certificateOrders","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"certificateOrders/certificates","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"validateCertificateRegistrationInformation","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicSubscription","namespace":"Microsoft.ClassicSubscription","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicInfrastructureMigrate","namespace":"Microsoft.ClassicInfrastructureMigrate","authorization":{"applicationId":"5e5abe2b-83cd-4786-826a-a05653ebb103","roleDefinitionId":"766c4d9b-ef83-4f73-8352-1450a506a69b"},"resourceTypes":[{"resourceType":"classicInfrastructureResources","locations":["East
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CertificateRegistration","namespace":"Microsoft.CertificateRegistration","authorization":{"applicationId":"f3c21649-0979-4721-ac85-b0216b2cf413","roleDefinitionId":"933fba7e-2ed3-4da8-973d-8bd8298a9b40"},"resourceTypes":[{"resourceType":"certificateOrders","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"certificateOrders/certificates","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"validateCertificateRegistrationInformation","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicSubscription","namespace":"Microsoft.ClassicSubscription","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-09-01","2017-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicInfrastructureMigrate","namespace":"Microsoft.ClassicInfrastructureMigrate","authorization":{"applicationId":"5e5abe2b-83cd-4786-826a-a05653ebb103","roleDefinitionId":"766c4d9b-ef83-4f73-8352-1450a506a69b"},"resourceTypes":[{"resourceType":"classicInfrastructureResources","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
         Central US","Central US","North Europe","West Europe","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","West
@@ -1584,8 +1809,9 @@ http_interactions:
         Asia","East Asia","West Central US","South Central US","East US","East US
         2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/updateAccountsCreationSettings","locations":["West
         US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/accountsCreationSettings","locations":["West
-        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2016-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Commerce","namespace":"Microsoft.Commerce","resourceTypes":[{"resourceType":"UsageAggregates","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]},{"resourceType":"RateCard","locations":[],"apiVersions":["2016-08-31-preview","2015-06-01-preview","2015-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Consumption","namespace":"Microsoft.Consumption","resourceTypes":[{"resourceType":"reservationsummaries","locations":[],"apiVersions":["2017-01-30"]},{"resourceType":"reservationdetails","locations":[],"apiVersions":["2017-01-30"]},{"resourceType":"UsageDetails","locations":[],"apiVersions":["2017-06-30-preview","2017-04-24-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-30-preview","2017-04-24-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","resourceTypes":[{"resourceType":"containerGroups","locations":["West
-        US","East US","West Europe"],"apiVersions":["2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
+        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2016-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Commerce","namespace":"Microsoft.Commerce","resourceTypes":[{"resourceType":"UsageAggregates","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]},{"resourceType":"RateCard","locations":[],"apiVersions":["2016-08-31-preview","2015-06-01-preview","2015-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Consumption","namespace":"Microsoft.Consumption","resourceTypes":[{"resourceType":"ReservationSummaries","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationTransactions","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"Balances","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"Pricesheets","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationDetails","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"Budgets","locations":[],"apiVersions":["2017-12-30-preview"]},{"resourceType":"Terms","locations":[],"apiVersions":["2017-12-30-preview"]},{"resourceType":"UsageDetails","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview","2017-04-24-preview"]},{"resourceType":"Operations","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview","2017-04-24-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","resourceTypes":[{"resourceType":"containerGroups","locations":["West
+        US","East US","West Europe","Southeast Asia"],"apiVersions":["2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US","East US","West Europe","Southeast Asia"],"apiVersions":["2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
         US"],"apiVersions":["2016-04-08"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CustomerInsights","namespace":"Microsoft.CustomerInsights","authorization":{"applicationId":"38c77d00-5fcb-4cce-9d93-af4738258e3c","roleDefinitionId":"E006F9C7-F333-477C-8AD6-1F3A9FE87F55"},"resourceTypes":[{"resourceType":"hubs","locations":["East
         US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/profiles","locations":["East
         US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/interactions","locations":["East
@@ -1608,8 +1834,8 @@ http_interactions:
         US","West US","Australia East","West Europe","North Europe","Southeast Asia","West
         Central US"],"apiVersions":["2016-03-30","2015-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataFactory","namespace":"Microsoft.DataFactory","resourceTypes":[{"resourceType":"dataFactories","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview","2014-04-01"]},{"resourceType":"factories","locations":["East
-        US","East US 2"],"apiVersions":["2017-09-01-preview","2017-03-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
-        US","East US 2"],"apiVersions":["2017-09-01-preview","2017-03-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
+        US","East US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
+        US","East US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
         Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"dataFactories/metricDefinitions","locations":["North
         Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"checkDataFactoryNameAvailability","locations":[],"apiVersions":["2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"checkAzureDataFactoryNameAvailability","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"dataFactorySchema","locations":["West
@@ -1621,69 +1847,71 @@ http_interactions:
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers/listSasTokens","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeStore","namespace":"Microsoft.DataLakeStore","authorization":{"applicationId":"e9f49c6b-5ce5-44c8-925d-015017e9f7ad","roleDefinitionId":"17eb9cca-f08a-4499-b2d3-852d175f614f"},"resourceTypes":[{"resourceType":"accounts","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/firewallRules","locations":["East
-        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","resourceTypes":[{"resourceType":"operations","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforPostgreSQL","namespace":"Microsoft.DBforPostgreSQL","resourceTypes":[{"resourceType":"operations","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"checkProvisioningServiceNameAvailability","locations":[],"apiVersions":["2017-08-21-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataMigration","namespace":"Microsoft.DataMigration","authorization":{"applicationId":"a4bad4aa-bf02-4631-9f78-a64ffdba8150","roleDefinitionId":"b831a21d-db98-4760-89cb-bef871952df1","managedByRoleDefinitionId":"6256fb55-9e59-4018-a9e1-76b11c0a4c89"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services/projects","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationStatuses","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforPostgreSQL","namespace":"Microsoft.DBforPostgreSQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"checkProvisioningServiceNameAvailability","locations":[],"apiVersions":["2017-11-15","2017-08-21-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
         US","North Europe","East Asia","East US","West Europe","Southeast Asia","Japan
         East","Japan West","Australia East","Australia Southeast","West US 2","West
         Central US","East US 2","Central US","UK South","UK West","South India","Central
-        India","Canada Central","Canada East"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"ProvisioningServices","locations":["East
-        US","West Europe","Southeast Asia"],"apiVersions":["2017-08-21-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
-        East","Australia Southeast","Canada Central","Canada East","Central India","Central
-        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
-        US","North Europe","South Central US","South India","Southeast Asia","West
-        Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"databaseAccountNames","locations":["Australia
-        East","Australia Southeast","Canada Central","Canada East","Central India","Central
-        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
-        US","North Europe","South Central US","South India","Southeast Asia","West
-        Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"operations","locations":["Australia
-        East","Australia Southeast","Canada Central","Canada East","Central India","Central
-        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
-        US","North Europe","South Central US","South India","Southeast Asia","West
-        Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DomainRegistration","namespace":"Microsoft.DomainRegistration","authorization":{"applicationId":"ea2f600a-4980-45b7-89bf-d34da487bda1","roleDefinitionId":"54d7f2e3-5040-48a7-ae90-eebf629cfa0b"},"resourceTypes":[{"resourceType":"domains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"domains/domainOwnershipIdentifiers","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"topLevelDomains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"checkDomainAvailability","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"listDomainRecommendations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"validateDomainRegistrationInformation","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"generateSsoRequest","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DynamicsLcs","namespace":"Microsoft.DynamicsLcs","resourceTypes":[{"resourceType":"lcsprojects","locations":["Brazil
+        India","Canada Central","Canada East","Brazil South","South Central US"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs/eventGridFilters","locations":["West
+        US","East US","West US 2","West Central US","East US 2","Central US"],"apiVersions":["2018-01-15-preview"]},{"resourceType":"ProvisioningServices","locations":["East
+        US","West US","West Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2017-11-15","2017-08-21-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DomainRegistration","namespace":"Microsoft.DomainRegistration","authorization":{"applicationId":"ea2f600a-4980-45b7-89bf-d34da487bda1","roleDefinitionId":"54d7f2e3-5040-48a7-ae90-eebf629cfa0b"},"resourceTypes":[{"resourceType":"domains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"domains/domainOwnershipIdentifiers","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"topLevelDomains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"checkDomainAvailability","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"listDomainRecommendations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"validateDomainRegistrationInformation","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"generateSsoRequest","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DynamicsLcs","namespace":"Microsoft.DynamicsLcs","resourceTypes":[{"resourceType":"lcsprojects","locations":["Brazil
         South","East Asia","East US","Japan East","Japan West","North Central US","North
         Europe","South Central US","West Europe","West US","Southeast Asia","Central
         US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"lcsprojects/connectors","locations":["Brazil
@@ -1695,21 +1923,21 @@ http_interactions:
         US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"operations","locations":["Brazil
         South","East Asia","East US","Japan East","Japan West","North Central US","North
         Europe","South Central US","West Europe","West US","Southeast Asia","Central
-        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topics","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operations","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topics","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operations","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","West
         US 2","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
         India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/consumergroups","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
         US","East US 2","West US","South Central US","Central US","Australia East","Australia
         Southeast","Central India","West Central US","West US 2","Canada East","Canada
         Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
@@ -1754,23 +1982,23 @@ http_interactions:
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations","locations":["Australia
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations/operationResults","locations":["Australia
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations/operationResults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"operations","locations":["Australia
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"operations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Logic","namespace":"Microsoft.Logic","authorization":{"applicationId":"7cd684f4-8a78-49b0-91ec-6a35d38739ba","roleDefinitionId":"cb3ef1fb-6e31-49e2-9d87-ed821053fe58"},"resourceTypes":[{"resourceType":"workflows","locations":["North
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.LocationBasedServices","namespace":"Microsoft.LocationBasedServices","resourceTypes":[{"resourceType":"accounts","locations":["Global"],"apiVersions":["2017-01-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Logic","namespace":"Microsoft.Logic","authorization":{"applicationId":"7cd684f4-8a78-49b0-91ec-6a35d38739ba","roleDefinitionId":"cb3ef1fb-6e31-49e2-9d87-ed821053fe58"},"resourceTypes":[{"resourceType":"workflows","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
@@ -1791,60 +2019,78 @@ http_interactions:
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada Central","Canada East","West US 2","West Central
-        US","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","West Central US"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"operations","locations":["South
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations","locations":["South
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operations","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"commitmentPlans","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningExperimentation","namespace":"Microsoft.MachineLearningExperimentation","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"accounts","locations":["Australia
-        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces","locations":["Australia
-        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces/projects","locations":["Australia
-        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningCompute","namespace":"Microsoft.MachineLearningCompute","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"376aa7d7-51a9-463d-bd4d-7e1691345612","managedByRoleDefinitionId":"91d00862-cf55-46a5-9dce-260bbd92ce25"},"resourceTypes":[{"resourceType":"operationalizationClusters","locations":["East
-        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"operations","locations":["East
+        US","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningExperimentation","namespace":"Microsoft.MachineLearningExperimentation","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"accounts","locations":["Australia
+        East","East US 2","West Central US","Southeast Asia","West Europe"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces","locations":["Australia
+        East","East US 2","West Central US","Southeast Asia","West Europe"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces/projects","locations":["Australia
+        East","East US 2","West Central US","Southeast Asia","West Europe"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"teamAccounts","locations":["Australia
+        East","West Central US","East US 2"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"teamAccounts/workspaces","locations":["Australia
+        East","West Central US","East US 2"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"teamAccounts/workspaces/projects","locations":["Australia
+        East","West Central US","East US 2"],"apiVersions":["2017-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningCompute","namespace":"Microsoft.MachineLearningCompute","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"376aa7d7-51a9-463d-bd4d-7e1691345612","managedByRoleDefinitionId":"91d00862-cf55-46a5-9dce-260bbd92ce25"},"resourceTypes":[{"resourceType":"operationalizationClusters","locations":["East
+        US 2","West Central US","Australia East","West Europe","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"operations","locations":["East
         US 2"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations","locations":["East
         US 2"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operations","locations":["East
-        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["East
-        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningModelManagement","namespace":"Microsoft.MachineLearningModelManagement","resourceTypes":[{"resourceType":"accounts","locations":["East
-        US 2","West Central US","Australia East"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"operations","locations":["West
-        Central US"],"apiVersions":["2017-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
+        US 2","West Central US","Australia East","West Europe","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["East
+        US 2","West Central US","Australia East","West Europe","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningModelManagement","namespace":"Microsoft.MachineLearningModelManagement","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US 2","West Central US","Australia East","West Europe","Southeast Asia"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"operations","locations":["West
+        Central US"],"apiVersions":["2017-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ManagedIdentity","namespace":"Microsoft.ManagedIdentity","resourceTypes":[{"resourceType":"Identities","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Brazil South","Central
+        India","West India","South India","Japan West","Japan East","East Asia","Southeast
+        Asia","Korea Central","Korea South","North Europe","West Europe","UK West","UK
+        South","Central US","North Central US","East US","East US 2","South Central
+        US","West US","West US 2","West Central US"],"apiVersions":["2015-08-31-PREVIEW"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Brazil South","Central
+        India","West India","South India","Japan West","Japan East","East Asia","Southeast
+        Asia","Korea Central","Korea South","North Europe","West Europe","UK West","UK
+        South","Central US","North Central US","East US","East US 2","South Central
+        US","West US","West US 2","West Central US"],"apiVersions":["2015-08-31-PREVIEW"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Management","namespace":"Microsoft.Management","authorization":{"applicationId":"f2c304cf-8e7e-4c3f-8164-16299ad9d272","roleDefinitionId":"c1cf3708-588a-4647-be7f-f400bbe214cf"},"resourceTypes":[{"resourceType":"resources","locations":[],"apiVersions":["2017-11-01-preview","2017-08-31-preview","2017-06-30-preview","2017-05-31-preview"]},{"resourceType":"managementGroups","locations":[],"apiVersions":["2017-11-01-preview","2017-08-31-preview","2017-06-30-preview","2017-05-31-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01-preview","2017-08-31-preview","2017-06-30-preview","2017-05-31-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceApps","namespace":"Microsoft.MarketplaceApps","resourceTypes":[{"resourceType":"classicDevServices","locations":["Northwest
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","Central US","North
+        Europe","West Europe","Japan East","Japan West","Brazil South","Australia
+        East","Australia Southeast","South India","Central India","Canada Central","Canada
+        East"],"apiVersions":["2017-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
         Central US","West US"],"apiVersions":["2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01"]},{"resourceType":"offertypes","locations":["South
         Central US","West US"],"apiVersions":["2015-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Media","namespace":"Microsoft.Media","authorization":{"applicationId":"374b2a64-3b6b-436b-934c-b820eacca870","roleDefinitionId":"aab70789-0cec-44b5-95d7-84b64c9487af"},"resourceTypes":[{"resourceType":"mediaservices","locations":["Japan
         West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
         US","West US","Australia East","Australia Southeast","Central US","Brazil
         South","Central India","West India","South India","South Central US","Canada
-        Central","Canada East","West Central US"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
+        Central","Canada East","West Central US","West US 2"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
+        Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"operations","locations":["West
+        Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
+        Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PolicyInsights","namespace":"Microsoft.PolicyInsights","authorization":{"applicationId":"1d78a85d-813d-46f0-b496-dd72f50a3ec0","roleDefinitionId":"63d2b225-4c34-4641-8768-21a1f7c68ce8"},"resourceTypes":[{"resourceType":"policyEvents","locations":[],"apiVersions":["2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"policyStates","locations":[],"apiVersions":["2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-17-preview","2017-08-09-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
         Central US","North Central US","East US 2","West US","West Europe","North
         Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
         East","UK South","West India"],"apiVersions":["2016-01-29"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-01-29"]},{"resourceType":"locations/checkNameAvailability","locations":["South
         Central US","North Central US","East US 2","West US","West Europe","North
         Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
-        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"capacities","locations":["West
-        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
-        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationresults","locations":["West
-        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
-        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"operations","locations":["East
-        US 2"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Relay","namespace":"Microsoft.Relay","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"capacities","locations":["Australia
+        Southeast","Brazil South","Canada Central","East Asia","East US","East US
+        2","West India","Japan East","West Central US","North Central US","North Europe","South
+        Central US","Southeast Asia","UK South","West Europe","West US","West US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":["Australia
+        Southeast","Brazil South","Canada Central","East Asia","East US","East US
+        2","West India","Japan East","West Central US","North Central US","North Europe","South
+        Central US","Southeast Asia","UK South","West Europe","West US","West US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationresults","locations":["Australia
+        Southeast","Brazil South","Canada Central","East Asia","East US","East US
+        2","West India","Japan East","West Central US","North Central US","North Europe","South
+        Central US","Southeast Asia","UK South","West Europe","West US","West US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["Australia
+        Southeast","Brazil South","Canada Central","East Asia","East US","East US
+        2","West India","Japan East","West Central US","North Central US","North Europe","South
+        Central US","Southeast Asia","UK South","West Europe","West US","West US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"operations","locations":["East
+        US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Relay","namespace":"Microsoft.Relay","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US 2","West
         US","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
         India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2017-08-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkPolicyCompliance","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/hybridconnections","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/hybridconnections/authorizationrules","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/wcfrelays","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/wcfrelays/authorizationrules","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkPolicyCompliance","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
         Central US","South Central US","North Europe","West Europe","East Asia","Southeast
         Asia","West US","East US","Japan West","Japan East","Brazil South","Central
         US","East US 2","Australia East","Australia Southeast","South India","Central
@@ -1868,12 +2114,12 @@ http_interactions:
         India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19","2015-02-28"]},{"resourceType":"checkServiceNameAvailability","locations":[],"apiVersions":["2015-02-28","2014-07-31-Preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2015-08-19"]},{"resourceType":"resourceHealthMetadata","locations":["West
         US","East US","North Europe","West Europe","Southeast Asia","East Asia","North
         Central US","South Central US","Japan West","Australia East","Brazil South","Central
-        India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","authorization":{"applicationId":"80a10ef9-8168-493d-abf9-3297c4ef6e3c","roleDefinitionId":"2b7763f7-bbe2-4e19-befe-28c79f1cf7f7"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US 2","West
         US","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
         India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"premiumMessagingRegions","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceFabric","namespace":"Microsoft.ServiceFabric","authorization":{"applicationId":"74cb6831-0dbb-4be1-8206-fd4df301cdc2","roleDefinitionId":"e55cc65f-6903-4917-b4ef-f8d4640b57f5"},"resourceTypes":[{"resourceType":"clusters","locations":["West
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/queues","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/queues/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/topics","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/topics/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/topics/subscriptions","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/topics/subscriptions/rules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"premiumMessagingRegions","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceFabric","namespace":"Microsoft.ServiceFabric","authorization":{"applicationId":"74cb6831-0dbb-4be1-8206-fd4df301cdc2","roleDefinitionId":"e55cc65f-6903-4917-b4ef-f8d4640b57f5"},"resourceTypes":[{"resourceType":"clusters","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
@@ -1887,17 +2133,43 @@ http_interactions:
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
-        India","West India","Central India","Brazil South","South Central US","Canada
-        Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
         Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
         Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applianceDefinitions","locations":["West
-        Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"locations","locations":["West
-        Central US"],"apiVersions":["2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
-        Central US"],"apiVersions":["2017-09-01","2016-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
+        Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applications","locations":["South
+        Central US","North Central US","West Central US","West US","West US 2","East
+        US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
+        Asia","Brazil South","Japan West","Japan East","Australia East","Australia
+        Southeast","South India","West India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
+        Central US","North Central US","West Central US","West US","West US 2","East
+        US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
+        Asia","Brazil South","Japan West","Japan East","Australia East","Australia
+        Southeast","South India","West India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
+        Central US"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
+        Central US","North Central US","West Central US","West US","West US 2","East
+        US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
+        Asia","Brazil South","Japan West","Japan East","Australia East","Australia
+        Southeast","South India","West India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/cloudEndpoints","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/serverEndpoints","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/registeredServers","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/workflows","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","West Central US","Japan East","Japan West","Australia East","Australia
         Southeast"],"apiVersions":["2017-06-01","2017-05-15","2017-01-01","2016-10-01","2016-06-01","2015-03-15","2014-09-01"]},{"resourceType":"operations","locations":["West
@@ -1928,23 +2200,11 @@ http_interactions:
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast"],"apiVersions":["2015-07-01-Preview","2015-03-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.TimeSeriesInsights","namespace":"Microsoft.TimeSeriesInsights","authorizations":[{"applicationId":"120d688d-1518-4cf7-bd38-182f158850b6","roleDefinitionId":"5a43abdf-bb87-42c4-9e56-1c24bf364150"}],"resourceTypes":[{"resourceType":"environments","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/eventsources","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/referenceDataSets","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/accessPolicies","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"operations","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
-        Central US","South Central US","East US","West US","Central US","North Europe","West
-        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
-        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/project","locations":["North
-        Central US","South Central US","East US","West US","Central US","North Europe","West
-        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
-        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/extension","locations":["North
-        Central US","South Central US","East US","West US","Central US","North Europe","West
-        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
-        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"checkNameAvailability","locations":["North
-        Central US","South Central US","East US","West US","Central US","North Europe","West
-        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
-        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Myget.PackageManagement","namespace":"Myget.PackageManagement","resourceTypes":[{"resourceType":"services","locations":["West
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]},{"resourceType":"environments/eventsources","locations":["East
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]},{"resourceType":"environments/referenceDataSets","locations":["East
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]},{"resourceType":"environments/accessPolicies","locations":["East
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]},{"resourceType":"operations","locations":["East
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Myget.PackageManagement","namespace":"Myget.PackageManagement","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/NewRelic.APM","namespace":"NewRelic.APM","authorization":{"allowedThirdPartyExtensions":[{"name":"NewRelic_AzurePortal_APM"}]},"resourceTypes":[{"resourceType":"accounts","locations":["North
         Central US","South Central US","West US","East US","North Europe","West Europe","Southeast
         Asia","East Asia","Japan East","Japan West"],"apiVersions":["2014-10-01","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/nuubit.nextgencdn","namespace":"nuubit.nextgencdn","resourceTypes":[{"resourceType":"accounts","locations":["East
@@ -1984,7 +2244,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:41:55 GMT
+  recorded_at: Tue, 23 Jan 2018 20:06:38 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
@@ -2001,9 +2261,11 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMTQsIm5iZiI6MTUwNjExNjIxNCwiZXhwIjoxNTA2MTIwMTE0LCJhaW8iOiJZMlZnWURoNkxlTFlueWZjdXhLM1AwbGxXakZ0Q3dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiM3RzLXgxNGotVVdQWW50M21LUUtBQSIsInZlciI6IjEuMCJ9.tNfZxYjnzlN9LDikmqxEQ9ZcfV9Yn8I3V3YgPPMCQLu3VgrgqT1_rVmxUL5elZ7234OpvauDuw7T2xQ1ea_cnqFrbD2iIEH3LeIndrF0vmL16m8SaE9Adbufc2txA0w0nKguQnS51reRhW196Cv_p_w7_KFjhOba6m9Xg6w2eAmeRZGVccg0Esjne3ymo09Hvq4cdUq-RfDoTuZk9Sm9QglJEcC9IIargAWz2A37cemo9amSIV1VQrz-UyCgbvXygTJXgMoix96kQ8FvsLtiNTjhsdoFC0jdytz3igNPoUEIJnflKEYUP9nYddgNqO95tJ4jns580aLjg_Yn_mnuTw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc2OTUsIm5iZiI6MTUxNjczNzY5NSwiZXhwIjoxNTE2NzQxNTk1LCJhaW8iOiJZMk5nWUhnbjkraHlncU9xK2lIZUw1OGpqdDdOQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNGs1Q1JVWXd5RTZFZzhtZ2g4WVJBQSIsInZlciI6IjEuMCJ9.nKuSlYhBpWZ4JicCfBpm7DuN4-ths2pQBH2TqUW_z9iKp3PVKoNtSHKIJBQ0pFeJDPN1qm_SRoxg3hw_r6B-TAE7g6M__z8C5VfRVLmhpgQvAkT2igsLsdzbVFf0WokGFq6XPtdycJOUBFL-tBC2STEH7wk152_qEYuhHea--oc1DOMmzYlZubBn34WHcOTBlDlXVkr6OiwuEXW8pOFwYA4MuZ_TixqpqUpWvwvO13yIZHX5h8dHmgKJaJGirButu_VWmaTfuOwhfF1huq1Vqy4WzTFuBsLBW_PW2sIRoMscVGplbeHwsW3TSHPy2W-_kYj6U3lZ2BOZl7a5AGgJBw
       Content-Length:
       - '42'
+      Host:
+      - management.azure.com
   response:
     status:
       code: 202
@@ -2013,39 +2275,41 @@ http_interactions:
       - no-cache
       Pragma:
       - no-cache
-      Content-Length:
-      - '0'
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/9bebab40-09b8-45da-b9ba-a758ad1171a5?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/8a6bff37-fd34-455f-894f-8f7d66664c11?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/9bebab40-09b8-45da-b9ba-a758ad1171a5?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/8a6bff37-fd34-455f-894f-8f7d66664c11?api-version=2017-03-30
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/HighCostHydrate3Min;239,Microsoft.Compute/HighCostHydrate30Min;1166
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131599701143261070
       X-Ms-Request-Id:
-      - 9bebab40-09b8-45da-b9ba-a758ad1171a5
+      - 8a6bff37-fd34-455f-894f-8f7d66664c11
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1173'
+      - '1163'
       X-Ms-Correlation-Request-Id:
-      - fee3a7c3-1e6f-488a-8bd2-9fc9fae7c332
+      - b723c2c9-0243-41ee-91be-f3d0a596c0ce
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214157Z:fee3a7c3-1e6f-488a-8bd2-9fc9fae7c332
+      - WESTUS:20180123T200639Z:b723c2c9-0243-41ee-91be-f3d0a596c0ce
       Date:
-      - Fri, 22 Sep 2017 21:41:57 GMT
+      - Tue, 23 Jan 2018 20:06:39 GMT
+      Content-Length:
+      - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:41:56 GMT
+  recorded_at: Tue, 23 Jan 2018 20:06:39 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/9bebab40-09b8-45da-b9ba-a758ad1171a5?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/8a6bff37-fd34-455f-894f-8f7d66664c11?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -2059,7 +2323,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMTQsIm5iZiI6MTUwNjExNjIxNCwiZXhwIjoxNTA2MTIwMTE0LCJhaW8iOiJZMlZnWURoNkxlTFlueWZjdXhLM1AwbGxXakZ0Q3dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiM3RzLXgxNGotVVdQWW50M21LUUtBQSIsInZlciI6IjEuMCJ9.tNfZxYjnzlN9LDikmqxEQ9ZcfV9Yn8I3V3YgPPMCQLu3VgrgqT1_rVmxUL5elZ7234OpvauDuw7T2xQ1ea_cnqFrbD2iIEH3LeIndrF0vmL16m8SaE9Adbufc2txA0w0nKguQnS51reRhW196Cv_p_w7_KFjhOba6m9Xg6w2eAmeRZGVccg0Esjne3ymo09Hvq4cdUq-RfDoTuZk9Sm9QglJEcC9IIargAWz2A37cemo9amSIV1VQrz-UyCgbvXygTJXgMoix96kQ8FvsLtiNTjhsdoFC0jdytz3igNPoUEIJnflKEYUP9nYddgNqO95tJ4jns580aLjg_Yn_mnuTw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc2OTUsIm5iZiI6MTUxNjczNzY5NSwiZXhwIjoxNTE2NzQxNTk1LCJhaW8iOiJZMk5nWUhnbjkraHlncU9xK2lIZUw1OGpqdDdOQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNGs1Q1JVWXd5RTZFZzhtZ2g4WVJBQSIsInZlciI6IjEuMCJ9.nKuSlYhBpWZ4JicCfBpm7DuN4-ths2pQBH2TqUW_z9iKp3PVKoNtSHKIJBQ0pFeJDPN1qm_SRoxg3hw_r6B-TAE7g6M__z8C5VfRVLmhpgQvAkT2igsLsdzbVFf0WokGFq6XPtdycJOUBFL-tBC2STEH7wk152_qEYuhHea--oc1DOMmzYlZubBn34WHcOTBlDlXVkr6OiwuEXW8pOFwYA4MuZ_TixqpqUpWvwvO13yIZHX5h8dHmgKJaJGirButu_VWmaTfuOwhfF1huq1Vqy4WzTFuBsLBW_PW2sIRoMscVGplbeHwsW3TSHPy2W-_kYj6U3lZ2BOZl7a5AGgJBw
+      Host:
+      - management.azure.com
   response:
     status:
       code: 200
@@ -2077,34 +2343,36 @@ http_interactions:
       - "-1"
       Vary:
       - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/GetOperation3Min;49999,Microsoft.Compute/GetOperation30Min;249999
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131599701143261070
       X-Ms-Request-Id:
-      - 4a176790-5c73-4402-8fb7-031bbf35015a
+      - c6ea54d0-5f47-45e7-b18a-29ec4c8d6154
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14925'
+      - '14840'
       X-Ms-Correlation-Request-Id:
-      - 94cd658b-b671-4c91-a32f-6fef61992b50
+      - 98a04459-c403-46ab-b4a2-e5639386ccf9
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214158Z:94cd658b-b671-4c91-a32f-6fef61992b50
+      - WESTUS:20180123T200646Z:98a04459-c403-46ab-b4a2-e5639386ccf9
       Date:
-      - Fri, 22 Sep 2017 21:41:58 GMT
+      - Tue, 23 Jan 2018 20:06:45 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-22T21:41:58.7916756+00:00\",\r\n  \"endTime\":
-        \"2017-09-22T21:41:59.1511353+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=77e13252-062c-4a6d-8a0c-3b66516ee304&sig=PGH9Q0CjbjMvM%2BIh4k51%2FXTS7ptkQfD8A2bngm5zxfs%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"9bebab40-09b8-45da-b9ba-a758ad1171a5\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2018-01-23T20:06:38.7586834+00:00\",\r\n  \"endTime\":
+        \"2018-01-23T20:06:39.2274394+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=e151be7c-afbe-4f86-942c-479421fd9e35&sig=AcBMpsFR44peCo0RUplHhpAn49u4im2ojmCBDvjYUIs%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"8a6bff37-fd34-455f-894f-8f7d66664c11\"\r\n}"
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:41:58 GMT
+  recorded_at: Tue, 23 Jan 2018 20:06:40 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/9bebab40-09b8-45da-b9ba-a758ad1171a5?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/8a6bff37-fd34-455f-894f-8f7d66664c11?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -2118,7 +2386,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMTQsIm5iZiI6MTUwNjExNjIxNCwiZXhwIjoxNTA2MTIwMTE0LCJhaW8iOiJZMlZnWURoNkxlTFlueWZjdXhLM1AwbGxXakZ0Q3dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiM3RzLXgxNGotVVdQWW50M21LUUtBQSIsInZlciI6IjEuMCJ9.tNfZxYjnzlN9LDikmqxEQ9ZcfV9Yn8I3V3YgPPMCQLu3VgrgqT1_rVmxUL5elZ7234OpvauDuw7T2xQ1ea_cnqFrbD2iIEH3LeIndrF0vmL16m8SaE9Adbufc2txA0w0nKguQnS51reRhW196Cv_p_w7_KFjhOba6m9Xg6w2eAmeRZGVccg0Esjne3ymo09Hvq4cdUq-RfDoTuZk9Sm9QglJEcC9IIargAWz2A37cemo9amSIV1VQrz-UyCgbvXygTJXgMoix96kQ8FvsLtiNTjhsdoFC0jdytz3igNPoUEIJnflKEYUP9nYddgNqO95tJ4jns580aLjg_Yn_mnuTw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc2OTUsIm5iZiI6MTUxNjczNzY5NSwiZXhwIjoxNTE2NzQxNTk1LCJhaW8iOiJZMk5nWUhnbjkraHlncU9xK2lIZUw1OGpqdDdOQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNGs1Q1JVWXd5RTZFZzhtZ2g4WVJBQSIsInZlciI6IjEuMCJ9.nKuSlYhBpWZ4JicCfBpm7DuN4-ths2pQBH2TqUW_z9iKp3PVKoNtSHKIJBQ0pFeJDPN1qm_SRoxg3hw_r6B-TAE7g6M__z8C5VfRVLmhpgQvAkT2igsLsdzbVFf0WokGFq6XPtdycJOUBFL-tBC2STEH7wk152_qEYuhHea--oc1DOMmzYlZubBn34WHcOTBlDlXVkr6OiwuEXW8pOFwYA4MuZ_TixqpqUpWvwvO13yIZHX5h8dHmgKJaJGirButu_VWmaTfuOwhfF1huq1Vqy4WzTFuBsLBW_PW2sIRoMscVGplbeHwsW3TSHPy2W-_kYj6U3lZ2BOZl7a5AGgJBw
+      Host:
+      - management.azure.com
   response:
     status:
       code: 200
@@ -2136,34 +2406,36 @@ http_interactions:
       - "-1"
       Vary:
       - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/GetOperation3Min;49998,Microsoft.Compute/GetOperation30Min;249998
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131599701143261070
       X-Ms-Request-Id:
-      - 7cf250ce-edd0-412e-bba1-3ac7ad2f6850
+      - 605a86b2-cdcb-49ad-a10a-2fd727b57195
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14922'
+      - '14853'
       X-Ms-Correlation-Request-Id:
-      - 4438ed5d-4eef-4623-8fd2-a3e67701abf2
+      - 137c2e81-c464-4ef9-8973-ed0bfa460d6c
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214159Z:4438ed5d-4eef-4623-8fd2-a3e67701abf2
+      - WESTUS:20180123T200641Z:137c2e81-c464-4ef9-8973-ed0bfa460d6c
       Date:
-      - Fri, 22 Sep 2017 21:41:59 GMT
+      - Tue, 23 Jan 2018 20:06:41 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-22T21:41:58.7916756+00:00\",\r\n  \"endTime\":
-        \"2017-09-22T21:41:59.1511353+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=77e13252-062c-4a6d-8a0c-3b66516ee304&sig=PGH9Q0CjbjMvM%2BIh4k51%2FXTS7ptkQfD8A2bngm5zxfs%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"9bebab40-09b8-45da-b9ba-a758ad1171a5\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2018-01-23T20:06:38.7586834+00:00\",\r\n  \"endTime\":
+        \"2018-01-23T20:06:39.2274394+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=e151be7c-afbe-4f86-942c-479421fd9e35&sig=AcBMpsFR44peCo0RUplHhpAn49u4im2ojmCBDvjYUIs%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"8a6bff37-fd34-455f-894f-8f7d66664c11\"\r\n}"
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:41:58 GMT
+  recorded_at: Tue, 23 Jan 2018 20:06:41 GMT
 - request:
     method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=77e13252-062c-4a6d-8a0c-3b66516ee304&sig=PGH9Q0CjbjMvM%2BIh4k51/XTS7ptkQfD8A2bngm5zxfs=&sr=b&sv=2016-05-31
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=e151be7c-afbe-4f86-942c-479421fd9e35&sig=AcBMpsFR44peCo0RUplHhpAn49u4im2ojmCBDvjYUIs=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2176,6 +2448,8 @@ http_interactions:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
       X-Ms-Range:
       - bytes=0-0
+      Host:
+      - md-t4jdgqqlgszp.blob.core.windows.net
   response:
     status:
       code: 206
@@ -2188,15 +2462,15 @@ http_interactions:
       Content-Range:
       - bytes 0-0/34359738880
       Last-Modified:
-      - Sat, 15 Jul 2017 14:23:07 GMT
+      - Tue, 23 Jan 2018 20:04:26 GMT
       Accept-Ranges:
       - bytes
       Etag:
-      - '"0x8D4CB8D039FC699"'
+      - '"0x8D5629C811B65EB"'
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - f5ca1ede-001e-00e5-4aeb-33b3da000000
+      - 85d158d2-001e-0063-7485-94e708000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2208,7 +2482,7 @@ http_interactions:
       X-Ms-Blob-Type:
       - PageBlob
       X-Ms-Blob-Sequence-Number:
-      - '20'
+      - '30'
       X-Ms-Copy-Id:
       - 30cedd78-548a-4fd8-967e-f8344f587e3c
       X-Ms-Copy-Source:
@@ -2222,250 +2496,16 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Fri, 22 Sep 2017 21:42:00 GMT
+      - Tue, 23 Jan 2018 20:06:41 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         6w==
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:41:59 GMT
-- request:
-    method: post
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/EndGetAccess?api-version=2017-03-30
-    body:
-      encoding: ASCII-8BIT
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMTQsIm5iZiI6MTUwNjExNjIxNCwiZXhwIjoxNTA2MTIwMTE0LCJhaW8iOiJZMlZnWURoNkxlTFlueWZjdXhLM1AwbGxXakZ0Q3dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiM3RzLXgxNGotVVdQWW50M21LUUtBQSIsInZlciI6IjEuMCJ9.tNfZxYjnzlN9LDikmqxEQ9ZcfV9Yn8I3V3YgPPMCQLu3VgrgqT1_rVmxUL5elZ7234OpvauDuw7T2xQ1ea_cnqFrbD2iIEH3LeIndrF0vmL16m8SaE9Adbufc2txA0w0nKguQnS51reRhW196Cv_p_w7_KFjhOba6m9Xg6w2eAmeRZGVccg0Esjne3ymo09Hvq4cdUq-RfDoTuZk9Sm9QglJEcC9IIargAWz2A37cemo9amSIV1VQrz-UyCgbvXygTJXgMoix96kQ8FvsLtiNTjhsdoFC0jdytz3igNPoUEIJnflKEYUP9nYddgNqO95tJ4jns580aLjg_Yn_mnuTw
-      Content-Length:
-      - '0'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '0'
-      Expires:
-      - "-1"
-      Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/72bde769-4fab-4f16-b7e4-8b99e794ea3f?monitor=true&api-version=2017-03-30
-      Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/72bde769-4fab-4f16-b7e4-8b99e794ea3f?api-version=2017-03-30
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - 72bde769-4fab-4f16-b7e4-8b99e794ea3f
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1182'
-      X-Ms-Correlation-Request-Id:
-      - 63159f83-669d-4641-bee2-1dbd29bd8a98
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214200Z:63159f83-669d-4641-bee2-1dbd29bd8a98
-      Date:
-      - Fri, 22 Sep 2017 21:42:00 GMT
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:41:59 GMT
-- request:
-    method: post
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
-    body:
-      encoding: UTF-8
-      string: '{"access":"read","durationInSeconds":3600}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMTQsIm5iZiI6MTUwNjExNjIxNCwiZXhwIjoxNTA2MTIwMTE0LCJhaW8iOiJZMlZnWURoNkxlTFlueWZjdXhLM1AwbGxXakZ0Q3dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiM3RzLXgxNGotVVdQWW50M21LUUtBQSIsInZlciI6IjEuMCJ9.tNfZxYjnzlN9LDikmqxEQ9ZcfV9Yn8I3V3YgPPMCQLu3VgrgqT1_rVmxUL5elZ7234OpvauDuw7T2xQ1ea_cnqFrbD2iIEH3LeIndrF0vmL16m8SaE9Adbufc2txA0w0nKguQnS51reRhW196Cv_p_w7_KFjhOba6m9Xg6w2eAmeRZGVccg0Esjne3ymo09Hvq4cdUq-RfDoTuZk9Sm9QglJEcC9IIargAWz2A37cemo9amSIV1VQrz-UyCgbvXygTJXgMoix96kQ8FvsLtiNTjhsdoFC0jdytz3igNPoUEIJnflKEYUP9nYddgNqO95tJ4jns580aLjg_Yn_mnuTw
-      Content-Length:
-      - '42'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '0'
-      Expires:
-      - "-1"
-      Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/4b7060de-ce50-4b4b-9942-459892222e80?monitor=true&api-version=2017-03-30
-      Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/4b7060de-ce50-4b4b-9942-459892222e80?api-version=2017-03-30
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - 4b7060de-ce50-4b4b-9942-459892222e80
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1183'
-      X-Ms-Correlation-Request-Id:
-      - b082a3ef-b564-4086-88dc-71d520304a88
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214203Z:b082a3ef-b564-4086-88dc-71d520304a88
-      Date:
-      - Fri, 22 Sep 2017 21:42:02 GMT
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:02 GMT
+  recorded_at: Tue, 23 Jan 2018 20:06:41 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/4b7060de-ce50-4b4b-9942-459892222e80?api-version=2017-03-30
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMTQsIm5iZiI6MTUwNjExNjIxNCwiZXhwIjoxNTA2MTIwMTE0LCJhaW8iOiJZMlZnWURoNkxlTFlueWZjdXhLM1AwbGxXakZ0Q3dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiM3RzLXgxNGotVVdQWW50M21LUUtBQSIsInZlciI6IjEuMCJ9.tNfZxYjnzlN9LDikmqxEQ9ZcfV9Yn8I3V3YgPPMCQLu3VgrgqT1_rVmxUL5elZ7234OpvauDuw7T2xQ1ea_cnqFrbD2iIEH3LeIndrF0vmL16m8SaE9Adbufc2txA0w0nKguQnS51reRhW196Cv_p_w7_KFjhOba6m9Xg6w2eAmeRZGVccg0Esjne3ymo09Hvq4cdUq-RfDoTuZk9Sm9QglJEcC9IIargAWz2A37cemo9amSIV1VQrz-UyCgbvXygTJXgMoix96kQ8FvsLtiNTjhsdoFC0jdytz3igNPoUEIJnflKEYUP9nYddgNqO95tJ4jns580aLjg_Yn_mnuTw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - b48ea611-42d2-4625-b04f-6ead71473e88
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14927'
-      X-Ms-Correlation-Request-Id:
-      - 2a108c21-40e6-4e0c-9ab2-695f25fd3297
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214204Z:2a108c21-40e6-4e0c-9ab2-695f25fd3297
-      Date:
-      - Fri, 22 Sep 2017 21:42:04 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-22T21:42:04.6837547+00:00\",\r\n  \"endTime\":
-        \"2017-09-22T21:42:04.808805+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=d9916b26-0b87-4700-b9e3-ffba4af4ad7f&sig=YsSuh4BiBjho%2F%2FMYfsE%2FOV0zmwYgUjOofVsMCjhP0Fo%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"4b7060de-ce50-4b4b-9942-459892222e80\"\r\n}"
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:03 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/4b7060de-ce50-4b4b-9942-459892222e80?api-version=2017-03-30
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMTQsIm5iZiI6MTUwNjExNjIxNCwiZXhwIjoxNTA2MTIwMTE0LCJhaW8iOiJZMlZnWURoNkxlTFlueWZjdXhLM1AwbGxXakZ0Q3dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiM3RzLXgxNGotVVdQWW50M21LUUtBQSIsInZlciI6IjEuMCJ9.tNfZxYjnzlN9LDikmqxEQ9ZcfV9Yn8I3V3YgPPMCQLu3VgrgqT1_rVmxUL5elZ7234OpvauDuw7T2xQ1ea_cnqFrbD2iIEH3LeIndrF0vmL16m8SaE9Adbufc2txA0w0nKguQnS51reRhW196Cv_p_w7_KFjhOba6m9Xg6w2eAmeRZGVccg0Esjne3ymo09Hvq4cdUq-RfDoTuZk9Sm9QglJEcC9IIargAWz2A37cemo9amSIV1VQrz-UyCgbvXygTJXgMoix96kQ8FvsLtiNTjhsdoFC0jdytz3igNPoUEIJnflKEYUP9nYddgNqO95tJ4jns580aLjg_Yn_mnuTw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - 457d0b3a-325f-4cad-a657-26868f0b4b08
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14913'
-      X-Ms-Correlation-Request-Id:
-      - 1f687fcd-41fd-4cb2-a052-cf4625fe05fc
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214205Z:1f687fcd-41fd-4cb2-a052-cf4625fe05fc
-      Date:
-      - Fri, 22 Sep 2017 21:42:05 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-22T21:42:04.6837547+00:00\",\r\n  \"endTime\":
-        \"2017-09-22T21:42:04.808805+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=d9916b26-0b87-4700-b9e3-ffba4af4ad7f&sig=YsSuh4BiBjho%2F%2FMYfsE%2FOV0zmwYgUjOofVsMCjhP0Fo%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"4b7060de-ce50-4b4b-9942-459892222e80\"\r\n}"
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:04 GMT
-- request:
-    method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=d9916b26-0b87-4700-b9e3-ffba4af4ad7f&sig=YsSuh4BiBjho//MYfsE/OV0zmwYgUjOofVsMCjhP0Fo=&sr=b&sv=2016-05-31
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=e151be7c-afbe-4f86-942c-479421fd9e35&sig=AcBMpsFR44peCo0RUplHhpAn49u4im2ojmCBDvjYUIs=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2478,6 +2518,8 @@ http_interactions:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
       X-Ms-Range:
       - bytes=440-443
+      Host:
+      - md-t4jdgqqlgszp.blob.core.windows.net
   response:
     status:
       code: 206
@@ -2490,15 +2532,15 @@ http_interactions:
       Content-Range:
       - bytes 440-443/34359738880
       Last-Modified:
-      - Sat, 15 Jul 2017 14:23:07 GMT
+      - Tue, 23 Jan 2018 20:04:26 GMT
       Accept-Ranges:
       - bytes
       Etag:
-      - '"0x8D4CB8D039FC699"'
+      - '"0x8D5629C811B65EB"'
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - ee137a0f-001e-0018-56eb-338cb8000000
+      - 7431a126-001e-005c-3285-9450d4000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2510,7 +2552,7 @@ http_interactions:
       X-Ms-Blob-Type:
       - PageBlob
       X-Ms-Blob-Sequence-Number:
-      - '20'
+      - '30'
       X-Ms-Copy-Id:
       - 30cedd78-548a-4fd8-967e-f8344f587e3c
       X-Ms-Copy-Source:
@@ -2524,69 +2566,11 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Fri, 22 Sep 2017 21:42:05 GMT
+      - Tue, 23 Jan 2018 20:06:41 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         U5MJAA==
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:04 GMT
-- request:
-    method: post
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/EndGetAccess?api-version=2017-03-30
-    body:
-      encoding: ASCII-8BIT
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMTQsIm5iZiI6MTUwNjExNjIxNCwiZXhwIjoxNTA2MTIwMTE0LCJhaW8iOiJZMlZnWURoNkxlTFlueWZjdXhLM1AwbGxXakZ0Q3dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiM3RzLXgxNGotVVdQWW50M21LUUtBQSIsInZlciI6IjEuMCJ9.tNfZxYjnzlN9LDikmqxEQ9ZcfV9Yn8I3V3YgPPMCQLu3VgrgqT1_rVmxUL5elZ7234OpvauDuw7T2xQ1ea_cnqFrbD2iIEH3LeIndrF0vmL16m8SaE9Adbufc2txA0w0nKguQnS51reRhW196Cv_p_w7_KFjhOba6m9Xg6w2eAmeRZGVccg0Esjne3ymo09Hvq4cdUq-RfDoTuZk9Sm9QglJEcC9IIargAWz2A37cemo9amSIV1VQrz-UyCgbvXygTJXgMoix96kQ8FvsLtiNTjhsdoFC0jdytz3igNPoUEIJnflKEYUP9nYddgNqO95tJ4jns580aLjg_Yn_mnuTw
-      Content-Length:
-      - '0'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '0'
-      Expires:
-      - "-1"
-      Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/363730c8-248b-4f32-b72f-1caf0d4ef20f?monitor=true&api-version=2017-03-30
-      Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/363730c8-248b-4f32-b72f-1caf0d4ef20f?api-version=2017-03-30
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - 363730c8-248b-4f32-b72f-1caf0d4ef20f
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1183'
-      X-Ms-Correlation-Request-Id:
-      - 7121e902-1466-4569-b6b4-3fd0788c388a
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214206Z:7121e902-1466-4569-b6b4-3fd0788c388a
-      Date:
-      - Fri, 22 Sep 2017 21:42:06 GMT
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:05 GMT
+  recorded_at: Tue, 23 Jan 2018 20:06:42 GMT
 recorded_with: VCR 3.0.3

--- a/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_endByteAddr-1.yml
+++ b/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_endByteAddr-1.yml
@@ -17,6 +17,8 @@ http_interactions:
       - '186'
       Content-Type:
       - application/x-www-form-urlencoded
+      Host:
+      - login.microsoftonline.com
   response:
     status:
       code: 200
@@ -37,25 +39,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 294c3a76-436c-4d92-900b-21d0165a0d00
+      - a1f08b31-5393-48f3-af47-9978e16e0100
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAAABlDrqfEFlSaui6xnRjX5EzujB1sWgyAff07ksrrKdj1kzpDLb6ndFCUV4zX2f6T6_Cl2HSfTrjOzCPJ0Zgkmp49lscoDXakb1ZnfOE1ftffhSDa2b-aY_yIVQsP2_yoLScDZhB6ebBm2qb5ygkwsbmg_jhrpWUWEu-jyAx7JACjAqwWcZsc4RkbIVO9drbEsgAA;
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzQkVdcV0diDQomyXZuozfjEzeZgYBYcOVXFf8TUL8dDCUxZ9d1h4T1Ogb2UMOHQdZckyOL4_jMMxBzwE80o3OxOEMbSBvCwnwSotq6bznNa-ocmbTCmOyjQVc0q738RNjyv92APHIgTM9zmf6LNfJozmcb63eul-YoFyX7HLtxRMgAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=003; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=008; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Fri, 22 Sep 2017 21:41:21 GMT
+      - Tue, 23 Jan 2018 20:06:46 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1506120081","not_before":"1506116181","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYxODEsIm5iZiI6MTUwNjExNjE4MSwiZXhwIjoxNTA2MTIwMDgxLCJhaW8iOiJZMlZnWU5pV0pXUHdMc2ZWM2ZoSVFWajJIT3N5QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZGpwTUtXeERrazJRQ3lIUUZsb05BQSIsInZlciI6IjEuMCJ9.GW2nffAcmgbaeE599i02qETJnYxCuvceko-eBNV-OBRreyQFQW5sN7oI6JvkbyNZj8IEvjsqhCdlnWX6P4dptVZD_sQxClGAW6mvLq83u4hdtzXVqEhD5rPU1ssRvkt8vxnSJ2LrgwcLud1UTmqwfVIeghqjVQN5qkewahU_YwYkb31LoDkLVbgpPPLxMTTMgjsXFWsE1qB5zTZj74U5Oo4TH312XuTH_KuYCQj3tbwZj4_HUNxxmGW-iT84wWxwTfEQuA1LW_eK9bYGXj_WLClwn-rFFWoYY_YogKayMoolQekRujbk41PCf_4UB2LbQ8QP6zOjsAOZbFMUZhODjw"}'
+      string: '{"token_type":"Bearer","expires_in":"3600","ext_expires_in":"0","expires_on":"1516741606","not_before":"1516737706","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3MDYsIm5iZiI6MTUxNjczNzcwNiwiZXhwIjoxNTE2NzQxNjA2LCJhaW8iOiJZMk5nWU5qWTM4RStWU2lPKzlxT2duY0JKOWN0QlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTVl2d29aTlQ4MGl2UjVsNDRXNEJBQSIsInZlciI6IjEuMCJ9.eOLoVWRIWbqFs545ywnN0TtMn3xELFO15Bcw1V2bp9OboFdCnfdnt9EyhCVKj6F3EvR-rW61Z_JM-h_LghzGMgP6KswcWezikCBYr3oweCD2j9i0pegFDDhYhi-IT35zV4gBR0goTGu0CSxbh7ntO7DaulT4cjkt-IPYI1IwX6f_gtW72-HRXq4RUaYA6SIM6Ka9zHcUwt-OW_hhqNCuHpfxqH3kQg8CLfLPTvscEqjrJZaLgOzwPQxBwZOe5RCn0fQuvZy5rrkCnqRqG-ZyQSUJ6L9CHBSZTBCWegbyWf4KVgQ0WxH14f1ztnfpMfxSb32mHt4XerxUVcSRZECiOg"}'
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:41:21 GMT
+  recorded_at: Tue, 23 Jan 2018 20:06:47 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -72,7 +74,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYxODEsIm5iZiI6MTUwNjExNjE4MSwiZXhwIjoxNTA2MTIwMDgxLCJhaW8iOiJZMlZnWU5pV0pXUHdMc2ZWM2ZoSVFWajJIT3N5QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZGpwTUtXeERrazJRQ3lIUUZsb05BQSIsInZlciI6IjEuMCJ9.GW2nffAcmgbaeE599i02qETJnYxCuvceko-eBNV-OBRreyQFQW5sN7oI6JvkbyNZj8IEvjsqhCdlnWX6P4dptVZD_sQxClGAW6mvLq83u4hdtzXVqEhD5rPU1ssRvkt8vxnSJ2LrgwcLud1UTmqwfVIeghqjVQN5qkewahU_YwYkb31LoDkLVbgpPPLxMTTMgjsXFWsE1qB5zTZj74U5Oo4TH312XuTH_KuYCQj3tbwZj4_HUNxxmGW-iT84wWxwTfEQuA1LW_eK9bYGXj_WLClwn-rFFWoYY_YogKayMoolQekRujbk41PCf_4UB2LbQ8QP6zOjsAOZbFMUZhODjw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3MDYsIm5iZiI6MTUxNjczNzcwNiwiZXhwIjoxNTE2NzQxNjA2LCJhaW8iOiJZMk5nWU5qWTM4RStWU2lPKzlxT2duY0JKOWN0QlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTVl2d29aTlQ4MGl2UjVsNDRXNEJBQSIsInZlciI6IjEuMCJ9.eOLoVWRIWbqFs545ywnN0TtMn3xELFO15Bcw1V2bp9OboFdCnfdnt9EyhCVKj6F3EvR-rW61Z_JM-h_LghzGMgP6KswcWezikCBYr3oweCD2j9i0pegFDDhYhi-IT35zV4gBR0goTGu0CSxbh7ntO7DaulT4cjkt-IPYI1IwX6f_gtW72-HRXq4RUaYA6SIM6Ka9zHcUwt-OW_hhqNCuHpfxqH3kQg8CLfLPTvscEqjrJZaLgOzwPQxBwZOe5RCn0fQuvZy5rrkCnqRqG-ZyQSUJ6L9CHBSZTBCWegbyWf4KVgQ0WxH14f1ztnfpMfxSb32mHt4XerxUVcSRZECiOg
+      Host:
+      - management.azure.com
   response:
     status:
       code: 200
@@ -93,21 +97,22 @@ http_interactions:
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
       - '14999'
       X-Ms-Request-Id:
-      - 9b837ba8-0878-4c91-8349-f5dfb29febe0
+      - 005f22df-063b-451e-b498-65f3b7d1706f
       X-Ms-Correlation-Request-Id:
-      - 9b837ba8-0878-4c91-8349-f5dfb29febe0
+      - 005f22df-063b-451e-b498-65f3b7d1706f
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214122Z:9b837ba8-0878-4c91-8349-f5dfb29febe0
+      - WESTUS:20180123T200647Z:005f22df-063b-451e-b498-65f3b7d1706f
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 22 Sep 2017 21:41:21 GMT
+      - Tue, 23 Jan 2018 20:06:47 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
-        Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
+      string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
+        Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
+        Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:41:22 GMT
+  recorded_at: Tue, 23 Jan 2018 20:06:47 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/azure_subscription_id/providers?api-version=2015-01-01
@@ -124,7 +129,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYxODEsIm5iZiI6MTUwNjExNjE4MSwiZXhwIjoxNTA2MTIwMDgxLCJhaW8iOiJZMlZnWU5pV0pXUHdMc2ZWM2ZoSVFWajJIT3N5QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZGpwTUtXeERrazJRQ3lIUUZsb05BQSIsInZlciI6IjEuMCJ9.GW2nffAcmgbaeE599i02qETJnYxCuvceko-eBNV-OBRreyQFQW5sN7oI6JvkbyNZj8IEvjsqhCdlnWX6P4dptVZD_sQxClGAW6mvLq83u4hdtzXVqEhD5rPU1ssRvkt8vxnSJ2LrgwcLud1UTmqwfVIeghqjVQN5qkewahU_YwYkb31LoDkLVbgpPPLxMTTMgjsXFWsE1qB5zTZj74U5Oo4TH312XuTH_KuYCQj3tbwZj4_HUNxxmGW-iT84wWxwTfEQuA1LW_eK9bYGXj_WLClwn-rFFWoYY_YogKayMoolQekRujbk41PCf_4UB2LbQ8QP6zOjsAOZbFMUZhODjw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3MDYsIm5iZiI6MTUxNjczNzcwNiwiZXhwIjoxNTE2NzQxNjA2LCJhaW8iOiJZMk5nWU5qWTM4RStWU2lPKzlxT2duY0JKOWN0QlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTVl2d29aTlQ4MGl2UjVsNDRXNEJBQSIsInZlciI6IjEuMCJ9.eOLoVWRIWbqFs545ywnN0TtMn3xELFO15Bcw1V2bp9OboFdCnfdnt9EyhCVKj6F3EvR-rW61Z_JM-h_LghzGMgP6KswcWezikCBYr3oweCD2j9i0pegFDDhYhi-IT35zV4gBR0goTGu0CSxbh7ntO7DaulT4cjkt-IPYI1IwX6f_gtW72-HRXq4RUaYA6SIM6Ka9zHcUwt-OW_hhqNCuHpfxqH3kQg8CLfLPTvscEqjrJZaLgOzwPQxBwZOe5RCn0fQuvZy5rrkCnqRqG-ZyQSUJ6L9CHBSZTBCWegbyWf4KVgQ0WxH14f1ztnfpMfxSb32mHt4XerxUVcSRZECiOg
+      Host:
+      - management.azure.com
   response:
     status:
       code: 200
@@ -141,19 +148,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14915'
+      - '14854'
       X-Ms-Request-Id:
-      - 62da508c-dec0-4408-8576-9c6ba8692e1b
+      - 2b8d344d-9f91-4b45-9157-163dbba2eccb
       X-Ms-Correlation-Request-Id:
-      - 62da508c-dec0-4408-8576-9c6ba8692e1b
+      - 2b8d344d-9f91-4b45-9157-163dbba2eccb
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214123Z:62da508c-dec0-4408-8576-9c6ba8692e1b
+      - WESTUS:20180123T200648Z:2b8d344d-9f91-4b45-9157-163dbba2eccb
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 22 Sep 2017 21:41:23 GMT
+      - Tue, 23 Jan 2018 20:06:48 GMT
       Content-Length:
-      - '254785'
+      - '293551'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
@@ -176,7 +183,7 @@ http_interactions:
         Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
         Central US","North Central US","Japan East","Japan West","Brazil South","Central
         India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
+        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-04-19","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-04-19","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-04-19","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-04-19","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","North Central
         US","South Central US","West Central US","West US","West US 2","Canada Central","Canada
         East","North Europe","West Europe","UK South","UK West","East Asia","Southeast
@@ -184,20 +191,26 @@ http_interactions:
         India","South India","West India"],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"validateServiceName","locations":[],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"checkServiceNameAvailability","locations":[],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"reportFeedback","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"checkFeedbackRequired","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Automation","namespace":"Microsoft.Automation","authorizations":[{"applicationId":"fc75330b-179d-49af-87dd-3b1acf6827fa","roleDefinitionId":"95fd5de3-d071-4362-92bf-cf341c1de832"}],"resourceTypes":[{"resourceType":"automationAccounts","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
         South","UK South","West Central US","North Europe","Canada Central","Australia
-        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/runbooks","locations":["Japan
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/runbooks","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
         South","UK South","West Central US","North Europe","Canada Central","Australia
-        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/configurations","locations":["Japan
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/configurations","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","North
-        Central US","Brazil South","UK South","West Central US","Central India","Australia
-        Southeast","Canada Central","North Europe"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/webhooks","locations":["Japan
+        Central US","Korea Central","East US","West US 2","Brazil South","UK South","West
+        Central US","Central India","Australia Southeast","Canada Central","North
+        Europe"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/webhooks","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
         South","UK South","West Central US","North Europe","Canada Central","Australia
-        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"operations","locations":["South
-        Central US"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/softwareUpdateConfigurations","locations":["Japan
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"operations","locations":["South
+        Central US"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/softwareUpdateConfigurations","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
         South","UK South","West Central US","North Europe","Canada Central","Australia
-        Southeast","Central India"],"apiVersions":["2017-05-15-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Backup","namespace":"Microsoft.Backup","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"BackupVault","locations":["West
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview"]},{"resourceType":"automationAccounts/jobs","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
+        South","UK South","West Central US","North Europe","Canada Central","Australia
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureActiveDirectory","namespace":"Microsoft.AzureActiveDirectory","resourceTypes":[{"resourceType":"b2cDirectories","locations":["Global","United
+        States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]},{"resourceType":"operations","locations":["Global","United
+        States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]}],"registrationState":"Unregistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Backup","namespace":"Microsoft.Backup","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"BackupVault","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
@@ -206,22 +219,22 @@ http_interactions:
         Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
         West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
         East","South India","Central India","Canada Central","Canada East","UK South","UK
-        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01","2015-07-01","2014-05-01-privatepreview"]},{"resourceType":"operations","locations":["West
+        West","West Central US","West US 2"],"apiVersions":["2017-09-01","2017-05-01","2017-01-01","2015-12-01","2015-09-01","2015-07-01","2014-05-01-privatepreview"]},{"resourceType":"operations","locations":["West
         Europe","East US","East US 2","West US","North Central US","Brazil South","North
         Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
         West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
         East","South India","Central India","Canada Central","Canada East","UK South","UK
-        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations/quotas","locations":["West
+        West","West Central US","West US 2"],"apiVersions":["2017-09-01","2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01","2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations/quotas","locations":["West
         Europe","East US","East US 2","West US","North Central US","Brazil South","North
         Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
         West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
         East","South India","Central India","Canada Central","Canada East","UK South","UK
-        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]}],"registrationState":"Unregistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicCompute","namespace":"Microsoft.ClassicCompute","resourceTypes":[{"resourceType":"domainNames","locations":["East
+        West","West Central US","West US 2"],"apiVersions":["2017-09-01","2017-05-01","2017-01-01","2015-12-01","2015-09-01"]}],"registrationState":"Unregistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicCompute","namespace":"Microsoft.ClassicCompute","resourceTypes":[{"resourceType":"domainNames","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
@@ -256,7 +269,7 @@ http_interactions:
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -296,92 +309,92 @@ http_interactions:
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30"]},{"resourceType":"locations/usages","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations/usages","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
+        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
@@ -411,76 +424,138 @@ http_interactions:
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
+        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
         US","East US","South Central US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
         Central","Central US","East US 2","North Central US","West Central US","West
-        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/webhooks","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/ping","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/getCallbackConfig","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/listEvents","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"locations","locations":["South
-        Central US","East US","West US","Central US","East US 2","North Central US","West
-        Central US","West US 2","Brazil South","Canada East","Canada Central","West
-        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
-        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"locations/operationResults","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/GetCredentials","locations":["West
+        US 2"],"apiVersions":["2017-10-01","2017-03-01"]},{"resourceType":"registries/replications","locations":["South
+        Central US","West Central US","East US","West Europe","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/webhooks","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/webhooks/ping","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/webhooks/getCallbackConfig","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/webhooks/listEvents","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"locations/operationResults","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/GetCredentials","locations":["West
         US","East US","South Central US","West Europe"],"apiVersions":["2016-06-27-preview"]},{"resourceType":"registries/listCredentials","locations":["South
         Central US","East US","West US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
         Central","Central US","East US 2","North Central US","West Central US","West
-        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/regenerateCredential","locations":["South
+        US 2"],"apiVersions":["2017-10-01","2017-03-01"]},{"resourceType":"registries/regenerateCredential","locations":["South
         Central US","West US","East US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
         Central","Central US","East US 2","North Central US","West Central US","West
-        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/listUsages","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/regenerateCredentials","locations":["West
+        US 2"],"apiVersions":["2017-10-01","2017-03-01"]},{"resourceType":"registries/listUsages","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/regenerateCredentials","locations":["West
         US","East US","South Central US","West Europe"],"apiVersions":["2016-06-27-preview"]},{"resourceType":"checkNameAvailability","locations":["South
         Central US","East US","West US","Central US","East US 2","North Central US","West
         Central US","West US 2","Brazil South","Canada East","Canada Central","West
         Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
-        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview","2017-03-01","2016-06-27-preview"]},{"resourceType":"operations","locations":["South
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-10-01","2017-06-01-preview","2017-03-01","2016-06-27-preview"]},{"resourceType":"operations","locations":["South
         Central US","East US","West US","Central US","East US 2","North Central US","West
         Central US","West US 2","Brazil South","Canada East","Canada Central","West
         Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
-        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview","2017-03-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerService","namespace":"Microsoft.ContainerService","authorization":{"applicationId":"7319c514-987d-4e9b-ac3d-d38c4f427f4c","roleDefinitionId":"1b4a0c7f-2217-416f-acfa-cf73452fdc1c"},"resourceTypes":[{"resourceType":"containerServices","locations":["Japan
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-10-01","2017-06-01-preview","2017-03-01"]},{"resourceType":"locations","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-10-01","2017-06-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerService","namespace":"Microsoft.ContainerService","authorization":{"applicationId":"7319c514-987d-4e9b-ac3d-d38c4f427f4c","roleDefinitionId":"1b4a0c7f-2217-416f-acfa-cf73452fdc1c","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"containerServices","locations":["Japan
         East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
         Central US","West US 2","South India","Central India","West India","Canada
-        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
+        East","Canada Central","Korea South","Korea Central"],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"managedClusters","locations":["East
+        US","West Europe","Central US","Canada Central","Canada East"],"apiVersions":["2017-08-31"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
         East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
         Central US","West US 2","South India","Central India","West India","Canada
-        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DevTestLab","namespace":"Microsoft.DevTestLab","authorization":{"applicationId":"1a14be2a-e903-4cec-99cf-b2e209259a0f","roleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525"},"resourceTypes":[{"resourceType":"labs","locations":["West
+        East","Canada Central","Korea South","Korea Central"],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/orchestrators","locations":["UK
+        West","West US 2","East US","West Europe","Central US"],"apiVersions":["2017-09-30"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DevTestLab","namespace":"Microsoft.DevTestLab","authorization":{"applicationId":"1a14be2a-e903-4cec-99cf-b2e209259a0f","roleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525","managedByRoleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525"},"resourceTypes":[{"resourceType":"labs","locations":["West
         Central US","Japan East","West US","Australia Southeast","Canada Central","Central
         India","Central US","East Asia","Korea Central","North Europe","South Central
-        US","UK West","Australia East","Brazil South","Canada East","East US","East
-        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        US","UK West","West India","Australia East","Brazil South","Canada East","East
+        US","East US 2","Japan West","Korea South","North Central US","South India","Southeast
         Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"schedules","locations":["West
         Central US","Japan East","West US","Australia Southeast","Canada Central","Central
         India","Central US","East Asia","Korea Central","North Europe","South Central
-        US","UK West","Australia East","Brazil South","Canada East","East US","East
-        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        US","UK West","West India","Australia East","Brazil South","Canada East","East
+        US","East US 2","Japan West","Korea South","North Central US","South India","Southeast
         Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"labs/virtualMachines","locations":["West
         Central US","Japan East","West US","Australia Southeast","Canada Central","Central
         India","Central US","East Asia","Korea Central","North Europe","South Central
-        US","UK West","Australia East","Brazil South","Canada East","East US","East
-        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        US","UK West","West India","Australia East","Brazil South","Canada East","East
+        US","East US 2","Japan West","Korea South","North Central US","South India","Southeast
         Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"labs/serviceRunners","locations":["Central
         US","East US 2","South Central US"],"apiVersions":["2017-04-26-preview","2016-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"locations/operations","locations":["West
         Central US","Japan East","West US","Australia Southeast","Canada Central","Central
         India","Central US","East Asia","Korea Central","North Europe","South Central
-        US","UK West","Australia East","Brazil South","Canada East","East US","East
-        US 2","Japan West","Korea South","North Central US","South India","Southeast
-        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"}],"resourceTypes":[{"resourceType":"components","locations":["East
-        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
-        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01","2014-04-01"]},{"resourceType":"queries","locations":["East
-        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
+        US","UK West","West India","Australia East","Brazil South","Canada East","East
+        US","East US 2","Japan West","Korea South","North Central US","South India","Southeast
+        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","authorizations":[{"applicationId":"57c0fc58-a83a-41d0-8ae9-08952659bdfd","roleDefinitionId":"FFFD5CF5-FFD3-4B24-B0E2-0715ADD4C282"}],"resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"databaseAccountNames","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"operationResults","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"},{"applicationId":"f5c26e74-f226-4ae8-85f0-b4af0080ac9e","roleDefinitionId":"529d7ae6-e892-4d43-809d-8547aeb90643"}],"resourceTypes":[{"resourceType":"components","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2015-05-01","2014-08-01","2014-04-01"]},{"resourceType":"queries","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"components/pricingPlans","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"migrateToNewPricingModel","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"rollbackToLegacyPricingModel","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"listMigrationdate","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
@@ -516,7 +591,7 @@ http_interactions:
         West","North Central US","South Central US","East US 2","Canada East","Canada
         Central","Central US","Australia East","Australia Southeast","Brazil South","South
         India","Central India","West India","North Europe","West US 2","West Central
-        US","Korea South","Korea Central","UK South","UK West","Global"],"apiVersions":["2017-05-01-preview","2016-03-01","2015-07-01"]},{"resourceType":"logDefinitions","locations":["West
+        US","Korea South","Korea Central","UK South","UK West","Global"],"apiVersions":["2017-09-01-preview","2017-05-01-preview","2016-03-01","2015-07-01"]},{"resourceType":"logDefinitions","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
@@ -526,7 +601,7 @@ http_interactions:
         West","North Central US","South Central US","East US 2","Canada East","Canada
         Central","Central US","Australia East","Australia Southeast","Brazil South","South
         India","Central India","West India","North Europe","West US 2","West Central
-        US","Korea South","Korea Central","UK South","UK West"],"apiVersions":["2017-05-01-preview","2016-09-01","2016-06-01"]},{"resourceType":"actiongroups","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]},{"resourceType":"activityLogAlerts","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.KeyVault","namespace":"Microsoft.KeyVault","resourceTypes":[{"resourceType":"vaults","locations":["North
+        US","Korea South","Korea Central","UK South","UK West"],"apiVersions":["2017-09-01-preview","2017-05-01-preview","2016-09-01","2016-06-01"]},{"resourceType":"actiongroups","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]},{"resourceType":"activityLogAlerts","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.KeyVault","namespace":"Microsoft.KeyVault","resourceTypes":[{"resourceType":"vaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
@@ -556,126 +631,153 @@ http_interactions:
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorizations":[{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},{"applicationId":"7c33bfcb-8d33-48d6-8e60-dc6404003489","roleDefinitionId":"ad6261e4-fa9a-4642-aa5f-104f1b67e9e3"},{"applicationId":"1e3e4475-288f-4018-a376-df66fd7fac5f","roleDefinitionId":"1d538b69-3d87-4e56-8ff8-25786fd48261"},{"applicationId":"a0be0c72-870e-46f0-9c49-c98333a996f7","roleDefinitionId":"7ce22727-ffce-45a9-930c-ddb2e56fa131"}],"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","West Central US"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"operations","locations":["South
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations","locations":["South
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operations","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"commitmentPlans","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"Registering"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorizations":[{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},{"applicationId":"7c33bfcb-8d33-48d6-8e60-dc6404003489","roleDefinitionId":"ad6261e4-fa9a-4642-aa5f-104f1b67e9e3"},{"applicationId":"1e3e4475-288f-4018-a376-df66fd7fac5f","roleDefinitionId":"1d538b69-3d87-4e56-8ff8-25786fd48261"},{"applicationId":"a0be0c72-870e-46f0-9c49-c98333a996f7","roleDefinitionId":"7ce22727-ffce-45a9-930c-ddb2e56fa131"}],"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
-        Central US"],"apiVersions":["2017-09-01"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
-        East","UK South","Central India","Canada Central"],"apiVersions":["2017-04-26-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"]},{"resourceType":"workspaces/dataSources","locations":["East
+        East","UK South","Central India","Canada Central"],"apiVersions":["2017-04-26-preview","2017-03-15-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"]},{"resourceType":"workspaces/query","locations":["West
+        Central US","Australia Southeast","West Europe","East US","Southeast Asia","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2017-10-01"]},{"resourceType":"workspaces/dataSources","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
         East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"storageInsightConfigs","locations":[],"apiVersions":["2014-10-10"]},{"resourceType":"workspaces/linkedServices","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
         East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"linkTargets","locations":["East
         US"],"apiVersions":["2015-03-20"]},{"resourceType":"operations","locations":[],"apiVersions":["2014-11-10"]},{"resourceType":"devices","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationsManagement","namespace":"Microsoft.OperationsManagement","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"aa249101-6816-4966-aafa-08175d795f14"},"resourceTypes":[{"resourceType":"solutions","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
-        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Portal","namespace":"Microsoft.Portal","resourceTypes":[{"resourceType":"dashboards","locations":["Central
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"managementconfigurations","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"managementassociations","locations":[],"apiVersions":["2015-11-01-preview"]},{"resourceType":"views","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2017-08-21-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Portal","namespace":"Microsoft.Portal","resourceTypes":[{"resourceType":"dashboards","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
@@ -687,9 +789,9 @@ http_interactions:
         East","West India","South India","Central India","Canada Central","Canada
         East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"consoles","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/consoles","locations":["West
         US","East US","Central India","North Europe","West Europe","South Central
-        US","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
+        US","Southeast Asia","East US 2","Central US"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
         US","East US","Central India","North Europe","West Europe","South Central
-        US","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
+        US","Southeast Asia","East US 2","Central US"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
@@ -710,7 +812,17 @@ http_interactions:
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ResourceHealth","namespace":"Microsoft.ResourceHealth","authorization":{"applicationId":"8bdebf23-c0fe-4187-a378-717ad86f6a53","roleDefinitionId":"cc026344-c8b1-4561-83ba-59eba84b27cc"},"resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2017-07-01","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"notifications","locations":["Australia
+        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]},{"resourceType":"locations/backupValidateFeatures","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-07-01"]},{"resourceType":"locations/backupPreValidateProtection","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-07-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ResourceHealth","namespace":"Microsoft.ResourceHealth","authorization":{"applicationId":"8bdebf23-c0fe-4187-a378-717ad86f6a53","roleDefinitionId":"cc026344-c8b1-4561-83ba-59eba84b27cc"},"resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2017-07-01","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"notifications","locations":["Australia
         Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Security","namespace":"Microsoft.Security","authorization":{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatuses","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/virtualMachines","locations":["Central
@@ -743,10 +855,14 @@ http_interactions:
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securitySolutionsReferenceData","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/securitySolutionsReferenceData","locations":["Central
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"jitNetworkAccessPolicies","locations":["Central
-        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/jitNetworkAccessPolicies","locations":["Central
-        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations","locations":["Central
+        US","East US","North Europe","West Europe","UK South","UK West","West Central
+        US","West US 2"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/jitNetworkAccessPolicies","locations":["Central
+        US","East US","North Europe","West Europe","UK South","UK West","West Central
+        US","West US 2"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatusesSummaries","locations":["Central
-        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/alerts","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"applicationWhitelistings","locations":["Central
+        US","East US","West Central US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/applicationWhitelistings","locations":["Central
+        US","West Central US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/alerts","locations":["Central
         US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/tasks","locations":["Central
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"externalSecuritySolutions","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/externalSecuritySolutions","locations":["Central
@@ -769,7 +885,17 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/databaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/databaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -814,7 +940,7 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01","2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -829,7 +955,7 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -859,12 +985,17 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/geoBackupPolicies","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -879,12 +1010,12 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/firewallrules","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/backupLongTermRetentionPolicies","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -999,6 +1130,16 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
         US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
@@ -1034,7 +1175,22 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -1144,7 +1300,47 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -1159,7 +1355,17 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/administratorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -1179,52 +1385,52 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorization":{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorizations":[{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},{"applicationId":"e406a681-f3d4-42a8-90b6-c2b029497af1"}],"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
         US","West US","West Europe","North Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","South India","Central
@@ -1234,7 +1440,19 @@ http_interactions:
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Web","namespace":"Microsoft.Web","authorization":{"applicationId":"abfa0a7c-a6b6-4736-8310-5855508787cd","roleDefinitionId":"f47ed98b-b063-4a5b-9e10-4b9b44fa7735"},"resourceTypes":[{"resourceType":"sites/extensions","locations":["South
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/project","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/extension","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"checkNameAvailability","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Web","namespace":"Microsoft.Web","authorization":{"applicationId":"abfa0a7c-a6b6-4736-8310-5855508787cd","roleDefinitionId":"f47ed98b-b063-4a5b-9e10-4b9b44fa7735"},"resourceTypes":[{"resourceType":"sites/extensions","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
         South","West US","East US","Japan West","Japan East","East Asia","East US
         2","North Central US","Central US","Brazil South","Australia East","Australia
@@ -1339,7 +1557,7 @@ http_interactions:
         South","West US","East US","Japan West","Japan East","East Asia","East US
         2","North Central US","Central US","Brazil South","Australia East","Australia
         Southeast","West India","Central India","South India","Canada Central","Canada
-        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms/workers","locations":["South
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms/workers","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
         South","West US","East US","Japan West","Japan East","East Asia","East US
         2","North Central US","Central US","Brazil South","Australia East","Australia
@@ -1394,7 +1612,17 @@ http_interactions:
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","West US 2","West Central US","Canada Central","Canada
-        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/managedApis","locations":["North
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/listWsdlInterfaces","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/extractApiDefinitionFromWsdl","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/managedApis","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
@@ -1445,8 +1673,11 @@ http_interactions:
         US","North Europe","Japan West","Japan East","East Asia","West Europe","East
         US","Southeast Asia","Central US"],"apiVersions":["2016-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Lombiq.DotNest","namespace":"Lombiq.DotNest","resourceTypes":[{"resourceType":"sites","locations":["East
         US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Mailjet.Email","namespace":"Mailjet.Email","resourceTypes":[{"resourceType":"services","locations":["West
-        US"],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
-        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
+        US","West Europe"],"apiVersions":["2017-10-01","2017-02-03"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-10-01","2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-10-01","2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]},{"resourceType":"diagnosticSettings","locations":[],"apiVersions":["2017-04-01"]},{"resourceType":"diagnosticSettingsCategories","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Addons","namespace":"Microsoft.Addons","authorization":{"applicationId":"24d3987b-be4a-48e0-a3e7-11c186f39e41","roleDefinitionId":"8004BAAB-A4CB-4981-8571-F7E44D039D93"},"resourceTypes":[{"resourceType":"supportProviders","locations":["West
+        Central US","South Central US","East US","West Europe"],"apiVersions":["2017-05-15"]},{"resourceType":"operations","locations":["West
+        Central US","South Central US","East US","West Europe"],"apiVersions":["2017-05-15"]},{"resourceType":"operationResults","locations":["West
+        Central US","South Central US","East US","West Europe"],"apiVersions":["2017-05-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"addsservices","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"configuration","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"operations","locations":["West
@@ -1456,51 +1687,45 @@ http_interactions:
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"servicehealthmetrics","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"logs","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"anonymousapiusers","locations":["West
-        US"],"apiVersions":["2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AnalysisServices","namespace":"Microsoft.AnalysisServices","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"servers","locations":["West
+        US"],"apiVersions":["2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AlertsManagement","namespace":"Microsoft.AlertsManagement","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-11-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AnalysisServices","namespace":"Microsoft.AnalysisServices","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"servers","locations":["West
         US","North Europe","South Central US","West Europe","West Central US","Southeast
         Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
-        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/checkNameAvailability","locations":["West
+        Southeast","Japan East","UK South","West India","West US 2","East US"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"locations/checkNameAvailability","locations":["West
         US","North Europe","South Central US","West Europe","West Central US","Southeast
         Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
-        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationresults","locations":["West
+        Southeast","Japan East","UK South","West India","West US 2","East US"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationresults","locations":["West
         US","North Europe","South Central US","West Europe","West Central US","Southeast
         Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
-        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationstatuses","locations":["West
+        Southeast","Japan East","UK South","West India","West US 2","East US"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationstatuses","locations":["West
         US","North Europe","South Central US","West Europe","West Central US","Southeast
         Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
-        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"operations","locations":["East
-        US 2","West Central US"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AppService","namespace":"Microsoft.AppService","authorization":{"applicationId":"dee7ba80-6a55-4f3b-a86c-746a9231ae49","roleDefinitionId":"6715d172-49c4-46f6-bb21-60512a8689dc"},"resourceTypes":[{"resourceType":"apiapps","locations":["East
-        US","West US","South Central US","North Europe","East Asia","Japan East","West
-        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
-        South","East US 2","Australia Southeast","Australia East","West India","South
-        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"appIdentities","locations":["East
-        US","West US","South Central US","North Europe","East Asia","Japan East","West
-        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
-        South","East US 2","Australia Southeast","Australia East","West India","South
-        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"gateways","locations":["East
-        US","West US","South Central US","North Europe","East Asia","Japan East","West
-        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
-        South","East US 2","Australia Southeast","Australia East","West India","South
-        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"deploymenttemplates","locations":[],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Authorization","namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"roleDefinitions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"classicAdministrators","locations":[],"apiVersions":["2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"permissions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"locks","locations":[],"apiVersions":["2017-04-01","2016-09-01","2015-06-01","2015-05-01-preview","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-01-01","2014-10-01-preview","2014-06-01"]},{"resourceType":"policyDefinitions","locations":[],"apiVersions":["2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"policySetDefinitions","locations":[],"apiVersions":["2017-06-01-preview"]},{"resourceType":"policyAssignments","locations":[],"apiVersions":["2017-06-01-preview","2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"providerOperations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01-preview","2015-07-01"]},{"resourceType":"elevateAccess","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureActiveDirectory","namespace":"Microsoft.AzureActiveDirectory","resourceTypes":[{"resourceType":"b2cDirectories","locations":["Global","United
-        States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureStack","namespace":"Microsoft.AzureStack","resourceTypes":[{"resourceType":"operations","locations":["Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations","locations":["West
+        Southeast","Japan East","UK South","West India","West US 2","East US"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"operations","locations":["East
+        US 2","West Central US","West US 2"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Authorization","namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[],"apiVersions":["2017-10-01-preview","2017-09-01","2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"roleDefinitions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"classicAdministrators","locations":[],"apiVersions":["2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"permissions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"locks","locations":[],"apiVersions":["2017-04-01","2016-09-01","2015-06-01","2015-05-01-preview","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-01-01","2014-10-01-preview","2014-06-01"]},{"resourceType":"policyDefinitions","locations":[],"apiVersions":["2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"policySetDefinitions","locations":[],"apiVersions":["2017-06-01-preview"]},{"resourceType":"policyAssignments","locations":[],"apiVersions":["2017-06-01-preview","2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"providerOperations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01-preview","2015-07-01"]},{"resourceType":"elevateAccess","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"checkAccess","locations":[],"apiVersions":["2017-10-01-preview","2017-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureStack","namespace":"Microsoft.AzureStack","resourceTypes":[{"resourceType":"operations","locations":["Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations","locations":["West
         Central US","Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations/products","locations":["West
-        Central US","Global"],"apiVersions":["2017-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Billing","namespace":"Microsoft.Billing","resourceTypes":[{"resourceType":"BillingPeriods","locations":["Central
+        Central US","Global"],"apiVersions":["2017-06-01","2016-01-01"]},{"resourceType":"registrations/customerSubscriptions","locations":["West
+        Central US","Global"],"apiVersions":["2017-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BatchAI","namespace":"Microsoft.BatchAI","authorization":{"applicationId":"9fcb3732-5f52-4135-8c08-9d4bbaf203ea","roleDefinitionId":"703B89C7-CE2C-431B-BDD8-FA34E39AF696","managedByRoleDefinitionId":"90B8E153-EBFF-4073-A95F-4DAD56B14C78"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"jobs","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"fileservers","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"operations","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01-preview"]},{"resourceType":"locations/operationresults","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Billing","namespace":"Microsoft.Billing","resourceTypes":[{"resourceType":"BillingPeriods","locations":["Central
         US"],"apiVersions":["2017-04-24-preview"]},{"resourceType":"Invoices","locations":["Central
         US"],"apiVersions":["2017-04-24-preview","2017-02-27-preview"]},{"resourceType":"operations","locations":["Central
         US"],"apiVersions":["2017-04-24-preview","2017-02-27-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BingMaps","namespace":"Microsoft.BingMaps","resourceTypes":[{"resourceType":"mapApis","locations":["West
         US"],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-18","2015-07-02"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BizTalkServices","namespace":"Microsoft.BizTalkServices","resourceTypes":[{"resourceType":"BizTalk","locations":["East
         US","West US","North Europe","West Europe","Southeast Asia","East Asia","North
-        Central US","Japan West","Japan East","South Central US"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Cache","namespace":"Microsoft.Cache","authorization":{"applicationId":"96231a05-34ce-4eb4-aa6a-70759cbb5e83","roleDefinitionId":"4f731528-ba85-45c7-acfb-cd0a9b3cf31b"},"resourceTypes":[{"resourceType":"Redis","locations":["North
+        Central US","Japan West","Japan East","South Central US"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BotService","namespace":"Microsoft.BotService","resourceTypes":[{"resourceType":"botServices","locations":["Global"],"apiVersions":["2017-12-01"]},{"resourceType":"checkNameAvailability","locations":["Global"],"apiVersions":["2017-12-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Cache","namespace":"Microsoft.Cache","authorization":{"applicationId":"96231a05-34ce-4eb4-aa6a-70759cbb5e83","roleDefinitionId":"4f731528-ba85-45c7-acfb-cd0a9b3cf31b"},"resourceTypes":[{"resourceType":"Redis","locations":["North
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","Canada Central","Canada East","UK South","UK West","West US 2","West
-        Central US","South India","Korea Central","Korea South"],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","South India","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","South India","Canada Central","Canada East","UK South","UK West","West
-        US 2","West Central US","Korea Central","Korea South"],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01"]},{"resourceType":"Redis/metricDefinitions","locations":["North
+        US 2","West Central US","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01"]},{"resourceType":"Redis/metricDefinitions","locations":["North
         Central US","South Central US","East US","East US 2","West US","Central US","East
         Asia","Southeast Asia","North Europe","West Europe","Japan East","Japan West","Brazil
         South","Australia Southeast","Australia East","Central India","West India","South
@@ -1514,59 +1739,59 @@ http_interactions:
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/origins","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/origins","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/customdomains","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/customdomains","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/originresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/originresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/customdomainresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/customdomainresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkResourceUsage","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkResourceUsage","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02"]},{"resourceType":"validateProbe","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02"]},{"resourceType":"validateProbe","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02"]},{"resourceType":"operations","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02"]},{"resourceType":"operations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"edgenodes","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"edgenodes","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CertificateRegistration","namespace":"Microsoft.CertificateRegistration","authorization":{"applicationId":"f3c21649-0979-4721-ac85-b0216b2cf413","roleDefinitionId":"933fba7e-2ed3-4da8-973d-8bd8298a9b40"},"resourceTypes":[{"resourceType":"certificateOrders","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"certificateOrders/certificates","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"validateCertificateRegistrationInformation","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicSubscription","namespace":"Microsoft.ClassicSubscription","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicInfrastructureMigrate","namespace":"Microsoft.ClassicInfrastructureMigrate","authorization":{"applicationId":"5e5abe2b-83cd-4786-826a-a05653ebb103","roleDefinitionId":"766c4d9b-ef83-4f73-8352-1450a506a69b"},"resourceTypes":[{"resourceType":"classicInfrastructureResources","locations":["East
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CertificateRegistration","namespace":"Microsoft.CertificateRegistration","authorization":{"applicationId":"f3c21649-0979-4721-ac85-b0216b2cf413","roleDefinitionId":"933fba7e-2ed3-4da8-973d-8bd8298a9b40"},"resourceTypes":[{"resourceType":"certificateOrders","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"certificateOrders/certificates","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"validateCertificateRegistrationInformation","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicSubscription","namespace":"Microsoft.ClassicSubscription","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-09-01","2017-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicInfrastructureMigrate","namespace":"Microsoft.ClassicInfrastructureMigrate","authorization":{"applicationId":"5e5abe2b-83cd-4786-826a-a05653ebb103","roleDefinitionId":"766c4d9b-ef83-4f73-8352-1450a506a69b"},"resourceTypes":[{"resourceType":"classicInfrastructureResources","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
         Central US","Central US","North Europe","West Europe","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","West
@@ -1584,8 +1809,9 @@ http_interactions:
         Asia","East Asia","West Central US","South Central US","East US","East US
         2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/updateAccountsCreationSettings","locations":["West
         US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/accountsCreationSettings","locations":["West
-        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2016-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Commerce","namespace":"Microsoft.Commerce","resourceTypes":[{"resourceType":"UsageAggregates","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]},{"resourceType":"RateCard","locations":[],"apiVersions":["2016-08-31-preview","2015-06-01-preview","2015-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Consumption","namespace":"Microsoft.Consumption","resourceTypes":[{"resourceType":"reservationsummaries","locations":[],"apiVersions":["2017-01-30"]},{"resourceType":"reservationdetails","locations":[],"apiVersions":["2017-01-30"]},{"resourceType":"UsageDetails","locations":[],"apiVersions":["2017-06-30-preview","2017-04-24-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-30-preview","2017-04-24-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","resourceTypes":[{"resourceType":"containerGroups","locations":["West
-        US","East US","West Europe"],"apiVersions":["2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
+        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2016-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Commerce","namespace":"Microsoft.Commerce","resourceTypes":[{"resourceType":"UsageAggregates","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]},{"resourceType":"RateCard","locations":[],"apiVersions":["2016-08-31-preview","2015-06-01-preview","2015-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Consumption","namespace":"Microsoft.Consumption","resourceTypes":[{"resourceType":"ReservationSummaries","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationTransactions","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"Balances","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"Pricesheets","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationDetails","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"Budgets","locations":[],"apiVersions":["2017-12-30-preview"]},{"resourceType":"Terms","locations":[],"apiVersions":["2017-12-30-preview"]},{"resourceType":"UsageDetails","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview","2017-04-24-preview"]},{"resourceType":"Operations","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview","2017-04-24-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","resourceTypes":[{"resourceType":"containerGroups","locations":["West
+        US","East US","West Europe","Southeast Asia"],"apiVersions":["2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US","East US","West Europe","Southeast Asia"],"apiVersions":["2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
         US"],"apiVersions":["2016-04-08"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CustomerInsights","namespace":"Microsoft.CustomerInsights","authorization":{"applicationId":"38c77d00-5fcb-4cce-9d93-af4738258e3c","roleDefinitionId":"E006F9C7-F333-477C-8AD6-1F3A9FE87F55"},"resourceTypes":[{"resourceType":"hubs","locations":["East
         US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/profiles","locations":["East
         US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/interactions","locations":["East
@@ -1608,8 +1834,8 @@ http_interactions:
         US","West US","Australia East","West Europe","North Europe","Southeast Asia","West
         Central US"],"apiVersions":["2016-03-30","2015-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataFactory","namespace":"Microsoft.DataFactory","resourceTypes":[{"resourceType":"dataFactories","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview","2014-04-01"]},{"resourceType":"factories","locations":["East
-        US","East US 2"],"apiVersions":["2017-09-01-preview","2017-03-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
-        US","East US 2"],"apiVersions":["2017-09-01-preview","2017-03-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
+        US","East US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
+        US","East US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
         Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"dataFactories/metricDefinitions","locations":["North
         Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"checkDataFactoryNameAvailability","locations":[],"apiVersions":["2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"checkAzureDataFactoryNameAvailability","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"dataFactorySchema","locations":["West
@@ -1621,69 +1847,71 @@ http_interactions:
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers/listSasTokens","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeStore","namespace":"Microsoft.DataLakeStore","authorization":{"applicationId":"e9f49c6b-5ce5-44c8-925d-015017e9f7ad","roleDefinitionId":"17eb9cca-f08a-4499-b2d3-852d175f614f"},"resourceTypes":[{"resourceType":"accounts","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/firewallRules","locations":["East
-        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","resourceTypes":[{"resourceType":"operations","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforPostgreSQL","namespace":"Microsoft.DBforPostgreSQL","resourceTypes":[{"resourceType":"operations","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"checkProvisioningServiceNameAvailability","locations":[],"apiVersions":["2017-08-21-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataMigration","namespace":"Microsoft.DataMigration","authorization":{"applicationId":"a4bad4aa-bf02-4631-9f78-a64ffdba8150","roleDefinitionId":"b831a21d-db98-4760-89cb-bef871952df1","managedByRoleDefinitionId":"6256fb55-9e59-4018-a9e1-76b11c0a4c89"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services/projects","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationStatuses","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforPostgreSQL","namespace":"Microsoft.DBforPostgreSQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"checkProvisioningServiceNameAvailability","locations":[],"apiVersions":["2017-11-15","2017-08-21-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
         US","North Europe","East Asia","East US","West Europe","Southeast Asia","Japan
         East","Japan West","Australia East","Australia Southeast","West US 2","West
         Central US","East US 2","Central US","UK South","UK West","South India","Central
-        India","Canada Central","Canada East"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"ProvisioningServices","locations":["East
-        US","West Europe","Southeast Asia"],"apiVersions":["2017-08-21-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
-        East","Australia Southeast","Canada Central","Canada East","Central India","Central
-        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
-        US","North Europe","South Central US","South India","Southeast Asia","West
-        Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"databaseAccountNames","locations":["Australia
-        East","Australia Southeast","Canada Central","Canada East","Central India","Central
-        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
-        US","North Europe","South Central US","South India","Southeast Asia","West
-        Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"operations","locations":["Australia
-        East","Australia Southeast","Canada Central","Canada East","Central India","Central
-        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
-        US","North Europe","South Central US","South India","Southeast Asia","West
-        Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DomainRegistration","namespace":"Microsoft.DomainRegistration","authorization":{"applicationId":"ea2f600a-4980-45b7-89bf-d34da487bda1","roleDefinitionId":"54d7f2e3-5040-48a7-ae90-eebf629cfa0b"},"resourceTypes":[{"resourceType":"domains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"domains/domainOwnershipIdentifiers","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"topLevelDomains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"checkDomainAvailability","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"listDomainRecommendations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"validateDomainRegistrationInformation","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"generateSsoRequest","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DynamicsLcs","namespace":"Microsoft.DynamicsLcs","resourceTypes":[{"resourceType":"lcsprojects","locations":["Brazil
+        India","Canada Central","Canada East","Brazil South","South Central US"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs/eventGridFilters","locations":["West
+        US","East US","West US 2","West Central US","East US 2","Central US"],"apiVersions":["2018-01-15-preview"]},{"resourceType":"ProvisioningServices","locations":["East
+        US","West US","West Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2017-11-15","2017-08-21-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DomainRegistration","namespace":"Microsoft.DomainRegistration","authorization":{"applicationId":"ea2f600a-4980-45b7-89bf-d34da487bda1","roleDefinitionId":"54d7f2e3-5040-48a7-ae90-eebf629cfa0b"},"resourceTypes":[{"resourceType":"domains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"domains/domainOwnershipIdentifiers","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"topLevelDomains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"checkDomainAvailability","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"listDomainRecommendations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"validateDomainRegistrationInformation","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"generateSsoRequest","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DynamicsLcs","namespace":"Microsoft.DynamicsLcs","resourceTypes":[{"resourceType":"lcsprojects","locations":["Brazil
         South","East Asia","East US","Japan East","Japan West","North Central US","North
         Europe","South Central US","West Europe","West US","Southeast Asia","Central
         US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"lcsprojects/connectors","locations":["Brazil
@@ -1695,21 +1923,21 @@ http_interactions:
         US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"operations","locations":["Brazil
         South","East Asia","East US","Japan East","Japan West","North Central US","North
         Europe","South Central US","West Europe","West US","Southeast Asia","Central
-        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topics","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operations","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topics","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operations","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","West
         US 2","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
         India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/consumergroups","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
         US","East US 2","West US","South Central US","Central US","Australia East","Australia
         Southeast","Central India","West Central US","West US 2","Canada East","Canada
         Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
@@ -1754,23 +1982,23 @@ http_interactions:
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations","locations":["Australia
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations/operationResults","locations":["Australia
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations/operationResults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"operations","locations":["Australia
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"operations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Logic","namespace":"Microsoft.Logic","authorization":{"applicationId":"7cd684f4-8a78-49b0-91ec-6a35d38739ba","roleDefinitionId":"cb3ef1fb-6e31-49e2-9d87-ed821053fe58"},"resourceTypes":[{"resourceType":"workflows","locations":["North
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.LocationBasedServices","namespace":"Microsoft.LocationBasedServices","resourceTypes":[{"resourceType":"accounts","locations":["Global"],"apiVersions":["2017-01-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Logic","namespace":"Microsoft.Logic","authorization":{"applicationId":"7cd684f4-8a78-49b0-91ec-6a35d38739ba","roleDefinitionId":"cb3ef1fb-6e31-49e2-9d87-ed821053fe58"},"resourceTypes":[{"resourceType":"workflows","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
@@ -1791,60 +2019,78 @@ http_interactions:
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada Central","Canada East","West US 2","West Central
-        US","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","West Central US"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"operations","locations":["South
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations","locations":["South
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operations","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"commitmentPlans","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningExperimentation","namespace":"Microsoft.MachineLearningExperimentation","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"accounts","locations":["Australia
-        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces","locations":["Australia
-        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces/projects","locations":["Australia
-        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningCompute","namespace":"Microsoft.MachineLearningCompute","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"376aa7d7-51a9-463d-bd4d-7e1691345612","managedByRoleDefinitionId":"91d00862-cf55-46a5-9dce-260bbd92ce25"},"resourceTypes":[{"resourceType":"operationalizationClusters","locations":["East
-        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"operations","locations":["East
+        US","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningExperimentation","namespace":"Microsoft.MachineLearningExperimentation","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"accounts","locations":["Australia
+        East","East US 2","West Central US","Southeast Asia","West Europe"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces","locations":["Australia
+        East","East US 2","West Central US","Southeast Asia","West Europe"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces/projects","locations":["Australia
+        East","East US 2","West Central US","Southeast Asia","West Europe"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"teamAccounts","locations":["Australia
+        East","West Central US","East US 2"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"teamAccounts/workspaces","locations":["Australia
+        East","West Central US","East US 2"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"teamAccounts/workspaces/projects","locations":["Australia
+        East","West Central US","East US 2"],"apiVersions":["2017-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningCompute","namespace":"Microsoft.MachineLearningCompute","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"376aa7d7-51a9-463d-bd4d-7e1691345612","managedByRoleDefinitionId":"91d00862-cf55-46a5-9dce-260bbd92ce25"},"resourceTypes":[{"resourceType":"operationalizationClusters","locations":["East
+        US 2","West Central US","Australia East","West Europe","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"operations","locations":["East
         US 2"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations","locations":["East
         US 2"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operations","locations":["East
-        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["East
-        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningModelManagement","namespace":"Microsoft.MachineLearningModelManagement","resourceTypes":[{"resourceType":"accounts","locations":["East
-        US 2","West Central US","Australia East"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"operations","locations":["West
-        Central US"],"apiVersions":["2017-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
+        US 2","West Central US","Australia East","West Europe","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["East
+        US 2","West Central US","Australia East","West Europe","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningModelManagement","namespace":"Microsoft.MachineLearningModelManagement","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US 2","West Central US","Australia East","West Europe","Southeast Asia"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"operations","locations":["West
+        Central US"],"apiVersions":["2017-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ManagedIdentity","namespace":"Microsoft.ManagedIdentity","resourceTypes":[{"resourceType":"Identities","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Brazil South","Central
+        India","West India","South India","Japan West","Japan East","East Asia","Southeast
+        Asia","Korea Central","Korea South","North Europe","West Europe","UK West","UK
+        South","Central US","North Central US","East US","East US 2","South Central
+        US","West US","West US 2","West Central US"],"apiVersions":["2015-08-31-PREVIEW"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Brazil South","Central
+        India","West India","South India","Japan West","Japan East","East Asia","Southeast
+        Asia","Korea Central","Korea South","North Europe","West Europe","UK West","UK
+        South","Central US","North Central US","East US","East US 2","South Central
+        US","West US","West US 2","West Central US"],"apiVersions":["2015-08-31-PREVIEW"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Management","namespace":"Microsoft.Management","authorization":{"applicationId":"f2c304cf-8e7e-4c3f-8164-16299ad9d272","roleDefinitionId":"c1cf3708-588a-4647-be7f-f400bbe214cf"},"resourceTypes":[{"resourceType":"resources","locations":[],"apiVersions":["2017-11-01-preview","2017-08-31-preview","2017-06-30-preview","2017-05-31-preview"]},{"resourceType":"managementGroups","locations":[],"apiVersions":["2017-11-01-preview","2017-08-31-preview","2017-06-30-preview","2017-05-31-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01-preview","2017-08-31-preview","2017-06-30-preview","2017-05-31-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceApps","namespace":"Microsoft.MarketplaceApps","resourceTypes":[{"resourceType":"classicDevServices","locations":["Northwest
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","Central US","North
+        Europe","West Europe","Japan East","Japan West","Brazil South","Australia
+        East","Australia Southeast","South India","Central India","Canada Central","Canada
+        East"],"apiVersions":["2017-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
         Central US","West US"],"apiVersions":["2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01"]},{"resourceType":"offertypes","locations":["South
         Central US","West US"],"apiVersions":["2015-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Media","namespace":"Microsoft.Media","authorization":{"applicationId":"374b2a64-3b6b-436b-934c-b820eacca870","roleDefinitionId":"aab70789-0cec-44b5-95d7-84b64c9487af"},"resourceTypes":[{"resourceType":"mediaservices","locations":["Japan
         West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
         US","West US","Australia East","Australia Southeast","Central US","Brazil
         South","Central India","West India","South India","South Central US","Canada
-        Central","Canada East","West Central US"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
+        Central","Canada East","West Central US","West US 2"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
+        Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"operations","locations":["West
+        Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
+        Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PolicyInsights","namespace":"Microsoft.PolicyInsights","authorization":{"applicationId":"1d78a85d-813d-46f0-b496-dd72f50a3ec0","roleDefinitionId":"63d2b225-4c34-4641-8768-21a1f7c68ce8"},"resourceTypes":[{"resourceType":"policyEvents","locations":[],"apiVersions":["2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"policyStates","locations":[],"apiVersions":["2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-17-preview","2017-08-09-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
         Central US","North Central US","East US 2","West US","West Europe","North
         Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
         East","UK South","West India"],"apiVersions":["2016-01-29"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-01-29"]},{"resourceType":"locations/checkNameAvailability","locations":["South
         Central US","North Central US","East US 2","West US","West Europe","North
         Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
-        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"capacities","locations":["West
-        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
-        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationresults","locations":["West
-        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
-        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"operations","locations":["East
-        US 2"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Relay","namespace":"Microsoft.Relay","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"capacities","locations":["Australia
+        Southeast","Brazil South","Canada Central","East Asia","East US","East US
+        2","West India","Japan East","West Central US","North Central US","North Europe","South
+        Central US","Southeast Asia","UK South","West Europe","West US","West US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":["Australia
+        Southeast","Brazil South","Canada Central","East Asia","East US","East US
+        2","West India","Japan East","West Central US","North Central US","North Europe","South
+        Central US","Southeast Asia","UK South","West Europe","West US","West US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationresults","locations":["Australia
+        Southeast","Brazil South","Canada Central","East Asia","East US","East US
+        2","West India","Japan East","West Central US","North Central US","North Europe","South
+        Central US","Southeast Asia","UK South","West Europe","West US","West US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["Australia
+        Southeast","Brazil South","Canada Central","East Asia","East US","East US
+        2","West India","Japan East","West Central US","North Central US","North Europe","South
+        Central US","Southeast Asia","UK South","West Europe","West US","West US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"operations","locations":["East
+        US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Relay","namespace":"Microsoft.Relay","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US 2","West
         US","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
         India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2017-08-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkPolicyCompliance","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/hybridconnections","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/hybridconnections/authorizationrules","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/wcfrelays","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/wcfrelays/authorizationrules","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkPolicyCompliance","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
         Central US","South Central US","North Europe","West Europe","East Asia","Southeast
         Asia","West US","East US","Japan West","Japan East","Brazil South","Central
         US","East US 2","Australia East","Australia Southeast","South India","Central
@@ -1868,12 +2114,12 @@ http_interactions:
         India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19","2015-02-28"]},{"resourceType":"checkServiceNameAvailability","locations":[],"apiVersions":["2015-02-28","2014-07-31-Preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2015-08-19"]},{"resourceType":"resourceHealthMetadata","locations":["West
         US","East US","North Europe","West Europe","Southeast Asia","East Asia","North
         Central US","South Central US","Japan West","Australia East","Brazil South","Central
-        India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","authorization":{"applicationId":"80a10ef9-8168-493d-abf9-3297c4ef6e3c","roleDefinitionId":"2b7763f7-bbe2-4e19-befe-28c79f1cf7f7"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US 2","West
         US","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
         India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"premiumMessagingRegions","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceFabric","namespace":"Microsoft.ServiceFabric","authorization":{"applicationId":"74cb6831-0dbb-4be1-8206-fd4df301cdc2","roleDefinitionId":"e55cc65f-6903-4917-b4ef-f8d4640b57f5"},"resourceTypes":[{"resourceType":"clusters","locations":["West
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/queues","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/queues/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/topics","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/topics/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/topics/subscriptions","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/topics/subscriptions/rules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"premiumMessagingRegions","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceFabric","namespace":"Microsoft.ServiceFabric","authorization":{"applicationId":"74cb6831-0dbb-4be1-8206-fd4df301cdc2","roleDefinitionId":"e55cc65f-6903-4917-b4ef-f8d4640b57f5"},"resourceTypes":[{"resourceType":"clusters","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
@@ -1887,17 +2133,43 @@ http_interactions:
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
-        India","West India","Central India","Brazil South","South Central US","Canada
-        Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
         Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
         Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applianceDefinitions","locations":["West
-        Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"locations","locations":["West
-        Central US"],"apiVersions":["2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
-        Central US"],"apiVersions":["2017-09-01","2016-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
+        Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applications","locations":["South
+        Central US","North Central US","West Central US","West US","West US 2","East
+        US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
+        Asia","Brazil South","Japan West","Japan East","Australia East","Australia
+        Southeast","South India","West India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
+        Central US","North Central US","West Central US","West US","West US 2","East
+        US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
+        Asia","Brazil South","Japan West","Japan East","Australia East","Australia
+        Southeast","South India","West India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
+        Central US"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
+        Central US","North Central US","West Central US","West US","West US 2","East
+        US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
+        Asia","Brazil South","Japan West","Japan East","Australia East","Australia
+        Southeast","South India","West India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/cloudEndpoints","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/serverEndpoints","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/registeredServers","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/workflows","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","West Central US","Japan East","Japan West","Australia East","Australia
         Southeast"],"apiVersions":["2017-06-01","2017-05-15","2017-01-01","2016-10-01","2016-06-01","2015-03-15","2014-09-01"]},{"resourceType":"operations","locations":["West
@@ -1928,23 +2200,11 @@ http_interactions:
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast"],"apiVersions":["2015-07-01-Preview","2015-03-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.TimeSeriesInsights","namespace":"Microsoft.TimeSeriesInsights","authorizations":[{"applicationId":"120d688d-1518-4cf7-bd38-182f158850b6","roleDefinitionId":"5a43abdf-bb87-42c4-9e56-1c24bf364150"}],"resourceTypes":[{"resourceType":"environments","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/eventsources","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/referenceDataSets","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/accessPolicies","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"operations","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
-        Central US","South Central US","East US","West US","Central US","North Europe","West
-        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
-        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/project","locations":["North
-        Central US","South Central US","East US","West US","Central US","North Europe","West
-        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
-        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/extension","locations":["North
-        Central US","South Central US","East US","West US","Central US","North Europe","West
-        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
-        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"checkNameAvailability","locations":["North
-        Central US","South Central US","East US","West US","Central US","North Europe","West
-        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
-        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Myget.PackageManagement","namespace":"Myget.PackageManagement","resourceTypes":[{"resourceType":"services","locations":["West
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]},{"resourceType":"environments/eventsources","locations":["East
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]},{"resourceType":"environments/referenceDataSets","locations":["East
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]},{"resourceType":"environments/accessPolicies","locations":["East
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]},{"resourceType":"operations","locations":["East
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Myget.PackageManagement","namespace":"Myget.PackageManagement","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/NewRelic.APM","namespace":"NewRelic.APM","authorization":{"allowedThirdPartyExtensions":[{"name":"NewRelic_AzurePortal_APM"}]},"resourceTypes":[{"resourceType":"accounts","locations":["North
         Central US","South Central US","West US","East US","North Europe","West Europe","Southeast
         Asia","East Asia","Japan East","Japan West"],"apiVersions":["2014-10-01","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/nuubit.nextgencdn","namespace":"nuubit.nextgencdn","resourceTypes":[{"resourceType":"accounts","locations":["East
@@ -1984,7 +2244,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:41:24 GMT
+  recorded_at: Tue, 23 Jan 2018 20:06:49 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
@@ -2001,9 +2261,11 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYxODEsIm5iZiI6MTUwNjExNjE4MSwiZXhwIjoxNTA2MTIwMDgxLCJhaW8iOiJZMlZnWU5pV0pXUHdMc2ZWM2ZoSVFWajJIT3N5QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZGpwTUtXeERrazJRQ3lIUUZsb05BQSIsInZlciI6IjEuMCJ9.GW2nffAcmgbaeE599i02qETJnYxCuvceko-eBNV-OBRreyQFQW5sN7oI6JvkbyNZj8IEvjsqhCdlnWX6P4dptVZD_sQxClGAW6mvLq83u4hdtzXVqEhD5rPU1ssRvkt8vxnSJ2LrgwcLud1UTmqwfVIeghqjVQN5qkewahU_YwYkb31LoDkLVbgpPPLxMTTMgjsXFWsE1qB5zTZj74U5Oo4TH312XuTH_KuYCQj3tbwZj4_HUNxxmGW-iT84wWxwTfEQuA1LW_eK9bYGXj_WLClwn-rFFWoYY_YogKayMoolQekRujbk41PCf_4UB2LbQ8QP6zOjsAOZbFMUZhODjw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3MDYsIm5iZiI6MTUxNjczNzcwNiwiZXhwIjoxNTE2NzQxNjA2LCJhaW8iOiJZMk5nWU5qWTM4RStWU2lPKzlxT2duY0JKOWN0QlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTVl2d29aTlQ4MGl2UjVsNDRXNEJBQSIsInZlciI6IjEuMCJ9.eOLoVWRIWbqFs545ywnN0TtMn3xELFO15Bcw1V2bp9OboFdCnfdnt9EyhCVKj6F3EvR-rW61Z_JM-h_LghzGMgP6KswcWezikCBYr3oweCD2j9i0pegFDDhYhi-IT35zV4gBR0goTGu0CSxbh7ntO7DaulT4cjkt-IPYI1IwX6f_gtW72-HRXq4RUaYA6SIM6Ka9zHcUwt-OW_hhqNCuHpfxqH3kQg8CLfLPTvscEqjrJZaLgOzwPQxBwZOe5RCn0fQuvZy5rrkCnqRqG-ZyQSUJ6L9CHBSZTBCWegbyWf4KVgQ0WxH14f1ztnfpMfxSb32mHt4XerxUVcSRZECiOg
       Content-Length:
       - '42'
+      Host:
+      - management.azure.com
   response:
     status:
       code: 202
@@ -2013,39 +2275,41 @@ http_interactions:
       - no-cache
       Pragma:
       - no-cache
-      Content-Length:
-      - '0'
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/8973aa0b-9987-47bd-aafe-5840eeed564c?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/efa1eaea-7818-4ef4-8e09-f99321ef9762?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/8973aa0b-9987-47bd-aafe-5840eeed564c?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/efa1eaea-7818-4ef4-8e09-f99321ef9762?api-version=2017-03-30
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/HighCostHydrate3Min;237,Microsoft.Compute/HighCostHydrate30Min;1164
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131599701143261070
       X-Ms-Request-Id:
-      - 8973aa0b-9987-47bd-aafe-5840eeed564c
+      - efa1eaea-7818-4ef4-8e09-f99321ef9762
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1183'
+      - '1160'
       X-Ms-Correlation-Request-Id:
-      - 9d1cc8fd-1af1-4d36-8521-fab923c32566
+      - e61ad281-9989-4fce-aaa5-fb008704babe
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214125Z:9d1cc8fd-1af1-4d36-8521-fab923c32566
+      - WESTUS:20180123T200650Z:e61ad281-9989-4fce-aaa5-fb008704babe
       Date:
-      - Fri, 22 Sep 2017 21:41:24 GMT
+      - Tue, 23 Jan 2018 20:06:50 GMT
+      Content-Length:
+      - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:41:25 GMT
+  recorded_at: Tue, 23 Jan 2018 20:06:50 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/8973aa0b-9987-47bd-aafe-5840eeed564c?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/efa1eaea-7818-4ef4-8e09-f99321ef9762?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -2059,7 +2323,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYxODEsIm5iZiI6MTUwNjExNjE4MSwiZXhwIjoxNTA2MTIwMDgxLCJhaW8iOiJZMlZnWU5pV0pXUHdMc2ZWM2ZoSVFWajJIT3N5QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZGpwTUtXeERrazJRQ3lIUUZsb05BQSIsInZlciI6IjEuMCJ9.GW2nffAcmgbaeE599i02qETJnYxCuvceko-eBNV-OBRreyQFQW5sN7oI6JvkbyNZj8IEvjsqhCdlnWX6P4dptVZD_sQxClGAW6mvLq83u4hdtzXVqEhD5rPU1ssRvkt8vxnSJ2LrgwcLud1UTmqwfVIeghqjVQN5qkewahU_YwYkb31LoDkLVbgpPPLxMTTMgjsXFWsE1qB5zTZj74U5Oo4TH312XuTH_KuYCQj3tbwZj4_HUNxxmGW-iT84wWxwTfEQuA1LW_eK9bYGXj_WLClwn-rFFWoYY_YogKayMoolQekRujbk41PCf_4UB2LbQ8QP6zOjsAOZbFMUZhODjw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3MDYsIm5iZiI6MTUxNjczNzcwNiwiZXhwIjoxNTE2NzQxNjA2LCJhaW8iOiJZMk5nWU5qWTM4RStWU2lPKzlxT2duY0JKOWN0QlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTVl2d29aTlQ4MGl2UjVsNDRXNEJBQSIsInZlciI6IjEuMCJ9.eOLoVWRIWbqFs545ywnN0TtMn3xELFO15Bcw1V2bp9OboFdCnfdnt9EyhCVKj6F3EvR-rW61Z_JM-h_LghzGMgP6KswcWezikCBYr3oweCD2j9i0pegFDDhYhi-IT35zV4gBR0goTGu0CSxbh7ntO7DaulT4cjkt-IPYI1IwX6f_gtW72-HRXq4RUaYA6SIM6Ka9zHcUwt-OW_hhqNCuHpfxqH3kQg8CLfLPTvscEqjrJZaLgOzwPQxBwZOe5RCn0fQuvZy5rrkCnqRqG-ZyQSUJ6L9CHBSZTBCWegbyWf4KVgQ0WxH14f1ztnfpMfxSb32mHt4XerxUVcSRZECiOg
+      Host:
+      - management.azure.com
   response:
     status:
       code: 200
@@ -2077,34 +2343,36 @@ http_interactions:
       - "-1"
       Vary:
       - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/GetOperation3Min;49995,Microsoft.Compute/GetOperation30Min;249995
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131599701143261070
       X-Ms-Request-Id:
-      - 13de60c8-686a-461f-816b-f1d0522f3122
+      - b5b6c871-ff49-4d4a-a782-53b140b95970
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14913'
+      - '14878'
       X-Ms-Correlation-Request-Id:
-      - a5c59d99-6bce-4422-a520-11d22007a68a
+      - adfa89e6-1c0b-49ce-8bb8-7b5a29da0cc6
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214126Z:a5c59d99-6bce-4422-a520-11d22007a68a
+      - WESTUS:20180123T200651Z:adfa89e6-1c0b-49ce-8bb8-7b5a29da0cc6
       Date:
-      - Fri, 22 Sep 2017 21:41:26 GMT
+      - Tue, 23 Jan 2018 20:06:50 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-22T21:41:26.689495+00:00\",\r\n  \"endTime\":
-        \"2017-09-22T21:41:27.1114835+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=d04f32e5-e61e-4758-b502-0163cabdd37c&sig=V9w2I2ViYlviR9GysjIBNBMGsDcUsfwk%2FxM2scXBJ9I%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"8973aa0b-9987-47bd-aafe-5840eeed564c\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2018-01-23T20:06:49.6061219+00:00\",\r\n  \"endTime\":
+        \"2018-01-23T20:06:49.7789749+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=b7979a94-63b1-4dba-acb7-ae4724044289&sig=1GyRb9KHSKXY6exF70A%2Fm7EUJw2bDzlzXtG7N2gPX1s%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"efa1eaea-7818-4ef4-8e09-f99321ef9762\"\r\n}"
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:41:26 GMT
+  recorded_at: Tue, 23 Jan 2018 20:06:51 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/8973aa0b-9987-47bd-aafe-5840eeed564c?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/efa1eaea-7818-4ef4-8e09-f99321ef9762?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -2118,7 +2386,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYxODEsIm5iZiI6MTUwNjExNjE4MSwiZXhwIjoxNTA2MTIwMDgxLCJhaW8iOiJZMlZnWU5pV0pXUHdMc2ZWM2ZoSVFWajJIT3N5QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZGpwTUtXeERrazJRQ3lIUUZsb05BQSIsInZlciI6IjEuMCJ9.GW2nffAcmgbaeE599i02qETJnYxCuvceko-eBNV-OBRreyQFQW5sN7oI6JvkbyNZj8IEvjsqhCdlnWX6P4dptVZD_sQxClGAW6mvLq83u4hdtzXVqEhD5rPU1ssRvkt8vxnSJ2LrgwcLud1UTmqwfVIeghqjVQN5qkewahU_YwYkb31LoDkLVbgpPPLxMTTMgjsXFWsE1qB5zTZj74U5Oo4TH312XuTH_KuYCQj3tbwZj4_HUNxxmGW-iT84wWxwTfEQuA1LW_eK9bYGXj_WLClwn-rFFWoYY_YogKayMoolQekRujbk41PCf_4UB2LbQ8QP6zOjsAOZbFMUZhODjw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3MDYsIm5iZiI6MTUxNjczNzcwNiwiZXhwIjoxNTE2NzQxNjA2LCJhaW8iOiJZMk5nWU5qWTM4RStWU2lPKzlxT2duY0JKOWN0QlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTVl2d29aTlQ4MGl2UjVsNDRXNEJBQSIsInZlciI6IjEuMCJ9.eOLoVWRIWbqFs545ywnN0TtMn3xELFO15Bcw1V2bp9OboFdCnfdnt9EyhCVKj6F3EvR-rW61Z_JM-h_LghzGMgP6KswcWezikCBYr3oweCD2j9i0pegFDDhYhi-IT35zV4gBR0goTGu0CSxbh7ntO7DaulT4cjkt-IPYI1IwX6f_gtW72-HRXq4RUaYA6SIM6Ka9zHcUwt-OW_hhqNCuHpfxqH3kQg8CLfLPTvscEqjrJZaLgOzwPQxBwZOe5RCn0fQuvZy5rrkCnqRqG-ZyQSUJ6L9CHBSZTBCWegbyWf4KVgQ0WxH14f1ztnfpMfxSb32mHt4XerxUVcSRZECiOg
+      Host:
+      - management.azure.com
   response:
     status:
       code: 200
@@ -2136,34 +2406,36 @@ http_interactions:
       - "-1"
       Vary:
       - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/GetOperation3Min;49994,Microsoft.Compute/GetOperation30Min;249994
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131599701143261070
       X-Ms-Request-Id:
-      - 0d0d2bcf-374b-4386-be9e-5f023e81a782
+      - 468babbe-7470-4873-92ca-a2afc37ae734
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14941'
+      - '14827'
       X-Ms-Correlation-Request-Id:
-      - 4435b746-daab-4812-99b4-5989bb9547c2
+      - 7221c860-725f-4d18-b25f-47a274f97a9a
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214127Z:4435b746-daab-4812-99b4-5989bb9547c2
+      - WESTUS:20180123T200651Z:7221c860-725f-4d18-b25f-47a274f97a9a
       Date:
-      - Fri, 22 Sep 2017 21:41:27 GMT
+      - Tue, 23 Jan 2018 20:06:51 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-22T21:41:26.689495+00:00\",\r\n  \"endTime\":
-        \"2017-09-22T21:41:27.1114835+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=d04f32e5-e61e-4758-b502-0163cabdd37c&sig=V9w2I2ViYlviR9GysjIBNBMGsDcUsfwk%2FxM2scXBJ9I%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"8973aa0b-9987-47bd-aafe-5840eeed564c\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2018-01-23T20:06:49.6061219+00:00\",\r\n  \"endTime\":
+        \"2018-01-23T20:06:49.7789749+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=b7979a94-63b1-4dba-acb7-ae4724044289&sig=1GyRb9KHSKXY6exF70A%2Fm7EUJw2bDzlzXtG7N2gPX1s%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"efa1eaea-7818-4ef4-8e09-f99321ef9762\"\r\n}"
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:41:27 GMT
+  recorded_at: Tue, 23 Jan 2018 20:06:51 GMT
 - request:
     method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=d04f32e5-e61e-4758-b502-0163cabdd37c&sig=V9w2I2ViYlviR9GysjIBNBMGsDcUsfwk/xM2scXBJ9I=&sr=b&sv=2016-05-31
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=b7979a94-63b1-4dba-acb7-ae4724044289&sig=1GyRb9KHSKXY6exF70A/m7EUJw2bDzlzXtG7N2gPX1s=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2176,6 +2448,8 @@ http_interactions:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
       X-Ms-Range:
       - bytes=0-0
+      Host:
+      - md-t4jdgqqlgszp.blob.core.windows.net
   response:
     status:
       code: 206
@@ -2188,15 +2462,15 @@ http_interactions:
       Content-Range:
       - bytes 0-0/34359738880
       Last-Modified:
-      - Sat, 15 Jul 2017 14:23:07 GMT
+      - Tue, 23 Jan 2018 20:04:26 GMT
       Accept-Ranges:
       - bytes
       Etag:
-      - '"0x8D4CB8D039FC699"'
+      - '"0x8D5629C811B65EB"'
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - cc8bcfc6-001e-003c-22eb-3315f6000000
+      - 8f9dac1b-001e-012c-5f85-946545000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2208,7 +2482,7 @@ http_interactions:
       X-Ms-Blob-Type:
       - PageBlob
       X-Ms-Blob-Sequence-Number:
-      - '20'
+      - '30'
       X-Ms-Copy-Id:
       - 30cedd78-548a-4fd8-967e-f8344f587e3c
       X-Ms-Copy-Source:
@@ -2222,250 +2496,16 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Fri, 22 Sep 2017 21:41:28 GMT
+      - Tue, 23 Jan 2018 20:06:51 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         6w==
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:41:28 GMT
-- request:
-    method: post
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/EndGetAccess?api-version=2017-03-30
-    body:
-      encoding: ASCII-8BIT
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYxODEsIm5iZiI6MTUwNjExNjE4MSwiZXhwIjoxNTA2MTIwMDgxLCJhaW8iOiJZMlZnWU5pV0pXUHdMc2ZWM2ZoSVFWajJIT3N5QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZGpwTUtXeERrazJRQ3lIUUZsb05BQSIsInZlciI6IjEuMCJ9.GW2nffAcmgbaeE599i02qETJnYxCuvceko-eBNV-OBRreyQFQW5sN7oI6JvkbyNZj8IEvjsqhCdlnWX6P4dptVZD_sQxClGAW6mvLq83u4hdtzXVqEhD5rPU1ssRvkt8vxnSJ2LrgwcLud1UTmqwfVIeghqjVQN5qkewahU_YwYkb31LoDkLVbgpPPLxMTTMgjsXFWsE1qB5zTZj74U5Oo4TH312XuTH_KuYCQj3tbwZj4_HUNxxmGW-iT84wWxwTfEQuA1LW_eK9bYGXj_WLClwn-rFFWoYY_YogKayMoolQekRujbk41PCf_4UB2LbQ8QP6zOjsAOZbFMUZhODjw
-      Content-Length:
-      - '0'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '0'
-      Expires:
-      - "-1"
-      Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/f35d908d-5a14-4258-8e46-5d7c03dd8d8f?monitor=true&api-version=2017-03-30
-      Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/f35d908d-5a14-4258-8e46-5d7c03dd8d8f?api-version=2017-03-30
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - f35d908d-5a14-4258-8e46-5d7c03dd8d8f
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1186'
-      X-Ms-Correlation-Request-Id:
-      - 5ccfb444-b67a-47a4-be58-d20d9f816ed1
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214129Z:5ccfb444-b67a-47a4-be58-d20d9f816ed1
-      Date:
-      - Fri, 22 Sep 2017 21:41:29 GMT
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:41:29 GMT
-- request:
-    method: post
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
-    body:
-      encoding: UTF-8
-      string: '{"access":"read","durationInSeconds":3600}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYxODEsIm5iZiI6MTUwNjExNjE4MSwiZXhwIjoxNTA2MTIwMDgxLCJhaW8iOiJZMlZnWU5pV0pXUHdMc2ZWM2ZoSVFWajJIT3N5QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZGpwTUtXeERrazJRQ3lIUUZsb05BQSIsInZlciI6IjEuMCJ9.GW2nffAcmgbaeE599i02qETJnYxCuvceko-eBNV-OBRreyQFQW5sN7oI6JvkbyNZj8IEvjsqhCdlnWX6P4dptVZD_sQxClGAW6mvLq83u4hdtzXVqEhD5rPU1ssRvkt8vxnSJ2LrgwcLud1UTmqwfVIeghqjVQN5qkewahU_YwYkb31LoDkLVbgpPPLxMTTMgjsXFWsE1qB5zTZj74U5Oo4TH312XuTH_KuYCQj3tbwZj4_HUNxxmGW-iT84wWxwTfEQuA1LW_eK9bYGXj_WLClwn-rFFWoYY_YogKayMoolQekRujbk41PCf_4UB2LbQ8QP6zOjsAOZbFMUZhODjw
-      Content-Length:
-      - '42'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '0'
-      Expires:
-      - "-1"
-      Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/e93e19f4-b505-4ba6-8aad-068b3e91fd31?monitor=true&api-version=2017-03-30
-      Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/e93e19f4-b505-4ba6-8aad-068b3e91fd31?api-version=2017-03-30
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - e93e19f4-b505-4ba6-8aad-068b3e91fd31
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1179'
-      X-Ms-Correlation-Request-Id:
-      - 844297a0-19f4-4b06-a67c-f3ef34ccb942
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214130Z:844297a0-19f4-4b06-a67c-f3ef34ccb942
-      Date:
-      - Fri, 22 Sep 2017 21:41:29 GMT
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:41:30 GMT
+  recorded_at: Tue, 23 Jan 2018 20:06:52 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/e93e19f4-b505-4ba6-8aad-068b3e91fd31?api-version=2017-03-30
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYxODEsIm5iZiI6MTUwNjExNjE4MSwiZXhwIjoxNTA2MTIwMDgxLCJhaW8iOiJZMlZnWU5pV0pXUHdMc2ZWM2ZoSVFWajJIT3N5QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZGpwTUtXeERrazJRQ3lIUUZsb05BQSIsInZlciI6IjEuMCJ9.GW2nffAcmgbaeE599i02qETJnYxCuvceko-eBNV-OBRreyQFQW5sN7oI6JvkbyNZj8IEvjsqhCdlnWX6P4dptVZD_sQxClGAW6mvLq83u4hdtzXVqEhD5rPU1ssRvkt8vxnSJ2LrgwcLud1UTmqwfVIeghqjVQN5qkewahU_YwYkb31LoDkLVbgpPPLxMTTMgjsXFWsE1qB5zTZj74U5Oo4TH312XuTH_KuYCQj3tbwZj4_HUNxxmGW-iT84wWxwTfEQuA1LW_eK9bYGXj_WLClwn-rFFWoYY_YogKayMoolQekRujbk41PCf_4UB2LbQ8QP6zOjsAOZbFMUZhODjw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - 9ce819f5-6777-4b0d-b45c-fd4cc2ddf58b
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14912'
-      X-Ms-Correlation-Request-Id:
-      - 9ea32759-170e-4bfa-b3c1-a3d97078e121
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214130Z:9ea32759-170e-4bfa-b3c1-a3d97078e121
-      Date:
-      - Fri, 22 Sep 2017 21:41:30 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-22T21:41:31.4629045+00:00\",\r\n  \"endTime\":
-        \"2017-09-22T21:41:31.6817336+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=460f78e9-249b-4746-89e9-8d4eebb08d7e&sig=XnRfEFEBHi3rVTSvztbPRQCqrIWKYINJy5qsNUWXR1o%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"e93e19f4-b505-4ba6-8aad-068b3e91fd31\"\r\n}"
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:41:30 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/e93e19f4-b505-4ba6-8aad-068b3e91fd31?api-version=2017-03-30
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYxODEsIm5iZiI6MTUwNjExNjE4MSwiZXhwIjoxNTA2MTIwMDgxLCJhaW8iOiJZMlZnWU5pV0pXUHdMc2ZWM2ZoSVFWajJIT3N5QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZGpwTUtXeERrazJRQ3lIUUZsb05BQSIsInZlciI6IjEuMCJ9.GW2nffAcmgbaeE599i02qETJnYxCuvceko-eBNV-OBRreyQFQW5sN7oI6JvkbyNZj8IEvjsqhCdlnWX6P4dptVZD_sQxClGAW6mvLq83u4hdtzXVqEhD5rPU1ssRvkt8vxnSJ2LrgwcLud1UTmqwfVIeghqjVQN5qkewahU_YwYkb31LoDkLVbgpPPLxMTTMgjsXFWsE1qB5zTZj74U5Oo4TH312XuTH_KuYCQj3tbwZj4_HUNxxmGW-iT84wWxwTfEQuA1LW_eK9bYGXj_WLClwn-rFFWoYY_YogKayMoolQekRujbk41PCf_4UB2LbQ8QP6zOjsAOZbFMUZhODjw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - 168a3d94-fef9-4c8b-a5b3-7c26dd7daf02
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14905'
-      X-Ms-Correlation-Request-Id:
-      - 87fe5af2-4856-4d16-8a4a-18b34663022d
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214131Z:87fe5af2-4856-4d16-8a4a-18b34663022d
-      Date:
-      - Fri, 22 Sep 2017 21:41:30 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-22T21:41:31.4629045+00:00\",\r\n  \"endTime\":
-        \"2017-09-22T21:41:31.6817336+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=460f78e9-249b-4746-89e9-8d4eebb08d7e&sig=XnRfEFEBHi3rVTSvztbPRQCqrIWKYINJy5qsNUWXR1o%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"e93e19f4-b505-4ba6-8aad-068b3e91fd31\"\r\n}"
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:41:31 GMT
-- request:
-    method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=460f78e9-249b-4746-89e9-8d4eebb08d7e&sig=XnRfEFEBHi3rVTSvztbPRQCqrIWKYINJy5qsNUWXR1o=&sr=b&sv=2016-05-31
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=b7979a94-63b1-4dba-acb7-ae4724044289&sig=1GyRb9KHSKXY6exF70A/m7EUJw2bDzlzXtG7N2gPX1s=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2478,6 +2518,8 @@ http_interactions:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
       X-Ms-Range:
       - bytes=440-443
+      Host:
+      - md-t4jdgqqlgszp.blob.core.windows.net
   response:
     status:
       code: 206
@@ -2490,15 +2532,15 @@ http_interactions:
       Content-Range:
       - bytes 440-443/34359738880
       Last-Modified:
-      - Sat, 15 Jul 2017 14:23:07 GMT
+      - Tue, 23 Jan 2018 20:04:26 GMT
       Accept-Ranges:
       - bytes
       Etag:
-      - '"0x8D4CB8D039FC699"'
+      - '"0x8D5629C811B65EB"'
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 60947d6b-001e-0037-01eb-330d82000000
+      - 97fd83ba-001e-00ea-3185-945e2c000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2510,7 +2552,7 @@ http_interactions:
       X-Ms-Blob-Type:
       - PageBlob
       X-Ms-Blob-Sequence-Number:
-      - '20'
+      - '30'
       X-Ms-Copy-Id:
       - 30cedd78-548a-4fd8-967e-f8344f587e3c
       X-Ms-Copy-Source:
@@ -2524,69 +2566,11 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Fri, 22 Sep 2017 21:41:30 GMT
+      - Tue, 23 Jan 2018 20:06:51 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         U5MJAA==
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:41:31 GMT
-- request:
-    method: post
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/EndGetAccess?api-version=2017-03-30
-    body:
-      encoding: ASCII-8BIT
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYxODEsIm5iZiI6MTUwNjExNjE4MSwiZXhwIjoxNTA2MTIwMDgxLCJhaW8iOiJZMlZnWU5pV0pXUHdMc2ZWM2ZoSVFWajJIT3N5QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZGpwTUtXeERrazJRQ3lIUUZsb05BQSIsInZlciI6IjEuMCJ9.GW2nffAcmgbaeE599i02qETJnYxCuvceko-eBNV-OBRreyQFQW5sN7oI6JvkbyNZj8IEvjsqhCdlnWX6P4dptVZD_sQxClGAW6mvLq83u4hdtzXVqEhD5rPU1ssRvkt8vxnSJ2LrgwcLud1UTmqwfVIeghqjVQN5qkewahU_YwYkb31LoDkLVbgpPPLxMTTMgjsXFWsE1qB5zTZj74U5Oo4TH312XuTH_KuYCQj3tbwZj4_HUNxxmGW-iT84wWxwTfEQuA1LW_eK9bYGXj_WLClwn-rFFWoYY_YogKayMoolQekRujbk41PCf_4UB2LbQ8QP6zOjsAOZbFMUZhODjw
-      Content-Length:
-      - '0'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '0'
-      Expires:
-      - "-1"
-      Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/6cf194be-322d-41ff-b82d-695ac3ee960a?monitor=true&api-version=2017-03-30
-      Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/6cf194be-322d-41ff-b82d-695ac3ee960a?api-version=2017-03-30
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - 6cf194be-322d-41ff-b82d-695ac3ee960a
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1183'
-      X-Ms-Correlation-Request-Id:
-      - bc7120f7-0ef3-4c4c-8bb8-92c407d797a7
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214132Z:bc7120f7-0ef3-4c4c-8bb8-92c407d797a7
-      Date:
-      - Fri, 22 Sep 2017 21:41:32 GMT
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:41:32 GMT
+  recorded_at: Tue, 23 Jan 2018 20:06:52 GMT
 recorded_with: VCR 3.0.3

--- a/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_endByteAddr-2.yml
+++ b/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_endByteAddr-2.yml
@@ -17,6 +17,8 @@ http_interactions:
       - '186'
       Content-Type:
       - application/x-www-form-urlencoded
+      Host:
+      - login.microsoftonline.com
   response:
     status:
       code: 200
@@ -37,25 +39,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 1628947a-a24c-4130-b465-548a2d7f0d00
+      - f984dbcb-f7ab-48e3-ae04-015550ff1100
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAAABlDrqfEFlSaui6xnRjX5EYCsFm1lsqzaGzZXbhdkCVQPU3XvvBnV5btJXBJMNZOpzRqkhcT8_jL5cmzzR4qDSsDTu1nr2x9ZJYKOJmeZ7wbpjjcwKNM6lILopBOLitBCc6k53BNCqKqaOs-0tIMPu6TG9If_4KZRGYKYNAj9-ZDuW_PVAcaEqaPnXLMV5bfAgAA;
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzBSTLP9A9TAWXKbUb_LgWFGp34ta8tDBg3ol6Ppkf_h9wfOkV5IHMlimQxgH0rDkq6vOdS8_OfU5h9mXDITANhbH9_aioEYSBT7swJY582-atV-uEQc3fsraroX5VifCrI1VF2fTQAVUfU-LoOVsqci606caqWNwBxYU_UsIsf3UgAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=005; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=003; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Fri, 22 Sep 2017 21:41:33 GMT
+      - Tue, 23 Jan 2018 20:06:40 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3600","ext_expires_in":"0","expires_on":"1506120093","not_before":"1506116193","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYxOTMsIm5iZiI6MTUwNjExNjE5MywiZXhwIjoxNTA2MTIwMDkzLCJhaW8iOiJZMlZnWU1oNXVyeWg5YVIrN0RhZVhhdlB2UlozQlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZXBRb0ZreWlNRUcwWlZTS0xYOE5BQSIsInZlciI6IjEuMCJ9.bSUowVQrbB6dhplwG1xITFYrbHN6C5axjxx-z6X6Eus2sxnPfNsQ46XCPdRAbsvdsO1fj-0Z0ZFxESrapH19O0IVF5aY270l5oNKqV_gDsaWMSJ6sz0SxPPhxQYBoQ0PF5PSlGKwTfkyMWIYrJ2PN6ZQIw3aq8MXKGcSqRZNDjq7wCtZG0Z8EHULyK3k5KQZevf_DbhvKzqHsFFbW_cK_c7DgYyOZDq82-Ljhy-Cva8sB2iXrVxYgft9k_WJ0X2siT21MBfE8_kvVrwbjTJ6IFPYCU1faOyqkSTRo3vB686d46mOmPKMhM-NEshNUummfI-DEZ3N27ZXlLU_lv4zFQ"}'
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1516741602","not_before":"1516737702","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3MDIsIm5iZiI6MTUxNjczNzcwMiwiZXhwIjoxNTE2NzQxNjAyLCJhaW8iOiJZMk5nWUxoL1VPWFFkWStKSVV3OFFWNWFnaWtKQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieTl1RS1hdjM0MGl1QkFGVlVQOFJBQSIsInZlciI6IjEuMCJ9.kIv5tdYHAarNVTZsWVxNEed-NKefscjTaNESdRZNcgTSni2-Nhcz6K-nNCpc8IifOIQHt03G0zPV43Mv_GRfzonEXreL66h4Kq7MHHlkv2-w3w9Ual-wrEtF1YympfZz1gPIYNh_7fTwKOzsD2xjA3kmS1axQxbgSYldEtcAbOzMUGyiTmouwmVw0wkQTacRTqCJdSRqJtNk3Pg-S6oS6V0sk14A2NVJvUSdWYElSASNUu-hr2RBJV_ypH-DnXLvsz6r8sBuPHJnvwS_HpXbANmNZX1pTEn42q6mN_r1biV0PwpT6UjJAOgUDvevvvTTFmvBlQUBQn8L0JeKzuTvSQ"}'
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:41:33 GMT
+  recorded_at: Tue, 23 Jan 2018 20:06:42 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -72,7 +74,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYxOTMsIm5iZiI6MTUwNjExNjE5MywiZXhwIjoxNTA2MTIwMDkzLCJhaW8iOiJZMlZnWU1oNXVyeWg5YVIrN0RhZVhhdlB2UlozQlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZXBRb0ZreWlNRUcwWlZTS0xYOE5BQSIsInZlciI6IjEuMCJ9.bSUowVQrbB6dhplwG1xITFYrbHN6C5axjxx-z6X6Eus2sxnPfNsQ46XCPdRAbsvdsO1fj-0Z0ZFxESrapH19O0IVF5aY270l5oNKqV_gDsaWMSJ6sz0SxPPhxQYBoQ0PF5PSlGKwTfkyMWIYrJ2PN6ZQIw3aq8MXKGcSqRZNDjq7wCtZG0Z8EHULyK3k5KQZevf_DbhvKzqHsFFbW_cK_c7DgYyOZDq82-Ljhy-Cva8sB2iXrVxYgft9k_WJ0X2siT21MBfE8_kvVrwbjTJ6IFPYCU1faOyqkSTRo3vB686d46mOmPKMhM-NEshNUummfI-DEZ3N27ZXlLU_lv4zFQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3MDIsIm5iZiI6MTUxNjczNzcwMiwiZXhwIjoxNTE2NzQxNjAyLCJhaW8iOiJZMk5nWUxoL1VPWFFkWStKSVV3OFFWNWFnaWtKQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieTl1RS1hdjM0MGl1QkFGVlVQOFJBQSIsInZlciI6IjEuMCJ9.kIv5tdYHAarNVTZsWVxNEed-NKefscjTaNESdRZNcgTSni2-Nhcz6K-nNCpc8IifOIQHt03G0zPV43Mv_GRfzonEXreL66h4Kq7MHHlkv2-w3w9Ual-wrEtF1YympfZz1gPIYNh_7fTwKOzsD2xjA3kmS1axQxbgSYldEtcAbOzMUGyiTmouwmVw0wkQTacRTqCJdSRqJtNk3Pg-S6oS6V0sk14A2NVJvUSdWYElSASNUu-hr2RBJV_ypH-DnXLvsz6r8sBuPHJnvwS_HpXbANmNZX1pTEn42q6mN_r1biV0PwpT6UjJAOgUDvevvvTTFmvBlQUBQn8L0JeKzuTvSQ
+      Host:
+      - management.azure.com
   response:
     status:
       code: 200
@@ -93,21 +97,22 @@ http_interactions:
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
       - '14999'
       X-Ms-Request-Id:
-      - ae31f283-1fc3-412f-a677-294ea9112029
+      - b09d7060-0ead-4a72-a856-4eae7398fe9a
       X-Ms-Correlation-Request-Id:
-      - ae31f283-1fc3-412f-a677-294ea9112029
+      - b09d7060-0ead-4a72-a856-4eae7398fe9a
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214133Z:ae31f283-1fc3-412f-a677-294ea9112029
+      - WESTUS:20180123T200641Z:b09d7060-0ead-4a72-a856-4eae7398fe9a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 22 Sep 2017 21:41:33 GMT
+      - Tue, 23 Jan 2018 20:06:40 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
-        Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
+      string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
+        Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
+        Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:41:33 GMT
+  recorded_at: Tue, 23 Jan 2018 20:06:42 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/azure_subscription_id/providers?api-version=2015-01-01
@@ -124,7 +129,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYxOTMsIm5iZiI6MTUwNjExNjE5MywiZXhwIjoxNTA2MTIwMDkzLCJhaW8iOiJZMlZnWU1oNXVyeWg5YVIrN0RhZVhhdlB2UlozQlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZXBRb0ZreWlNRUcwWlZTS0xYOE5BQSIsInZlciI6IjEuMCJ9.bSUowVQrbB6dhplwG1xITFYrbHN6C5axjxx-z6X6Eus2sxnPfNsQ46XCPdRAbsvdsO1fj-0Z0ZFxESrapH19O0IVF5aY270l5oNKqV_gDsaWMSJ6sz0SxPPhxQYBoQ0PF5PSlGKwTfkyMWIYrJ2PN6ZQIw3aq8MXKGcSqRZNDjq7wCtZG0Z8EHULyK3k5KQZevf_DbhvKzqHsFFbW_cK_c7DgYyOZDq82-Ljhy-Cva8sB2iXrVxYgft9k_WJ0X2siT21MBfE8_kvVrwbjTJ6IFPYCU1faOyqkSTRo3vB686d46mOmPKMhM-NEshNUummfI-DEZ3N27ZXlLU_lv4zFQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3MDIsIm5iZiI6MTUxNjczNzcwMiwiZXhwIjoxNTE2NzQxNjAyLCJhaW8iOiJZMk5nWUxoL1VPWFFkWStKSVV3OFFWNWFnaWtKQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieTl1RS1hdjM0MGl1QkFGVlVQOFJBQSIsInZlciI6IjEuMCJ9.kIv5tdYHAarNVTZsWVxNEed-NKefscjTaNESdRZNcgTSni2-Nhcz6K-nNCpc8IifOIQHt03G0zPV43Mv_GRfzonEXreL66h4Kq7MHHlkv2-w3w9Ual-wrEtF1YympfZz1gPIYNh_7fTwKOzsD2xjA3kmS1axQxbgSYldEtcAbOzMUGyiTmouwmVw0wkQTacRTqCJdSRqJtNk3Pg-S6oS6V0sk14A2NVJvUSdWYElSASNUu-hr2RBJV_ypH-DnXLvsz6r8sBuPHJnvwS_HpXbANmNZX1pTEn42q6mN_r1biV0PwpT6UjJAOgUDvevvvTTFmvBlQUBQn8L0JeKzuTvSQ
+      Host:
+      - management.azure.com
   response:
     status:
       code: 200
@@ -141,19 +148,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14923'
+      - '14795'
       X-Ms-Request-Id:
-      - c8566295-7f12-4ad4-89c8-4a66ab43e863
+      - 2b9e1d86-a83e-4d3b-953a-e09892e6c58e
       X-Ms-Correlation-Request-Id:
-      - c8566295-7f12-4ad4-89c8-4a66ab43e863
+      - 2b9e1d86-a83e-4d3b-953a-e09892e6c58e
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214135Z:c8566295-7f12-4ad4-89c8-4a66ab43e863
+      - WESTUS:20180123T200644Z:2b9e1d86-a83e-4d3b-953a-e09892e6c58e
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 22 Sep 2017 21:41:34 GMT
+      - Tue, 23 Jan 2018 20:06:43 GMT
       Content-Length:
-      - '254785'
+      - '293551'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
@@ -176,7 +183,7 @@ http_interactions:
         Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
         Central US","North Central US","Japan East","Japan West","Brazil South","Central
         India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
+        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-04-19","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-04-19","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-04-19","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-04-19","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","North Central
         US","South Central US","West Central US","West US","West US 2","Canada Central","Canada
         East","North Europe","West Europe","UK South","UK West","East Asia","Southeast
@@ -184,20 +191,26 @@ http_interactions:
         India","South India","West India"],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"validateServiceName","locations":[],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"checkServiceNameAvailability","locations":[],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"reportFeedback","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"checkFeedbackRequired","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Automation","namespace":"Microsoft.Automation","authorizations":[{"applicationId":"fc75330b-179d-49af-87dd-3b1acf6827fa","roleDefinitionId":"95fd5de3-d071-4362-92bf-cf341c1de832"}],"resourceTypes":[{"resourceType":"automationAccounts","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
         South","UK South","West Central US","North Europe","Canada Central","Australia
-        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/runbooks","locations":["Japan
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/runbooks","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
         South","UK South","West Central US","North Europe","Canada Central","Australia
-        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/configurations","locations":["Japan
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/configurations","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","North
-        Central US","Brazil South","UK South","West Central US","Central India","Australia
-        Southeast","Canada Central","North Europe"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/webhooks","locations":["Japan
+        Central US","Korea Central","East US","West US 2","Brazil South","UK South","West
+        Central US","Central India","Australia Southeast","Canada Central","North
+        Europe"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/webhooks","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
         South","UK South","West Central US","North Europe","Canada Central","Australia
-        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"operations","locations":["South
-        Central US"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/softwareUpdateConfigurations","locations":["Japan
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"operations","locations":["South
+        Central US"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/softwareUpdateConfigurations","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
         South","UK South","West Central US","North Europe","Canada Central","Australia
-        Southeast","Central India"],"apiVersions":["2017-05-15-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Backup","namespace":"Microsoft.Backup","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"BackupVault","locations":["West
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview"]},{"resourceType":"automationAccounts/jobs","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
+        South","UK South","West Central US","North Europe","Canada Central","Australia
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureActiveDirectory","namespace":"Microsoft.AzureActiveDirectory","resourceTypes":[{"resourceType":"b2cDirectories","locations":["Global","United
+        States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]},{"resourceType":"operations","locations":["Global","United
+        States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]}],"registrationState":"Unregistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Backup","namespace":"Microsoft.Backup","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"BackupVault","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
@@ -206,22 +219,22 @@ http_interactions:
         Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
         West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
         East","South India","Central India","Canada Central","Canada East","UK South","UK
-        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01","2015-07-01","2014-05-01-privatepreview"]},{"resourceType":"operations","locations":["West
+        West","West Central US","West US 2"],"apiVersions":["2017-09-01","2017-05-01","2017-01-01","2015-12-01","2015-09-01","2015-07-01","2014-05-01-privatepreview"]},{"resourceType":"operations","locations":["West
         Europe","East US","East US 2","West US","North Central US","Brazil South","North
         Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
         West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
         East","South India","Central India","Canada Central","Canada East","UK South","UK
-        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations/quotas","locations":["West
+        West","West Central US","West US 2"],"apiVersions":["2017-09-01","2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01","2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations/quotas","locations":["West
         Europe","East US","East US 2","West US","North Central US","Brazil South","North
         Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
         West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
         East","South India","Central India","Canada Central","Canada East","UK South","UK
-        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]}],"registrationState":"Unregistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicCompute","namespace":"Microsoft.ClassicCompute","resourceTypes":[{"resourceType":"domainNames","locations":["East
+        West","West Central US","West US 2"],"apiVersions":["2017-09-01","2017-05-01","2017-01-01","2015-12-01","2015-09-01"]}],"registrationState":"Unregistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicCompute","namespace":"Microsoft.ClassicCompute","resourceTypes":[{"resourceType":"domainNames","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
@@ -256,7 +269,7 @@ http_interactions:
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -296,92 +309,92 @@ http_interactions:
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30"]},{"resourceType":"locations/usages","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations/usages","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
+        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
@@ -411,76 +424,138 @@ http_interactions:
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
+        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
         US","East US","South Central US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
         Central","Central US","East US 2","North Central US","West Central US","West
-        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/webhooks","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/ping","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/getCallbackConfig","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/listEvents","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"locations","locations":["South
-        Central US","East US","West US","Central US","East US 2","North Central US","West
-        Central US","West US 2","Brazil South","Canada East","Canada Central","West
-        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
-        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"locations/operationResults","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/GetCredentials","locations":["West
+        US 2"],"apiVersions":["2017-10-01","2017-03-01"]},{"resourceType":"registries/replications","locations":["South
+        Central US","West Central US","East US","West Europe","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/webhooks","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/webhooks/ping","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/webhooks/getCallbackConfig","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/webhooks/listEvents","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"locations/operationResults","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/GetCredentials","locations":["West
         US","East US","South Central US","West Europe"],"apiVersions":["2016-06-27-preview"]},{"resourceType":"registries/listCredentials","locations":["South
         Central US","East US","West US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
         Central","Central US","East US 2","North Central US","West Central US","West
-        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/regenerateCredential","locations":["South
+        US 2"],"apiVersions":["2017-10-01","2017-03-01"]},{"resourceType":"registries/regenerateCredential","locations":["South
         Central US","West US","East US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
         Central","Central US","East US 2","North Central US","West Central US","West
-        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/listUsages","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/regenerateCredentials","locations":["West
+        US 2"],"apiVersions":["2017-10-01","2017-03-01"]},{"resourceType":"registries/listUsages","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/regenerateCredentials","locations":["West
         US","East US","South Central US","West Europe"],"apiVersions":["2016-06-27-preview"]},{"resourceType":"checkNameAvailability","locations":["South
         Central US","East US","West US","Central US","East US 2","North Central US","West
         Central US","West US 2","Brazil South","Canada East","Canada Central","West
         Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
-        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview","2017-03-01","2016-06-27-preview"]},{"resourceType":"operations","locations":["South
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-10-01","2017-06-01-preview","2017-03-01","2016-06-27-preview"]},{"resourceType":"operations","locations":["South
         Central US","East US","West US","Central US","East US 2","North Central US","West
         Central US","West US 2","Brazil South","Canada East","Canada Central","West
         Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
-        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview","2017-03-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerService","namespace":"Microsoft.ContainerService","authorization":{"applicationId":"7319c514-987d-4e9b-ac3d-d38c4f427f4c","roleDefinitionId":"1b4a0c7f-2217-416f-acfa-cf73452fdc1c"},"resourceTypes":[{"resourceType":"containerServices","locations":["Japan
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-10-01","2017-06-01-preview","2017-03-01"]},{"resourceType":"locations","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-10-01","2017-06-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerService","namespace":"Microsoft.ContainerService","authorization":{"applicationId":"7319c514-987d-4e9b-ac3d-d38c4f427f4c","roleDefinitionId":"1b4a0c7f-2217-416f-acfa-cf73452fdc1c","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"containerServices","locations":["Japan
         East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
         Central US","West US 2","South India","Central India","West India","Canada
-        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
+        East","Canada Central","Korea South","Korea Central"],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"managedClusters","locations":["East
+        US","West Europe","Central US","Canada Central","Canada East"],"apiVersions":["2017-08-31"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
         East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
         Central US","West US 2","South India","Central India","West India","Canada
-        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DevTestLab","namespace":"Microsoft.DevTestLab","authorization":{"applicationId":"1a14be2a-e903-4cec-99cf-b2e209259a0f","roleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525"},"resourceTypes":[{"resourceType":"labs","locations":["West
+        East","Canada Central","Korea South","Korea Central"],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/orchestrators","locations":["UK
+        West","West US 2","East US","West Europe","Central US"],"apiVersions":["2017-09-30"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DevTestLab","namespace":"Microsoft.DevTestLab","authorization":{"applicationId":"1a14be2a-e903-4cec-99cf-b2e209259a0f","roleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525","managedByRoleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525"},"resourceTypes":[{"resourceType":"labs","locations":["West
         Central US","Japan East","West US","Australia Southeast","Canada Central","Central
         India","Central US","East Asia","Korea Central","North Europe","South Central
-        US","UK West","Australia East","Brazil South","Canada East","East US","East
-        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        US","UK West","West India","Australia East","Brazil South","Canada East","East
+        US","East US 2","Japan West","Korea South","North Central US","South India","Southeast
         Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"schedules","locations":["West
         Central US","Japan East","West US","Australia Southeast","Canada Central","Central
         India","Central US","East Asia","Korea Central","North Europe","South Central
-        US","UK West","Australia East","Brazil South","Canada East","East US","East
-        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        US","UK West","West India","Australia East","Brazil South","Canada East","East
+        US","East US 2","Japan West","Korea South","North Central US","South India","Southeast
         Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"labs/virtualMachines","locations":["West
         Central US","Japan East","West US","Australia Southeast","Canada Central","Central
         India","Central US","East Asia","Korea Central","North Europe","South Central
-        US","UK West","Australia East","Brazil South","Canada East","East US","East
-        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        US","UK West","West India","Australia East","Brazil South","Canada East","East
+        US","East US 2","Japan West","Korea South","North Central US","South India","Southeast
         Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"labs/serviceRunners","locations":["Central
         US","East US 2","South Central US"],"apiVersions":["2017-04-26-preview","2016-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"locations/operations","locations":["West
         Central US","Japan East","West US","Australia Southeast","Canada Central","Central
         India","Central US","East Asia","Korea Central","North Europe","South Central
-        US","UK West","Australia East","Brazil South","Canada East","East US","East
-        US 2","Japan West","Korea South","North Central US","South India","Southeast
-        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"}],"resourceTypes":[{"resourceType":"components","locations":["East
-        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
-        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01","2014-04-01"]},{"resourceType":"queries","locations":["East
-        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
+        US","UK West","West India","Australia East","Brazil South","Canada East","East
+        US","East US 2","Japan West","Korea South","North Central US","South India","Southeast
+        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","authorizations":[{"applicationId":"57c0fc58-a83a-41d0-8ae9-08952659bdfd","roleDefinitionId":"FFFD5CF5-FFD3-4B24-B0E2-0715ADD4C282"}],"resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"databaseAccountNames","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"operationResults","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"},{"applicationId":"f5c26e74-f226-4ae8-85f0-b4af0080ac9e","roleDefinitionId":"529d7ae6-e892-4d43-809d-8547aeb90643"}],"resourceTypes":[{"resourceType":"components","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2015-05-01","2014-08-01","2014-04-01"]},{"resourceType":"queries","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"components/pricingPlans","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"migrateToNewPricingModel","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"rollbackToLegacyPricingModel","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"listMigrationdate","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
@@ -516,7 +591,7 @@ http_interactions:
         West","North Central US","South Central US","East US 2","Canada East","Canada
         Central","Central US","Australia East","Australia Southeast","Brazil South","South
         India","Central India","West India","North Europe","West US 2","West Central
-        US","Korea South","Korea Central","UK South","UK West","Global"],"apiVersions":["2017-05-01-preview","2016-03-01","2015-07-01"]},{"resourceType":"logDefinitions","locations":["West
+        US","Korea South","Korea Central","UK South","UK West","Global"],"apiVersions":["2017-09-01-preview","2017-05-01-preview","2016-03-01","2015-07-01"]},{"resourceType":"logDefinitions","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
@@ -526,7 +601,7 @@ http_interactions:
         West","North Central US","South Central US","East US 2","Canada East","Canada
         Central","Central US","Australia East","Australia Southeast","Brazil South","South
         India","Central India","West India","North Europe","West US 2","West Central
-        US","Korea South","Korea Central","UK South","UK West"],"apiVersions":["2017-05-01-preview","2016-09-01","2016-06-01"]},{"resourceType":"actiongroups","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]},{"resourceType":"activityLogAlerts","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.KeyVault","namespace":"Microsoft.KeyVault","resourceTypes":[{"resourceType":"vaults","locations":["North
+        US","Korea South","Korea Central","UK South","UK West"],"apiVersions":["2017-09-01-preview","2017-05-01-preview","2016-09-01","2016-06-01"]},{"resourceType":"actiongroups","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]},{"resourceType":"activityLogAlerts","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.KeyVault","namespace":"Microsoft.KeyVault","resourceTypes":[{"resourceType":"vaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
@@ -556,126 +631,153 @@ http_interactions:
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorizations":[{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},{"applicationId":"7c33bfcb-8d33-48d6-8e60-dc6404003489","roleDefinitionId":"ad6261e4-fa9a-4642-aa5f-104f1b67e9e3"},{"applicationId":"1e3e4475-288f-4018-a376-df66fd7fac5f","roleDefinitionId":"1d538b69-3d87-4e56-8ff8-25786fd48261"},{"applicationId":"a0be0c72-870e-46f0-9c49-c98333a996f7","roleDefinitionId":"7ce22727-ffce-45a9-930c-ddb2e56fa131"}],"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","West Central US"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"operations","locations":["South
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations","locations":["South
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operations","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"commitmentPlans","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"Registering"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorizations":[{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},{"applicationId":"7c33bfcb-8d33-48d6-8e60-dc6404003489","roleDefinitionId":"ad6261e4-fa9a-4642-aa5f-104f1b67e9e3"},{"applicationId":"1e3e4475-288f-4018-a376-df66fd7fac5f","roleDefinitionId":"1d538b69-3d87-4e56-8ff8-25786fd48261"},{"applicationId":"a0be0c72-870e-46f0-9c49-c98333a996f7","roleDefinitionId":"7ce22727-ffce-45a9-930c-ddb2e56fa131"}],"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
-        Central US"],"apiVersions":["2017-09-01"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
-        East","UK South","Central India","Canada Central"],"apiVersions":["2017-04-26-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"]},{"resourceType":"workspaces/dataSources","locations":["East
+        East","UK South","Central India","Canada Central"],"apiVersions":["2017-04-26-preview","2017-03-15-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"]},{"resourceType":"workspaces/query","locations":["West
+        Central US","Australia Southeast","West Europe","East US","Southeast Asia","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2017-10-01"]},{"resourceType":"workspaces/dataSources","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
         East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"storageInsightConfigs","locations":[],"apiVersions":["2014-10-10"]},{"resourceType":"workspaces/linkedServices","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
         East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"linkTargets","locations":["East
         US"],"apiVersions":["2015-03-20"]},{"resourceType":"operations","locations":[],"apiVersions":["2014-11-10"]},{"resourceType":"devices","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationsManagement","namespace":"Microsoft.OperationsManagement","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"aa249101-6816-4966-aafa-08175d795f14"},"resourceTypes":[{"resourceType":"solutions","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
-        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Portal","namespace":"Microsoft.Portal","resourceTypes":[{"resourceType":"dashboards","locations":["Central
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"managementconfigurations","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"managementassociations","locations":[],"apiVersions":["2015-11-01-preview"]},{"resourceType":"views","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2017-08-21-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Portal","namespace":"Microsoft.Portal","resourceTypes":[{"resourceType":"dashboards","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
@@ -687,9 +789,9 @@ http_interactions:
         East","West India","South India","Central India","Canada Central","Canada
         East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"consoles","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/consoles","locations":["West
         US","East US","Central India","North Europe","West Europe","South Central
-        US","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
+        US","Southeast Asia","East US 2","Central US"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
         US","East US","Central India","North Europe","West Europe","South Central
-        US","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
+        US","Southeast Asia","East US 2","Central US"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
@@ -710,7 +812,17 @@ http_interactions:
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ResourceHealth","namespace":"Microsoft.ResourceHealth","authorization":{"applicationId":"8bdebf23-c0fe-4187-a378-717ad86f6a53","roleDefinitionId":"cc026344-c8b1-4561-83ba-59eba84b27cc"},"resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2017-07-01","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"notifications","locations":["Australia
+        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]},{"resourceType":"locations/backupValidateFeatures","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-07-01"]},{"resourceType":"locations/backupPreValidateProtection","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-07-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ResourceHealth","namespace":"Microsoft.ResourceHealth","authorization":{"applicationId":"8bdebf23-c0fe-4187-a378-717ad86f6a53","roleDefinitionId":"cc026344-c8b1-4561-83ba-59eba84b27cc"},"resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2017-07-01","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"notifications","locations":["Australia
         Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Security","namespace":"Microsoft.Security","authorization":{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatuses","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/virtualMachines","locations":["Central
@@ -743,10 +855,14 @@ http_interactions:
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securitySolutionsReferenceData","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/securitySolutionsReferenceData","locations":["Central
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"jitNetworkAccessPolicies","locations":["Central
-        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/jitNetworkAccessPolicies","locations":["Central
-        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations","locations":["Central
+        US","East US","North Europe","West Europe","UK South","UK West","West Central
+        US","West US 2"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/jitNetworkAccessPolicies","locations":["Central
+        US","East US","North Europe","West Europe","UK South","UK West","West Central
+        US","West US 2"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatusesSummaries","locations":["Central
-        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/alerts","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"applicationWhitelistings","locations":["Central
+        US","East US","West Central US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/applicationWhitelistings","locations":["Central
+        US","West Central US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/alerts","locations":["Central
         US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/tasks","locations":["Central
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"externalSecuritySolutions","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/externalSecuritySolutions","locations":["Central
@@ -769,7 +885,17 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/databaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/databaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -814,7 +940,7 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01","2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -829,7 +955,7 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -859,12 +985,17 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/geoBackupPolicies","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -879,12 +1010,12 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/firewallrules","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/backupLongTermRetentionPolicies","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -999,6 +1130,16 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
         US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
@@ -1034,7 +1175,22 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -1144,7 +1300,47 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -1159,7 +1355,17 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/administratorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -1179,52 +1385,52 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorization":{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorizations":[{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},{"applicationId":"e406a681-f3d4-42a8-90b6-c2b029497af1"}],"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
         US","West US","West Europe","North Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","South India","Central
@@ -1234,7 +1440,19 @@ http_interactions:
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Web","namespace":"Microsoft.Web","authorization":{"applicationId":"abfa0a7c-a6b6-4736-8310-5855508787cd","roleDefinitionId":"f47ed98b-b063-4a5b-9e10-4b9b44fa7735"},"resourceTypes":[{"resourceType":"sites/extensions","locations":["South
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/project","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/extension","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"checkNameAvailability","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Web","namespace":"Microsoft.Web","authorization":{"applicationId":"abfa0a7c-a6b6-4736-8310-5855508787cd","roleDefinitionId":"f47ed98b-b063-4a5b-9e10-4b9b44fa7735"},"resourceTypes":[{"resourceType":"sites/extensions","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
         South","West US","East US","Japan West","Japan East","East Asia","East US
         2","North Central US","Central US","Brazil South","Australia East","Australia
@@ -1339,7 +1557,7 @@ http_interactions:
         South","West US","East US","Japan West","Japan East","East Asia","East US
         2","North Central US","Central US","Brazil South","Australia East","Australia
         Southeast","West India","Central India","South India","Canada Central","Canada
-        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms/workers","locations":["South
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms/workers","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
         South","West US","East US","Japan West","Japan East","East Asia","East US
         2","North Central US","Central US","Brazil South","Australia East","Australia
@@ -1394,7 +1612,17 @@ http_interactions:
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","West US 2","West Central US","Canada Central","Canada
-        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/managedApis","locations":["North
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/listWsdlInterfaces","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/extractApiDefinitionFromWsdl","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/managedApis","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
@@ -1445,8 +1673,11 @@ http_interactions:
         US","North Europe","Japan West","Japan East","East Asia","West Europe","East
         US","Southeast Asia","Central US"],"apiVersions":["2016-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Lombiq.DotNest","namespace":"Lombiq.DotNest","resourceTypes":[{"resourceType":"sites","locations":["East
         US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Mailjet.Email","namespace":"Mailjet.Email","resourceTypes":[{"resourceType":"services","locations":["West
-        US"],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
-        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
+        US","West Europe"],"apiVersions":["2017-10-01","2017-02-03"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-10-01","2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-10-01","2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]},{"resourceType":"diagnosticSettings","locations":[],"apiVersions":["2017-04-01"]},{"resourceType":"diagnosticSettingsCategories","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Addons","namespace":"Microsoft.Addons","authorization":{"applicationId":"24d3987b-be4a-48e0-a3e7-11c186f39e41","roleDefinitionId":"8004BAAB-A4CB-4981-8571-F7E44D039D93"},"resourceTypes":[{"resourceType":"supportProviders","locations":["West
+        Central US","South Central US","East US","West Europe"],"apiVersions":["2017-05-15"]},{"resourceType":"operations","locations":["West
+        Central US","South Central US","East US","West Europe"],"apiVersions":["2017-05-15"]},{"resourceType":"operationResults","locations":["West
+        Central US","South Central US","East US","West Europe"],"apiVersions":["2017-05-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"addsservices","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"configuration","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"operations","locations":["West
@@ -1456,51 +1687,45 @@ http_interactions:
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"servicehealthmetrics","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"logs","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"anonymousapiusers","locations":["West
-        US"],"apiVersions":["2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AnalysisServices","namespace":"Microsoft.AnalysisServices","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"servers","locations":["West
+        US"],"apiVersions":["2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AlertsManagement","namespace":"Microsoft.AlertsManagement","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-11-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AnalysisServices","namespace":"Microsoft.AnalysisServices","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"servers","locations":["West
         US","North Europe","South Central US","West Europe","West Central US","Southeast
         Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
-        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/checkNameAvailability","locations":["West
+        Southeast","Japan East","UK South","West India","West US 2","East US"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"locations/checkNameAvailability","locations":["West
         US","North Europe","South Central US","West Europe","West Central US","Southeast
         Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
-        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationresults","locations":["West
+        Southeast","Japan East","UK South","West India","West US 2","East US"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationresults","locations":["West
         US","North Europe","South Central US","West Europe","West Central US","Southeast
         Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
-        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationstatuses","locations":["West
+        Southeast","Japan East","UK South","West India","West US 2","East US"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationstatuses","locations":["West
         US","North Europe","South Central US","West Europe","West Central US","Southeast
         Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
-        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"operations","locations":["East
-        US 2","West Central US"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AppService","namespace":"Microsoft.AppService","authorization":{"applicationId":"dee7ba80-6a55-4f3b-a86c-746a9231ae49","roleDefinitionId":"6715d172-49c4-46f6-bb21-60512a8689dc"},"resourceTypes":[{"resourceType":"apiapps","locations":["East
-        US","West US","South Central US","North Europe","East Asia","Japan East","West
-        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
-        South","East US 2","Australia Southeast","Australia East","West India","South
-        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"appIdentities","locations":["East
-        US","West US","South Central US","North Europe","East Asia","Japan East","West
-        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
-        South","East US 2","Australia Southeast","Australia East","West India","South
-        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"gateways","locations":["East
-        US","West US","South Central US","North Europe","East Asia","Japan East","West
-        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
-        South","East US 2","Australia Southeast","Australia East","West India","South
-        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"deploymenttemplates","locations":[],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Authorization","namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"roleDefinitions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"classicAdministrators","locations":[],"apiVersions":["2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"permissions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"locks","locations":[],"apiVersions":["2017-04-01","2016-09-01","2015-06-01","2015-05-01-preview","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-01-01","2014-10-01-preview","2014-06-01"]},{"resourceType":"policyDefinitions","locations":[],"apiVersions":["2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"policySetDefinitions","locations":[],"apiVersions":["2017-06-01-preview"]},{"resourceType":"policyAssignments","locations":[],"apiVersions":["2017-06-01-preview","2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"providerOperations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01-preview","2015-07-01"]},{"resourceType":"elevateAccess","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureActiveDirectory","namespace":"Microsoft.AzureActiveDirectory","resourceTypes":[{"resourceType":"b2cDirectories","locations":["Global","United
-        States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureStack","namespace":"Microsoft.AzureStack","resourceTypes":[{"resourceType":"operations","locations":["Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations","locations":["West
+        Southeast","Japan East","UK South","West India","West US 2","East US"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"operations","locations":["East
+        US 2","West Central US","West US 2"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Authorization","namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[],"apiVersions":["2017-10-01-preview","2017-09-01","2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"roleDefinitions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"classicAdministrators","locations":[],"apiVersions":["2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"permissions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"locks","locations":[],"apiVersions":["2017-04-01","2016-09-01","2015-06-01","2015-05-01-preview","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-01-01","2014-10-01-preview","2014-06-01"]},{"resourceType":"policyDefinitions","locations":[],"apiVersions":["2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"policySetDefinitions","locations":[],"apiVersions":["2017-06-01-preview"]},{"resourceType":"policyAssignments","locations":[],"apiVersions":["2017-06-01-preview","2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"providerOperations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01-preview","2015-07-01"]},{"resourceType":"elevateAccess","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"checkAccess","locations":[],"apiVersions":["2017-10-01-preview","2017-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureStack","namespace":"Microsoft.AzureStack","resourceTypes":[{"resourceType":"operations","locations":["Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations","locations":["West
         Central US","Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations/products","locations":["West
-        Central US","Global"],"apiVersions":["2017-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Billing","namespace":"Microsoft.Billing","resourceTypes":[{"resourceType":"BillingPeriods","locations":["Central
+        Central US","Global"],"apiVersions":["2017-06-01","2016-01-01"]},{"resourceType":"registrations/customerSubscriptions","locations":["West
+        Central US","Global"],"apiVersions":["2017-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BatchAI","namespace":"Microsoft.BatchAI","authorization":{"applicationId":"9fcb3732-5f52-4135-8c08-9d4bbaf203ea","roleDefinitionId":"703B89C7-CE2C-431B-BDD8-FA34E39AF696","managedByRoleDefinitionId":"90B8E153-EBFF-4073-A95F-4DAD56B14C78"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"jobs","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"fileservers","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"operations","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01-preview"]},{"resourceType":"locations/operationresults","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Billing","namespace":"Microsoft.Billing","resourceTypes":[{"resourceType":"BillingPeriods","locations":["Central
         US"],"apiVersions":["2017-04-24-preview"]},{"resourceType":"Invoices","locations":["Central
         US"],"apiVersions":["2017-04-24-preview","2017-02-27-preview"]},{"resourceType":"operations","locations":["Central
         US"],"apiVersions":["2017-04-24-preview","2017-02-27-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BingMaps","namespace":"Microsoft.BingMaps","resourceTypes":[{"resourceType":"mapApis","locations":["West
         US"],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-18","2015-07-02"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BizTalkServices","namespace":"Microsoft.BizTalkServices","resourceTypes":[{"resourceType":"BizTalk","locations":["East
         US","West US","North Europe","West Europe","Southeast Asia","East Asia","North
-        Central US","Japan West","Japan East","South Central US"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Cache","namespace":"Microsoft.Cache","authorization":{"applicationId":"96231a05-34ce-4eb4-aa6a-70759cbb5e83","roleDefinitionId":"4f731528-ba85-45c7-acfb-cd0a9b3cf31b"},"resourceTypes":[{"resourceType":"Redis","locations":["North
+        Central US","Japan West","Japan East","South Central US"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BotService","namespace":"Microsoft.BotService","resourceTypes":[{"resourceType":"botServices","locations":["Global"],"apiVersions":["2017-12-01"]},{"resourceType":"checkNameAvailability","locations":["Global"],"apiVersions":["2017-12-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Cache","namespace":"Microsoft.Cache","authorization":{"applicationId":"96231a05-34ce-4eb4-aa6a-70759cbb5e83","roleDefinitionId":"4f731528-ba85-45c7-acfb-cd0a9b3cf31b"},"resourceTypes":[{"resourceType":"Redis","locations":["North
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","Canada Central","Canada East","UK South","UK West","West US 2","West
-        Central US","South India","Korea Central","Korea South"],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","South India","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","South India","Canada Central","Canada East","UK South","UK West","West
-        US 2","West Central US","Korea Central","Korea South"],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01"]},{"resourceType":"Redis/metricDefinitions","locations":["North
+        US 2","West Central US","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01"]},{"resourceType":"Redis/metricDefinitions","locations":["North
         Central US","South Central US","East US","East US 2","West US","Central US","East
         Asia","Southeast Asia","North Europe","West Europe","Japan East","Japan West","Brazil
         South","Australia Southeast","Australia East","Central India","West India","South
@@ -1514,59 +1739,59 @@ http_interactions:
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/origins","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/origins","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/customdomains","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/customdomains","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/originresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/originresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/customdomainresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/customdomainresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkResourceUsage","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkResourceUsage","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02"]},{"resourceType":"validateProbe","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02"]},{"resourceType":"validateProbe","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02"]},{"resourceType":"operations","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02"]},{"resourceType":"operations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"edgenodes","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"edgenodes","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CertificateRegistration","namespace":"Microsoft.CertificateRegistration","authorization":{"applicationId":"f3c21649-0979-4721-ac85-b0216b2cf413","roleDefinitionId":"933fba7e-2ed3-4da8-973d-8bd8298a9b40"},"resourceTypes":[{"resourceType":"certificateOrders","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"certificateOrders/certificates","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"validateCertificateRegistrationInformation","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicSubscription","namespace":"Microsoft.ClassicSubscription","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicInfrastructureMigrate","namespace":"Microsoft.ClassicInfrastructureMigrate","authorization":{"applicationId":"5e5abe2b-83cd-4786-826a-a05653ebb103","roleDefinitionId":"766c4d9b-ef83-4f73-8352-1450a506a69b"},"resourceTypes":[{"resourceType":"classicInfrastructureResources","locations":["East
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CertificateRegistration","namespace":"Microsoft.CertificateRegistration","authorization":{"applicationId":"f3c21649-0979-4721-ac85-b0216b2cf413","roleDefinitionId":"933fba7e-2ed3-4da8-973d-8bd8298a9b40"},"resourceTypes":[{"resourceType":"certificateOrders","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"certificateOrders/certificates","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"validateCertificateRegistrationInformation","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicSubscription","namespace":"Microsoft.ClassicSubscription","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-09-01","2017-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicInfrastructureMigrate","namespace":"Microsoft.ClassicInfrastructureMigrate","authorization":{"applicationId":"5e5abe2b-83cd-4786-826a-a05653ebb103","roleDefinitionId":"766c4d9b-ef83-4f73-8352-1450a506a69b"},"resourceTypes":[{"resourceType":"classicInfrastructureResources","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
         Central US","Central US","North Europe","West Europe","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","West
@@ -1584,8 +1809,9 @@ http_interactions:
         Asia","East Asia","West Central US","South Central US","East US","East US
         2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/updateAccountsCreationSettings","locations":["West
         US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/accountsCreationSettings","locations":["West
-        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2016-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Commerce","namespace":"Microsoft.Commerce","resourceTypes":[{"resourceType":"UsageAggregates","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]},{"resourceType":"RateCard","locations":[],"apiVersions":["2016-08-31-preview","2015-06-01-preview","2015-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Consumption","namespace":"Microsoft.Consumption","resourceTypes":[{"resourceType":"reservationsummaries","locations":[],"apiVersions":["2017-01-30"]},{"resourceType":"reservationdetails","locations":[],"apiVersions":["2017-01-30"]},{"resourceType":"UsageDetails","locations":[],"apiVersions":["2017-06-30-preview","2017-04-24-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-30-preview","2017-04-24-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","resourceTypes":[{"resourceType":"containerGroups","locations":["West
-        US","East US","West Europe"],"apiVersions":["2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
+        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2016-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Commerce","namespace":"Microsoft.Commerce","resourceTypes":[{"resourceType":"UsageAggregates","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]},{"resourceType":"RateCard","locations":[],"apiVersions":["2016-08-31-preview","2015-06-01-preview","2015-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Consumption","namespace":"Microsoft.Consumption","resourceTypes":[{"resourceType":"ReservationSummaries","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationTransactions","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"Balances","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"Pricesheets","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationDetails","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"Budgets","locations":[],"apiVersions":["2017-12-30-preview"]},{"resourceType":"Terms","locations":[],"apiVersions":["2017-12-30-preview"]},{"resourceType":"UsageDetails","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview","2017-04-24-preview"]},{"resourceType":"Operations","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview","2017-04-24-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","resourceTypes":[{"resourceType":"containerGroups","locations":["West
+        US","East US","West Europe","Southeast Asia"],"apiVersions":["2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US","East US","West Europe","Southeast Asia"],"apiVersions":["2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
         US"],"apiVersions":["2016-04-08"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CustomerInsights","namespace":"Microsoft.CustomerInsights","authorization":{"applicationId":"38c77d00-5fcb-4cce-9d93-af4738258e3c","roleDefinitionId":"E006F9C7-F333-477C-8AD6-1F3A9FE87F55"},"resourceTypes":[{"resourceType":"hubs","locations":["East
         US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/profiles","locations":["East
         US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/interactions","locations":["East
@@ -1608,8 +1834,8 @@ http_interactions:
         US","West US","Australia East","West Europe","North Europe","Southeast Asia","West
         Central US"],"apiVersions":["2016-03-30","2015-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataFactory","namespace":"Microsoft.DataFactory","resourceTypes":[{"resourceType":"dataFactories","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview","2014-04-01"]},{"resourceType":"factories","locations":["East
-        US","East US 2"],"apiVersions":["2017-09-01-preview","2017-03-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
-        US","East US 2"],"apiVersions":["2017-09-01-preview","2017-03-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
+        US","East US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
+        US","East US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
         Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"dataFactories/metricDefinitions","locations":["North
         Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"checkDataFactoryNameAvailability","locations":[],"apiVersions":["2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"checkAzureDataFactoryNameAvailability","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"dataFactorySchema","locations":["West
@@ -1621,69 +1847,71 @@ http_interactions:
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers/listSasTokens","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeStore","namespace":"Microsoft.DataLakeStore","authorization":{"applicationId":"e9f49c6b-5ce5-44c8-925d-015017e9f7ad","roleDefinitionId":"17eb9cca-f08a-4499-b2d3-852d175f614f"},"resourceTypes":[{"resourceType":"accounts","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/firewallRules","locations":["East
-        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","resourceTypes":[{"resourceType":"operations","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforPostgreSQL","namespace":"Microsoft.DBforPostgreSQL","resourceTypes":[{"resourceType":"operations","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"checkProvisioningServiceNameAvailability","locations":[],"apiVersions":["2017-08-21-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataMigration","namespace":"Microsoft.DataMigration","authorization":{"applicationId":"a4bad4aa-bf02-4631-9f78-a64ffdba8150","roleDefinitionId":"b831a21d-db98-4760-89cb-bef871952df1","managedByRoleDefinitionId":"6256fb55-9e59-4018-a9e1-76b11c0a4c89"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services/projects","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationStatuses","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforPostgreSQL","namespace":"Microsoft.DBforPostgreSQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"checkProvisioningServiceNameAvailability","locations":[],"apiVersions":["2017-11-15","2017-08-21-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
         US","North Europe","East Asia","East US","West Europe","Southeast Asia","Japan
         East","Japan West","Australia East","Australia Southeast","West US 2","West
         Central US","East US 2","Central US","UK South","UK West","South India","Central
-        India","Canada Central","Canada East"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"ProvisioningServices","locations":["East
-        US","West Europe","Southeast Asia"],"apiVersions":["2017-08-21-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
-        East","Australia Southeast","Canada Central","Canada East","Central India","Central
-        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
-        US","North Europe","South Central US","South India","Southeast Asia","West
-        Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"databaseAccountNames","locations":["Australia
-        East","Australia Southeast","Canada Central","Canada East","Central India","Central
-        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
-        US","North Europe","South Central US","South India","Southeast Asia","West
-        Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"operations","locations":["Australia
-        East","Australia Southeast","Canada Central","Canada East","Central India","Central
-        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
-        US","North Europe","South Central US","South India","Southeast Asia","West
-        Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DomainRegistration","namespace":"Microsoft.DomainRegistration","authorization":{"applicationId":"ea2f600a-4980-45b7-89bf-d34da487bda1","roleDefinitionId":"54d7f2e3-5040-48a7-ae90-eebf629cfa0b"},"resourceTypes":[{"resourceType":"domains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"domains/domainOwnershipIdentifiers","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"topLevelDomains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"checkDomainAvailability","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"listDomainRecommendations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"validateDomainRegistrationInformation","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"generateSsoRequest","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DynamicsLcs","namespace":"Microsoft.DynamicsLcs","resourceTypes":[{"resourceType":"lcsprojects","locations":["Brazil
+        India","Canada Central","Canada East","Brazil South","South Central US"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs/eventGridFilters","locations":["West
+        US","East US","West US 2","West Central US","East US 2","Central US"],"apiVersions":["2018-01-15-preview"]},{"resourceType":"ProvisioningServices","locations":["East
+        US","West US","West Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2017-11-15","2017-08-21-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DomainRegistration","namespace":"Microsoft.DomainRegistration","authorization":{"applicationId":"ea2f600a-4980-45b7-89bf-d34da487bda1","roleDefinitionId":"54d7f2e3-5040-48a7-ae90-eebf629cfa0b"},"resourceTypes":[{"resourceType":"domains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"domains/domainOwnershipIdentifiers","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"topLevelDomains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"checkDomainAvailability","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"listDomainRecommendations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"validateDomainRegistrationInformation","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"generateSsoRequest","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DynamicsLcs","namespace":"Microsoft.DynamicsLcs","resourceTypes":[{"resourceType":"lcsprojects","locations":["Brazil
         South","East Asia","East US","Japan East","Japan West","North Central US","North
         Europe","South Central US","West Europe","West US","Southeast Asia","Central
         US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"lcsprojects/connectors","locations":["Brazil
@@ -1695,21 +1923,21 @@ http_interactions:
         US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"operations","locations":["Brazil
         South","East Asia","East US","Japan East","Japan West","North Central US","North
         Europe","South Central US","West Europe","West US","Southeast Asia","Central
-        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topics","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operations","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topics","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operations","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","West
         US 2","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
         India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/consumergroups","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
         US","East US 2","West US","South Central US","Central US","Australia East","Australia
         Southeast","Central India","West Central US","West US 2","Canada East","Canada
         Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
@@ -1754,23 +1982,23 @@ http_interactions:
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations","locations":["Australia
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations/operationResults","locations":["Australia
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations/operationResults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"operations","locations":["Australia
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"operations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Logic","namespace":"Microsoft.Logic","authorization":{"applicationId":"7cd684f4-8a78-49b0-91ec-6a35d38739ba","roleDefinitionId":"cb3ef1fb-6e31-49e2-9d87-ed821053fe58"},"resourceTypes":[{"resourceType":"workflows","locations":["North
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.LocationBasedServices","namespace":"Microsoft.LocationBasedServices","resourceTypes":[{"resourceType":"accounts","locations":["Global"],"apiVersions":["2017-01-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Logic","namespace":"Microsoft.Logic","authorization":{"applicationId":"7cd684f4-8a78-49b0-91ec-6a35d38739ba","roleDefinitionId":"cb3ef1fb-6e31-49e2-9d87-ed821053fe58"},"resourceTypes":[{"resourceType":"workflows","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
@@ -1791,60 +2019,78 @@ http_interactions:
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada Central","Canada East","West US 2","West Central
-        US","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","West Central US"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"operations","locations":["South
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations","locations":["South
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operations","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"commitmentPlans","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningExperimentation","namespace":"Microsoft.MachineLearningExperimentation","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"accounts","locations":["Australia
-        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces","locations":["Australia
-        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces/projects","locations":["Australia
-        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningCompute","namespace":"Microsoft.MachineLearningCompute","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"376aa7d7-51a9-463d-bd4d-7e1691345612","managedByRoleDefinitionId":"91d00862-cf55-46a5-9dce-260bbd92ce25"},"resourceTypes":[{"resourceType":"operationalizationClusters","locations":["East
-        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"operations","locations":["East
+        US","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningExperimentation","namespace":"Microsoft.MachineLearningExperimentation","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"accounts","locations":["Australia
+        East","East US 2","West Central US","Southeast Asia","West Europe"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces","locations":["Australia
+        East","East US 2","West Central US","Southeast Asia","West Europe"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces/projects","locations":["Australia
+        East","East US 2","West Central US","Southeast Asia","West Europe"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"teamAccounts","locations":["Australia
+        East","West Central US","East US 2"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"teamAccounts/workspaces","locations":["Australia
+        East","West Central US","East US 2"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"teamAccounts/workspaces/projects","locations":["Australia
+        East","West Central US","East US 2"],"apiVersions":["2017-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningCompute","namespace":"Microsoft.MachineLearningCompute","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"376aa7d7-51a9-463d-bd4d-7e1691345612","managedByRoleDefinitionId":"91d00862-cf55-46a5-9dce-260bbd92ce25"},"resourceTypes":[{"resourceType":"operationalizationClusters","locations":["East
+        US 2","West Central US","Australia East","West Europe","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"operations","locations":["East
         US 2"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations","locations":["East
         US 2"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operations","locations":["East
-        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["East
-        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningModelManagement","namespace":"Microsoft.MachineLearningModelManagement","resourceTypes":[{"resourceType":"accounts","locations":["East
-        US 2","West Central US","Australia East"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"operations","locations":["West
-        Central US"],"apiVersions":["2017-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
+        US 2","West Central US","Australia East","West Europe","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["East
+        US 2","West Central US","Australia East","West Europe","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningModelManagement","namespace":"Microsoft.MachineLearningModelManagement","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US 2","West Central US","Australia East","West Europe","Southeast Asia"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"operations","locations":["West
+        Central US"],"apiVersions":["2017-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ManagedIdentity","namespace":"Microsoft.ManagedIdentity","resourceTypes":[{"resourceType":"Identities","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Brazil South","Central
+        India","West India","South India","Japan West","Japan East","East Asia","Southeast
+        Asia","Korea Central","Korea South","North Europe","West Europe","UK West","UK
+        South","Central US","North Central US","East US","East US 2","South Central
+        US","West US","West US 2","West Central US"],"apiVersions":["2015-08-31-PREVIEW"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Brazil South","Central
+        India","West India","South India","Japan West","Japan East","East Asia","Southeast
+        Asia","Korea Central","Korea South","North Europe","West Europe","UK West","UK
+        South","Central US","North Central US","East US","East US 2","South Central
+        US","West US","West US 2","West Central US"],"apiVersions":["2015-08-31-PREVIEW"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Management","namespace":"Microsoft.Management","authorization":{"applicationId":"f2c304cf-8e7e-4c3f-8164-16299ad9d272","roleDefinitionId":"c1cf3708-588a-4647-be7f-f400bbe214cf"},"resourceTypes":[{"resourceType":"resources","locations":[],"apiVersions":["2017-11-01-preview","2017-08-31-preview","2017-06-30-preview","2017-05-31-preview"]},{"resourceType":"managementGroups","locations":[],"apiVersions":["2017-11-01-preview","2017-08-31-preview","2017-06-30-preview","2017-05-31-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01-preview","2017-08-31-preview","2017-06-30-preview","2017-05-31-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceApps","namespace":"Microsoft.MarketplaceApps","resourceTypes":[{"resourceType":"classicDevServices","locations":["Northwest
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","Central US","North
+        Europe","West Europe","Japan East","Japan West","Brazil South","Australia
+        East","Australia Southeast","South India","Central India","Canada Central","Canada
+        East"],"apiVersions":["2017-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
         Central US","West US"],"apiVersions":["2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01"]},{"resourceType":"offertypes","locations":["South
         Central US","West US"],"apiVersions":["2015-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Media","namespace":"Microsoft.Media","authorization":{"applicationId":"374b2a64-3b6b-436b-934c-b820eacca870","roleDefinitionId":"aab70789-0cec-44b5-95d7-84b64c9487af"},"resourceTypes":[{"resourceType":"mediaservices","locations":["Japan
         West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
         US","West US","Australia East","Australia Southeast","Central US","Brazil
         South","Central India","West India","South India","South Central US","Canada
-        Central","Canada East","West Central US"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
+        Central","Canada East","West Central US","West US 2"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
+        Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"operations","locations":["West
+        Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
+        Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PolicyInsights","namespace":"Microsoft.PolicyInsights","authorization":{"applicationId":"1d78a85d-813d-46f0-b496-dd72f50a3ec0","roleDefinitionId":"63d2b225-4c34-4641-8768-21a1f7c68ce8"},"resourceTypes":[{"resourceType":"policyEvents","locations":[],"apiVersions":["2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"policyStates","locations":[],"apiVersions":["2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-17-preview","2017-08-09-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
         Central US","North Central US","East US 2","West US","West Europe","North
         Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
         East","UK South","West India"],"apiVersions":["2016-01-29"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-01-29"]},{"resourceType":"locations/checkNameAvailability","locations":["South
         Central US","North Central US","East US 2","West US","West Europe","North
         Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
-        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"capacities","locations":["West
-        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
-        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationresults","locations":["West
-        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
-        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"operations","locations":["East
-        US 2"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Relay","namespace":"Microsoft.Relay","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"capacities","locations":["Australia
+        Southeast","Brazil South","Canada Central","East Asia","East US","East US
+        2","West India","Japan East","West Central US","North Central US","North Europe","South
+        Central US","Southeast Asia","UK South","West Europe","West US","West US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":["Australia
+        Southeast","Brazil South","Canada Central","East Asia","East US","East US
+        2","West India","Japan East","West Central US","North Central US","North Europe","South
+        Central US","Southeast Asia","UK South","West Europe","West US","West US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationresults","locations":["Australia
+        Southeast","Brazil South","Canada Central","East Asia","East US","East US
+        2","West India","Japan East","West Central US","North Central US","North Europe","South
+        Central US","Southeast Asia","UK South","West Europe","West US","West US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["Australia
+        Southeast","Brazil South","Canada Central","East Asia","East US","East US
+        2","West India","Japan East","West Central US","North Central US","North Europe","South
+        Central US","Southeast Asia","UK South","West Europe","West US","West US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"operations","locations":["East
+        US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Relay","namespace":"Microsoft.Relay","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US 2","West
         US","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
         India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2017-08-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkPolicyCompliance","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/hybridconnections","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/hybridconnections/authorizationrules","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/wcfrelays","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/wcfrelays/authorizationrules","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkPolicyCompliance","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
         Central US","South Central US","North Europe","West Europe","East Asia","Southeast
         Asia","West US","East US","Japan West","Japan East","Brazil South","Central
         US","East US 2","Australia East","Australia Southeast","South India","Central
@@ -1868,12 +2114,12 @@ http_interactions:
         India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19","2015-02-28"]},{"resourceType":"checkServiceNameAvailability","locations":[],"apiVersions":["2015-02-28","2014-07-31-Preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2015-08-19"]},{"resourceType":"resourceHealthMetadata","locations":["West
         US","East US","North Europe","West Europe","Southeast Asia","East Asia","North
         Central US","South Central US","Japan West","Australia East","Brazil South","Central
-        India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","authorization":{"applicationId":"80a10ef9-8168-493d-abf9-3297c4ef6e3c","roleDefinitionId":"2b7763f7-bbe2-4e19-befe-28c79f1cf7f7"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US 2","West
         US","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
         India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"premiumMessagingRegions","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceFabric","namespace":"Microsoft.ServiceFabric","authorization":{"applicationId":"74cb6831-0dbb-4be1-8206-fd4df301cdc2","roleDefinitionId":"e55cc65f-6903-4917-b4ef-f8d4640b57f5"},"resourceTypes":[{"resourceType":"clusters","locations":["West
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/queues","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/queues/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/topics","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/topics/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/topics/subscriptions","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/topics/subscriptions/rules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"premiumMessagingRegions","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceFabric","namespace":"Microsoft.ServiceFabric","authorization":{"applicationId":"74cb6831-0dbb-4be1-8206-fd4df301cdc2","roleDefinitionId":"e55cc65f-6903-4917-b4ef-f8d4640b57f5"},"resourceTypes":[{"resourceType":"clusters","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
@@ -1887,17 +2133,43 @@ http_interactions:
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
-        India","West India","Central India","Brazil South","South Central US","Canada
-        Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
         Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
         Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applianceDefinitions","locations":["West
-        Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"locations","locations":["West
-        Central US"],"apiVersions":["2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
-        Central US"],"apiVersions":["2017-09-01","2016-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
+        Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applications","locations":["South
+        Central US","North Central US","West Central US","West US","West US 2","East
+        US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
+        Asia","Brazil South","Japan West","Japan East","Australia East","Australia
+        Southeast","South India","West India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
+        Central US","North Central US","West Central US","West US","West US 2","East
+        US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
+        Asia","Brazil South","Japan West","Japan East","Australia East","Australia
+        Southeast","South India","West India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
+        Central US"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
+        Central US","North Central US","West Central US","West US","West US 2","East
+        US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
+        Asia","Brazil South","Japan West","Japan East","Australia East","Australia
+        Southeast","South India","West India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/cloudEndpoints","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/serverEndpoints","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/registeredServers","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/workflows","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","West Central US","Japan East","Japan West","Australia East","Australia
         Southeast"],"apiVersions":["2017-06-01","2017-05-15","2017-01-01","2016-10-01","2016-06-01","2015-03-15","2014-09-01"]},{"resourceType":"operations","locations":["West
@@ -1928,23 +2200,11 @@ http_interactions:
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast"],"apiVersions":["2015-07-01-Preview","2015-03-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.TimeSeriesInsights","namespace":"Microsoft.TimeSeriesInsights","authorizations":[{"applicationId":"120d688d-1518-4cf7-bd38-182f158850b6","roleDefinitionId":"5a43abdf-bb87-42c4-9e56-1c24bf364150"}],"resourceTypes":[{"resourceType":"environments","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/eventsources","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/referenceDataSets","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/accessPolicies","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"operations","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
-        Central US","South Central US","East US","West US","Central US","North Europe","West
-        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
-        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/project","locations":["North
-        Central US","South Central US","East US","West US","Central US","North Europe","West
-        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
-        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/extension","locations":["North
-        Central US","South Central US","East US","West US","Central US","North Europe","West
-        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
-        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"checkNameAvailability","locations":["North
-        Central US","South Central US","East US","West US","Central US","North Europe","West
-        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
-        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Myget.PackageManagement","namespace":"Myget.PackageManagement","resourceTypes":[{"resourceType":"services","locations":["West
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]},{"resourceType":"environments/eventsources","locations":["East
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]},{"resourceType":"environments/referenceDataSets","locations":["East
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]},{"resourceType":"environments/accessPolicies","locations":["East
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]},{"resourceType":"operations","locations":["East
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Myget.PackageManagement","namespace":"Myget.PackageManagement","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/NewRelic.APM","namespace":"NewRelic.APM","authorization":{"allowedThirdPartyExtensions":[{"name":"NewRelic_AzurePortal_APM"}]},"resourceTypes":[{"resourceType":"accounts","locations":["North
         Central US","South Central US","West US","East US","North Europe","West Europe","Southeast
         Asia","East Asia","Japan East","Japan West"],"apiVersions":["2014-10-01","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/nuubit.nextgencdn","namespace":"nuubit.nextgencdn","resourceTypes":[{"resourceType":"accounts","locations":["East
@@ -1984,7 +2244,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:41:35 GMT
+  recorded_at: Tue, 23 Jan 2018 20:06:44 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
@@ -2001,9 +2261,11 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYxOTMsIm5iZiI6MTUwNjExNjE5MywiZXhwIjoxNTA2MTIwMDkzLCJhaW8iOiJZMlZnWU1oNXVyeWg5YVIrN0RhZVhhdlB2UlozQlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZXBRb0ZreWlNRUcwWlZTS0xYOE5BQSIsInZlciI6IjEuMCJ9.bSUowVQrbB6dhplwG1xITFYrbHN6C5axjxx-z6X6Eus2sxnPfNsQ46XCPdRAbsvdsO1fj-0Z0ZFxESrapH19O0IVF5aY270l5oNKqV_gDsaWMSJ6sz0SxPPhxQYBoQ0PF5PSlGKwTfkyMWIYrJ2PN6ZQIw3aq8MXKGcSqRZNDjq7wCtZG0Z8EHULyK3k5KQZevf_DbhvKzqHsFFbW_cK_c7DgYyOZDq82-Ljhy-Cva8sB2iXrVxYgft9k_WJ0X2siT21MBfE8_kvVrwbjTJ6IFPYCU1faOyqkSTRo3vB686d46mOmPKMhM-NEshNUummfI-DEZ3N27ZXlLU_lv4zFQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3MDIsIm5iZiI6MTUxNjczNzcwMiwiZXhwIjoxNTE2NzQxNjAyLCJhaW8iOiJZMk5nWUxoL1VPWFFkWStKSVV3OFFWNWFnaWtKQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieTl1RS1hdjM0MGl1QkFGVlVQOFJBQSIsInZlciI6IjEuMCJ9.kIv5tdYHAarNVTZsWVxNEed-NKefscjTaNESdRZNcgTSni2-Nhcz6K-nNCpc8IifOIQHt03G0zPV43Mv_GRfzonEXreL66h4Kq7MHHlkv2-w3w9Ual-wrEtF1YympfZz1gPIYNh_7fTwKOzsD2xjA3kmS1axQxbgSYldEtcAbOzMUGyiTmouwmVw0wkQTacRTqCJdSRqJtNk3Pg-S6oS6V0sk14A2NVJvUSdWYElSASNUu-hr2RBJV_ypH-DnXLvsz6r8sBuPHJnvwS_HpXbANmNZX1pTEn42q6mN_r1biV0PwpT6UjJAOgUDvevvvTTFmvBlQUBQn8L0JeKzuTvSQ
       Content-Length:
       - '42'
+      Host:
+      - management.azure.com
   response:
     status:
       code: 202
@@ -2013,39 +2275,41 @@ http_interactions:
       - no-cache
       Pragma:
       - no-cache
-      Content-Length:
-      - '0'
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/07c18977-815a-4d40-ae4b-fcb36eca0515?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/231bd4f4-2c05-49a7-8636-4f033e901994?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/07c18977-815a-4d40-ae4b-fcb36eca0515?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/231bd4f4-2c05-49a7-8636-4f033e901994?api-version=2017-03-30
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/HighCostHydrate3Min;238,Microsoft.Compute/HighCostHydrate30Min;1165
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131599701143261070
       X-Ms-Request-Id:
-      - 07c18977-815a-4d40-ae4b-fcb36eca0515
+      - 231bd4f4-2c05-49a7-8636-4f033e901994
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1183'
+      - '1155'
       X-Ms-Correlation-Request-Id:
-      - 2ac1a9f5-8ab5-4463-865e-29a10c4ca5b6
+      - b2d4ffb6-743b-4403-affb-94d9d6ea1757
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214136Z:2ac1a9f5-8ab5-4463-865e-29a10c4ca5b6
+      - WESTUS:20180123T200645Z:b2d4ffb6-743b-4403-affb-94d9d6ea1757
       Date:
-      - Fri, 22 Sep 2017 21:41:36 GMT
+      - Tue, 23 Jan 2018 20:06:44 GMT
+      Content-Length:
+      - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:41:36 GMT
+  recorded_at: Tue, 23 Jan 2018 20:06:45 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/07c18977-815a-4d40-ae4b-fcb36eca0515?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/231bd4f4-2c05-49a7-8636-4f033e901994?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -2059,7 +2323,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYxOTMsIm5iZiI6MTUwNjExNjE5MywiZXhwIjoxNTA2MTIwMDkzLCJhaW8iOiJZMlZnWU1oNXVyeWg5YVIrN0RhZVhhdlB2UlozQlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZXBRb0ZreWlNRUcwWlZTS0xYOE5BQSIsInZlciI6IjEuMCJ9.bSUowVQrbB6dhplwG1xITFYrbHN6C5axjxx-z6X6Eus2sxnPfNsQ46XCPdRAbsvdsO1fj-0Z0ZFxESrapH19O0IVF5aY270l5oNKqV_gDsaWMSJ6sz0SxPPhxQYBoQ0PF5PSlGKwTfkyMWIYrJ2PN6ZQIw3aq8MXKGcSqRZNDjq7wCtZG0Z8EHULyK3k5KQZevf_DbhvKzqHsFFbW_cK_c7DgYyOZDq82-Ljhy-Cva8sB2iXrVxYgft9k_WJ0X2siT21MBfE8_kvVrwbjTJ6IFPYCU1faOyqkSTRo3vB686d46mOmPKMhM-NEshNUummfI-DEZ3N27ZXlLU_lv4zFQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3MDIsIm5iZiI6MTUxNjczNzcwMiwiZXhwIjoxNTE2NzQxNjAyLCJhaW8iOiJZMk5nWUxoL1VPWFFkWStKSVV3OFFWNWFnaWtKQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieTl1RS1hdjM0MGl1QkFGVlVQOFJBQSIsInZlciI6IjEuMCJ9.kIv5tdYHAarNVTZsWVxNEed-NKefscjTaNESdRZNcgTSni2-Nhcz6K-nNCpc8IifOIQHt03G0zPV43Mv_GRfzonEXreL66h4Kq7MHHlkv2-w3w9Ual-wrEtF1YympfZz1gPIYNh_7fTwKOzsD2xjA3kmS1axQxbgSYldEtcAbOzMUGyiTmouwmVw0wkQTacRTqCJdSRqJtNk3Pg-S6oS6V0sk14A2NVJvUSdWYElSASNUu-hr2RBJV_ypH-DnXLvsz6r8sBuPHJnvwS_HpXbANmNZX1pTEn42q6mN_r1biV0PwpT6UjJAOgUDvevvvTTFmvBlQUBQn8L0JeKzuTvSQ
+      Host:
+      - management.azure.com
   response:
     status:
       code: 200
@@ -2077,34 +2343,36 @@ http_interactions:
       - "-1"
       Vary:
       - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/GetOperation3Min;49997,Microsoft.Compute/GetOperation30Min;249997
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131599701143261070
       X-Ms-Request-Id:
-      - 9cba70c6-d6a5-40f7-a3a9-7884eed15925
+      - 9fa4cade-868f-44c4-b52c-6d696e0e1ec8
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14923'
+      - '14852'
       X-Ms-Correlation-Request-Id:
-      - d9fa3bad-3698-41d6-ae3a-9815119ecea5
+      - f4a5b0eb-814c-4fac-83db-1f58fc9ba9d7
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214137Z:d9fa3bad-3698-41d6-ae3a-9815119ecea5
+      - WESTUS:20180123T200645Z:f4a5b0eb-814c-4fac-83db-1f58fc9ba9d7
       Date:
-      - Fri, 22 Sep 2017 21:41:36 GMT
+      - Tue, 23 Jan 2018 20:06:45 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-22T21:41:37.9645176+00:00\",\r\n  \"endTime\":
-        \"2017-09-22T21:41:38.1364228+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=4711879f-012c-4b6a-9544-ac180aa21949&sig=eeu%2BMSTte9EeZbqn4z0eFSFCK%2F0na4etIKu6aiLRNsw%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"07c18977-815a-4d40-ae4b-fcb36eca0515\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2018-01-23T20:06:44.6649281+00:00\",\r\n  \"endTime\":
+        \"2018-01-23T20:06:44.9149325+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=01c2f7db-4917-4ab6-a4e3-17b2e046e9d7&sig=XIZHQKzOVenY2j9GBkt%2FonK7Mtktn3odF0QBFH6Uw34%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"231bd4f4-2c05-49a7-8636-4f033e901994\"\r\n}"
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:41:37 GMT
+  recorded_at: Tue, 23 Jan 2018 20:06:46 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/07c18977-815a-4d40-ae4b-fcb36eca0515?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/231bd4f4-2c05-49a7-8636-4f033e901994?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -2118,7 +2386,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYxOTMsIm5iZiI6MTUwNjExNjE5MywiZXhwIjoxNTA2MTIwMDkzLCJhaW8iOiJZMlZnWU1oNXVyeWg5YVIrN0RhZVhhdlB2UlozQlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZXBRb0ZreWlNRUcwWlZTS0xYOE5BQSIsInZlciI6IjEuMCJ9.bSUowVQrbB6dhplwG1xITFYrbHN6C5axjxx-z6X6Eus2sxnPfNsQ46XCPdRAbsvdsO1fj-0Z0ZFxESrapH19O0IVF5aY270l5oNKqV_gDsaWMSJ6sz0SxPPhxQYBoQ0PF5PSlGKwTfkyMWIYrJ2PN6ZQIw3aq8MXKGcSqRZNDjq7wCtZG0Z8EHULyK3k5KQZevf_DbhvKzqHsFFbW_cK_c7DgYyOZDq82-Ljhy-Cva8sB2iXrVxYgft9k_WJ0X2siT21MBfE8_kvVrwbjTJ6IFPYCU1faOyqkSTRo3vB686d46mOmPKMhM-NEshNUummfI-DEZ3N27ZXlLU_lv4zFQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3MDIsIm5iZiI6MTUxNjczNzcwMiwiZXhwIjoxNTE2NzQxNjAyLCJhaW8iOiJZMk5nWUxoL1VPWFFkWStKSVV3OFFWNWFnaWtKQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieTl1RS1hdjM0MGl1QkFGVlVQOFJBQSIsInZlciI6IjEuMCJ9.kIv5tdYHAarNVTZsWVxNEed-NKefscjTaNESdRZNcgTSni2-Nhcz6K-nNCpc8IifOIQHt03G0zPV43Mv_GRfzonEXreL66h4Kq7MHHlkv2-w3w9Ual-wrEtF1YympfZz1gPIYNh_7fTwKOzsD2xjA3kmS1axQxbgSYldEtcAbOzMUGyiTmouwmVw0wkQTacRTqCJdSRqJtNk3Pg-S6oS6V0sk14A2NVJvUSdWYElSASNUu-hr2RBJV_ypH-DnXLvsz6r8sBuPHJnvwS_HpXbANmNZX1pTEn42q6mN_r1biV0PwpT6UjJAOgUDvevvvTTFmvBlQUBQn8L0JeKzuTvSQ
+      Host:
+      - management.azure.com
   response:
     status:
       code: 200
@@ -2136,34 +2406,36 @@ http_interactions:
       - "-1"
       Vary:
       - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/GetOperation3Min;49996,Microsoft.Compute/GetOperation30Min;249996
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131599701143261070
       X-Ms-Request-Id:
-      - a4086942-e641-4338-9007-c582e1fd6127
+      - b84f2684-67df-478f-90ad-8fc7ec256da7
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14865'
       X-Ms-Correlation-Request-Id:
-      - 9158a374-e9fa-492a-8be1-4a74d3d68367
+      - d6574a96-21e6-46c5-9486-d173deaf51a3
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214138Z:9158a374-e9fa-492a-8be1-4a74d3d68367
+      - WESTUS:20180123T200646Z:d6574a96-21e6-46c5-9486-d173deaf51a3
       Date:
-      - Fri, 22 Sep 2017 21:41:38 GMT
+      - Tue, 23 Jan 2018 20:06:46 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-22T21:41:37.9645176+00:00\",\r\n  \"endTime\":
-        \"2017-09-22T21:41:38.1364228+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=4711879f-012c-4b6a-9544-ac180aa21949&sig=eeu%2BMSTte9EeZbqn4z0eFSFCK%2F0na4etIKu6aiLRNsw%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"07c18977-815a-4d40-ae4b-fcb36eca0515\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2018-01-23T20:06:44.6649281+00:00\",\r\n  \"endTime\":
+        \"2018-01-23T20:06:44.9149325+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=01c2f7db-4917-4ab6-a4e3-17b2e046e9d7&sig=XIZHQKzOVenY2j9GBkt%2FonK7Mtktn3odF0QBFH6Uw34%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"231bd4f4-2c05-49a7-8636-4f033e901994\"\r\n}"
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:41:38 GMT
+  recorded_at: Tue, 23 Jan 2018 20:06:46 GMT
 - request:
     method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=4711879f-012c-4b6a-9544-ac180aa21949&sig=eeu%2BMSTte9EeZbqn4z0eFSFCK/0na4etIKu6aiLRNsw=&sr=b&sv=2016-05-31
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=01c2f7db-4917-4ab6-a4e3-17b2e046e9d7&sig=XIZHQKzOVenY2j9GBkt/onK7Mtktn3odF0QBFH6Uw34=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2176,6 +2448,8 @@ http_interactions:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
       X-Ms-Range:
       - bytes=0-0
+      Host:
+      - md-t4jdgqqlgszp.blob.core.windows.net
   response:
     status:
       code: 206
@@ -2188,15 +2462,15 @@ http_interactions:
       Content-Range:
       - bytes 0-0/34359738880
       Last-Modified:
-      - Sat, 15 Jul 2017 14:23:07 GMT
+      - Tue, 23 Jan 2018 20:04:26 GMT
       Accept-Ranges:
       - bytes
       Etag:
-      - '"0x8D4CB8D039FC699"'
+      - '"0x8D5629C811B65EB"'
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - a5eb9334-001e-0048-20eb-3393b0000000
+      - bec31f8a-001e-00ba-6b85-944124000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2208,7 +2482,7 @@ http_interactions:
       X-Ms-Blob-Type:
       - PageBlob
       X-Ms-Blob-Sequence-Number:
-      - '20'
+      - '30'
       X-Ms-Copy-Id:
       - 30cedd78-548a-4fd8-967e-f8344f587e3c
       X-Ms-Copy-Source:
@@ -2222,250 +2496,16 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Fri, 22 Sep 2017 21:41:37 GMT
+      - Tue, 23 Jan 2018 20:06:46 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         6w==
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:41:38 GMT
-- request:
-    method: post
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/EndGetAccess?api-version=2017-03-30
-    body:
-      encoding: ASCII-8BIT
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYxOTMsIm5iZiI6MTUwNjExNjE5MywiZXhwIjoxNTA2MTIwMDkzLCJhaW8iOiJZMlZnWU1oNXVyeWg5YVIrN0RhZVhhdlB2UlozQlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZXBRb0ZreWlNRUcwWlZTS0xYOE5BQSIsInZlciI6IjEuMCJ9.bSUowVQrbB6dhplwG1xITFYrbHN6C5axjxx-z6X6Eus2sxnPfNsQ46XCPdRAbsvdsO1fj-0Z0ZFxESrapH19O0IVF5aY270l5oNKqV_gDsaWMSJ6sz0SxPPhxQYBoQ0PF5PSlGKwTfkyMWIYrJ2PN6ZQIw3aq8MXKGcSqRZNDjq7wCtZG0Z8EHULyK3k5KQZevf_DbhvKzqHsFFbW_cK_c7DgYyOZDq82-Ljhy-Cva8sB2iXrVxYgft9k_WJ0X2siT21MBfE8_kvVrwbjTJ6IFPYCU1faOyqkSTRo3vB686d46mOmPKMhM-NEshNUummfI-DEZ3N27ZXlLU_lv4zFQ
-      Content-Length:
-      - '0'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '0'
-      Expires:
-      - "-1"
-      Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/958f655e-a5c2-4fda-948f-66bde07d7814?monitor=true&api-version=2017-03-30
-      Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/958f655e-a5c2-4fda-948f-66bde07d7814?api-version=2017-03-30
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - 958f655e-a5c2-4fda-948f-66bde07d7814
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1187'
-      X-Ms-Correlation-Request-Id:
-      - 7263498b-3bf3-4c3d-b91f-d77c5dda3e80
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214139Z:7263498b-3bf3-4c3d-b91f-d77c5dda3e80
-      Date:
-      - Fri, 22 Sep 2017 21:41:39 GMT
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:41:39 GMT
-- request:
-    method: post
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
-    body:
-      encoding: UTF-8
-      string: '{"access":"read","durationInSeconds":3600}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYxOTMsIm5iZiI6MTUwNjExNjE5MywiZXhwIjoxNTA2MTIwMDkzLCJhaW8iOiJZMlZnWU1oNXVyeWg5YVIrN0RhZVhhdlB2UlozQlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZXBRb0ZreWlNRUcwWlZTS0xYOE5BQSIsInZlciI6IjEuMCJ9.bSUowVQrbB6dhplwG1xITFYrbHN6C5axjxx-z6X6Eus2sxnPfNsQ46XCPdRAbsvdsO1fj-0Z0ZFxESrapH19O0IVF5aY270l5oNKqV_gDsaWMSJ6sz0SxPPhxQYBoQ0PF5PSlGKwTfkyMWIYrJ2PN6ZQIw3aq8MXKGcSqRZNDjq7wCtZG0Z8EHULyK3k5KQZevf_DbhvKzqHsFFbW_cK_c7DgYyOZDq82-Ljhy-Cva8sB2iXrVxYgft9k_WJ0X2siT21MBfE8_kvVrwbjTJ6IFPYCU1faOyqkSTRo3vB686d46mOmPKMhM-NEshNUummfI-DEZ3N27ZXlLU_lv4zFQ
-      Content-Length:
-      - '42'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '0'
-      Expires:
-      - "-1"
-      Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/246c943d-3566-4c53-abc3-438f56f47feb?monitor=true&api-version=2017-03-30
-      Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/246c943d-3566-4c53-abc3-438f56f47feb?api-version=2017-03-30
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - 246c943d-3566-4c53-abc3-438f56f47feb
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1183'
-      X-Ms-Correlation-Request-Id:
-      - dffcbe3e-523d-408e-bec9-b89577a10743
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214140Z:dffcbe3e-523d-408e-bec9-b89577a10743
-      Date:
-      - Fri, 22 Sep 2017 21:41:39 GMT
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:41:40 GMT
+  recorded_at: Tue, 23 Jan 2018 20:06:46 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/246c943d-3566-4c53-abc3-438f56f47feb?api-version=2017-03-30
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYxOTMsIm5iZiI6MTUwNjExNjE5MywiZXhwIjoxNTA2MTIwMDkzLCJhaW8iOiJZMlZnWU1oNXVyeWg5YVIrN0RhZVhhdlB2UlozQlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZXBRb0ZreWlNRUcwWlZTS0xYOE5BQSIsInZlciI6IjEuMCJ9.bSUowVQrbB6dhplwG1xITFYrbHN6C5axjxx-z6X6Eus2sxnPfNsQ46XCPdRAbsvdsO1fj-0Z0ZFxESrapH19O0IVF5aY270l5oNKqV_gDsaWMSJ6sz0SxPPhxQYBoQ0PF5PSlGKwTfkyMWIYrJ2PN6ZQIw3aq8MXKGcSqRZNDjq7wCtZG0Z8EHULyK3k5KQZevf_DbhvKzqHsFFbW_cK_c7DgYyOZDq82-Ljhy-Cva8sB2iXrVxYgft9k_WJ0X2siT21MBfE8_kvVrwbjTJ6IFPYCU1faOyqkSTRo3vB686d46mOmPKMhM-NEshNUummfI-DEZ3N27ZXlLU_lv4zFQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - 5d08af2c-64ef-4197-a4e9-2bfbab79172c
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14914'
-      X-Ms-Correlation-Request-Id:
-      - 5a653fe9-3929-43ac-b0e2-35e1be1dd7cb
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214141Z:5a653fe9-3929-43ac-b0e2-35e1be1dd7cb
-      Date:
-      - Fri, 22 Sep 2017 21:41:40 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-22T21:41:41.755767+00:00\",\r\n  \"endTime\":
-        \"2017-09-22T21:41:41.8964099+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=8f54bbae-2265-43d0-aaa4-33ce7f94ba5a&sig=zumH0F1f7d52a1x8OpTtnqLhHzhANTJbKzq8vB3TMn0%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"246c943d-3566-4c53-abc3-438f56f47feb\"\r\n}"
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:41:41 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/246c943d-3566-4c53-abc3-438f56f47feb?api-version=2017-03-30
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYxOTMsIm5iZiI6MTUwNjExNjE5MywiZXhwIjoxNTA2MTIwMDkzLCJhaW8iOiJZMlZnWU1oNXVyeWg5YVIrN0RhZVhhdlB2UlozQlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZXBRb0ZreWlNRUcwWlZTS0xYOE5BQSIsInZlciI6IjEuMCJ9.bSUowVQrbB6dhplwG1xITFYrbHN6C5axjxx-z6X6Eus2sxnPfNsQ46XCPdRAbsvdsO1fj-0Z0ZFxESrapH19O0IVF5aY270l5oNKqV_gDsaWMSJ6sz0SxPPhxQYBoQ0PF5PSlGKwTfkyMWIYrJ2PN6ZQIw3aq8MXKGcSqRZNDjq7wCtZG0Z8EHULyK3k5KQZevf_DbhvKzqHsFFbW_cK_c7DgYyOZDq82-Ljhy-Cva8sB2iXrVxYgft9k_WJ0X2siT21MBfE8_kvVrwbjTJ6IFPYCU1faOyqkSTRo3vB686d46mOmPKMhM-NEshNUummfI-DEZ3N27ZXlLU_lv4zFQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - c458f96b-868b-41f5-b056-89f3346a75bd
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14923'
-      X-Ms-Correlation-Request-Id:
-      - 9037e978-3ad8-4282-be2b-64d39198b95b
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214141Z:9037e978-3ad8-4282-be2b-64d39198b95b
-      Date:
-      - Fri, 22 Sep 2017 21:41:41 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-22T21:41:41.755767+00:00\",\r\n  \"endTime\":
-        \"2017-09-22T21:41:41.8964099+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=8f54bbae-2265-43d0-aaa4-33ce7f94ba5a&sig=zumH0F1f7d52a1x8OpTtnqLhHzhANTJbKzq8vB3TMn0%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"246c943d-3566-4c53-abc3-438f56f47feb\"\r\n}"
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:41:41 GMT
-- request:
-    method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=8f54bbae-2265-43d0-aaa4-33ce7f94ba5a&sig=zumH0F1f7d52a1x8OpTtnqLhHzhANTJbKzq8vB3TMn0=&sr=b&sv=2016-05-31
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=01c2f7db-4917-4ab6-a4e3-17b2e046e9d7&sig=XIZHQKzOVenY2j9GBkt/onK7Mtktn3odF0QBFH6Uw34=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2478,6 +2518,8 @@ http_interactions:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
       X-Ms-Range:
       - bytes=440-443
+      Host:
+      - md-t4jdgqqlgszp.blob.core.windows.net
   response:
     status:
       code: 206
@@ -2490,15 +2532,15 @@ http_interactions:
       Content-Range:
       - bytes 440-443/34359738880
       Last-Modified:
-      - Sat, 15 Jul 2017 14:23:07 GMT
+      - Tue, 23 Jan 2018 20:04:26 GMT
       Accept-Ranges:
       - bytes
       Etag:
-      - '"0x8D4CB8D039FC699"'
+      - '"0x8D5629C811B65EB"'
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 67431d07-001e-00f7-48eb-3387c6000000
+      - a57348e9-001e-005e-0185-94522e000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2510,7 +2552,7 @@ http_interactions:
       X-Ms-Blob-Type:
       - PageBlob
       X-Ms-Blob-Sequence-Number:
-      - '20'
+      - '30'
       X-Ms-Copy-Id:
       - 30cedd78-548a-4fd8-967e-f8344f587e3c
       X-Ms-Copy-Source:
@@ -2524,69 +2566,11 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Fri, 22 Sep 2017 21:41:41 GMT
+      - Tue, 23 Jan 2018 20:06:46 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         U5MJAA==
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:41:41 GMT
-- request:
-    method: post
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/EndGetAccess?api-version=2017-03-30
-    body:
-      encoding: ASCII-8BIT
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYxOTMsIm5iZiI6MTUwNjExNjE5MywiZXhwIjoxNTA2MTIwMDkzLCJhaW8iOiJZMlZnWU1oNXVyeWg5YVIrN0RhZVhhdlB2UlozQlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZXBRb0ZreWlNRUcwWlZTS0xYOE5BQSIsInZlciI6IjEuMCJ9.bSUowVQrbB6dhplwG1xITFYrbHN6C5axjxx-z6X6Eus2sxnPfNsQ46XCPdRAbsvdsO1fj-0Z0ZFxESrapH19O0IVF5aY270l5oNKqV_gDsaWMSJ6sz0SxPPhxQYBoQ0PF5PSlGKwTfkyMWIYrJ2PN6ZQIw3aq8MXKGcSqRZNDjq7wCtZG0Z8EHULyK3k5KQZevf_DbhvKzqHsFFbW_cK_c7DgYyOZDq82-Ljhy-Cva8sB2iXrVxYgft9k_WJ0X2siT21MBfE8_kvVrwbjTJ6IFPYCU1faOyqkSTRo3vB686d46mOmPKMhM-NEshNUummfI-DEZ3N27ZXlLU_lv4zFQ
-      Content-Length:
-      - '0'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '0'
-      Expires:
-      - "-1"
-      Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/05490e04-8794-4ba7-9e76-9ed2f661bc2b?monitor=true&api-version=2017-03-30
-      Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/05490e04-8794-4ba7-9e76-9ed2f661bc2b?api-version=2017-03-30
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - 05490e04-8794-4ba7-9e76-9ed2f661bc2b
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1183'
-      X-Ms-Correlation-Request-Id:
-      - 519d6ef4-912b-46eb-83b0-16a57c42a2b8
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214143Z:519d6ef4-912b-46eb-83b0-16a57c42a2b8
-      Date:
-      - Fri, 22 Sep 2017 21:41:42 GMT
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:41:42 GMT
+  recorded_at: Tue, 23 Jan 2018 20:06:47 GMT
 recorded_with: VCR 3.0.3

--- a/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_getPartitions-1.yml
+++ b/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_getPartitions-1.yml
@@ -17,6 +17,8 @@ http_interactions:
       - '186'
       Content-Type:
       - application/x-www-form-urlencoded
+      Host:
+      - login.microsoftonline.com
   response:
     status:
       code: 200
@@ -37,25 +39,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - fbe1b25e-78df-4a2f-ac74-5cbec9be0c00
+      - 9830fab3-30d8-4d62-895d-20a62cf30000
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAAABlDrqfEFlSaui6xnRjX5E-gLcU8v_PiOOjdXcKp7DKg_6MSjal_rtCLGr17DFpkFBIVuJayBdXGkIl2jcG8PJpNUuG6K7y7bG_8XWbJrKn2YJXI56dtmHWvMTX0ExK_pWR6Gnm7sFweHazc6-ztHXh8p2ujP68DxJkJFpz5r6IEFR1Av-vEQgdX2yX3lIgPsgAA;
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzcC1fkYV0PSMlGIzutHRFTT67tPAHBzxRMaBetTeKe-4XIXqJ-UfLsb2C95qeNzXy52jkVtq0EPdd8gus6M209o8jNyKPAE-6dC3jlj_BCVS2w7j6Vuo85URugSrbJLE9DLI85wjuLpMq3Bj2jdqGeNDimo3q4l2JhNZb_FO3Eq0gAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=008; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=006; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Fri, 22 Sep 2017 21:42:49 GMT
+      - Tue, 23 Jan 2018 20:07:34 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1506120170","not_before":"1506116270","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNzAsIm5iZiI6MTUwNjExNjI3MCwiZXhwIjoxNTA2MTIwMTcwLCJhaW8iOiJZMlZnWUpEd25SaVpIekpYMS8ycHBhK3M5KzlPQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWHJMaC05OTRMMHFzZEZ5LXliNE1BQSIsInZlciI6IjEuMCJ9.RYqwva04HYBBTt1elTlp5jG6GmjsEcWxLG6GSuCn5W2jLTQ0hZjO8rhC7fzGkbReFh2orTx368wcKypoKDLl1SzkCpJkbNDTa_L1MQDUo9Mam6Nm5b7pEs4QGl7O1zqK2JYZwyBWD6kcWdT3yXosVIWwv3vMUor9JgwR1X0chCObJAed--plBG0QFsXkztVWEjO0gw42iqLedAGz9Juzt3aZdQOiuQNTO_4Mog-_piCb3b5A-NZkfsaqr1RUNj00nPkoNpZGorw5euIeW7ikqWyjaR_CCefaP97a46djlIha9y3JAjpFkp1GdjJt06Udr8J6soVuZKzK6RTYsIEFYg"}'
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1516741655","not_before":"1516737755","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3NTUsIm5iZiI6MTUxNjczNzc1NSwiZXhwIjoxNTE2NzQxNjU1LCJhaW8iOiJZMk5nWUxBNWNUbkgxTXo2aG1oRW9GWFlaaXN0QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoic19vd21OZ3dZazJKWFNDbUxQTUFBQSIsInZlciI6IjEuMCJ9.bw-NT9ZKcpZp73UVZaDPnh9LV6JQdNB52kdIK3dCObOHBLsec2Ev1V1FOpPscEqoYyqhURK5zFk3krmZXeqDt55VT4D3ofIO1nKBqIvGUBrGY1DCaiO1N-gyPqnsgmvP2MjI2TDEN6meDIOPgnsjtYvhs7NbbOXefGw5hlKN47RGAvEJgbvFALhDktUFEUnnp7zdHVS7_sjPrbGFCgkeIj7U4oXPqxxfZh7Q4skpWji2AyYaWlpR5P2KjxOorTIADGvkGhhrmDr6IhvJPY2AuNc_E6MsUduO7N5deFb8ycVdJTafX034d_UNxFdheX0xaxWtii2G31dIz5u2VksOSA"}'
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:49 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:35 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -72,7 +74,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNzAsIm5iZiI6MTUwNjExNjI3MCwiZXhwIjoxNTA2MTIwMTcwLCJhaW8iOiJZMlZnWUpEd25SaVpIekpYMS8ycHBhK3M5KzlPQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWHJMaC05OTRMMHFzZEZ5LXliNE1BQSIsInZlciI6IjEuMCJ9.RYqwva04HYBBTt1elTlp5jG6GmjsEcWxLG6GSuCn5W2jLTQ0hZjO8rhC7fzGkbReFh2orTx368wcKypoKDLl1SzkCpJkbNDTa_L1MQDUo9Mam6Nm5b7pEs4QGl7O1zqK2JYZwyBWD6kcWdT3yXosVIWwv3vMUor9JgwR1X0chCObJAed--plBG0QFsXkztVWEjO0gw42iqLedAGz9Juzt3aZdQOiuQNTO_4Mog-_piCb3b5A-NZkfsaqr1RUNj00nPkoNpZGorw5euIeW7ikqWyjaR_CCefaP97a46djlIha9y3JAjpFkp1GdjJt06Udr8J6soVuZKzK6RTYsIEFYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3NTUsIm5iZiI6MTUxNjczNzc1NSwiZXhwIjoxNTE2NzQxNjU1LCJhaW8iOiJZMk5nWUxBNWNUbkgxTXo2aG1oRW9GWFlaaXN0QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoic19vd21OZ3dZazJKWFNDbUxQTUFBQSIsInZlciI6IjEuMCJ9.bw-NT9ZKcpZp73UVZaDPnh9LV6JQdNB52kdIK3dCObOHBLsec2Ev1V1FOpPscEqoYyqhURK5zFk3krmZXeqDt55VT4D3ofIO1nKBqIvGUBrGY1DCaiO1N-gyPqnsgmvP2MjI2TDEN6meDIOPgnsjtYvhs7NbbOXefGw5hlKN47RGAvEJgbvFALhDktUFEUnnp7zdHVS7_sjPrbGFCgkeIj7U4oXPqxxfZh7Q4skpWji2AyYaWlpR5P2KjxOorTIADGvkGhhrmDr6IhvJPY2AuNc_E6MsUduO7N5deFb8ycVdJTafX034d_UNxFdheX0xaxWtii2G31dIz5u2VksOSA
+      Host:
+      - management.azure.com
   response:
     status:
       code: 200
@@ -93,21 +97,22 @@ http_interactions:
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
       - '14999'
       X-Ms-Request-Id:
-      - 81d5198d-653a-4ff1-a942-0267e79f0bfd
+      - 432dc8bb-c83c-4287-bd3c-5c4f33e0e06e
       X-Ms-Correlation-Request-Id:
-      - 81d5198d-653a-4ff1-a942-0267e79f0bfd
+      - 432dc8bb-c83c-4287-bd3c-5c4f33e0e06e
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214251Z:81d5198d-653a-4ff1-a942-0267e79f0bfd
+      - WESTUS:20180123T200735Z:432dc8bb-c83c-4287-bd3c-5c4f33e0e06e
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 22 Sep 2017 21:42:51 GMT
+      - Tue, 23 Jan 2018 20:07:35 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
-        Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
+      string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
+        Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
+        Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:50 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:35 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/azure_subscription_id/providers?api-version=2015-01-01
@@ -124,7 +129,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNzAsIm5iZiI6MTUwNjExNjI3MCwiZXhwIjoxNTA2MTIwMTcwLCJhaW8iOiJZMlZnWUpEd25SaVpIekpYMS8ycHBhK3M5KzlPQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWHJMaC05OTRMMHFzZEZ5LXliNE1BQSIsInZlciI6IjEuMCJ9.RYqwva04HYBBTt1elTlp5jG6GmjsEcWxLG6GSuCn5W2jLTQ0hZjO8rhC7fzGkbReFh2orTx368wcKypoKDLl1SzkCpJkbNDTa_L1MQDUo9Mam6Nm5b7pEs4QGl7O1zqK2JYZwyBWD6kcWdT3yXosVIWwv3vMUor9JgwR1X0chCObJAed--plBG0QFsXkztVWEjO0gw42iqLedAGz9Juzt3aZdQOiuQNTO_4Mog-_piCb3b5A-NZkfsaqr1RUNj00nPkoNpZGorw5euIeW7ikqWyjaR_CCefaP97a46djlIha9y3JAjpFkp1GdjJt06Udr8J6soVuZKzK6RTYsIEFYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3NTUsIm5iZiI6MTUxNjczNzc1NSwiZXhwIjoxNTE2NzQxNjU1LCJhaW8iOiJZMk5nWUxBNWNUbkgxTXo2aG1oRW9GWFlaaXN0QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoic19vd21OZ3dZazJKWFNDbUxQTUFBQSIsInZlciI6IjEuMCJ9.bw-NT9ZKcpZp73UVZaDPnh9LV6JQdNB52kdIK3dCObOHBLsec2Ev1V1FOpPscEqoYyqhURK5zFk3krmZXeqDt55VT4D3ofIO1nKBqIvGUBrGY1DCaiO1N-gyPqnsgmvP2MjI2TDEN6meDIOPgnsjtYvhs7NbbOXefGw5hlKN47RGAvEJgbvFALhDktUFEUnnp7zdHVS7_sjPrbGFCgkeIj7U4oXPqxxfZh7Q4skpWji2AyYaWlpR5P2KjxOorTIADGvkGhhrmDr6IhvJPY2AuNc_E6MsUduO7N5deFb8ycVdJTafX034d_UNxFdheX0xaxWtii2G31dIz5u2VksOSA
+      Host:
+      - management.azure.com
   response:
     status:
       code: 200
@@ -141,19 +148,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14922'
+      - '14859'
       X-Ms-Request-Id:
-      - 0a28d784-136f-4189-9522-ac265e355d3c
+      - ced57c40-d879-4700-95e8-e66f76d36634
       X-Ms-Correlation-Request-Id:
-      - 0a28d784-136f-4189-9522-ac265e355d3c
+      - ced57c40-d879-4700-95e8-e66f76d36634
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214252Z:0a28d784-136f-4189-9522-ac265e355d3c
+      - WESTUS:20180123T200735Z:ced57c40-d879-4700-95e8-e66f76d36634
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 22 Sep 2017 21:42:52 GMT
+      - Tue, 23 Jan 2018 20:07:34 GMT
       Content-Length:
-      - '254785'
+      - '293551'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
@@ -176,7 +183,7 @@ http_interactions:
         Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
         Central US","North Central US","Japan East","Japan West","Brazil South","Central
         India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
+        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-04-19","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-04-19","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-04-19","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-04-19","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","North Central
         US","South Central US","West Central US","West US","West US 2","Canada Central","Canada
         East","North Europe","West Europe","UK South","UK West","East Asia","Southeast
@@ -184,20 +191,26 @@ http_interactions:
         India","South India","West India"],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"validateServiceName","locations":[],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"checkServiceNameAvailability","locations":[],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"reportFeedback","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"checkFeedbackRequired","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Automation","namespace":"Microsoft.Automation","authorizations":[{"applicationId":"fc75330b-179d-49af-87dd-3b1acf6827fa","roleDefinitionId":"95fd5de3-d071-4362-92bf-cf341c1de832"}],"resourceTypes":[{"resourceType":"automationAccounts","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
         South","UK South","West Central US","North Europe","Canada Central","Australia
-        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/runbooks","locations":["Japan
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/runbooks","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
         South","UK South","West Central US","North Europe","Canada Central","Australia
-        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/configurations","locations":["Japan
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/configurations","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","North
-        Central US","Brazil South","UK South","West Central US","Central India","Australia
-        Southeast","Canada Central","North Europe"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/webhooks","locations":["Japan
+        Central US","Korea Central","East US","West US 2","Brazil South","UK South","West
+        Central US","Central India","Australia Southeast","Canada Central","North
+        Europe"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/webhooks","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
         South","UK South","West Central US","North Europe","Canada Central","Australia
-        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"operations","locations":["South
-        Central US"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/softwareUpdateConfigurations","locations":["Japan
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"operations","locations":["South
+        Central US"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/softwareUpdateConfigurations","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
         South","UK South","West Central US","North Europe","Canada Central","Australia
-        Southeast","Central India"],"apiVersions":["2017-05-15-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Backup","namespace":"Microsoft.Backup","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"BackupVault","locations":["West
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview"]},{"resourceType":"automationAccounts/jobs","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
+        South","UK South","West Central US","North Europe","Canada Central","Australia
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureActiveDirectory","namespace":"Microsoft.AzureActiveDirectory","resourceTypes":[{"resourceType":"b2cDirectories","locations":["Global","United
+        States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]},{"resourceType":"operations","locations":["Global","United
+        States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]}],"registrationState":"Unregistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Backup","namespace":"Microsoft.Backup","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"BackupVault","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
@@ -206,22 +219,22 @@ http_interactions:
         Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
         West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
         East","South India","Central India","Canada Central","Canada East","UK South","UK
-        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01","2015-07-01","2014-05-01-privatepreview"]},{"resourceType":"operations","locations":["West
+        West","West Central US","West US 2"],"apiVersions":["2017-09-01","2017-05-01","2017-01-01","2015-12-01","2015-09-01","2015-07-01","2014-05-01-privatepreview"]},{"resourceType":"operations","locations":["West
         Europe","East US","East US 2","West US","North Central US","Brazil South","North
         Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
         West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
         East","South India","Central India","Canada Central","Canada East","UK South","UK
-        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations/quotas","locations":["West
+        West","West Central US","West US 2"],"apiVersions":["2017-09-01","2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01","2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations/quotas","locations":["West
         Europe","East US","East US 2","West US","North Central US","Brazil South","North
         Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
         West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
         East","South India","Central India","Canada Central","Canada East","UK South","UK
-        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]}],"registrationState":"Unregistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicCompute","namespace":"Microsoft.ClassicCompute","resourceTypes":[{"resourceType":"domainNames","locations":["East
+        West","West Central US","West US 2"],"apiVersions":["2017-09-01","2017-05-01","2017-01-01","2015-12-01","2015-09-01"]}],"registrationState":"Unregistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicCompute","namespace":"Microsoft.ClassicCompute","resourceTypes":[{"resourceType":"domainNames","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
@@ -256,7 +269,7 @@ http_interactions:
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -296,92 +309,92 @@ http_interactions:
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30"]},{"resourceType":"locations/usages","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations/usages","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
+        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
@@ -411,76 +424,138 @@ http_interactions:
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
+        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
         US","East US","South Central US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
         Central","Central US","East US 2","North Central US","West Central US","West
-        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/webhooks","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/ping","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/getCallbackConfig","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/listEvents","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"locations","locations":["South
-        Central US","East US","West US","Central US","East US 2","North Central US","West
-        Central US","West US 2","Brazil South","Canada East","Canada Central","West
-        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
-        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"locations/operationResults","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/GetCredentials","locations":["West
+        US 2"],"apiVersions":["2017-10-01","2017-03-01"]},{"resourceType":"registries/replications","locations":["South
+        Central US","West Central US","East US","West Europe","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/webhooks","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/webhooks/ping","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/webhooks/getCallbackConfig","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/webhooks/listEvents","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"locations/operationResults","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/GetCredentials","locations":["West
         US","East US","South Central US","West Europe"],"apiVersions":["2016-06-27-preview"]},{"resourceType":"registries/listCredentials","locations":["South
         Central US","East US","West US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
         Central","Central US","East US 2","North Central US","West Central US","West
-        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/regenerateCredential","locations":["South
+        US 2"],"apiVersions":["2017-10-01","2017-03-01"]},{"resourceType":"registries/regenerateCredential","locations":["South
         Central US","West US","East US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
         Central","Central US","East US 2","North Central US","West Central US","West
-        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/listUsages","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/regenerateCredentials","locations":["West
+        US 2"],"apiVersions":["2017-10-01","2017-03-01"]},{"resourceType":"registries/listUsages","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/regenerateCredentials","locations":["West
         US","East US","South Central US","West Europe"],"apiVersions":["2016-06-27-preview"]},{"resourceType":"checkNameAvailability","locations":["South
         Central US","East US","West US","Central US","East US 2","North Central US","West
         Central US","West US 2","Brazil South","Canada East","Canada Central","West
         Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
-        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview","2017-03-01","2016-06-27-preview"]},{"resourceType":"operations","locations":["South
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-10-01","2017-06-01-preview","2017-03-01","2016-06-27-preview"]},{"resourceType":"operations","locations":["South
         Central US","East US","West US","Central US","East US 2","North Central US","West
         Central US","West US 2","Brazil South","Canada East","Canada Central","West
         Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
-        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview","2017-03-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerService","namespace":"Microsoft.ContainerService","authorization":{"applicationId":"7319c514-987d-4e9b-ac3d-d38c4f427f4c","roleDefinitionId":"1b4a0c7f-2217-416f-acfa-cf73452fdc1c"},"resourceTypes":[{"resourceType":"containerServices","locations":["Japan
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-10-01","2017-06-01-preview","2017-03-01"]},{"resourceType":"locations","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-10-01","2017-06-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerService","namespace":"Microsoft.ContainerService","authorization":{"applicationId":"7319c514-987d-4e9b-ac3d-d38c4f427f4c","roleDefinitionId":"1b4a0c7f-2217-416f-acfa-cf73452fdc1c","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"containerServices","locations":["Japan
         East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
         Central US","West US 2","South India","Central India","West India","Canada
-        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
+        East","Canada Central","Korea South","Korea Central"],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"managedClusters","locations":["East
+        US","West Europe","Central US","Canada Central","Canada East"],"apiVersions":["2017-08-31"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
         East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
         Central US","West US 2","South India","Central India","West India","Canada
-        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DevTestLab","namespace":"Microsoft.DevTestLab","authorization":{"applicationId":"1a14be2a-e903-4cec-99cf-b2e209259a0f","roleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525"},"resourceTypes":[{"resourceType":"labs","locations":["West
+        East","Canada Central","Korea South","Korea Central"],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/orchestrators","locations":["UK
+        West","West US 2","East US","West Europe","Central US"],"apiVersions":["2017-09-30"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DevTestLab","namespace":"Microsoft.DevTestLab","authorization":{"applicationId":"1a14be2a-e903-4cec-99cf-b2e209259a0f","roleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525","managedByRoleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525"},"resourceTypes":[{"resourceType":"labs","locations":["West
         Central US","Japan East","West US","Australia Southeast","Canada Central","Central
         India","Central US","East Asia","Korea Central","North Europe","South Central
-        US","UK West","Australia East","Brazil South","Canada East","East US","East
-        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        US","UK West","West India","Australia East","Brazil South","Canada East","East
+        US","East US 2","Japan West","Korea South","North Central US","South India","Southeast
         Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"schedules","locations":["West
         Central US","Japan East","West US","Australia Southeast","Canada Central","Central
         India","Central US","East Asia","Korea Central","North Europe","South Central
-        US","UK West","Australia East","Brazil South","Canada East","East US","East
-        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        US","UK West","West India","Australia East","Brazil South","Canada East","East
+        US","East US 2","Japan West","Korea South","North Central US","South India","Southeast
         Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"labs/virtualMachines","locations":["West
         Central US","Japan East","West US","Australia Southeast","Canada Central","Central
         India","Central US","East Asia","Korea Central","North Europe","South Central
-        US","UK West","Australia East","Brazil South","Canada East","East US","East
-        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        US","UK West","West India","Australia East","Brazil South","Canada East","East
+        US","East US 2","Japan West","Korea South","North Central US","South India","Southeast
         Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"labs/serviceRunners","locations":["Central
         US","East US 2","South Central US"],"apiVersions":["2017-04-26-preview","2016-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"locations/operations","locations":["West
         Central US","Japan East","West US","Australia Southeast","Canada Central","Central
         India","Central US","East Asia","Korea Central","North Europe","South Central
-        US","UK West","Australia East","Brazil South","Canada East","East US","East
-        US 2","Japan West","Korea South","North Central US","South India","Southeast
-        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"}],"resourceTypes":[{"resourceType":"components","locations":["East
-        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
-        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01","2014-04-01"]},{"resourceType":"queries","locations":["East
-        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
+        US","UK West","West India","Australia East","Brazil South","Canada East","East
+        US","East US 2","Japan West","Korea South","North Central US","South India","Southeast
+        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","authorizations":[{"applicationId":"57c0fc58-a83a-41d0-8ae9-08952659bdfd","roleDefinitionId":"FFFD5CF5-FFD3-4B24-B0E2-0715ADD4C282"}],"resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"databaseAccountNames","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"operationResults","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"},{"applicationId":"f5c26e74-f226-4ae8-85f0-b4af0080ac9e","roleDefinitionId":"529d7ae6-e892-4d43-809d-8547aeb90643"}],"resourceTypes":[{"resourceType":"components","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2015-05-01","2014-08-01","2014-04-01"]},{"resourceType":"queries","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"components/pricingPlans","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"migrateToNewPricingModel","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"rollbackToLegacyPricingModel","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"listMigrationdate","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
@@ -516,7 +591,7 @@ http_interactions:
         West","North Central US","South Central US","East US 2","Canada East","Canada
         Central","Central US","Australia East","Australia Southeast","Brazil South","South
         India","Central India","West India","North Europe","West US 2","West Central
-        US","Korea South","Korea Central","UK South","UK West","Global"],"apiVersions":["2017-05-01-preview","2016-03-01","2015-07-01"]},{"resourceType":"logDefinitions","locations":["West
+        US","Korea South","Korea Central","UK South","UK West","Global"],"apiVersions":["2017-09-01-preview","2017-05-01-preview","2016-03-01","2015-07-01"]},{"resourceType":"logDefinitions","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
@@ -526,7 +601,7 @@ http_interactions:
         West","North Central US","South Central US","East US 2","Canada East","Canada
         Central","Central US","Australia East","Australia Southeast","Brazil South","South
         India","Central India","West India","North Europe","West US 2","West Central
-        US","Korea South","Korea Central","UK South","UK West"],"apiVersions":["2017-05-01-preview","2016-09-01","2016-06-01"]},{"resourceType":"actiongroups","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]},{"resourceType":"activityLogAlerts","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.KeyVault","namespace":"Microsoft.KeyVault","resourceTypes":[{"resourceType":"vaults","locations":["North
+        US","Korea South","Korea Central","UK South","UK West"],"apiVersions":["2017-09-01-preview","2017-05-01-preview","2016-09-01","2016-06-01"]},{"resourceType":"actiongroups","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]},{"resourceType":"activityLogAlerts","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.KeyVault","namespace":"Microsoft.KeyVault","resourceTypes":[{"resourceType":"vaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
@@ -556,126 +631,153 @@ http_interactions:
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorizations":[{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},{"applicationId":"7c33bfcb-8d33-48d6-8e60-dc6404003489","roleDefinitionId":"ad6261e4-fa9a-4642-aa5f-104f1b67e9e3"},{"applicationId":"1e3e4475-288f-4018-a376-df66fd7fac5f","roleDefinitionId":"1d538b69-3d87-4e56-8ff8-25786fd48261"},{"applicationId":"a0be0c72-870e-46f0-9c49-c98333a996f7","roleDefinitionId":"7ce22727-ffce-45a9-930c-ddb2e56fa131"}],"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","West Central US"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"operations","locations":["South
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations","locations":["South
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operations","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"commitmentPlans","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"Registering"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorizations":[{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},{"applicationId":"7c33bfcb-8d33-48d6-8e60-dc6404003489","roleDefinitionId":"ad6261e4-fa9a-4642-aa5f-104f1b67e9e3"},{"applicationId":"1e3e4475-288f-4018-a376-df66fd7fac5f","roleDefinitionId":"1d538b69-3d87-4e56-8ff8-25786fd48261"},{"applicationId":"a0be0c72-870e-46f0-9c49-c98333a996f7","roleDefinitionId":"7ce22727-ffce-45a9-930c-ddb2e56fa131"}],"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
-        Central US"],"apiVersions":["2017-09-01"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
-        East","UK South","Central India","Canada Central"],"apiVersions":["2017-04-26-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"]},{"resourceType":"workspaces/dataSources","locations":["East
+        East","UK South","Central India","Canada Central"],"apiVersions":["2017-04-26-preview","2017-03-15-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"]},{"resourceType":"workspaces/query","locations":["West
+        Central US","Australia Southeast","West Europe","East US","Southeast Asia","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2017-10-01"]},{"resourceType":"workspaces/dataSources","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
         East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"storageInsightConfigs","locations":[],"apiVersions":["2014-10-10"]},{"resourceType":"workspaces/linkedServices","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
         East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"linkTargets","locations":["East
         US"],"apiVersions":["2015-03-20"]},{"resourceType":"operations","locations":[],"apiVersions":["2014-11-10"]},{"resourceType":"devices","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationsManagement","namespace":"Microsoft.OperationsManagement","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"aa249101-6816-4966-aafa-08175d795f14"},"resourceTypes":[{"resourceType":"solutions","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
-        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Portal","namespace":"Microsoft.Portal","resourceTypes":[{"resourceType":"dashboards","locations":["Central
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"managementconfigurations","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"managementassociations","locations":[],"apiVersions":["2015-11-01-preview"]},{"resourceType":"views","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2017-08-21-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Portal","namespace":"Microsoft.Portal","resourceTypes":[{"resourceType":"dashboards","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
@@ -687,9 +789,9 @@ http_interactions:
         East","West India","South India","Central India","Canada Central","Canada
         East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"consoles","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/consoles","locations":["West
         US","East US","Central India","North Europe","West Europe","South Central
-        US","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
+        US","Southeast Asia","East US 2","Central US"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
         US","East US","Central India","North Europe","West Europe","South Central
-        US","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
+        US","Southeast Asia","East US 2","Central US"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
@@ -710,7 +812,17 @@ http_interactions:
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ResourceHealth","namespace":"Microsoft.ResourceHealth","authorization":{"applicationId":"8bdebf23-c0fe-4187-a378-717ad86f6a53","roleDefinitionId":"cc026344-c8b1-4561-83ba-59eba84b27cc"},"resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2017-07-01","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"notifications","locations":["Australia
+        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]},{"resourceType":"locations/backupValidateFeatures","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-07-01"]},{"resourceType":"locations/backupPreValidateProtection","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-07-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ResourceHealth","namespace":"Microsoft.ResourceHealth","authorization":{"applicationId":"8bdebf23-c0fe-4187-a378-717ad86f6a53","roleDefinitionId":"cc026344-c8b1-4561-83ba-59eba84b27cc"},"resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2017-07-01","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"notifications","locations":["Australia
         Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Security","namespace":"Microsoft.Security","authorization":{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatuses","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/virtualMachines","locations":["Central
@@ -743,10 +855,14 @@ http_interactions:
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securitySolutionsReferenceData","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/securitySolutionsReferenceData","locations":["Central
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"jitNetworkAccessPolicies","locations":["Central
-        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/jitNetworkAccessPolicies","locations":["Central
-        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations","locations":["Central
+        US","East US","North Europe","West Europe","UK South","UK West","West Central
+        US","West US 2"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/jitNetworkAccessPolicies","locations":["Central
+        US","East US","North Europe","West Europe","UK South","UK West","West Central
+        US","West US 2"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatusesSummaries","locations":["Central
-        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/alerts","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"applicationWhitelistings","locations":["Central
+        US","East US","West Central US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/applicationWhitelistings","locations":["Central
+        US","West Central US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/alerts","locations":["Central
         US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/tasks","locations":["Central
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"externalSecuritySolutions","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/externalSecuritySolutions","locations":["Central
@@ -769,7 +885,17 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/databaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/databaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -814,7 +940,7 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01","2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -829,7 +955,7 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -859,12 +985,17 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/geoBackupPolicies","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -879,12 +1010,12 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/firewallrules","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/backupLongTermRetentionPolicies","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -999,6 +1130,16 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
         US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
@@ -1034,7 +1175,22 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -1144,7 +1300,47 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -1159,7 +1355,17 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/administratorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -1179,52 +1385,52 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorization":{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorizations":[{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},{"applicationId":"e406a681-f3d4-42a8-90b6-c2b029497af1"}],"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
         US","West US","West Europe","North Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","South India","Central
@@ -1234,7 +1440,19 @@ http_interactions:
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Web","namespace":"Microsoft.Web","authorization":{"applicationId":"abfa0a7c-a6b6-4736-8310-5855508787cd","roleDefinitionId":"f47ed98b-b063-4a5b-9e10-4b9b44fa7735"},"resourceTypes":[{"resourceType":"sites/extensions","locations":["South
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/project","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/extension","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"checkNameAvailability","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Web","namespace":"Microsoft.Web","authorization":{"applicationId":"abfa0a7c-a6b6-4736-8310-5855508787cd","roleDefinitionId":"f47ed98b-b063-4a5b-9e10-4b9b44fa7735"},"resourceTypes":[{"resourceType":"sites/extensions","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
         South","West US","East US","Japan West","Japan East","East Asia","East US
         2","North Central US","Central US","Brazil South","Australia East","Australia
@@ -1339,7 +1557,7 @@ http_interactions:
         South","West US","East US","Japan West","Japan East","East Asia","East US
         2","North Central US","Central US","Brazil South","Australia East","Australia
         Southeast","West India","Central India","South India","Canada Central","Canada
-        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms/workers","locations":["South
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms/workers","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
         South","West US","East US","Japan West","Japan East","East Asia","East US
         2","North Central US","Central US","Brazil South","Australia East","Australia
@@ -1394,7 +1612,17 @@ http_interactions:
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","West US 2","West Central US","Canada Central","Canada
-        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/managedApis","locations":["North
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/listWsdlInterfaces","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/extractApiDefinitionFromWsdl","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/managedApis","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
@@ -1445,8 +1673,11 @@ http_interactions:
         US","North Europe","Japan West","Japan East","East Asia","West Europe","East
         US","Southeast Asia","Central US"],"apiVersions":["2016-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Lombiq.DotNest","namespace":"Lombiq.DotNest","resourceTypes":[{"resourceType":"sites","locations":["East
         US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Mailjet.Email","namespace":"Mailjet.Email","resourceTypes":[{"resourceType":"services","locations":["West
-        US"],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
-        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
+        US","West Europe"],"apiVersions":["2017-10-01","2017-02-03"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-10-01","2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-10-01","2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]},{"resourceType":"diagnosticSettings","locations":[],"apiVersions":["2017-04-01"]},{"resourceType":"diagnosticSettingsCategories","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Addons","namespace":"Microsoft.Addons","authorization":{"applicationId":"24d3987b-be4a-48e0-a3e7-11c186f39e41","roleDefinitionId":"8004BAAB-A4CB-4981-8571-F7E44D039D93"},"resourceTypes":[{"resourceType":"supportProviders","locations":["West
+        Central US","South Central US","East US","West Europe"],"apiVersions":["2017-05-15"]},{"resourceType":"operations","locations":["West
+        Central US","South Central US","East US","West Europe"],"apiVersions":["2017-05-15"]},{"resourceType":"operationResults","locations":["West
+        Central US","South Central US","East US","West Europe"],"apiVersions":["2017-05-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"addsservices","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"configuration","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"operations","locations":["West
@@ -1456,51 +1687,45 @@ http_interactions:
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"servicehealthmetrics","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"logs","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"anonymousapiusers","locations":["West
-        US"],"apiVersions":["2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AnalysisServices","namespace":"Microsoft.AnalysisServices","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"servers","locations":["West
+        US"],"apiVersions":["2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AlertsManagement","namespace":"Microsoft.AlertsManagement","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-11-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AnalysisServices","namespace":"Microsoft.AnalysisServices","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"servers","locations":["West
         US","North Europe","South Central US","West Europe","West Central US","Southeast
         Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
-        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/checkNameAvailability","locations":["West
+        Southeast","Japan East","UK South","West India","West US 2","East US"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"locations/checkNameAvailability","locations":["West
         US","North Europe","South Central US","West Europe","West Central US","Southeast
         Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
-        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationresults","locations":["West
+        Southeast","Japan East","UK South","West India","West US 2","East US"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationresults","locations":["West
         US","North Europe","South Central US","West Europe","West Central US","Southeast
         Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
-        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationstatuses","locations":["West
+        Southeast","Japan East","UK South","West India","West US 2","East US"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationstatuses","locations":["West
         US","North Europe","South Central US","West Europe","West Central US","Southeast
         Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
-        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"operations","locations":["East
-        US 2","West Central US"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AppService","namespace":"Microsoft.AppService","authorization":{"applicationId":"dee7ba80-6a55-4f3b-a86c-746a9231ae49","roleDefinitionId":"6715d172-49c4-46f6-bb21-60512a8689dc"},"resourceTypes":[{"resourceType":"apiapps","locations":["East
-        US","West US","South Central US","North Europe","East Asia","Japan East","West
-        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
-        South","East US 2","Australia Southeast","Australia East","West India","South
-        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"appIdentities","locations":["East
-        US","West US","South Central US","North Europe","East Asia","Japan East","West
-        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
-        South","East US 2","Australia Southeast","Australia East","West India","South
-        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"gateways","locations":["East
-        US","West US","South Central US","North Europe","East Asia","Japan East","West
-        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
-        South","East US 2","Australia Southeast","Australia East","West India","South
-        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"deploymenttemplates","locations":[],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Authorization","namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"roleDefinitions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"classicAdministrators","locations":[],"apiVersions":["2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"permissions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"locks","locations":[],"apiVersions":["2017-04-01","2016-09-01","2015-06-01","2015-05-01-preview","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-01-01","2014-10-01-preview","2014-06-01"]},{"resourceType":"policyDefinitions","locations":[],"apiVersions":["2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"policySetDefinitions","locations":[],"apiVersions":["2017-06-01-preview"]},{"resourceType":"policyAssignments","locations":[],"apiVersions":["2017-06-01-preview","2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"providerOperations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01-preview","2015-07-01"]},{"resourceType":"elevateAccess","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureActiveDirectory","namespace":"Microsoft.AzureActiveDirectory","resourceTypes":[{"resourceType":"b2cDirectories","locations":["Global","United
-        States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureStack","namespace":"Microsoft.AzureStack","resourceTypes":[{"resourceType":"operations","locations":["Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations","locations":["West
+        Southeast","Japan East","UK South","West India","West US 2","East US"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"operations","locations":["East
+        US 2","West Central US","West US 2"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Authorization","namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[],"apiVersions":["2017-10-01-preview","2017-09-01","2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"roleDefinitions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"classicAdministrators","locations":[],"apiVersions":["2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"permissions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"locks","locations":[],"apiVersions":["2017-04-01","2016-09-01","2015-06-01","2015-05-01-preview","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-01-01","2014-10-01-preview","2014-06-01"]},{"resourceType":"policyDefinitions","locations":[],"apiVersions":["2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"policySetDefinitions","locations":[],"apiVersions":["2017-06-01-preview"]},{"resourceType":"policyAssignments","locations":[],"apiVersions":["2017-06-01-preview","2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"providerOperations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01-preview","2015-07-01"]},{"resourceType":"elevateAccess","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"checkAccess","locations":[],"apiVersions":["2017-10-01-preview","2017-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureStack","namespace":"Microsoft.AzureStack","resourceTypes":[{"resourceType":"operations","locations":["Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations","locations":["West
         Central US","Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations/products","locations":["West
-        Central US","Global"],"apiVersions":["2017-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Billing","namespace":"Microsoft.Billing","resourceTypes":[{"resourceType":"BillingPeriods","locations":["Central
+        Central US","Global"],"apiVersions":["2017-06-01","2016-01-01"]},{"resourceType":"registrations/customerSubscriptions","locations":["West
+        Central US","Global"],"apiVersions":["2017-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BatchAI","namespace":"Microsoft.BatchAI","authorization":{"applicationId":"9fcb3732-5f52-4135-8c08-9d4bbaf203ea","roleDefinitionId":"703B89C7-CE2C-431B-BDD8-FA34E39AF696","managedByRoleDefinitionId":"90B8E153-EBFF-4073-A95F-4DAD56B14C78"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"jobs","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"fileservers","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"operations","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01-preview"]},{"resourceType":"locations/operationresults","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Billing","namespace":"Microsoft.Billing","resourceTypes":[{"resourceType":"BillingPeriods","locations":["Central
         US"],"apiVersions":["2017-04-24-preview"]},{"resourceType":"Invoices","locations":["Central
         US"],"apiVersions":["2017-04-24-preview","2017-02-27-preview"]},{"resourceType":"operations","locations":["Central
         US"],"apiVersions":["2017-04-24-preview","2017-02-27-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BingMaps","namespace":"Microsoft.BingMaps","resourceTypes":[{"resourceType":"mapApis","locations":["West
         US"],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-18","2015-07-02"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BizTalkServices","namespace":"Microsoft.BizTalkServices","resourceTypes":[{"resourceType":"BizTalk","locations":["East
         US","West US","North Europe","West Europe","Southeast Asia","East Asia","North
-        Central US","Japan West","Japan East","South Central US"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Cache","namespace":"Microsoft.Cache","authorization":{"applicationId":"96231a05-34ce-4eb4-aa6a-70759cbb5e83","roleDefinitionId":"4f731528-ba85-45c7-acfb-cd0a9b3cf31b"},"resourceTypes":[{"resourceType":"Redis","locations":["North
+        Central US","Japan West","Japan East","South Central US"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BotService","namespace":"Microsoft.BotService","resourceTypes":[{"resourceType":"botServices","locations":["Global"],"apiVersions":["2017-12-01"]},{"resourceType":"checkNameAvailability","locations":["Global"],"apiVersions":["2017-12-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Cache","namespace":"Microsoft.Cache","authorization":{"applicationId":"96231a05-34ce-4eb4-aa6a-70759cbb5e83","roleDefinitionId":"4f731528-ba85-45c7-acfb-cd0a9b3cf31b"},"resourceTypes":[{"resourceType":"Redis","locations":["North
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","Canada Central","Canada East","UK South","UK West","West US 2","West
-        Central US","South India","Korea Central","Korea South"],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","South India","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","South India","Canada Central","Canada East","UK South","UK West","West
-        US 2","West Central US","Korea Central","Korea South"],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01"]},{"resourceType":"Redis/metricDefinitions","locations":["North
+        US 2","West Central US","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01"]},{"resourceType":"Redis/metricDefinitions","locations":["North
         Central US","South Central US","East US","East US 2","West US","Central US","East
         Asia","Southeast Asia","North Europe","West Europe","Japan East","Japan West","Brazil
         South","Australia Southeast","Australia East","Central India","West India","South
@@ -1514,59 +1739,59 @@ http_interactions:
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/origins","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/origins","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/customdomains","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/customdomains","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/originresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/originresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/customdomainresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/customdomainresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkResourceUsage","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkResourceUsage","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02"]},{"resourceType":"validateProbe","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02"]},{"resourceType":"validateProbe","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02"]},{"resourceType":"operations","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02"]},{"resourceType":"operations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"edgenodes","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"edgenodes","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CertificateRegistration","namespace":"Microsoft.CertificateRegistration","authorization":{"applicationId":"f3c21649-0979-4721-ac85-b0216b2cf413","roleDefinitionId":"933fba7e-2ed3-4da8-973d-8bd8298a9b40"},"resourceTypes":[{"resourceType":"certificateOrders","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"certificateOrders/certificates","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"validateCertificateRegistrationInformation","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicSubscription","namespace":"Microsoft.ClassicSubscription","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicInfrastructureMigrate","namespace":"Microsoft.ClassicInfrastructureMigrate","authorization":{"applicationId":"5e5abe2b-83cd-4786-826a-a05653ebb103","roleDefinitionId":"766c4d9b-ef83-4f73-8352-1450a506a69b"},"resourceTypes":[{"resourceType":"classicInfrastructureResources","locations":["East
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CertificateRegistration","namespace":"Microsoft.CertificateRegistration","authorization":{"applicationId":"f3c21649-0979-4721-ac85-b0216b2cf413","roleDefinitionId":"933fba7e-2ed3-4da8-973d-8bd8298a9b40"},"resourceTypes":[{"resourceType":"certificateOrders","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"certificateOrders/certificates","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"validateCertificateRegistrationInformation","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicSubscription","namespace":"Microsoft.ClassicSubscription","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-09-01","2017-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicInfrastructureMigrate","namespace":"Microsoft.ClassicInfrastructureMigrate","authorization":{"applicationId":"5e5abe2b-83cd-4786-826a-a05653ebb103","roleDefinitionId":"766c4d9b-ef83-4f73-8352-1450a506a69b"},"resourceTypes":[{"resourceType":"classicInfrastructureResources","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
         Central US","Central US","North Europe","West Europe","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","West
@@ -1584,8 +1809,9 @@ http_interactions:
         Asia","East Asia","West Central US","South Central US","East US","East US
         2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/updateAccountsCreationSettings","locations":["West
         US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/accountsCreationSettings","locations":["West
-        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2016-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Commerce","namespace":"Microsoft.Commerce","resourceTypes":[{"resourceType":"UsageAggregates","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]},{"resourceType":"RateCard","locations":[],"apiVersions":["2016-08-31-preview","2015-06-01-preview","2015-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Consumption","namespace":"Microsoft.Consumption","resourceTypes":[{"resourceType":"reservationsummaries","locations":[],"apiVersions":["2017-01-30"]},{"resourceType":"reservationdetails","locations":[],"apiVersions":["2017-01-30"]},{"resourceType":"UsageDetails","locations":[],"apiVersions":["2017-06-30-preview","2017-04-24-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-30-preview","2017-04-24-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","resourceTypes":[{"resourceType":"containerGroups","locations":["West
-        US","East US","West Europe"],"apiVersions":["2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
+        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2016-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Commerce","namespace":"Microsoft.Commerce","resourceTypes":[{"resourceType":"UsageAggregates","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]},{"resourceType":"RateCard","locations":[],"apiVersions":["2016-08-31-preview","2015-06-01-preview","2015-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Consumption","namespace":"Microsoft.Consumption","resourceTypes":[{"resourceType":"ReservationSummaries","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationTransactions","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"Balances","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"Pricesheets","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationDetails","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"Budgets","locations":[],"apiVersions":["2017-12-30-preview"]},{"resourceType":"Terms","locations":[],"apiVersions":["2017-12-30-preview"]},{"resourceType":"UsageDetails","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview","2017-04-24-preview"]},{"resourceType":"Operations","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview","2017-04-24-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","resourceTypes":[{"resourceType":"containerGroups","locations":["West
+        US","East US","West Europe","Southeast Asia"],"apiVersions":["2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US","East US","West Europe","Southeast Asia"],"apiVersions":["2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
         US"],"apiVersions":["2016-04-08"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CustomerInsights","namespace":"Microsoft.CustomerInsights","authorization":{"applicationId":"38c77d00-5fcb-4cce-9d93-af4738258e3c","roleDefinitionId":"E006F9C7-F333-477C-8AD6-1F3A9FE87F55"},"resourceTypes":[{"resourceType":"hubs","locations":["East
         US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/profiles","locations":["East
         US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/interactions","locations":["East
@@ -1608,8 +1834,8 @@ http_interactions:
         US","West US","Australia East","West Europe","North Europe","Southeast Asia","West
         Central US"],"apiVersions":["2016-03-30","2015-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataFactory","namespace":"Microsoft.DataFactory","resourceTypes":[{"resourceType":"dataFactories","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview","2014-04-01"]},{"resourceType":"factories","locations":["East
-        US","East US 2"],"apiVersions":["2017-09-01-preview","2017-03-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
-        US","East US 2"],"apiVersions":["2017-09-01-preview","2017-03-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
+        US","East US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
+        US","East US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
         Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"dataFactories/metricDefinitions","locations":["North
         Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"checkDataFactoryNameAvailability","locations":[],"apiVersions":["2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"checkAzureDataFactoryNameAvailability","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"dataFactorySchema","locations":["West
@@ -1621,69 +1847,71 @@ http_interactions:
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers/listSasTokens","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeStore","namespace":"Microsoft.DataLakeStore","authorization":{"applicationId":"e9f49c6b-5ce5-44c8-925d-015017e9f7ad","roleDefinitionId":"17eb9cca-f08a-4499-b2d3-852d175f614f"},"resourceTypes":[{"resourceType":"accounts","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/firewallRules","locations":["East
-        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","resourceTypes":[{"resourceType":"operations","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforPostgreSQL","namespace":"Microsoft.DBforPostgreSQL","resourceTypes":[{"resourceType":"operations","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"checkProvisioningServiceNameAvailability","locations":[],"apiVersions":["2017-08-21-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataMigration","namespace":"Microsoft.DataMigration","authorization":{"applicationId":"a4bad4aa-bf02-4631-9f78-a64ffdba8150","roleDefinitionId":"b831a21d-db98-4760-89cb-bef871952df1","managedByRoleDefinitionId":"6256fb55-9e59-4018-a9e1-76b11c0a4c89"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services/projects","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationStatuses","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforPostgreSQL","namespace":"Microsoft.DBforPostgreSQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"checkProvisioningServiceNameAvailability","locations":[],"apiVersions":["2017-11-15","2017-08-21-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
         US","North Europe","East Asia","East US","West Europe","Southeast Asia","Japan
         East","Japan West","Australia East","Australia Southeast","West US 2","West
         Central US","East US 2","Central US","UK South","UK West","South India","Central
-        India","Canada Central","Canada East"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"ProvisioningServices","locations":["East
-        US","West Europe","Southeast Asia"],"apiVersions":["2017-08-21-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
-        East","Australia Southeast","Canada Central","Canada East","Central India","Central
-        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
-        US","North Europe","South Central US","South India","Southeast Asia","West
-        Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"databaseAccountNames","locations":["Australia
-        East","Australia Southeast","Canada Central","Canada East","Central India","Central
-        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
-        US","North Europe","South Central US","South India","Southeast Asia","West
-        Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"operations","locations":["Australia
-        East","Australia Southeast","Canada Central","Canada East","Central India","Central
-        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
-        US","North Europe","South Central US","South India","Southeast Asia","West
-        Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DomainRegistration","namespace":"Microsoft.DomainRegistration","authorization":{"applicationId":"ea2f600a-4980-45b7-89bf-d34da487bda1","roleDefinitionId":"54d7f2e3-5040-48a7-ae90-eebf629cfa0b"},"resourceTypes":[{"resourceType":"domains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"domains/domainOwnershipIdentifiers","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"topLevelDomains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"checkDomainAvailability","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"listDomainRecommendations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"validateDomainRegistrationInformation","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"generateSsoRequest","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DynamicsLcs","namespace":"Microsoft.DynamicsLcs","resourceTypes":[{"resourceType":"lcsprojects","locations":["Brazil
+        India","Canada Central","Canada East","Brazil South","South Central US"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs/eventGridFilters","locations":["West
+        US","East US","West US 2","West Central US","East US 2","Central US"],"apiVersions":["2018-01-15-preview"]},{"resourceType":"ProvisioningServices","locations":["East
+        US","West US","West Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2017-11-15","2017-08-21-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DomainRegistration","namespace":"Microsoft.DomainRegistration","authorization":{"applicationId":"ea2f600a-4980-45b7-89bf-d34da487bda1","roleDefinitionId":"54d7f2e3-5040-48a7-ae90-eebf629cfa0b"},"resourceTypes":[{"resourceType":"domains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"domains/domainOwnershipIdentifiers","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"topLevelDomains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"checkDomainAvailability","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"listDomainRecommendations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"validateDomainRegistrationInformation","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"generateSsoRequest","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DynamicsLcs","namespace":"Microsoft.DynamicsLcs","resourceTypes":[{"resourceType":"lcsprojects","locations":["Brazil
         South","East Asia","East US","Japan East","Japan West","North Central US","North
         Europe","South Central US","West Europe","West US","Southeast Asia","Central
         US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"lcsprojects/connectors","locations":["Brazil
@@ -1695,21 +1923,21 @@ http_interactions:
         US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"operations","locations":["Brazil
         South","East Asia","East US","Japan East","Japan West","North Central US","North
         Europe","South Central US","West Europe","West US","Southeast Asia","Central
-        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topics","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operations","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topics","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operations","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","West
         US 2","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
         India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/consumergroups","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
         US","East US 2","West US","South Central US","Central US","Australia East","Australia
         Southeast","Central India","West Central US","West US 2","Canada East","Canada
         Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
@@ -1754,23 +1982,23 @@ http_interactions:
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations","locations":["Australia
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations/operationResults","locations":["Australia
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations/operationResults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"operations","locations":["Australia
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"operations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Logic","namespace":"Microsoft.Logic","authorization":{"applicationId":"7cd684f4-8a78-49b0-91ec-6a35d38739ba","roleDefinitionId":"cb3ef1fb-6e31-49e2-9d87-ed821053fe58"},"resourceTypes":[{"resourceType":"workflows","locations":["North
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.LocationBasedServices","namespace":"Microsoft.LocationBasedServices","resourceTypes":[{"resourceType":"accounts","locations":["Global"],"apiVersions":["2017-01-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Logic","namespace":"Microsoft.Logic","authorization":{"applicationId":"7cd684f4-8a78-49b0-91ec-6a35d38739ba","roleDefinitionId":"cb3ef1fb-6e31-49e2-9d87-ed821053fe58"},"resourceTypes":[{"resourceType":"workflows","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
@@ -1791,60 +2019,78 @@ http_interactions:
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada Central","Canada East","West US 2","West Central
-        US","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","West Central US"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"operations","locations":["South
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations","locations":["South
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operations","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"commitmentPlans","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningExperimentation","namespace":"Microsoft.MachineLearningExperimentation","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"accounts","locations":["Australia
-        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces","locations":["Australia
-        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces/projects","locations":["Australia
-        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningCompute","namespace":"Microsoft.MachineLearningCompute","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"376aa7d7-51a9-463d-bd4d-7e1691345612","managedByRoleDefinitionId":"91d00862-cf55-46a5-9dce-260bbd92ce25"},"resourceTypes":[{"resourceType":"operationalizationClusters","locations":["East
-        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"operations","locations":["East
+        US","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningExperimentation","namespace":"Microsoft.MachineLearningExperimentation","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"accounts","locations":["Australia
+        East","East US 2","West Central US","Southeast Asia","West Europe"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces","locations":["Australia
+        East","East US 2","West Central US","Southeast Asia","West Europe"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces/projects","locations":["Australia
+        East","East US 2","West Central US","Southeast Asia","West Europe"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"teamAccounts","locations":["Australia
+        East","West Central US","East US 2"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"teamAccounts/workspaces","locations":["Australia
+        East","West Central US","East US 2"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"teamAccounts/workspaces/projects","locations":["Australia
+        East","West Central US","East US 2"],"apiVersions":["2017-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningCompute","namespace":"Microsoft.MachineLearningCompute","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"376aa7d7-51a9-463d-bd4d-7e1691345612","managedByRoleDefinitionId":"91d00862-cf55-46a5-9dce-260bbd92ce25"},"resourceTypes":[{"resourceType":"operationalizationClusters","locations":["East
+        US 2","West Central US","Australia East","West Europe","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"operations","locations":["East
         US 2"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations","locations":["East
         US 2"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operations","locations":["East
-        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["East
-        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningModelManagement","namespace":"Microsoft.MachineLearningModelManagement","resourceTypes":[{"resourceType":"accounts","locations":["East
-        US 2","West Central US","Australia East"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"operations","locations":["West
-        Central US"],"apiVersions":["2017-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
+        US 2","West Central US","Australia East","West Europe","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["East
+        US 2","West Central US","Australia East","West Europe","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningModelManagement","namespace":"Microsoft.MachineLearningModelManagement","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US 2","West Central US","Australia East","West Europe","Southeast Asia"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"operations","locations":["West
+        Central US"],"apiVersions":["2017-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ManagedIdentity","namespace":"Microsoft.ManagedIdentity","resourceTypes":[{"resourceType":"Identities","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Brazil South","Central
+        India","West India","South India","Japan West","Japan East","East Asia","Southeast
+        Asia","Korea Central","Korea South","North Europe","West Europe","UK West","UK
+        South","Central US","North Central US","East US","East US 2","South Central
+        US","West US","West US 2","West Central US"],"apiVersions":["2015-08-31-PREVIEW"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Brazil South","Central
+        India","West India","South India","Japan West","Japan East","East Asia","Southeast
+        Asia","Korea Central","Korea South","North Europe","West Europe","UK West","UK
+        South","Central US","North Central US","East US","East US 2","South Central
+        US","West US","West US 2","West Central US"],"apiVersions":["2015-08-31-PREVIEW"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Management","namespace":"Microsoft.Management","authorization":{"applicationId":"f2c304cf-8e7e-4c3f-8164-16299ad9d272","roleDefinitionId":"c1cf3708-588a-4647-be7f-f400bbe214cf"},"resourceTypes":[{"resourceType":"resources","locations":[],"apiVersions":["2017-11-01-preview","2017-08-31-preview","2017-06-30-preview","2017-05-31-preview"]},{"resourceType":"managementGroups","locations":[],"apiVersions":["2017-11-01-preview","2017-08-31-preview","2017-06-30-preview","2017-05-31-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01-preview","2017-08-31-preview","2017-06-30-preview","2017-05-31-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceApps","namespace":"Microsoft.MarketplaceApps","resourceTypes":[{"resourceType":"classicDevServices","locations":["Northwest
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","Central US","North
+        Europe","West Europe","Japan East","Japan West","Brazil South","Australia
+        East","Australia Southeast","South India","Central India","Canada Central","Canada
+        East"],"apiVersions":["2017-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
         Central US","West US"],"apiVersions":["2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01"]},{"resourceType":"offertypes","locations":["South
         Central US","West US"],"apiVersions":["2015-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Media","namespace":"Microsoft.Media","authorization":{"applicationId":"374b2a64-3b6b-436b-934c-b820eacca870","roleDefinitionId":"aab70789-0cec-44b5-95d7-84b64c9487af"},"resourceTypes":[{"resourceType":"mediaservices","locations":["Japan
         West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
         US","West US","Australia East","Australia Southeast","Central US","Brazil
         South","Central India","West India","South India","South Central US","Canada
-        Central","Canada East","West Central US"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
+        Central","Canada East","West Central US","West US 2"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
+        Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"operations","locations":["West
+        Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
+        Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PolicyInsights","namespace":"Microsoft.PolicyInsights","authorization":{"applicationId":"1d78a85d-813d-46f0-b496-dd72f50a3ec0","roleDefinitionId":"63d2b225-4c34-4641-8768-21a1f7c68ce8"},"resourceTypes":[{"resourceType":"policyEvents","locations":[],"apiVersions":["2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"policyStates","locations":[],"apiVersions":["2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-17-preview","2017-08-09-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
         Central US","North Central US","East US 2","West US","West Europe","North
         Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
         East","UK South","West India"],"apiVersions":["2016-01-29"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-01-29"]},{"resourceType":"locations/checkNameAvailability","locations":["South
         Central US","North Central US","East US 2","West US","West Europe","North
         Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
-        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"capacities","locations":["West
-        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
-        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationresults","locations":["West
-        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
-        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"operations","locations":["East
-        US 2"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Relay","namespace":"Microsoft.Relay","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"capacities","locations":["Australia
+        Southeast","Brazil South","Canada Central","East Asia","East US","East US
+        2","West India","Japan East","West Central US","North Central US","North Europe","South
+        Central US","Southeast Asia","UK South","West Europe","West US","West US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":["Australia
+        Southeast","Brazil South","Canada Central","East Asia","East US","East US
+        2","West India","Japan East","West Central US","North Central US","North Europe","South
+        Central US","Southeast Asia","UK South","West Europe","West US","West US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationresults","locations":["Australia
+        Southeast","Brazil South","Canada Central","East Asia","East US","East US
+        2","West India","Japan East","West Central US","North Central US","North Europe","South
+        Central US","Southeast Asia","UK South","West Europe","West US","West US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["Australia
+        Southeast","Brazil South","Canada Central","East Asia","East US","East US
+        2","West India","Japan East","West Central US","North Central US","North Europe","South
+        Central US","Southeast Asia","UK South","West Europe","West US","West US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"operations","locations":["East
+        US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Relay","namespace":"Microsoft.Relay","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US 2","West
         US","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
         India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2017-08-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkPolicyCompliance","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/hybridconnections","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/hybridconnections/authorizationrules","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/wcfrelays","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/wcfrelays/authorizationrules","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkPolicyCompliance","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
         Central US","South Central US","North Europe","West Europe","East Asia","Southeast
         Asia","West US","East US","Japan West","Japan East","Brazil South","Central
         US","East US 2","Australia East","Australia Southeast","South India","Central
@@ -1868,12 +2114,12 @@ http_interactions:
         India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19","2015-02-28"]},{"resourceType":"checkServiceNameAvailability","locations":[],"apiVersions":["2015-02-28","2014-07-31-Preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2015-08-19"]},{"resourceType":"resourceHealthMetadata","locations":["West
         US","East US","North Europe","West Europe","Southeast Asia","East Asia","North
         Central US","South Central US","Japan West","Australia East","Brazil South","Central
-        India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","authorization":{"applicationId":"80a10ef9-8168-493d-abf9-3297c4ef6e3c","roleDefinitionId":"2b7763f7-bbe2-4e19-befe-28c79f1cf7f7"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US 2","West
         US","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
         India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"premiumMessagingRegions","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceFabric","namespace":"Microsoft.ServiceFabric","authorization":{"applicationId":"74cb6831-0dbb-4be1-8206-fd4df301cdc2","roleDefinitionId":"e55cc65f-6903-4917-b4ef-f8d4640b57f5"},"resourceTypes":[{"resourceType":"clusters","locations":["West
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/queues","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/queues/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/topics","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/topics/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/topics/subscriptions","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/topics/subscriptions/rules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"premiumMessagingRegions","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceFabric","namespace":"Microsoft.ServiceFabric","authorization":{"applicationId":"74cb6831-0dbb-4be1-8206-fd4df301cdc2","roleDefinitionId":"e55cc65f-6903-4917-b4ef-f8d4640b57f5"},"resourceTypes":[{"resourceType":"clusters","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
@@ -1887,17 +2133,43 @@ http_interactions:
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
-        India","West India","Central India","Brazil South","South Central US","Canada
-        Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
         Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
         Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applianceDefinitions","locations":["West
-        Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"locations","locations":["West
-        Central US"],"apiVersions":["2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
-        Central US"],"apiVersions":["2017-09-01","2016-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
+        Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applications","locations":["South
+        Central US","North Central US","West Central US","West US","West US 2","East
+        US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
+        Asia","Brazil South","Japan West","Japan East","Australia East","Australia
+        Southeast","South India","West India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
+        Central US","North Central US","West Central US","West US","West US 2","East
+        US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
+        Asia","Brazil South","Japan West","Japan East","Australia East","Australia
+        Southeast","South India","West India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
+        Central US"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
+        Central US","North Central US","West Central US","West US","West US 2","East
+        US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
+        Asia","Brazil South","Japan West","Japan East","Australia East","Australia
+        Southeast","South India","West India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/cloudEndpoints","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/serverEndpoints","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/registeredServers","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/workflows","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","West Central US","Japan East","Japan West","Australia East","Australia
         Southeast"],"apiVersions":["2017-06-01","2017-05-15","2017-01-01","2016-10-01","2016-06-01","2015-03-15","2014-09-01"]},{"resourceType":"operations","locations":["West
@@ -1928,23 +2200,11 @@ http_interactions:
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast"],"apiVersions":["2015-07-01-Preview","2015-03-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.TimeSeriesInsights","namespace":"Microsoft.TimeSeriesInsights","authorizations":[{"applicationId":"120d688d-1518-4cf7-bd38-182f158850b6","roleDefinitionId":"5a43abdf-bb87-42c4-9e56-1c24bf364150"}],"resourceTypes":[{"resourceType":"environments","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/eventsources","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/referenceDataSets","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/accessPolicies","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"operations","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
-        Central US","South Central US","East US","West US","Central US","North Europe","West
-        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
-        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/project","locations":["North
-        Central US","South Central US","East US","West US","Central US","North Europe","West
-        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
-        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/extension","locations":["North
-        Central US","South Central US","East US","West US","Central US","North Europe","West
-        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
-        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"checkNameAvailability","locations":["North
-        Central US","South Central US","East US","West US","Central US","North Europe","West
-        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
-        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Myget.PackageManagement","namespace":"Myget.PackageManagement","resourceTypes":[{"resourceType":"services","locations":["West
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]},{"resourceType":"environments/eventsources","locations":["East
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]},{"resourceType":"environments/referenceDataSets","locations":["East
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]},{"resourceType":"environments/accessPolicies","locations":["East
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]},{"resourceType":"operations","locations":["East
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Myget.PackageManagement","namespace":"Myget.PackageManagement","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/NewRelic.APM","namespace":"NewRelic.APM","authorization":{"allowedThirdPartyExtensions":[{"name":"NewRelic_AzurePortal_APM"}]},"resourceTypes":[{"resourceType":"accounts","locations":["North
         Central US","South Central US","West US","East US","North Europe","West Europe","Southeast
         Asia","East Asia","Japan East","Japan West"],"apiVersions":["2014-10-01","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/nuubit.nextgencdn","namespace":"nuubit.nextgencdn","resourceTypes":[{"resourceType":"accounts","locations":["East
@@ -1984,7 +2244,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:51 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:37 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
@@ -2001,9 +2261,11 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNzAsIm5iZiI6MTUwNjExNjI3MCwiZXhwIjoxNTA2MTIwMTcwLCJhaW8iOiJZMlZnWUpEd25SaVpIekpYMS8ycHBhK3M5KzlPQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWHJMaC05OTRMMHFzZEZ5LXliNE1BQSIsInZlciI6IjEuMCJ9.RYqwva04HYBBTt1elTlp5jG6GmjsEcWxLG6GSuCn5W2jLTQ0hZjO8rhC7fzGkbReFh2orTx368wcKypoKDLl1SzkCpJkbNDTa_L1MQDUo9Mam6Nm5b7pEs4QGl7O1zqK2JYZwyBWD6kcWdT3yXosVIWwv3vMUor9JgwR1X0chCObJAed--plBG0QFsXkztVWEjO0gw42iqLedAGz9Juzt3aZdQOiuQNTO_4Mog-_piCb3b5A-NZkfsaqr1RUNj00nPkoNpZGorw5euIeW7ikqWyjaR_CCefaP97a46djlIha9y3JAjpFkp1GdjJt06Udr8J6soVuZKzK6RTYsIEFYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3NTUsIm5iZiI6MTUxNjczNzc1NSwiZXhwIjoxNTE2NzQxNjU1LCJhaW8iOiJZMk5nWUxBNWNUbkgxTXo2aG1oRW9GWFlaaXN0QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoic19vd21OZ3dZazJKWFNDbUxQTUFBQSIsInZlciI6IjEuMCJ9.bw-NT9ZKcpZp73UVZaDPnh9LV6JQdNB52kdIK3dCObOHBLsec2Ev1V1FOpPscEqoYyqhURK5zFk3krmZXeqDt55VT4D3ofIO1nKBqIvGUBrGY1DCaiO1N-gyPqnsgmvP2MjI2TDEN6meDIOPgnsjtYvhs7NbbOXefGw5hlKN47RGAvEJgbvFALhDktUFEUnnp7zdHVS7_sjPrbGFCgkeIj7U4oXPqxxfZh7Q4skpWji2AyYaWlpR5P2KjxOorTIADGvkGhhrmDr6IhvJPY2AuNc_E6MsUduO7N5deFb8ycVdJTafX034d_UNxFdheX0xaxWtii2G31dIz5u2VksOSA
       Content-Length:
       - '42'
+      Host:
+      - management.azure.com
   response:
     status:
       code: 202
@@ -2013,39 +2275,41 @@ http_interactions:
       - no-cache
       Pragma:
       - no-cache
-      Content-Length:
-      - '0'
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/6aa793e5-ae23-4c00-97ff-8a473abd2172?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/8659182a-e9f9-4d5a-9b36-ef0f86cf63bb?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/6aa793e5-ae23-4c00-97ff-8a473abd2172?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/8659182a-e9f9-4d5a-9b36-ef0f86cf63bb?api-version=2017-03-30
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/HighCostHydrate3Min;229,Microsoft.Compute/HighCostHydrate30Min;1156
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131599701143261070
       X-Ms-Request-Id:
-      - 6aa793e5-ae23-4c00-97ff-8a473abd2172
+      - 8659182a-e9f9-4d5a-9b36-ef0f86cf63bb
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1182'
+      - '1164'
       X-Ms-Correlation-Request-Id:
-      - 103739ce-8f02-44d9-ae37-2b89741f3e10
+      - 1ba673b4-26f6-45f4-bcf9-a4428fb43149
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214253Z:103739ce-8f02-44d9-ae37-2b89741f3e10
+      - WESTUS:20180123T200738Z:1ba673b4-26f6-45f4-bcf9-a4428fb43149
       Date:
-      - Fri, 22 Sep 2017 21:42:53 GMT
+      - Tue, 23 Jan 2018 20:07:37 GMT
+      Content-Length:
+      - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:52 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:38 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/6aa793e5-ae23-4c00-97ff-8a473abd2172?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/8659182a-e9f9-4d5a-9b36-ef0f86cf63bb?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -2059,7 +2323,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNzAsIm5iZiI6MTUwNjExNjI3MCwiZXhwIjoxNTA2MTIwMTcwLCJhaW8iOiJZMlZnWUpEd25SaVpIekpYMS8ycHBhK3M5KzlPQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWHJMaC05OTRMMHFzZEZ5LXliNE1BQSIsInZlciI6IjEuMCJ9.RYqwva04HYBBTt1elTlp5jG6GmjsEcWxLG6GSuCn5W2jLTQ0hZjO8rhC7fzGkbReFh2orTx368wcKypoKDLl1SzkCpJkbNDTa_L1MQDUo9Mam6Nm5b7pEs4QGl7O1zqK2JYZwyBWD6kcWdT3yXosVIWwv3vMUor9JgwR1X0chCObJAed--plBG0QFsXkztVWEjO0gw42iqLedAGz9Juzt3aZdQOiuQNTO_4Mog-_piCb3b5A-NZkfsaqr1RUNj00nPkoNpZGorw5euIeW7ikqWyjaR_CCefaP97a46djlIha9y3JAjpFkp1GdjJt06Udr8J6soVuZKzK6RTYsIEFYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3NTUsIm5iZiI6MTUxNjczNzc1NSwiZXhwIjoxNTE2NzQxNjU1LCJhaW8iOiJZMk5nWUxBNWNUbkgxTXo2aG1oRW9GWFlaaXN0QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoic19vd21OZ3dZazJKWFNDbUxQTUFBQSIsInZlciI6IjEuMCJ9.bw-NT9ZKcpZp73UVZaDPnh9LV6JQdNB52kdIK3dCObOHBLsec2Ev1V1FOpPscEqoYyqhURK5zFk3krmZXeqDt55VT4D3ofIO1nKBqIvGUBrGY1DCaiO1N-gyPqnsgmvP2MjI2TDEN6meDIOPgnsjtYvhs7NbbOXefGw5hlKN47RGAvEJgbvFALhDktUFEUnnp7zdHVS7_sjPrbGFCgkeIj7U4oXPqxxfZh7Q4skpWji2AyYaWlpR5P2KjxOorTIADGvkGhhrmDr6IhvJPY2AuNc_E6MsUduO7N5deFb8ycVdJTafX034d_UNxFdheX0xaxWtii2G31dIz5u2VksOSA
+      Host:
+      - management.azure.com
   response:
     status:
       code: 200
@@ -2077,34 +2343,36 @@ http_interactions:
       - "-1"
       Vary:
       - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/GetOperation3Min;49971,Microsoft.Compute/GetOperation30Min;249971
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131599701143261070
       X-Ms-Request-Id:
-      - a9c891ed-855e-4583-9120-e6fbc9da4d66
+      - 1aff90a6-a943-49ff-bb9a-ccdb0749c780
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14920'
+      - '14860'
       X-Ms-Correlation-Request-Id:
-      - 6a541593-6db3-43b2-bade-609f4a5e4f88
+      - 8b181c0d-b989-4f56-881f-7ea0ef2277bf
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214255Z:6a541593-6db3-43b2-bade-609f4a5e4f88
+      - WESTUS:20180123T200737Z:8b181c0d-b989-4f56-881f-7ea0ef2277bf
       Date:
-      - Fri, 22 Sep 2017 21:42:54 GMT
+      - Tue, 23 Jan 2018 20:07:37 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-22T21:42:55.357306+00:00\",\r\n  \"endTime\":
-        \"2017-09-22T21:42:55.5147962+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=65d8ae5d-a416-4835-bdc3-3a99e7e0c3f5&sig=YLdZxP8AEHTzzV7mOTbUI52z2zwTTf9GhUNLeqGQxK8%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"6aa793e5-ae23-4c00-97ff-8a473abd2172\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2018-01-23T20:07:37.3977389+00:00\",\r\n  \"endTime\":
+        \"2018-01-23T20:07:37.6633671+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=5da4587d-bea5-427d-b09d-c0a85f8a04f1&sig=lpqxWX4mM5dSnv48bJcWjv5PdOck6WuNKIfpwpl4wkc%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"8659182a-e9f9-4d5a-9b36-ef0f86cf63bb\"\r\n}"
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:54 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:38 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/6aa793e5-ae23-4c00-97ff-8a473abd2172?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/8659182a-e9f9-4d5a-9b36-ef0f86cf63bb?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -2118,7 +2386,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNzAsIm5iZiI6MTUwNjExNjI3MCwiZXhwIjoxNTA2MTIwMTcwLCJhaW8iOiJZMlZnWUpEd25SaVpIekpYMS8ycHBhK3M5KzlPQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWHJMaC05OTRMMHFzZEZ5LXliNE1BQSIsInZlciI6IjEuMCJ9.RYqwva04HYBBTt1elTlp5jG6GmjsEcWxLG6GSuCn5W2jLTQ0hZjO8rhC7fzGkbReFh2orTx368wcKypoKDLl1SzkCpJkbNDTa_L1MQDUo9Mam6Nm5b7pEs4QGl7O1zqK2JYZwyBWD6kcWdT3yXosVIWwv3vMUor9JgwR1X0chCObJAed--plBG0QFsXkztVWEjO0gw42iqLedAGz9Juzt3aZdQOiuQNTO_4Mog-_piCb3b5A-NZkfsaqr1RUNj00nPkoNpZGorw5euIeW7ikqWyjaR_CCefaP97a46djlIha9y3JAjpFkp1GdjJt06Udr8J6soVuZKzK6RTYsIEFYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3NTUsIm5iZiI6MTUxNjczNzc1NSwiZXhwIjoxNTE2NzQxNjU1LCJhaW8iOiJZMk5nWUxBNWNUbkgxTXo2aG1oRW9GWFlaaXN0QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoic19vd21OZ3dZazJKWFNDbUxQTUFBQSIsInZlciI6IjEuMCJ9.bw-NT9ZKcpZp73UVZaDPnh9LV6JQdNB52kdIK3dCObOHBLsec2Ev1V1FOpPscEqoYyqhURK5zFk3krmZXeqDt55VT4D3ofIO1nKBqIvGUBrGY1DCaiO1N-gyPqnsgmvP2MjI2TDEN6meDIOPgnsjtYvhs7NbbOXefGw5hlKN47RGAvEJgbvFALhDktUFEUnnp7zdHVS7_sjPrbGFCgkeIj7U4oXPqxxfZh7Q4skpWji2AyYaWlpR5P2KjxOorTIADGvkGhhrmDr6IhvJPY2AuNc_E6MsUduO7N5deFb8ycVdJTafX034d_UNxFdheX0xaxWtii2G31dIz5u2VksOSA
+      Host:
+      - management.azure.com
   response:
     status:
       code: 200
@@ -2136,34 +2406,36 @@ http_interactions:
       - "-1"
       Vary:
       - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/GetOperation3Min;49970,Microsoft.Compute/GetOperation30Min;249970
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131599701143261070
       X-Ms-Request-Id:
-      - a84567ff-f2b1-4319-b64d-23f3afb0f87f
+      - 4d00c66d-d7d9-4c2a-a0d0-b75f5979ae72
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14927'
+      - '14858'
       X-Ms-Correlation-Request-Id:
-      - 60ddcc2a-28e4-4c2d-900a-aa453714ae96
+      - 56cce09a-b3cb-47c3-b015-f0bcb133fbff
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214256Z:60ddcc2a-28e4-4c2d-900a-aa453714ae96
+      - WESTUS:20180123T200739Z:56cce09a-b3cb-47c3-b015-f0bcb133fbff
       Date:
-      - Fri, 22 Sep 2017 21:42:55 GMT
+      - Tue, 23 Jan 2018 20:07:39 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-22T21:42:55.357306+00:00\",\r\n  \"endTime\":
-        \"2017-09-22T21:42:55.5147962+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=65d8ae5d-a416-4835-bdc3-3a99e7e0c3f5&sig=YLdZxP8AEHTzzV7mOTbUI52z2zwTTf9GhUNLeqGQxK8%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"6aa793e5-ae23-4c00-97ff-8a473abd2172\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2018-01-23T20:07:37.3977389+00:00\",\r\n  \"endTime\":
+        \"2018-01-23T20:07:37.6633671+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=5da4587d-bea5-427d-b09d-c0a85f8a04f1&sig=lpqxWX4mM5dSnv48bJcWjv5PdOck6WuNKIfpwpl4wkc%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"8659182a-e9f9-4d5a-9b36-ef0f86cf63bb\"\r\n}"
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:55 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:40 GMT
 - request:
     method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=65d8ae5d-a416-4835-bdc3-3a99e7e0c3f5&sig=YLdZxP8AEHTzzV7mOTbUI52z2zwTTf9GhUNLeqGQxK8=&sr=b&sv=2016-05-31
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=5da4587d-bea5-427d-b09d-c0a85f8a04f1&sig=lpqxWX4mM5dSnv48bJcWjv5PdOck6WuNKIfpwpl4wkc=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2176,6 +2448,8 @@ http_interactions:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
       X-Ms-Range:
       - bytes=0-0
+      Host:
+      - md-t4jdgqqlgszp.blob.core.windows.net
   response:
     status:
       code: 206
@@ -2188,15 +2462,15 @@ http_interactions:
       Content-Range:
       - bytes 0-0/34359738880
       Last-Modified:
-      - Sat, 15 Jul 2017 14:23:07 GMT
+      - Tue, 23 Jan 2018 20:04:26 GMT
       Accept-Ranges:
       - bytes
       Etag:
-      - '"0x8D4CB8D039FC699"'
+      - '"0x8D5629C811B65EB"'
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 7f106389-001e-00cf-40eb-33c69f000000
+      - 4d1bb956-001e-00ab-0985-94763f000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2208,7 +2482,7 @@ http_interactions:
       X-Ms-Blob-Type:
       - PageBlob
       X-Ms-Blob-Sequence-Number:
-      - '20'
+      - '30'
       X-Ms-Copy-Id:
       - 30cedd78-548a-4fd8-967e-f8344f587e3c
       X-Ms-Copy-Source:
@@ -2222,250 +2496,16 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Fri, 22 Sep 2017 21:42:56 GMT
+      - Tue, 23 Jan 2018 20:07:39 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         6w==
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:55 GMT
-- request:
-    method: post
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/EndGetAccess?api-version=2017-03-30
-    body:
-      encoding: ASCII-8BIT
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNzAsIm5iZiI6MTUwNjExNjI3MCwiZXhwIjoxNTA2MTIwMTcwLCJhaW8iOiJZMlZnWUpEd25SaVpIekpYMS8ycHBhK3M5KzlPQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWHJMaC05OTRMMHFzZEZ5LXliNE1BQSIsInZlciI6IjEuMCJ9.RYqwva04HYBBTt1elTlp5jG6GmjsEcWxLG6GSuCn5W2jLTQ0hZjO8rhC7fzGkbReFh2orTx368wcKypoKDLl1SzkCpJkbNDTa_L1MQDUo9Mam6Nm5b7pEs4QGl7O1zqK2JYZwyBWD6kcWdT3yXosVIWwv3vMUor9JgwR1X0chCObJAed--plBG0QFsXkztVWEjO0gw42iqLedAGz9Juzt3aZdQOiuQNTO_4Mog-_piCb3b5A-NZkfsaqr1RUNj00nPkoNpZGorw5euIeW7ikqWyjaR_CCefaP97a46djlIha9y3JAjpFkp1GdjJt06Udr8J6soVuZKzK6RTYsIEFYg
-      Content-Length:
-      - '0'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '0'
-      Expires:
-      - "-1"
-      Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/de55c9f4-48bf-4946-9723-35a223c6217b?monitor=true&api-version=2017-03-30
-      Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/de55c9f4-48bf-4946-9723-35a223c6217b?api-version=2017-03-30
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - de55c9f4-48bf-4946-9723-35a223c6217b
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1181'
-      X-Ms-Correlation-Request-Id:
-      - 255dd4a4-728d-44a8-91e6-75610f65606d
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214257Z:255dd4a4-728d-44a8-91e6-75610f65606d
-      Date:
-      - Fri, 22 Sep 2017 21:42:57 GMT
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:56 GMT
-- request:
-    method: post
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
-    body:
-      encoding: UTF-8
-      string: '{"access":"read","durationInSeconds":3600}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNzAsIm5iZiI6MTUwNjExNjI3MCwiZXhwIjoxNTA2MTIwMTcwLCJhaW8iOiJZMlZnWUpEd25SaVpIekpYMS8ycHBhK3M5KzlPQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWHJMaC05OTRMMHFzZEZ5LXliNE1BQSIsInZlciI6IjEuMCJ9.RYqwva04HYBBTt1elTlp5jG6GmjsEcWxLG6GSuCn5W2jLTQ0hZjO8rhC7fzGkbReFh2orTx368wcKypoKDLl1SzkCpJkbNDTa_L1MQDUo9Mam6Nm5b7pEs4QGl7O1zqK2JYZwyBWD6kcWdT3yXosVIWwv3vMUor9JgwR1X0chCObJAed--plBG0QFsXkztVWEjO0gw42iqLedAGz9Juzt3aZdQOiuQNTO_4Mog-_piCb3b5A-NZkfsaqr1RUNj00nPkoNpZGorw5euIeW7ikqWyjaR_CCefaP97a46djlIha9y3JAjpFkp1GdjJt06Udr8J6soVuZKzK6RTYsIEFYg
-      Content-Length:
-      - '42'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '0'
-      Expires:
-      - "-1"
-      Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/2cdbb173-e41d-4750-a162-62f1009d00ba?monitor=true&api-version=2017-03-30
-      Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/2cdbb173-e41d-4750-a162-62f1009d00ba?api-version=2017-03-30
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - 2cdbb173-e41d-4750-a162-62f1009d00ba
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1180'
-      X-Ms-Correlation-Request-Id:
-      - 2cf1bf97-6633-4c9c-9d13-aee31511d1d8
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214258Z:2cf1bf97-6633-4c9c-9d13-aee31511d1d8
-      Date:
-      - Fri, 22 Sep 2017 21:42:58 GMT
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:57 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:40 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/2cdbb173-e41d-4750-a162-62f1009d00ba?api-version=2017-03-30
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNzAsIm5iZiI6MTUwNjExNjI3MCwiZXhwIjoxNTA2MTIwMTcwLCJhaW8iOiJZMlZnWUpEd25SaVpIekpYMS8ycHBhK3M5KzlPQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWHJMaC05OTRMMHFzZEZ5LXliNE1BQSIsInZlciI6IjEuMCJ9.RYqwva04HYBBTt1elTlp5jG6GmjsEcWxLG6GSuCn5W2jLTQ0hZjO8rhC7fzGkbReFh2orTx368wcKypoKDLl1SzkCpJkbNDTa_L1MQDUo9Mam6Nm5b7pEs4QGl7O1zqK2JYZwyBWD6kcWdT3yXosVIWwv3vMUor9JgwR1X0chCObJAed--plBG0QFsXkztVWEjO0gw42iqLedAGz9Juzt3aZdQOiuQNTO_4Mog-_piCb3b5A-NZkfsaqr1RUNj00nPkoNpZGorw5euIeW7ikqWyjaR_CCefaP97a46djlIha9y3JAjpFkp1GdjJt06Udr8J6soVuZKzK6RTYsIEFYg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - 4ec9ce09-db78-485d-915e-f5cab72ef2a5
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
-      X-Ms-Correlation-Request-Id:
-      - 48850c2b-183f-48ed-be81-0ecbdef17fcf
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214259Z:48850c2b-183f-48ed-be81-0ecbdef17fcf
-      Date:
-      - Fri, 22 Sep 2017 21:42:58 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-22T21:43:00.4077627+00:00\",\r\n  \"endTime\":
-        \"2017-09-22T21:43:00.6422048+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=0e9ab2eb-a1cd-4eb8-bd2f-17fdbd8a0ffa&sig=2kWDvUpAqkGAD2PFchNRWypCpFMc2zqtF%2BLFpHvHouo%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"2cdbb173-e41d-4750-a162-62f1009d00ba\"\r\n}"
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:58 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/2cdbb173-e41d-4750-a162-62f1009d00ba?api-version=2017-03-30
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNzAsIm5iZiI6MTUwNjExNjI3MCwiZXhwIjoxNTA2MTIwMTcwLCJhaW8iOiJZMlZnWUpEd25SaVpIekpYMS8ycHBhK3M5KzlPQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWHJMaC05OTRMMHFzZEZ5LXliNE1BQSIsInZlciI6IjEuMCJ9.RYqwva04HYBBTt1elTlp5jG6GmjsEcWxLG6GSuCn5W2jLTQ0hZjO8rhC7fzGkbReFh2orTx368wcKypoKDLl1SzkCpJkbNDTa_L1MQDUo9Mam6Nm5b7pEs4QGl7O1zqK2JYZwyBWD6kcWdT3yXosVIWwv3vMUor9JgwR1X0chCObJAed--plBG0QFsXkztVWEjO0gw42iqLedAGz9Juzt3aZdQOiuQNTO_4Mog-_piCb3b5A-NZkfsaqr1RUNj00nPkoNpZGorw5euIeW7ikqWyjaR_CCefaP97a46djlIha9y3JAjpFkp1GdjJt06Udr8J6soVuZKzK6RTYsIEFYg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - dadcbf77-704a-4830-bfc9-cc3c249fa3e6
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14911'
-      X-Ms-Correlation-Request-Id:
-      - 0dfef1e9-66de-408e-ac13-31bc8028e98d
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214300Z:0dfef1e9-66de-408e-ac13-31bc8028e98d
-      Date:
-      - Fri, 22 Sep 2017 21:42:59 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-22T21:43:00.4077627+00:00\",\r\n  \"endTime\":
-        \"2017-09-22T21:43:00.6422048+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=0e9ab2eb-a1cd-4eb8-bd2f-17fdbd8a0ffa&sig=2kWDvUpAqkGAD2PFchNRWypCpFMc2zqtF%2BLFpHvHouo%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"2cdbb173-e41d-4750-a162-62f1009d00ba\"\r\n}"
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:59 GMT
-- request:
-    method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=0e9ab2eb-a1cd-4eb8-bd2f-17fdbd8a0ffa&sig=2kWDvUpAqkGAD2PFchNRWypCpFMc2zqtF%2BLFpHvHouo=&sr=b&sv=2016-05-31
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=5da4587d-bea5-427d-b09d-c0a85f8a04f1&sig=lpqxWX4mM5dSnv48bJcWjv5PdOck6WuNKIfpwpl4wkc=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2478,6 +2518,8 @@ http_interactions:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
       X-Ms-Range:
       - bytes=440-443
+      Host:
+      - md-t4jdgqqlgszp.blob.core.windows.net
   response:
     status:
       code: 206
@@ -2490,15 +2532,15 @@ http_interactions:
       Content-Range:
       - bytes 440-443/34359738880
       Last-Modified:
-      - Sat, 15 Jul 2017 14:23:07 GMT
+      - Tue, 23 Jan 2018 20:04:26 GMT
       Accept-Ranges:
       - bytes
       Etag:
-      - '"0x8D4CB8D039FC699"'
+      - '"0x8D5629C811B65EB"'
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 368bf9ed-001e-0113-6feb-33d299000000
+      - 8c0272fb-001e-002d-0c85-9422ed000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2510,7 +2552,7 @@ http_interactions:
       X-Ms-Blob-Type:
       - PageBlob
       X-Ms-Blob-Sequence-Number:
-      - '20'
+      - '30'
       X-Ms-Copy-Id:
       - 30cedd78-548a-4fd8-967e-f8344f587e3c
       X-Ms-Copy-Source:
@@ -2524,250 +2566,16 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Fri, 22 Sep 2017 21:43:00 GMT
+      - Tue, 23 Jan 2018 20:07:39 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         U5MJAA==
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:59 GMT
-- request:
-    method: post
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/EndGetAccess?api-version=2017-03-30
-    body:
-      encoding: ASCII-8BIT
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNzAsIm5iZiI6MTUwNjExNjI3MCwiZXhwIjoxNTA2MTIwMTcwLCJhaW8iOiJZMlZnWUpEd25SaVpIekpYMS8ycHBhK3M5KzlPQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWHJMaC05OTRMMHFzZEZ5LXliNE1BQSIsInZlciI6IjEuMCJ9.RYqwva04HYBBTt1elTlp5jG6GmjsEcWxLG6GSuCn5W2jLTQ0hZjO8rhC7fzGkbReFh2orTx368wcKypoKDLl1SzkCpJkbNDTa_L1MQDUo9Mam6Nm5b7pEs4QGl7O1zqK2JYZwyBWD6kcWdT3yXosVIWwv3vMUor9JgwR1X0chCObJAed--plBG0QFsXkztVWEjO0gw42iqLedAGz9Juzt3aZdQOiuQNTO_4Mog-_piCb3b5A-NZkfsaqr1RUNj00nPkoNpZGorw5euIeW7ikqWyjaR_CCefaP97a46djlIha9y3JAjpFkp1GdjJt06Udr8J6soVuZKzK6RTYsIEFYg
-      Content-Length:
-      - '0'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '0'
-      Expires:
-      - "-1"
-      Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/0629eff0-a2ac-42af-9987-269a7cc5fe68?monitor=true&api-version=2017-03-30
-      Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/0629eff0-a2ac-42af-9987-269a7cc5fe68?api-version=2017-03-30
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - 0629eff0-a2ac-42af-9987-269a7cc5fe68
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1177'
-      X-Ms-Correlation-Request-Id:
-      - 31614b12-a1f2-4716-975c-719f7677b8f0
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214301Z:31614b12-a1f2-4716-975c-719f7677b8f0
-      Date:
-      - Fri, 22 Sep 2017 21:43:00 GMT
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:43:00 GMT
-- request:
-    method: post
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
-    body:
-      encoding: UTF-8
-      string: '{"access":"read","durationInSeconds":3600}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNzAsIm5iZiI6MTUwNjExNjI3MCwiZXhwIjoxNTA2MTIwMTcwLCJhaW8iOiJZMlZnWUpEd25SaVpIekpYMS8ycHBhK3M5KzlPQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWHJMaC05OTRMMHFzZEZ5LXliNE1BQSIsInZlciI6IjEuMCJ9.RYqwva04HYBBTt1elTlp5jG6GmjsEcWxLG6GSuCn5W2jLTQ0hZjO8rhC7fzGkbReFh2orTx368wcKypoKDLl1SzkCpJkbNDTa_L1MQDUo9Mam6Nm5b7pEs4QGl7O1zqK2JYZwyBWD6kcWdT3yXosVIWwv3vMUor9JgwR1X0chCObJAed--plBG0QFsXkztVWEjO0gw42iqLedAGz9Juzt3aZdQOiuQNTO_4Mog-_piCb3b5A-NZkfsaqr1RUNj00nPkoNpZGorw5euIeW7ikqWyjaR_CCefaP97a46djlIha9y3JAjpFkp1GdjJt06Udr8J6soVuZKzK6RTYsIEFYg
-      Content-Length:
-      - '42'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '0'
-      Expires:
-      - "-1"
-      Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/6425bb7e-d962-49b3-a5ec-d7777b2c75ee?monitor=true&api-version=2017-03-30
-      Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/6425bb7e-d962-49b3-a5ec-d7777b2c75ee?api-version=2017-03-30
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - 6425bb7e-d962-49b3-a5ec-d7777b2c75ee
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1182'
-      X-Ms-Correlation-Request-Id:
-      - 945472b2-fe3e-46d1-8a88-6e7202291204
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214302Z:945472b2-fe3e-46d1-8a88-6e7202291204
-      Date:
-      - Fri, 22 Sep 2017 21:43:01 GMT
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:43:01 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:40 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/6425bb7e-d962-49b3-a5ec-d7777b2c75ee?api-version=2017-03-30
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNzAsIm5iZiI6MTUwNjExNjI3MCwiZXhwIjoxNTA2MTIwMTcwLCJhaW8iOiJZMlZnWUpEd25SaVpIekpYMS8ycHBhK3M5KzlPQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWHJMaC05OTRMMHFzZEZ5LXliNE1BQSIsInZlciI6IjEuMCJ9.RYqwva04HYBBTt1elTlp5jG6GmjsEcWxLG6GSuCn5W2jLTQ0hZjO8rhC7fzGkbReFh2orTx368wcKypoKDLl1SzkCpJkbNDTa_L1MQDUo9Mam6Nm5b7pEs4QGl7O1zqK2JYZwyBWD6kcWdT3yXosVIWwv3vMUor9JgwR1X0chCObJAed--plBG0QFsXkztVWEjO0gw42iqLedAGz9Juzt3aZdQOiuQNTO_4Mog-_piCb3b5A-NZkfsaqr1RUNj00nPkoNpZGorw5euIeW7ikqWyjaR_CCefaP97a46djlIha9y3JAjpFkp1GdjJt06Udr8J6soVuZKzK6RTYsIEFYg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - baf58614-1e08-4ab4-a2e2-38e054ac53bc
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14941'
-      X-Ms-Correlation-Request-Id:
-      - 16d5d6c0-f58c-4829-a1a0-a916641444df
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214303Z:16d5d6c0-f58c-4829-a1a0-a916641444df
-      Date:
-      - Fri, 22 Sep 2017 21:43:03 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-22T21:43:03.9399025+00:00\",\r\n  \"endTime\":
-        \"2017-09-22T21:43:04.1587247+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=926afda5-f8d5-463f-a682-f5472a797c2e&sig=x22VtokL4uZ%2B9ZoYvUK1ssM28NodijwPdWjwp%2BUubjA%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"6425bb7e-d962-49b3-a5ec-d7777b2c75ee\"\r\n}"
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:43:01 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/6425bb7e-d962-49b3-a5ec-d7777b2c75ee?api-version=2017-03-30
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNzAsIm5iZiI6MTUwNjExNjI3MCwiZXhwIjoxNTA2MTIwMTcwLCJhaW8iOiJZMlZnWUpEd25SaVpIekpYMS8ycHBhK3M5KzlPQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWHJMaC05OTRMMHFzZEZ5LXliNE1BQSIsInZlciI6IjEuMCJ9.RYqwva04HYBBTt1elTlp5jG6GmjsEcWxLG6GSuCn5W2jLTQ0hZjO8rhC7fzGkbReFh2orTx368wcKypoKDLl1SzkCpJkbNDTa_L1MQDUo9Mam6Nm5b7pEs4QGl7O1zqK2JYZwyBWD6kcWdT3yXosVIWwv3vMUor9JgwR1X0chCObJAed--plBG0QFsXkztVWEjO0gw42iqLedAGz9Juzt3aZdQOiuQNTO_4Mog-_piCb3b5A-NZkfsaqr1RUNj00nPkoNpZGorw5euIeW7ikqWyjaR_CCefaP97a46djlIha9y3JAjpFkp1GdjJt06Udr8J6soVuZKzK6RTYsIEFYg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - 6a23fbba-dac1-4942-8a80-82dc9deec4be
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14912'
-      X-Ms-Correlation-Request-Id:
-      - ce0c78a6-adbd-4b2b-a965-d711294edd84
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214304Z:ce0c78a6-adbd-4b2b-a965-d711294edd84
-      Date:
-      - Fri, 22 Sep 2017 21:43:04 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-22T21:43:03.9399025+00:00\",\r\n  \"endTime\":
-        \"2017-09-22T21:43:04.1587247+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=926afda5-f8d5-463f-a682-f5472a797c2e&sig=x22VtokL4uZ%2B9ZoYvUK1ssM28NodijwPdWjwp%2BUubjA%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"6425bb7e-d962-49b3-a5ec-d7777b2c75ee\"\r\n}"
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:43:03 GMT
-- request:
-    method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=926afda5-f8d5-463f-a682-f5472a797c2e&sig=x22VtokL4uZ%2B9ZoYvUK1ssM28NodijwPdWjwp%2BUubjA=&sr=b&sv=2016-05-31
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=5da4587d-bea5-427d-b09d-c0a85f8a04f1&sig=lpqxWX4mM5dSnv48bJcWjv5PdOck6WuNKIfpwpl4wkc=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2780,6 +2588,8 @@ http_interactions:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
       X-Ms-Range:
       - bytes=0-511
+      Host:
+      - md-t4jdgqqlgszp.blob.core.windows.net
   response:
     status:
       code: 206
@@ -2792,15 +2602,15 @@ http_interactions:
       Content-Range:
       - bytes 0-511/34359738880
       Last-Modified:
-      - Sat, 15 Jul 2017 14:23:07 GMT
+      - Tue, 23 Jan 2018 20:04:26 GMT
       Accept-Ranges:
       - bytes
       Etag:
-      - '"0x8D4CB8D039FC699"'
+      - '"0x8D5629C811B65EB"'
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 5808dce3-001e-011c-60eb-333f6f000000
+      - a25103ef-001e-008b-6585-941af3000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2812,7 +2622,7 @@ http_interactions:
       X-Ms-Blob-Type:
       - PageBlob
       X-Ms-Blob-Sequence-Number:
-      - '20'
+      - '30'
       X-Ms-Copy-Id:
       - 30cedd78-548a-4fd8-967e-f8344f587e3c
       X-Ms-Copy-Source:
@@ -2826,80 +2636,11 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Fri, 22 Sep 2017 21:43:04 GMT
+      - Tue, 23 Jan 2018 20:07:40 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        62OQEI7QvACwuAAAjtiOwPu+AHy/AAa5AALzpOohBgAAvr4HOAR1C4PGEIH+
-        /gd18+sWtAKwAbsAfLKAinQBi0wCzRPqAHwAAOv+AAAAAAAAAAAAAAAAAAAA
-        AIABAAAAAAAAAP/6kJD2woB0BfbCcHQCsoDqeXwAADHAjtiO0LwAIPugZHw8
-        /3QCiMJSvgV8tEG7qlXNE1pScj2B+1WqdTeD4QF0MjHAiUQEQIhE/4lEAscE
-        EABmix5cfGaJXAhmix5gfGaJXAzHRAYAcLRCzRNyBbsAcOt2tAjNE3MNWoTS
-        D4PeAL6FfemCAGYPtsaIZP9AZolEBA+20cHiAojoiPRAiUQID7bCwOgCZokE
-        ZqFgfGYJwHVOZqFcfGYx0mb3NIjRMdJm93QEO0QIfTf+wYjFMMDB6AIIwYjQ
-        WojGuwBwjsMx27gBAs0Tch6Mw2AeuQABjtsx9r8AgI7G/POlH2H/Jlp8voB9
-        6wO+j33oNAC+lH3oLgDNGOv+R1JVQiAAR2VvbQBIYXJkIERpc2sAUmVhZAAg
-        RXJyb3INCgC7AQC0Ds0QrDwAdfTDAAAAAAAAAAAAAAAAAABTkwkAAACAICEA
-        g90ePwAIAAAAoA8AAN0fP4P+//8AqA8AAFjwAwAAAAAAAAAAAAAAAAAAAAAA
-        AAAAAAAAAAAAAAAAAAAAVao=
+        62OQEI7QvACwuAAAjtiOwPu+AHy/AAa5AALzpOohBgAAvr4HOAR1C4PGEIH+/gd18+sWtAKwAbsAfLKAinQBi0wCzRPqAHwAAOv+AAAAAAAAAAAAAAAAAAAAAIABAAAAAAAAAP/6kJD2woB0BfbCcHQCsoDqeXwAADHAjtiO0LwAIPugZHw8/3QCiMJSvgV8tEG7qlXNE1pScj2B+1WqdTeD4QF0MjHAiUQEQIhE/4lEAscEEABmix5cfGaJXAhmix5gfGaJXAzHRAYAcLRCzRNyBbsAcOt2tAjNE3MNWoTSD4PeAL6FfemCAGYPtsaIZP9AZolEBA+20cHiAojoiPRAiUQID7bCwOgCZokEZqFgfGYJwHVOZqFcfGYx0mb3NIjRMdJm93QEO0QIfTf+wYjFMMDB6AIIwYjQWojGuwBwjsMx27gBAs0Tch6Mw2AeuQABjtsx9r8AgI7G/POlH2H/Jlp8voB96wO+j33oNAC+lH3oLgDNGOv+R1JVQiAAR2VvbQBIYXJkIERpc2sAUmVhZAAgRXJyb3INCgC7AQC0Ds0QrDwAdfTDAAAAAAAAAAAAAAAAAABTkwkAAACAICEAg90ePwAIAAAAoA8AAN0fP4P+//8AqA8AAFjwAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVao=
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:43:03 GMT
-- request:
-    method: post
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/EndGetAccess?api-version=2017-03-30
-    body:
-      encoding: ASCII-8BIT
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNzAsIm5iZiI6MTUwNjExNjI3MCwiZXhwIjoxNTA2MTIwMTcwLCJhaW8iOiJZMlZnWUpEd25SaVpIekpYMS8ycHBhK3M5KzlPQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWHJMaC05OTRMMHFzZEZ5LXliNE1BQSIsInZlciI6IjEuMCJ9.RYqwva04HYBBTt1elTlp5jG6GmjsEcWxLG6GSuCn5W2jLTQ0hZjO8rhC7fzGkbReFh2orTx368wcKypoKDLl1SzkCpJkbNDTa_L1MQDUo9Mam6Nm5b7pEs4QGl7O1zqK2JYZwyBWD6kcWdT3yXosVIWwv3vMUor9JgwR1X0chCObJAed--plBG0QFsXkztVWEjO0gw42iqLedAGz9Juzt3aZdQOiuQNTO_4Mog-_piCb3b5A-NZkfsaqr1RUNj00nPkoNpZGorw5euIeW7ikqWyjaR_CCefaP97a46djlIha9y3JAjpFkp1GdjJt06Udr8J6soVuZKzK6RTYsIEFYg
-      Content-Length:
-      - '0'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '0'
-      Expires:
-      - "-1"
-      Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/05c0f6ab-b0de-4569-baa2-91052ec6b2df?monitor=true&api-version=2017-03-30
-      Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/05c0f6ab-b0de-4569-baa2-91052ec6b2df?api-version=2017-03-30
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - 05c0f6ab-b0de-4569-baa2-91052ec6b2df
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1185'
-      X-Ms-Correlation-Request-Id:
-      - d2a1d112-2d32-4bc6-a9b4-4f6d0c0f6e6c
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214305Z:d2a1d112-2d32-4bc6-a9b4-4f6d0c0f6e6c
-      Date:
-      - Fri, 22 Sep 2017 21:43:04 GMT
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:43:03 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:40 GMT
 recorded_with: VCR 3.0.3

--- a/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_lbaEnd-1.yml
+++ b/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_lbaEnd-1.yml
@@ -17,6 +17,8 @@ http_interactions:
       - '186'
       Content-Type:
       - application/x-www-form-urlencoded
+      Host:
+      - login.microsoftonline.com
   response:
     status:
       code: 200
@@ -37,25 +39,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 43168b3a-d2d8-43dc-b8be-9b0662000b00
+      - b36ecd8b-f3cd-4644-9811-8946e6f20000
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAAABlDrqfEFlSaui6xnRjX5ESA_ph76_avmigByRA1M3ULQJKGu8j-ECkoRFbWO266pEqLQzqX4ybIZF01FGGG6s42aOPx2ypSA2Jlo2g-b2ZVcScE4LWP_yxQTKx-6YHVIychW3T3QM_reu_BKS-3ppde1SOSASOPMcg3IhM2o1fMwrKiOVZ_LvKyPumHRI8qQgAA;
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzEpfXKXfzq2L8E6ciO36zorUNQclHX2ncQiTPd_bl3MbhYHymbP43nyuunTxegT3EDOZ69eU0EMyUQOL0LAWdadfiIyRi515ZDcNxu26SRX05wRUhgQ8HV0FN0NR2NBRwKiXA-l-T15_al4cmC1sVVZdY7_sPIvQswnOyGXN-6i8gAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=004; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=006; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Fri, 22 Sep 2017 21:41:43 GMT
+      - Tue, 23 Jan 2018 20:07:24 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3600","ext_expires_in":"0","expires_on":"1506120103","not_before":"1506116203","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMDMsIm5iZiI6MTUwNjExNjIwMywiZXhwIjoxNTA2MTIwMTAzLCJhaW8iOiJZMlZnWVBDVnFid3k0MUdUOWhQeFIvczVwZlJlQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiT29zV1E5alMzRU80dnBzR1lnQUxBQSIsInZlciI6IjEuMCJ9.qW2dETkABqLKjPpG1kNgiKjWDSGCrK2O436_yOUSiUEbgpEPPUqJy_4XcMu7FneQJg1gaLLLIl7ViyzJVBs_rftEdrJmuoUjufj8MetXeIaJQUh8hx-fNOrb9UEYpwK4mSK01HfRe3U-A3DT-6POIQFwbLf78M_nXJohlijBYEL0WZ02Vx2ZRqGVwpGQ8Jo--Iqcf3IELsE8RSuhDJAbLk4JAjxIen7f04U3S4dU4DxvN87n0tODuGTOD58uuY-Fsk8JMGfg47p_OQrhhZI8rg6qLu4vGVlZk_JjDqzFaVbRBWgB1QnwqnHjUqrtgjD9AsVlhuvWgUvG1swYo97bCQ"}'
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1516741644","not_before":"1516737744","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3NDQsIm5iZiI6MTUxNjczNzc0NCwiZXhwIjoxNTE2NzQxNjQ0LCJhaW8iOiJZMk5nWURBTjFDdDJkcHEzYjE1K2V1Lys2UnRMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiaTgxdXM4M3pSRWFZRVlsRzV2SUFBQSIsInZlciI6IjEuMCJ9.bhuZbwr_DUbUHhY7EeZI_nzv42PIpod-gtIasMU8f2WzgYqVdB9mZlFvc129yMGW5M5GOTE5RTNUxSx4RKNpx2w43_HMdFijkjsVnXsjq9WKLE-jS6sadsWwH86475tWaX7QhhHyIfF0pT09icUd5YlwupxNYpUDsZo5SULJbqgGbqKLjdLbrTx1s1mXtr6jHuXDwKJNjpNea3vOXmD57xTVKzlIJDCDcWCGeghKUncgbGX77IkRWp-8KgVeApyrPfMhFpnH74FqbDn092ZCrOthzI8hOGlu1HPAcA9rxxs2i7L90J86WKsaKjSYepHU4dMkS2mjVO4xJoKe05d3tg"}'
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:41:43 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:24 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -72,7 +74,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMDMsIm5iZiI6MTUwNjExNjIwMywiZXhwIjoxNTA2MTIwMTAzLCJhaW8iOiJZMlZnWVBDVnFid3k0MUdUOWhQeFIvczVwZlJlQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiT29zV1E5alMzRU80dnBzR1lnQUxBQSIsInZlciI6IjEuMCJ9.qW2dETkABqLKjPpG1kNgiKjWDSGCrK2O436_yOUSiUEbgpEPPUqJy_4XcMu7FneQJg1gaLLLIl7ViyzJVBs_rftEdrJmuoUjufj8MetXeIaJQUh8hx-fNOrb9UEYpwK4mSK01HfRe3U-A3DT-6POIQFwbLf78M_nXJohlijBYEL0WZ02Vx2ZRqGVwpGQ8Jo--Iqcf3IELsE8RSuhDJAbLk4JAjxIen7f04U3S4dU4DxvN87n0tODuGTOD58uuY-Fsk8JMGfg47p_OQrhhZI8rg6qLu4vGVlZk_JjDqzFaVbRBWgB1QnwqnHjUqrtgjD9AsVlhuvWgUvG1swYo97bCQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3NDQsIm5iZiI6MTUxNjczNzc0NCwiZXhwIjoxNTE2NzQxNjQ0LCJhaW8iOiJZMk5nWURBTjFDdDJkcHEzYjE1K2V1Lys2UnRMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiaTgxdXM4M3pSRWFZRVlsRzV2SUFBQSIsInZlciI6IjEuMCJ9.bhuZbwr_DUbUHhY7EeZI_nzv42PIpod-gtIasMU8f2WzgYqVdB9mZlFvc129yMGW5M5GOTE5RTNUxSx4RKNpx2w43_HMdFijkjsVnXsjq9WKLE-jS6sadsWwH86475tWaX7QhhHyIfF0pT09icUd5YlwupxNYpUDsZo5SULJbqgGbqKLjdLbrTx1s1mXtr6jHuXDwKJNjpNea3vOXmD57xTVKzlIJDCDcWCGeghKUncgbGX77IkRWp-8KgVeApyrPfMhFpnH74FqbDn092ZCrOthzI8hOGlu1HPAcA9rxxs2i7L90J86WKsaKjSYepHU4dMkS2mjVO4xJoKe05d3tg
+      Host:
+      - management.azure.com
   response:
     status:
       code: 200
@@ -93,21 +97,22 @@ http_interactions:
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
       - '14999'
       X-Ms-Request-Id:
-      - 87bf4022-19de-4aca-8eda-e27e3ef51cb0
+      - 676f8733-74a3-4b61-88a7-a7ac6aae84ed
       X-Ms-Correlation-Request-Id:
-      - 87bf4022-19de-4aca-8eda-e27e3ef51cb0
+      - 676f8733-74a3-4b61-88a7-a7ac6aae84ed
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214144Z:87bf4022-19de-4aca-8eda-e27e3ef51cb0
+      - WESTUS:20180123T200730Z:676f8733-74a3-4b61-88a7-a7ac6aae84ed
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 22 Sep 2017 21:41:43 GMT
+      - Tue, 23 Jan 2018 20:07:30 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
-        Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
+      string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
+        Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
+        Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:41:43 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:25 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/azure_subscription_id/providers?api-version=2015-01-01
@@ -124,7 +129,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMDMsIm5iZiI6MTUwNjExNjIwMywiZXhwIjoxNTA2MTIwMTAzLCJhaW8iOiJZMlZnWVBDVnFid3k0MUdUOWhQeFIvczVwZlJlQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiT29zV1E5alMzRU80dnBzR1lnQUxBQSIsInZlciI6IjEuMCJ9.qW2dETkABqLKjPpG1kNgiKjWDSGCrK2O436_yOUSiUEbgpEPPUqJy_4XcMu7FneQJg1gaLLLIl7ViyzJVBs_rftEdrJmuoUjufj8MetXeIaJQUh8hx-fNOrb9UEYpwK4mSK01HfRe3U-A3DT-6POIQFwbLf78M_nXJohlijBYEL0WZ02Vx2ZRqGVwpGQ8Jo--Iqcf3IELsE8RSuhDJAbLk4JAjxIen7f04U3S4dU4DxvN87n0tODuGTOD58uuY-Fsk8JMGfg47p_OQrhhZI8rg6qLu4vGVlZk_JjDqzFaVbRBWgB1QnwqnHjUqrtgjD9AsVlhuvWgUvG1swYo97bCQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3NDQsIm5iZiI6MTUxNjczNzc0NCwiZXhwIjoxNTE2NzQxNjQ0LCJhaW8iOiJZMk5nWURBTjFDdDJkcHEzYjE1K2V1Lys2UnRMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiaTgxdXM4M3pSRWFZRVlsRzV2SUFBQSIsInZlciI6IjEuMCJ9.bhuZbwr_DUbUHhY7EeZI_nzv42PIpod-gtIasMU8f2WzgYqVdB9mZlFvc129yMGW5M5GOTE5RTNUxSx4RKNpx2w43_HMdFijkjsVnXsjq9WKLE-jS6sadsWwH86475tWaX7QhhHyIfF0pT09icUd5YlwupxNYpUDsZo5SULJbqgGbqKLjdLbrTx1s1mXtr6jHuXDwKJNjpNea3vOXmD57xTVKzlIJDCDcWCGeghKUncgbGX77IkRWp-8KgVeApyrPfMhFpnH74FqbDn092ZCrOthzI8hOGlu1HPAcA9rxxs2i7L90J86WKsaKjSYepHU4dMkS2mjVO4xJoKe05d3tg
+      Host:
+      - management.azure.com
   response:
     status:
       code: 200
@@ -141,19 +148,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14914'
+      - '14850'
       X-Ms-Request-Id:
-      - 4be550d8-aab4-44eb-be95-8ddfe92c1fdd
+      - b3fc8991-170a-4856-8aa8-428b73d68669
       X-Ms-Correlation-Request-Id:
-      - 4be550d8-aab4-44eb-be95-8ddfe92c1fdd
+      - b3fc8991-170a-4856-8aa8-428b73d68669
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214145Z:4be550d8-aab4-44eb-be95-8ddfe92c1fdd
+      - WESTUS:20180123T200726Z:b3fc8991-170a-4856-8aa8-428b73d68669
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 22 Sep 2017 21:41:45 GMT
+      - Tue, 23 Jan 2018 20:07:26 GMT
       Content-Length:
-      - '254785'
+      - '293551'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
@@ -176,7 +183,7 @@ http_interactions:
         Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
         Central US","North Central US","Japan East","Japan West","Brazil South","Central
         India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
+        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-04-19","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-04-19","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-04-19","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-04-19","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","North Central
         US","South Central US","West Central US","West US","West US 2","Canada Central","Canada
         East","North Europe","West Europe","UK South","UK West","East Asia","Southeast
@@ -184,20 +191,26 @@ http_interactions:
         India","South India","West India"],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"validateServiceName","locations":[],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"checkServiceNameAvailability","locations":[],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"reportFeedback","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"checkFeedbackRequired","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Automation","namespace":"Microsoft.Automation","authorizations":[{"applicationId":"fc75330b-179d-49af-87dd-3b1acf6827fa","roleDefinitionId":"95fd5de3-d071-4362-92bf-cf341c1de832"}],"resourceTypes":[{"resourceType":"automationAccounts","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
         South","UK South","West Central US","North Europe","Canada Central","Australia
-        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/runbooks","locations":["Japan
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/runbooks","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
         South","UK South","West Central US","North Europe","Canada Central","Australia
-        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/configurations","locations":["Japan
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/configurations","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","North
-        Central US","Brazil South","UK South","West Central US","Central India","Australia
-        Southeast","Canada Central","North Europe"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/webhooks","locations":["Japan
+        Central US","Korea Central","East US","West US 2","Brazil South","UK South","West
+        Central US","Central India","Australia Southeast","Canada Central","North
+        Europe"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/webhooks","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
         South","UK South","West Central US","North Europe","Canada Central","Australia
-        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"operations","locations":["South
-        Central US"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/softwareUpdateConfigurations","locations":["Japan
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"operations","locations":["South
+        Central US"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/softwareUpdateConfigurations","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
         South","UK South","West Central US","North Europe","Canada Central","Australia
-        Southeast","Central India"],"apiVersions":["2017-05-15-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Backup","namespace":"Microsoft.Backup","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"BackupVault","locations":["West
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview"]},{"resourceType":"automationAccounts/jobs","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
+        South","UK South","West Central US","North Europe","Canada Central","Australia
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureActiveDirectory","namespace":"Microsoft.AzureActiveDirectory","resourceTypes":[{"resourceType":"b2cDirectories","locations":["Global","United
+        States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]},{"resourceType":"operations","locations":["Global","United
+        States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]}],"registrationState":"Unregistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Backup","namespace":"Microsoft.Backup","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"BackupVault","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
@@ -206,22 +219,22 @@ http_interactions:
         Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
         West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
         East","South India","Central India","Canada Central","Canada East","UK South","UK
-        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01","2015-07-01","2014-05-01-privatepreview"]},{"resourceType":"operations","locations":["West
+        West","West Central US","West US 2"],"apiVersions":["2017-09-01","2017-05-01","2017-01-01","2015-12-01","2015-09-01","2015-07-01","2014-05-01-privatepreview"]},{"resourceType":"operations","locations":["West
         Europe","East US","East US 2","West US","North Central US","Brazil South","North
         Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
         West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
         East","South India","Central India","Canada Central","Canada East","UK South","UK
-        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations/quotas","locations":["West
+        West","West Central US","West US 2"],"apiVersions":["2017-09-01","2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01","2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations/quotas","locations":["West
         Europe","East US","East US 2","West US","North Central US","Brazil South","North
         Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
         West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
         East","South India","Central India","Canada Central","Canada East","UK South","UK
-        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]}],"registrationState":"Unregistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicCompute","namespace":"Microsoft.ClassicCompute","resourceTypes":[{"resourceType":"domainNames","locations":["East
+        West","West Central US","West US 2"],"apiVersions":["2017-09-01","2017-05-01","2017-01-01","2015-12-01","2015-09-01"]}],"registrationState":"Unregistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicCompute","namespace":"Microsoft.ClassicCompute","resourceTypes":[{"resourceType":"domainNames","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
@@ -256,7 +269,7 @@ http_interactions:
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -296,92 +309,92 @@ http_interactions:
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30"]},{"resourceType":"locations/usages","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations/usages","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
+        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
@@ -411,76 +424,138 @@ http_interactions:
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
+        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
         US","East US","South Central US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
         Central","Central US","East US 2","North Central US","West Central US","West
-        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/webhooks","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/ping","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/getCallbackConfig","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/listEvents","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"locations","locations":["South
-        Central US","East US","West US","Central US","East US 2","North Central US","West
-        Central US","West US 2","Brazil South","Canada East","Canada Central","West
-        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
-        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"locations/operationResults","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/GetCredentials","locations":["West
+        US 2"],"apiVersions":["2017-10-01","2017-03-01"]},{"resourceType":"registries/replications","locations":["South
+        Central US","West Central US","East US","West Europe","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/webhooks","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/webhooks/ping","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/webhooks/getCallbackConfig","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/webhooks/listEvents","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"locations/operationResults","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/GetCredentials","locations":["West
         US","East US","South Central US","West Europe"],"apiVersions":["2016-06-27-preview"]},{"resourceType":"registries/listCredentials","locations":["South
         Central US","East US","West US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
         Central","Central US","East US 2","North Central US","West Central US","West
-        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/regenerateCredential","locations":["South
+        US 2"],"apiVersions":["2017-10-01","2017-03-01"]},{"resourceType":"registries/regenerateCredential","locations":["South
         Central US","West US","East US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
         Central","Central US","East US 2","North Central US","West Central US","West
-        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/listUsages","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/regenerateCredentials","locations":["West
+        US 2"],"apiVersions":["2017-10-01","2017-03-01"]},{"resourceType":"registries/listUsages","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/regenerateCredentials","locations":["West
         US","East US","South Central US","West Europe"],"apiVersions":["2016-06-27-preview"]},{"resourceType":"checkNameAvailability","locations":["South
         Central US","East US","West US","Central US","East US 2","North Central US","West
         Central US","West US 2","Brazil South","Canada East","Canada Central","West
         Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
-        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview","2017-03-01","2016-06-27-preview"]},{"resourceType":"operations","locations":["South
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-10-01","2017-06-01-preview","2017-03-01","2016-06-27-preview"]},{"resourceType":"operations","locations":["South
         Central US","East US","West US","Central US","East US 2","North Central US","West
         Central US","West US 2","Brazil South","Canada East","Canada Central","West
         Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
-        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview","2017-03-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerService","namespace":"Microsoft.ContainerService","authorization":{"applicationId":"7319c514-987d-4e9b-ac3d-d38c4f427f4c","roleDefinitionId":"1b4a0c7f-2217-416f-acfa-cf73452fdc1c"},"resourceTypes":[{"resourceType":"containerServices","locations":["Japan
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-10-01","2017-06-01-preview","2017-03-01"]},{"resourceType":"locations","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-10-01","2017-06-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerService","namespace":"Microsoft.ContainerService","authorization":{"applicationId":"7319c514-987d-4e9b-ac3d-d38c4f427f4c","roleDefinitionId":"1b4a0c7f-2217-416f-acfa-cf73452fdc1c","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"containerServices","locations":["Japan
         East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
         Central US","West US 2","South India","Central India","West India","Canada
-        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
+        East","Canada Central","Korea South","Korea Central"],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"managedClusters","locations":["East
+        US","West Europe","Central US","Canada Central","Canada East"],"apiVersions":["2017-08-31"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
         East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
         Central US","West US 2","South India","Central India","West India","Canada
-        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DevTestLab","namespace":"Microsoft.DevTestLab","authorization":{"applicationId":"1a14be2a-e903-4cec-99cf-b2e209259a0f","roleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525"},"resourceTypes":[{"resourceType":"labs","locations":["West
+        East","Canada Central","Korea South","Korea Central"],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/orchestrators","locations":["UK
+        West","West US 2","East US","West Europe","Central US"],"apiVersions":["2017-09-30"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DevTestLab","namespace":"Microsoft.DevTestLab","authorization":{"applicationId":"1a14be2a-e903-4cec-99cf-b2e209259a0f","roleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525","managedByRoleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525"},"resourceTypes":[{"resourceType":"labs","locations":["West
         Central US","Japan East","West US","Australia Southeast","Canada Central","Central
         India","Central US","East Asia","Korea Central","North Europe","South Central
-        US","UK West","Australia East","Brazil South","Canada East","East US","East
-        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        US","UK West","West India","Australia East","Brazil South","Canada East","East
+        US","East US 2","Japan West","Korea South","North Central US","South India","Southeast
         Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"schedules","locations":["West
         Central US","Japan East","West US","Australia Southeast","Canada Central","Central
         India","Central US","East Asia","Korea Central","North Europe","South Central
-        US","UK West","Australia East","Brazil South","Canada East","East US","East
-        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        US","UK West","West India","Australia East","Brazil South","Canada East","East
+        US","East US 2","Japan West","Korea South","North Central US","South India","Southeast
         Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"labs/virtualMachines","locations":["West
         Central US","Japan East","West US","Australia Southeast","Canada Central","Central
         India","Central US","East Asia","Korea Central","North Europe","South Central
-        US","UK West","Australia East","Brazil South","Canada East","East US","East
-        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        US","UK West","West India","Australia East","Brazil South","Canada East","East
+        US","East US 2","Japan West","Korea South","North Central US","South India","Southeast
         Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"labs/serviceRunners","locations":["Central
         US","East US 2","South Central US"],"apiVersions":["2017-04-26-preview","2016-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"locations/operations","locations":["West
         Central US","Japan East","West US","Australia Southeast","Canada Central","Central
         India","Central US","East Asia","Korea Central","North Europe","South Central
-        US","UK West","Australia East","Brazil South","Canada East","East US","East
-        US 2","Japan West","Korea South","North Central US","South India","Southeast
-        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"}],"resourceTypes":[{"resourceType":"components","locations":["East
-        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
-        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01","2014-04-01"]},{"resourceType":"queries","locations":["East
-        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
+        US","UK West","West India","Australia East","Brazil South","Canada East","East
+        US","East US 2","Japan West","Korea South","North Central US","South India","Southeast
+        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","authorizations":[{"applicationId":"57c0fc58-a83a-41d0-8ae9-08952659bdfd","roleDefinitionId":"FFFD5CF5-FFD3-4B24-B0E2-0715ADD4C282"}],"resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"databaseAccountNames","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"operationResults","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"},{"applicationId":"f5c26e74-f226-4ae8-85f0-b4af0080ac9e","roleDefinitionId":"529d7ae6-e892-4d43-809d-8547aeb90643"}],"resourceTypes":[{"resourceType":"components","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2015-05-01","2014-08-01","2014-04-01"]},{"resourceType":"queries","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"components/pricingPlans","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"migrateToNewPricingModel","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"rollbackToLegacyPricingModel","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"listMigrationdate","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
@@ -516,7 +591,7 @@ http_interactions:
         West","North Central US","South Central US","East US 2","Canada East","Canada
         Central","Central US","Australia East","Australia Southeast","Brazil South","South
         India","Central India","West India","North Europe","West US 2","West Central
-        US","Korea South","Korea Central","UK South","UK West","Global"],"apiVersions":["2017-05-01-preview","2016-03-01","2015-07-01"]},{"resourceType":"logDefinitions","locations":["West
+        US","Korea South","Korea Central","UK South","UK West","Global"],"apiVersions":["2017-09-01-preview","2017-05-01-preview","2016-03-01","2015-07-01"]},{"resourceType":"logDefinitions","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
@@ -526,7 +601,7 @@ http_interactions:
         West","North Central US","South Central US","East US 2","Canada East","Canada
         Central","Central US","Australia East","Australia Southeast","Brazil South","South
         India","Central India","West India","North Europe","West US 2","West Central
-        US","Korea South","Korea Central","UK South","UK West"],"apiVersions":["2017-05-01-preview","2016-09-01","2016-06-01"]},{"resourceType":"actiongroups","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]},{"resourceType":"activityLogAlerts","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.KeyVault","namespace":"Microsoft.KeyVault","resourceTypes":[{"resourceType":"vaults","locations":["North
+        US","Korea South","Korea Central","UK South","UK West"],"apiVersions":["2017-09-01-preview","2017-05-01-preview","2016-09-01","2016-06-01"]},{"resourceType":"actiongroups","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]},{"resourceType":"activityLogAlerts","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.KeyVault","namespace":"Microsoft.KeyVault","resourceTypes":[{"resourceType":"vaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
@@ -556,126 +631,153 @@ http_interactions:
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorizations":[{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},{"applicationId":"7c33bfcb-8d33-48d6-8e60-dc6404003489","roleDefinitionId":"ad6261e4-fa9a-4642-aa5f-104f1b67e9e3"},{"applicationId":"1e3e4475-288f-4018-a376-df66fd7fac5f","roleDefinitionId":"1d538b69-3d87-4e56-8ff8-25786fd48261"},{"applicationId":"a0be0c72-870e-46f0-9c49-c98333a996f7","roleDefinitionId":"7ce22727-ffce-45a9-930c-ddb2e56fa131"}],"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","West Central US"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"operations","locations":["South
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations","locations":["South
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operations","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"commitmentPlans","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"Registering"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorizations":[{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},{"applicationId":"7c33bfcb-8d33-48d6-8e60-dc6404003489","roleDefinitionId":"ad6261e4-fa9a-4642-aa5f-104f1b67e9e3"},{"applicationId":"1e3e4475-288f-4018-a376-df66fd7fac5f","roleDefinitionId":"1d538b69-3d87-4e56-8ff8-25786fd48261"},{"applicationId":"a0be0c72-870e-46f0-9c49-c98333a996f7","roleDefinitionId":"7ce22727-ffce-45a9-930c-ddb2e56fa131"}],"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
-        Central US"],"apiVersions":["2017-09-01"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
-        East","UK South","Central India","Canada Central"],"apiVersions":["2017-04-26-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"]},{"resourceType":"workspaces/dataSources","locations":["East
+        East","UK South","Central India","Canada Central"],"apiVersions":["2017-04-26-preview","2017-03-15-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"]},{"resourceType":"workspaces/query","locations":["West
+        Central US","Australia Southeast","West Europe","East US","Southeast Asia","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2017-10-01"]},{"resourceType":"workspaces/dataSources","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
         East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"storageInsightConfigs","locations":[],"apiVersions":["2014-10-10"]},{"resourceType":"workspaces/linkedServices","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
         East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"linkTargets","locations":["East
         US"],"apiVersions":["2015-03-20"]},{"resourceType":"operations","locations":[],"apiVersions":["2014-11-10"]},{"resourceType":"devices","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationsManagement","namespace":"Microsoft.OperationsManagement","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"aa249101-6816-4966-aafa-08175d795f14"},"resourceTypes":[{"resourceType":"solutions","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
-        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Portal","namespace":"Microsoft.Portal","resourceTypes":[{"resourceType":"dashboards","locations":["Central
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"managementconfigurations","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"managementassociations","locations":[],"apiVersions":["2015-11-01-preview"]},{"resourceType":"views","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2017-08-21-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Portal","namespace":"Microsoft.Portal","resourceTypes":[{"resourceType":"dashboards","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
@@ -687,9 +789,9 @@ http_interactions:
         East","West India","South India","Central India","Canada Central","Canada
         East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"consoles","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/consoles","locations":["West
         US","East US","Central India","North Europe","West Europe","South Central
-        US","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
+        US","Southeast Asia","East US 2","Central US"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
         US","East US","Central India","North Europe","West Europe","South Central
-        US","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
+        US","Southeast Asia","East US 2","Central US"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
@@ -710,7 +812,17 @@ http_interactions:
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ResourceHealth","namespace":"Microsoft.ResourceHealth","authorization":{"applicationId":"8bdebf23-c0fe-4187-a378-717ad86f6a53","roleDefinitionId":"cc026344-c8b1-4561-83ba-59eba84b27cc"},"resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2017-07-01","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"notifications","locations":["Australia
+        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]},{"resourceType":"locations/backupValidateFeatures","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-07-01"]},{"resourceType":"locations/backupPreValidateProtection","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-07-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ResourceHealth","namespace":"Microsoft.ResourceHealth","authorization":{"applicationId":"8bdebf23-c0fe-4187-a378-717ad86f6a53","roleDefinitionId":"cc026344-c8b1-4561-83ba-59eba84b27cc"},"resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2017-07-01","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"notifications","locations":["Australia
         Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Security","namespace":"Microsoft.Security","authorization":{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatuses","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/virtualMachines","locations":["Central
@@ -743,10 +855,14 @@ http_interactions:
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securitySolutionsReferenceData","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/securitySolutionsReferenceData","locations":["Central
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"jitNetworkAccessPolicies","locations":["Central
-        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/jitNetworkAccessPolicies","locations":["Central
-        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations","locations":["Central
+        US","East US","North Europe","West Europe","UK South","UK West","West Central
+        US","West US 2"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/jitNetworkAccessPolicies","locations":["Central
+        US","East US","North Europe","West Europe","UK South","UK West","West Central
+        US","West US 2"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatusesSummaries","locations":["Central
-        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/alerts","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"applicationWhitelistings","locations":["Central
+        US","East US","West Central US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/applicationWhitelistings","locations":["Central
+        US","West Central US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/alerts","locations":["Central
         US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/tasks","locations":["Central
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"externalSecuritySolutions","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/externalSecuritySolutions","locations":["Central
@@ -769,7 +885,17 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/databaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/databaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -814,7 +940,7 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01","2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -829,7 +955,7 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -859,12 +985,17 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/geoBackupPolicies","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -879,12 +1010,12 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/firewallrules","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/backupLongTermRetentionPolicies","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -999,6 +1130,16 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
         US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
@@ -1034,7 +1175,22 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -1144,7 +1300,47 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -1159,7 +1355,17 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/administratorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -1179,52 +1385,52 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorization":{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorizations":[{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},{"applicationId":"e406a681-f3d4-42a8-90b6-c2b029497af1"}],"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
         US","West US","West Europe","North Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","South India","Central
@@ -1234,7 +1440,19 @@ http_interactions:
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Web","namespace":"Microsoft.Web","authorization":{"applicationId":"abfa0a7c-a6b6-4736-8310-5855508787cd","roleDefinitionId":"f47ed98b-b063-4a5b-9e10-4b9b44fa7735"},"resourceTypes":[{"resourceType":"sites/extensions","locations":["South
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/project","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/extension","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"checkNameAvailability","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Web","namespace":"Microsoft.Web","authorization":{"applicationId":"abfa0a7c-a6b6-4736-8310-5855508787cd","roleDefinitionId":"f47ed98b-b063-4a5b-9e10-4b9b44fa7735"},"resourceTypes":[{"resourceType":"sites/extensions","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
         South","West US","East US","Japan West","Japan East","East Asia","East US
         2","North Central US","Central US","Brazil South","Australia East","Australia
@@ -1339,7 +1557,7 @@ http_interactions:
         South","West US","East US","Japan West","Japan East","East Asia","East US
         2","North Central US","Central US","Brazil South","Australia East","Australia
         Southeast","West India","Central India","South India","Canada Central","Canada
-        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms/workers","locations":["South
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms/workers","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
         South","West US","East US","Japan West","Japan East","East Asia","East US
         2","North Central US","Central US","Brazil South","Australia East","Australia
@@ -1394,7 +1612,17 @@ http_interactions:
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","West US 2","West Central US","Canada Central","Canada
-        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/managedApis","locations":["North
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/listWsdlInterfaces","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/extractApiDefinitionFromWsdl","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/managedApis","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
@@ -1445,8 +1673,11 @@ http_interactions:
         US","North Europe","Japan West","Japan East","East Asia","West Europe","East
         US","Southeast Asia","Central US"],"apiVersions":["2016-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Lombiq.DotNest","namespace":"Lombiq.DotNest","resourceTypes":[{"resourceType":"sites","locations":["East
         US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Mailjet.Email","namespace":"Mailjet.Email","resourceTypes":[{"resourceType":"services","locations":["West
-        US"],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
-        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
+        US","West Europe"],"apiVersions":["2017-10-01","2017-02-03"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-10-01","2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-10-01","2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]},{"resourceType":"diagnosticSettings","locations":[],"apiVersions":["2017-04-01"]},{"resourceType":"diagnosticSettingsCategories","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Addons","namespace":"Microsoft.Addons","authorization":{"applicationId":"24d3987b-be4a-48e0-a3e7-11c186f39e41","roleDefinitionId":"8004BAAB-A4CB-4981-8571-F7E44D039D93"},"resourceTypes":[{"resourceType":"supportProviders","locations":["West
+        Central US","South Central US","East US","West Europe"],"apiVersions":["2017-05-15"]},{"resourceType":"operations","locations":["West
+        Central US","South Central US","East US","West Europe"],"apiVersions":["2017-05-15"]},{"resourceType":"operationResults","locations":["West
+        Central US","South Central US","East US","West Europe"],"apiVersions":["2017-05-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"addsservices","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"configuration","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"operations","locations":["West
@@ -1456,51 +1687,45 @@ http_interactions:
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"servicehealthmetrics","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"logs","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"anonymousapiusers","locations":["West
-        US"],"apiVersions":["2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AnalysisServices","namespace":"Microsoft.AnalysisServices","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"servers","locations":["West
+        US"],"apiVersions":["2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AlertsManagement","namespace":"Microsoft.AlertsManagement","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-11-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AnalysisServices","namespace":"Microsoft.AnalysisServices","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"servers","locations":["West
         US","North Europe","South Central US","West Europe","West Central US","Southeast
         Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
-        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/checkNameAvailability","locations":["West
+        Southeast","Japan East","UK South","West India","West US 2","East US"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"locations/checkNameAvailability","locations":["West
         US","North Europe","South Central US","West Europe","West Central US","Southeast
         Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
-        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationresults","locations":["West
+        Southeast","Japan East","UK South","West India","West US 2","East US"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationresults","locations":["West
         US","North Europe","South Central US","West Europe","West Central US","Southeast
         Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
-        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationstatuses","locations":["West
+        Southeast","Japan East","UK South","West India","West US 2","East US"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationstatuses","locations":["West
         US","North Europe","South Central US","West Europe","West Central US","Southeast
         Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
-        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"operations","locations":["East
-        US 2","West Central US"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AppService","namespace":"Microsoft.AppService","authorization":{"applicationId":"dee7ba80-6a55-4f3b-a86c-746a9231ae49","roleDefinitionId":"6715d172-49c4-46f6-bb21-60512a8689dc"},"resourceTypes":[{"resourceType":"apiapps","locations":["East
-        US","West US","South Central US","North Europe","East Asia","Japan East","West
-        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
-        South","East US 2","Australia Southeast","Australia East","West India","South
-        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"appIdentities","locations":["East
-        US","West US","South Central US","North Europe","East Asia","Japan East","West
-        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
-        South","East US 2","Australia Southeast","Australia East","West India","South
-        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"gateways","locations":["East
-        US","West US","South Central US","North Europe","East Asia","Japan East","West
-        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
-        South","East US 2","Australia Southeast","Australia East","West India","South
-        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"deploymenttemplates","locations":[],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Authorization","namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"roleDefinitions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"classicAdministrators","locations":[],"apiVersions":["2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"permissions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"locks","locations":[],"apiVersions":["2017-04-01","2016-09-01","2015-06-01","2015-05-01-preview","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-01-01","2014-10-01-preview","2014-06-01"]},{"resourceType":"policyDefinitions","locations":[],"apiVersions":["2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"policySetDefinitions","locations":[],"apiVersions":["2017-06-01-preview"]},{"resourceType":"policyAssignments","locations":[],"apiVersions":["2017-06-01-preview","2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"providerOperations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01-preview","2015-07-01"]},{"resourceType":"elevateAccess","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureActiveDirectory","namespace":"Microsoft.AzureActiveDirectory","resourceTypes":[{"resourceType":"b2cDirectories","locations":["Global","United
-        States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureStack","namespace":"Microsoft.AzureStack","resourceTypes":[{"resourceType":"operations","locations":["Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations","locations":["West
+        Southeast","Japan East","UK South","West India","West US 2","East US"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"operations","locations":["East
+        US 2","West Central US","West US 2"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Authorization","namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[],"apiVersions":["2017-10-01-preview","2017-09-01","2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"roleDefinitions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"classicAdministrators","locations":[],"apiVersions":["2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"permissions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"locks","locations":[],"apiVersions":["2017-04-01","2016-09-01","2015-06-01","2015-05-01-preview","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-01-01","2014-10-01-preview","2014-06-01"]},{"resourceType":"policyDefinitions","locations":[],"apiVersions":["2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"policySetDefinitions","locations":[],"apiVersions":["2017-06-01-preview"]},{"resourceType":"policyAssignments","locations":[],"apiVersions":["2017-06-01-preview","2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"providerOperations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01-preview","2015-07-01"]},{"resourceType":"elevateAccess","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"checkAccess","locations":[],"apiVersions":["2017-10-01-preview","2017-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureStack","namespace":"Microsoft.AzureStack","resourceTypes":[{"resourceType":"operations","locations":["Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations","locations":["West
         Central US","Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations/products","locations":["West
-        Central US","Global"],"apiVersions":["2017-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Billing","namespace":"Microsoft.Billing","resourceTypes":[{"resourceType":"BillingPeriods","locations":["Central
+        Central US","Global"],"apiVersions":["2017-06-01","2016-01-01"]},{"resourceType":"registrations/customerSubscriptions","locations":["West
+        Central US","Global"],"apiVersions":["2017-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BatchAI","namespace":"Microsoft.BatchAI","authorization":{"applicationId":"9fcb3732-5f52-4135-8c08-9d4bbaf203ea","roleDefinitionId":"703B89C7-CE2C-431B-BDD8-FA34E39AF696","managedByRoleDefinitionId":"90B8E153-EBFF-4073-A95F-4DAD56B14C78"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"jobs","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"fileservers","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"operations","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01-preview"]},{"resourceType":"locations/operationresults","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Billing","namespace":"Microsoft.Billing","resourceTypes":[{"resourceType":"BillingPeriods","locations":["Central
         US"],"apiVersions":["2017-04-24-preview"]},{"resourceType":"Invoices","locations":["Central
         US"],"apiVersions":["2017-04-24-preview","2017-02-27-preview"]},{"resourceType":"operations","locations":["Central
         US"],"apiVersions":["2017-04-24-preview","2017-02-27-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BingMaps","namespace":"Microsoft.BingMaps","resourceTypes":[{"resourceType":"mapApis","locations":["West
         US"],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-18","2015-07-02"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BizTalkServices","namespace":"Microsoft.BizTalkServices","resourceTypes":[{"resourceType":"BizTalk","locations":["East
         US","West US","North Europe","West Europe","Southeast Asia","East Asia","North
-        Central US","Japan West","Japan East","South Central US"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Cache","namespace":"Microsoft.Cache","authorization":{"applicationId":"96231a05-34ce-4eb4-aa6a-70759cbb5e83","roleDefinitionId":"4f731528-ba85-45c7-acfb-cd0a9b3cf31b"},"resourceTypes":[{"resourceType":"Redis","locations":["North
+        Central US","Japan West","Japan East","South Central US"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BotService","namespace":"Microsoft.BotService","resourceTypes":[{"resourceType":"botServices","locations":["Global"],"apiVersions":["2017-12-01"]},{"resourceType":"checkNameAvailability","locations":["Global"],"apiVersions":["2017-12-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Cache","namespace":"Microsoft.Cache","authorization":{"applicationId":"96231a05-34ce-4eb4-aa6a-70759cbb5e83","roleDefinitionId":"4f731528-ba85-45c7-acfb-cd0a9b3cf31b"},"resourceTypes":[{"resourceType":"Redis","locations":["North
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","Canada Central","Canada East","UK South","UK West","West US 2","West
-        Central US","South India","Korea Central","Korea South"],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","South India","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","South India","Canada Central","Canada East","UK South","UK West","West
-        US 2","West Central US","Korea Central","Korea South"],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01"]},{"resourceType":"Redis/metricDefinitions","locations":["North
+        US 2","West Central US","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01"]},{"resourceType":"Redis/metricDefinitions","locations":["North
         Central US","South Central US","East US","East US 2","West US","Central US","East
         Asia","Southeast Asia","North Europe","West Europe","Japan East","Japan West","Brazil
         South","Australia Southeast","Australia East","Central India","West India","South
@@ -1514,59 +1739,59 @@ http_interactions:
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/origins","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/origins","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/customdomains","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/customdomains","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/originresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/originresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/customdomainresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/customdomainresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkResourceUsage","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkResourceUsage","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02"]},{"resourceType":"validateProbe","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02"]},{"resourceType":"validateProbe","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02"]},{"resourceType":"operations","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02"]},{"resourceType":"operations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"edgenodes","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"edgenodes","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CertificateRegistration","namespace":"Microsoft.CertificateRegistration","authorization":{"applicationId":"f3c21649-0979-4721-ac85-b0216b2cf413","roleDefinitionId":"933fba7e-2ed3-4da8-973d-8bd8298a9b40"},"resourceTypes":[{"resourceType":"certificateOrders","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"certificateOrders/certificates","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"validateCertificateRegistrationInformation","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicSubscription","namespace":"Microsoft.ClassicSubscription","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicInfrastructureMigrate","namespace":"Microsoft.ClassicInfrastructureMigrate","authorization":{"applicationId":"5e5abe2b-83cd-4786-826a-a05653ebb103","roleDefinitionId":"766c4d9b-ef83-4f73-8352-1450a506a69b"},"resourceTypes":[{"resourceType":"classicInfrastructureResources","locations":["East
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CertificateRegistration","namespace":"Microsoft.CertificateRegistration","authorization":{"applicationId":"f3c21649-0979-4721-ac85-b0216b2cf413","roleDefinitionId":"933fba7e-2ed3-4da8-973d-8bd8298a9b40"},"resourceTypes":[{"resourceType":"certificateOrders","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"certificateOrders/certificates","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"validateCertificateRegistrationInformation","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicSubscription","namespace":"Microsoft.ClassicSubscription","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-09-01","2017-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicInfrastructureMigrate","namespace":"Microsoft.ClassicInfrastructureMigrate","authorization":{"applicationId":"5e5abe2b-83cd-4786-826a-a05653ebb103","roleDefinitionId":"766c4d9b-ef83-4f73-8352-1450a506a69b"},"resourceTypes":[{"resourceType":"classicInfrastructureResources","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
         Central US","Central US","North Europe","West Europe","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","West
@@ -1584,8 +1809,9 @@ http_interactions:
         Asia","East Asia","West Central US","South Central US","East US","East US
         2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/updateAccountsCreationSettings","locations":["West
         US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/accountsCreationSettings","locations":["West
-        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2016-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Commerce","namespace":"Microsoft.Commerce","resourceTypes":[{"resourceType":"UsageAggregates","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]},{"resourceType":"RateCard","locations":[],"apiVersions":["2016-08-31-preview","2015-06-01-preview","2015-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Consumption","namespace":"Microsoft.Consumption","resourceTypes":[{"resourceType":"reservationsummaries","locations":[],"apiVersions":["2017-01-30"]},{"resourceType":"reservationdetails","locations":[],"apiVersions":["2017-01-30"]},{"resourceType":"UsageDetails","locations":[],"apiVersions":["2017-06-30-preview","2017-04-24-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-30-preview","2017-04-24-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","resourceTypes":[{"resourceType":"containerGroups","locations":["West
-        US","East US","West Europe"],"apiVersions":["2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
+        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2016-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Commerce","namespace":"Microsoft.Commerce","resourceTypes":[{"resourceType":"UsageAggregates","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]},{"resourceType":"RateCard","locations":[],"apiVersions":["2016-08-31-preview","2015-06-01-preview","2015-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Consumption","namespace":"Microsoft.Consumption","resourceTypes":[{"resourceType":"ReservationSummaries","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationTransactions","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"Balances","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"Pricesheets","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationDetails","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"Budgets","locations":[],"apiVersions":["2017-12-30-preview"]},{"resourceType":"Terms","locations":[],"apiVersions":["2017-12-30-preview"]},{"resourceType":"UsageDetails","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview","2017-04-24-preview"]},{"resourceType":"Operations","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview","2017-04-24-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","resourceTypes":[{"resourceType":"containerGroups","locations":["West
+        US","East US","West Europe","Southeast Asia"],"apiVersions":["2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US","East US","West Europe","Southeast Asia"],"apiVersions":["2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
         US"],"apiVersions":["2016-04-08"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CustomerInsights","namespace":"Microsoft.CustomerInsights","authorization":{"applicationId":"38c77d00-5fcb-4cce-9d93-af4738258e3c","roleDefinitionId":"E006F9C7-F333-477C-8AD6-1F3A9FE87F55"},"resourceTypes":[{"resourceType":"hubs","locations":["East
         US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/profiles","locations":["East
         US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/interactions","locations":["East
@@ -1608,8 +1834,8 @@ http_interactions:
         US","West US","Australia East","West Europe","North Europe","Southeast Asia","West
         Central US"],"apiVersions":["2016-03-30","2015-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataFactory","namespace":"Microsoft.DataFactory","resourceTypes":[{"resourceType":"dataFactories","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview","2014-04-01"]},{"resourceType":"factories","locations":["East
-        US","East US 2"],"apiVersions":["2017-09-01-preview","2017-03-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
-        US","East US 2"],"apiVersions":["2017-09-01-preview","2017-03-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
+        US","East US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
+        US","East US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
         Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"dataFactories/metricDefinitions","locations":["North
         Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"checkDataFactoryNameAvailability","locations":[],"apiVersions":["2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"checkAzureDataFactoryNameAvailability","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"dataFactorySchema","locations":["West
@@ -1621,69 +1847,71 @@ http_interactions:
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers/listSasTokens","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeStore","namespace":"Microsoft.DataLakeStore","authorization":{"applicationId":"e9f49c6b-5ce5-44c8-925d-015017e9f7ad","roleDefinitionId":"17eb9cca-f08a-4499-b2d3-852d175f614f"},"resourceTypes":[{"resourceType":"accounts","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/firewallRules","locations":["East
-        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","resourceTypes":[{"resourceType":"operations","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforPostgreSQL","namespace":"Microsoft.DBforPostgreSQL","resourceTypes":[{"resourceType":"operations","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"checkProvisioningServiceNameAvailability","locations":[],"apiVersions":["2017-08-21-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataMigration","namespace":"Microsoft.DataMigration","authorization":{"applicationId":"a4bad4aa-bf02-4631-9f78-a64ffdba8150","roleDefinitionId":"b831a21d-db98-4760-89cb-bef871952df1","managedByRoleDefinitionId":"6256fb55-9e59-4018-a9e1-76b11c0a4c89"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services/projects","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationStatuses","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforPostgreSQL","namespace":"Microsoft.DBforPostgreSQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"checkProvisioningServiceNameAvailability","locations":[],"apiVersions":["2017-11-15","2017-08-21-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
         US","North Europe","East Asia","East US","West Europe","Southeast Asia","Japan
         East","Japan West","Australia East","Australia Southeast","West US 2","West
         Central US","East US 2","Central US","UK South","UK West","South India","Central
-        India","Canada Central","Canada East"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"ProvisioningServices","locations":["East
-        US","West Europe","Southeast Asia"],"apiVersions":["2017-08-21-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
-        East","Australia Southeast","Canada Central","Canada East","Central India","Central
-        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
-        US","North Europe","South Central US","South India","Southeast Asia","West
-        Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"databaseAccountNames","locations":["Australia
-        East","Australia Southeast","Canada Central","Canada East","Central India","Central
-        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
-        US","North Europe","South Central US","South India","Southeast Asia","West
-        Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"operations","locations":["Australia
-        East","Australia Southeast","Canada Central","Canada East","Central India","Central
-        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
-        US","North Europe","South Central US","South India","Southeast Asia","West
-        Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DomainRegistration","namespace":"Microsoft.DomainRegistration","authorization":{"applicationId":"ea2f600a-4980-45b7-89bf-d34da487bda1","roleDefinitionId":"54d7f2e3-5040-48a7-ae90-eebf629cfa0b"},"resourceTypes":[{"resourceType":"domains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"domains/domainOwnershipIdentifiers","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"topLevelDomains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"checkDomainAvailability","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"listDomainRecommendations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"validateDomainRegistrationInformation","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"generateSsoRequest","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DynamicsLcs","namespace":"Microsoft.DynamicsLcs","resourceTypes":[{"resourceType":"lcsprojects","locations":["Brazil
+        India","Canada Central","Canada East","Brazil South","South Central US"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs/eventGridFilters","locations":["West
+        US","East US","West US 2","West Central US","East US 2","Central US"],"apiVersions":["2018-01-15-preview"]},{"resourceType":"ProvisioningServices","locations":["East
+        US","West US","West Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2017-11-15","2017-08-21-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DomainRegistration","namespace":"Microsoft.DomainRegistration","authorization":{"applicationId":"ea2f600a-4980-45b7-89bf-d34da487bda1","roleDefinitionId":"54d7f2e3-5040-48a7-ae90-eebf629cfa0b"},"resourceTypes":[{"resourceType":"domains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"domains/domainOwnershipIdentifiers","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"topLevelDomains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"checkDomainAvailability","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"listDomainRecommendations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"validateDomainRegistrationInformation","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"generateSsoRequest","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DynamicsLcs","namespace":"Microsoft.DynamicsLcs","resourceTypes":[{"resourceType":"lcsprojects","locations":["Brazil
         South","East Asia","East US","Japan East","Japan West","North Central US","North
         Europe","South Central US","West Europe","West US","Southeast Asia","Central
         US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"lcsprojects/connectors","locations":["Brazil
@@ -1695,21 +1923,21 @@ http_interactions:
         US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"operations","locations":["Brazil
         South","East Asia","East US","Japan East","Japan West","North Central US","North
         Europe","South Central US","West Europe","West US","Southeast Asia","Central
-        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topics","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operations","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topics","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operations","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","West
         US 2","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
         India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/consumergroups","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
         US","East US 2","West US","South Central US","Central US","Australia East","Australia
         Southeast","Central India","West Central US","West US 2","Canada East","Canada
         Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
@@ -1754,23 +1982,23 @@ http_interactions:
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations","locations":["Australia
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations/operationResults","locations":["Australia
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations/operationResults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"operations","locations":["Australia
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"operations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Logic","namespace":"Microsoft.Logic","authorization":{"applicationId":"7cd684f4-8a78-49b0-91ec-6a35d38739ba","roleDefinitionId":"cb3ef1fb-6e31-49e2-9d87-ed821053fe58"},"resourceTypes":[{"resourceType":"workflows","locations":["North
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.LocationBasedServices","namespace":"Microsoft.LocationBasedServices","resourceTypes":[{"resourceType":"accounts","locations":["Global"],"apiVersions":["2017-01-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Logic","namespace":"Microsoft.Logic","authorization":{"applicationId":"7cd684f4-8a78-49b0-91ec-6a35d38739ba","roleDefinitionId":"cb3ef1fb-6e31-49e2-9d87-ed821053fe58"},"resourceTypes":[{"resourceType":"workflows","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
@@ -1791,60 +2019,78 @@ http_interactions:
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada Central","Canada East","West US 2","West Central
-        US","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","West Central US"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"operations","locations":["South
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations","locations":["South
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operations","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"commitmentPlans","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningExperimentation","namespace":"Microsoft.MachineLearningExperimentation","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"accounts","locations":["Australia
-        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces","locations":["Australia
-        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces/projects","locations":["Australia
-        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningCompute","namespace":"Microsoft.MachineLearningCompute","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"376aa7d7-51a9-463d-bd4d-7e1691345612","managedByRoleDefinitionId":"91d00862-cf55-46a5-9dce-260bbd92ce25"},"resourceTypes":[{"resourceType":"operationalizationClusters","locations":["East
-        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"operations","locations":["East
+        US","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningExperimentation","namespace":"Microsoft.MachineLearningExperimentation","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"accounts","locations":["Australia
+        East","East US 2","West Central US","Southeast Asia","West Europe"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces","locations":["Australia
+        East","East US 2","West Central US","Southeast Asia","West Europe"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces/projects","locations":["Australia
+        East","East US 2","West Central US","Southeast Asia","West Europe"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"teamAccounts","locations":["Australia
+        East","West Central US","East US 2"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"teamAccounts/workspaces","locations":["Australia
+        East","West Central US","East US 2"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"teamAccounts/workspaces/projects","locations":["Australia
+        East","West Central US","East US 2"],"apiVersions":["2017-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningCompute","namespace":"Microsoft.MachineLearningCompute","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"376aa7d7-51a9-463d-bd4d-7e1691345612","managedByRoleDefinitionId":"91d00862-cf55-46a5-9dce-260bbd92ce25"},"resourceTypes":[{"resourceType":"operationalizationClusters","locations":["East
+        US 2","West Central US","Australia East","West Europe","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"operations","locations":["East
         US 2"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations","locations":["East
         US 2"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operations","locations":["East
-        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["East
-        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningModelManagement","namespace":"Microsoft.MachineLearningModelManagement","resourceTypes":[{"resourceType":"accounts","locations":["East
-        US 2","West Central US","Australia East"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"operations","locations":["West
-        Central US"],"apiVersions":["2017-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
+        US 2","West Central US","Australia East","West Europe","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["East
+        US 2","West Central US","Australia East","West Europe","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningModelManagement","namespace":"Microsoft.MachineLearningModelManagement","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US 2","West Central US","Australia East","West Europe","Southeast Asia"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"operations","locations":["West
+        Central US"],"apiVersions":["2017-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ManagedIdentity","namespace":"Microsoft.ManagedIdentity","resourceTypes":[{"resourceType":"Identities","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Brazil South","Central
+        India","West India","South India","Japan West","Japan East","East Asia","Southeast
+        Asia","Korea Central","Korea South","North Europe","West Europe","UK West","UK
+        South","Central US","North Central US","East US","East US 2","South Central
+        US","West US","West US 2","West Central US"],"apiVersions":["2015-08-31-PREVIEW"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Brazil South","Central
+        India","West India","South India","Japan West","Japan East","East Asia","Southeast
+        Asia","Korea Central","Korea South","North Europe","West Europe","UK West","UK
+        South","Central US","North Central US","East US","East US 2","South Central
+        US","West US","West US 2","West Central US"],"apiVersions":["2015-08-31-PREVIEW"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Management","namespace":"Microsoft.Management","authorization":{"applicationId":"f2c304cf-8e7e-4c3f-8164-16299ad9d272","roleDefinitionId":"c1cf3708-588a-4647-be7f-f400bbe214cf"},"resourceTypes":[{"resourceType":"resources","locations":[],"apiVersions":["2017-11-01-preview","2017-08-31-preview","2017-06-30-preview","2017-05-31-preview"]},{"resourceType":"managementGroups","locations":[],"apiVersions":["2017-11-01-preview","2017-08-31-preview","2017-06-30-preview","2017-05-31-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01-preview","2017-08-31-preview","2017-06-30-preview","2017-05-31-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceApps","namespace":"Microsoft.MarketplaceApps","resourceTypes":[{"resourceType":"classicDevServices","locations":["Northwest
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","Central US","North
+        Europe","West Europe","Japan East","Japan West","Brazil South","Australia
+        East","Australia Southeast","South India","Central India","Canada Central","Canada
+        East"],"apiVersions":["2017-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
         Central US","West US"],"apiVersions":["2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01"]},{"resourceType":"offertypes","locations":["South
         Central US","West US"],"apiVersions":["2015-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Media","namespace":"Microsoft.Media","authorization":{"applicationId":"374b2a64-3b6b-436b-934c-b820eacca870","roleDefinitionId":"aab70789-0cec-44b5-95d7-84b64c9487af"},"resourceTypes":[{"resourceType":"mediaservices","locations":["Japan
         West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
         US","West US","Australia East","Australia Southeast","Central US","Brazil
         South","Central India","West India","South India","South Central US","Canada
-        Central","Canada East","West Central US"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
+        Central","Canada East","West Central US","West US 2"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
+        Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"operations","locations":["West
+        Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
+        Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PolicyInsights","namespace":"Microsoft.PolicyInsights","authorization":{"applicationId":"1d78a85d-813d-46f0-b496-dd72f50a3ec0","roleDefinitionId":"63d2b225-4c34-4641-8768-21a1f7c68ce8"},"resourceTypes":[{"resourceType":"policyEvents","locations":[],"apiVersions":["2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"policyStates","locations":[],"apiVersions":["2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-17-preview","2017-08-09-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
         Central US","North Central US","East US 2","West US","West Europe","North
         Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
         East","UK South","West India"],"apiVersions":["2016-01-29"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-01-29"]},{"resourceType":"locations/checkNameAvailability","locations":["South
         Central US","North Central US","East US 2","West US","West Europe","North
         Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
-        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"capacities","locations":["West
-        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
-        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationresults","locations":["West
-        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
-        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"operations","locations":["East
-        US 2"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Relay","namespace":"Microsoft.Relay","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"capacities","locations":["Australia
+        Southeast","Brazil South","Canada Central","East Asia","East US","East US
+        2","West India","Japan East","West Central US","North Central US","North Europe","South
+        Central US","Southeast Asia","UK South","West Europe","West US","West US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":["Australia
+        Southeast","Brazil South","Canada Central","East Asia","East US","East US
+        2","West India","Japan East","West Central US","North Central US","North Europe","South
+        Central US","Southeast Asia","UK South","West Europe","West US","West US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationresults","locations":["Australia
+        Southeast","Brazil South","Canada Central","East Asia","East US","East US
+        2","West India","Japan East","West Central US","North Central US","North Europe","South
+        Central US","Southeast Asia","UK South","West Europe","West US","West US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["Australia
+        Southeast","Brazil South","Canada Central","East Asia","East US","East US
+        2","West India","Japan East","West Central US","North Central US","North Europe","South
+        Central US","Southeast Asia","UK South","West Europe","West US","West US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"operations","locations":["East
+        US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Relay","namespace":"Microsoft.Relay","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US 2","West
         US","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
         India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2017-08-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkPolicyCompliance","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/hybridconnections","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/hybridconnections/authorizationrules","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/wcfrelays","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/wcfrelays/authorizationrules","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkPolicyCompliance","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
         Central US","South Central US","North Europe","West Europe","East Asia","Southeast
         Asia","West US","East US","Japan West","Japan East","Brazil South","Central
         US","East US 2","Australia East","Australia Southeast","South India","Central
@@ -1868,12 +2114,12 @@ http_interactions:
         India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19","2015-02-28"]},{"resourceType":"checkServiceNameAvailability","locations":[],"apiVersions":["2015-02-28","2014-07-31-Preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2015-08-19"]},{"resourceType":"resourceHealthMetadata","locations":["West
         US","East US","North Europe","West Europe","Southeast Asia","East Asia","North
         Central US","South Central US","Japan West","Australia East","Brazil South","Central
-        India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","authorization":{"applicationId":"80a10ef9-8168-493d-abf9-3297c4ef6e3c","roleDefinitionId":"2b7763f7-bbe2-4e19-befe-28c79f1cf7f7"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US 2","West
         US","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
         India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"premiumMessagingRegions","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceFabric","namespace":"Microsoft.ServiceFabric","authorization":{"applicationId":"74cb6831-0dbb-4be1-8206-fd4df301cdc2","roleDefinitionId":"e55cc65f-6903-4917-b4ef-f8d4640b57f5"},"resourceTypes":[{"resourceType":"clusters","locations":["West
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/queues","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/queues/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/topics","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/topics/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/topics/subscriptions","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/topics/subscriptions/rules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"premiumMessagingRegions","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceFabric","namespace":"Microsoft.ServiceFabric","authorization":{"applicationId":"74cb6831-0dbb-4be1-8206-fd4df301cdc2","roleDefinitionId":"e55cc65f-6903-4917-b4ef-f8d4640b57f5"},"resourceTypes":[{"resourceType":"clusters","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
@@ -1887,17 +2133,43 @@ http_interactions:
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
-        India","West India","Central India","Brazil South","South Central US","Canada
-        Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
         Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
         Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applianceDefinitions","locations":["West
-        Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"locations","locations":["West
-        Central US"],"apiVersions":["2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
-        Central US"],"apiVersions":["2017-09-01","2016-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
+        Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applications","locations":["South
+        Central US","North Central US","West Central US","West US","West US 2","East
+        US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
+        Asia","Brazil South","Japan West","Japan East","Australia East","Australia
+        Southeast","South India","West India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
+        Central US","North Central US","West Central US","West US","West US 2","East
+        US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
+        Asia","Brazil South","Japan West","Japan East","Australia East","Australia
+        Southeast","South India","West India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
+        Central US"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
+        Central US","North Central US","West Central US","West US","West US 2","East
+        US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
+        Asia","Brazil South","Japan West","Japan East","Australia East","Australia
+        Southeast","South India","West India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/cloudEndpoints","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/serverEndpoints","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/registeredServers","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/workflows","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","West Central US","Japan East","Japan West","Australia East","Australia
         Southeast"],"apiVersions":["2017-06-01","2017-05-15","2017-01-01","2016-10-01","2016-06-01","2015-03-15","2014-09-01"]},{"resourceType":"operations","locations":["West
@@ -1928,23 +2200,11 @@ http_interactions:
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast"],"apiVersions":["2015-07-01-Preview","2015-03-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.TimeSeriesInsights","namespace":"Microsoft.TimeSeriesInsights","authorizations":[{"applicationId":"120d688d-1518-4cf7-bd38-182f158850b6","roleDefinitionId":"5a43abdf-bb87-42c4-9e56-1c24bf364150"}],"resourceTypes":[{"resourceType":"environments","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/eventsources","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/referenceDataSets","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/accessPolicies","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"operations","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
-        Central US","South Central US","East US","West US","Central US","North Europe","West
-        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
-        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/project","locations":["North
-        Central US","South Central US","East US","West US","Central US","North Europe","West
-        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
-        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/extension","locations":["North
-        Central US","South Central US","East US","West US","Central US","North Europe","West
-        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
-        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"checkNameAvailability","locations":["North
-        Central US","South Central US","East US","West US","Central US","North Europe","West
-        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
-        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Myget.PackageManagement","namespace":"Myget.PackageManagement","resourceTypes":[{"resourceType":"services","locations":["West
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]},{"resourceType":"environments/eventsources","locations":["East
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]},{"resourceType":"environments/referenceDataSets","locations":["East
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]},{"resourceType":"environments/accessPolicies","locations":["East
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]},{"resourceType":"operations","locations":["East
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Myget.PackageManagement","namespace":"Myget.PackageManagement","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/NewRelic.APM","namespace":"NewRelic.APM","authorization":{"allowedThirdPartyExtensions":[{"name":"NewRelic_AzurePortal_APM"}]},"resourceTypes":[{"resourceType":"accounts","locations":["North
         Central US","South Central US","West US","East US","North Europe","West Europe","Southeast
         Asia","East Asia","Japan East","Japan West"],"apiVersions":["2014-10-01","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/nuubit.nextgencdn","namespace":"nuubit.nextgencdn","resourceTypes":[{"resourceType":"accounts","locations":["East
@@ -1984,7 +2244,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:41:45 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:26 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
@@ -2001,9 +2261,11 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMDMsIm5iZiI6MTUwNjExNjIwMywiZXhwIjoxNTA2MTIwMTAzLCJhaW8iOiJZMlZnWVBDVnFid3k0MUdUOWhQeFIvczVwZlJlQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiT29zV1E5alMzRU80dnBzR1lnQUxBQSIsInZlciI6IjEuMCJ9.qW2dETkABqLKjPpG1kNgiKjWDSGCrK2O436_yOUSiUEbgpEPPUqJy_4XcMu7FneQJg1gaLLLIl7ViyzJVBs_rftEdrJmuoUjufj8MetXeIaJQUh8hx-fNOrb9UEYpwK4mSK01HfRe3U-A3DT-6POIQFwbLf78M_nXJohlijBYEL0WZ02Vx2ZRqGVwpGQ8Jo--Iqcf3IELsE8RSuhDJAbLk4JAjxIen7f04U3S4dU4DxvN87n0tODuGTOD58uuY-Fsk8JMGfg47p_OQrhhZI8rg6qLu4vGVlZk_JjDqzFaVbRBWgB1QnwqnHjUqrtgjD9AsVlhuvWgUvG1swYo97bCQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3NDQsIm5iZiI6MTUxNjczNzc0NCwiZXhwIjoxNTE2NzQxNjQ0LCJhaW8iOiJZMk5nWURBTjFDdDJkcHEzYjE1K2V1Lys2UnRMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiaTgxdXM4M3pSRWFZRVlsRzV2SUFBQSIsInZlciI6IjEuMCJ9.bhuZbwr_DUbUHhY7EeZI_nzv42PIpod-gtIasMU8f2WzgYqVdB9mZlFvc129yMGW5M5GOTE5RTNUxSx4RKNpx2w43_HMdFijkjsVnXsjq9WKLE-jS6sadsWwH86475tWaX7QhhHyIfF0pT09icUd5YlwupxNYpUDsZo5SULJbqgGbqKLjdLbrTx1s1mXtr6jHuXDwKJNjpNea3vOXmD57xTVKzlIJDCDcWCGeghKUncgbGX77IkRWp-8KgVeApyrPfMhFpnH74FqbDn092ZCrOthzI8hOGlu1HPAcA9rxxs2i7L90J86WKsaKjSYepHU4dMkS2mjVO4xJoKe05d3tg
       Content-Length:
       - '42'
+      Host:
+      - management.azure.com
   response:
     status:
       code: 202
@@ -2013,39 +2275,41 @@ http_interactions:
       - no-cache
       Pragma:
       - no-cache
-      Content-Length:
-      - '0'
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/da68c226-01b6-45a7-a0f1-159e65965942?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/b3bfc721-45b6-4443-b5e6-bc4103769f64?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/da68c226-01b6-45a7-a0f1-159e65965942?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/b3bfc721-45b6-4443-b5e6-bc4103769f64?api-version=2017-03-30
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/HighCostHydrate3Min;231,Microsoft.Compute/HighCostHydrate30Min;1158
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131599701143261070
       X-Ms-Request-Id:
-      - da68c226-01b6-45a7-a0f1-159e65965942
+      - b3bfc721-45b6-4443-b5e6-bc4103769f64
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1178'
+      - '1153'
       X-Ms-Correlation-Request-Id:
-      - 60bfa6f0-3cf3-4f1d-b1d7-5e57ad7b1b11
+      - 395bf97b-44de-485e-a829-0353ae73cb4d
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214146Z:60bfa6f0-3cf3-4f1d-b1d7-5e57ad7b1b11
+      - WESTUS:20180123T200727Z:395bf97b-44de-485e-a829-0353ae73cb4d
       Date:
-      - Fri, 22 Sep 2017 21:41:46 GMT
+      - Tue, 23 Jan 2018 20:07:27 GMT
+      Content-Length:
+      - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:41:46 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:27 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/da68c226-01b6-45a7-a0f1-159e65965942?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/b3bfc721-45b6-4443-b5e6-bc4103769f64?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -2059,7 +2323,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMDMsIm5iZiI6MTUwNjExNjIwMywiZXhwIjoxNTA2MTIwMTAzLCJhaW8iOiJZMlZnWVBDVnFid3k0MUdUOWhQeFIvczVwZlJlQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiT29zV1E5alMzRU80dnBzR1lnQUxBQSIsInZlciI6IjEuMCJ9.qW2dETkABqLKjPpG1kNgiKjWDSGCrK2O436_yOUSiUEbgpEPPUqJy_4XcMu7FneQJg1gaLLLIl7ViyzJVBs_rftEdrJmuoUjufj8MetXeIaJQUh8hx-fNOrb9UEYpwK4mSK01HfRe3U-A3DT-6POIQFwbLf78M_nXJohlijBYEL0WZ02Vx2ZRqGVwpGQ8Jo--Iqcf3IELsE8RSuhDJAbLk4JAjxIen7f04U3S4dU4DxvN87n0tODuGTOD58uuY-Fsk8JMGfg47p_OQrhhZI8rg6qLu4vGVlZk_JjDqzFaVbRBWgB1QnwqnHjUqrtgjD9AsVlhuvWgUvG1swYo97bCQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3NDQsIm5iZiI6MTUxNjczNzc0NCwiZXhwIjoxNTE2NzQxNjQ0LCJhaW8iOiJZMk5nWURBTjFDdDJkcHEzYjE1K2V1Lys2UnRMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiaTgxdXM4M3pSRWFZRVlsRzV2SUFBQSIsInZlciI6IjEuMCJ9.bhuZbwr_DUbUHhY7EeZI_nzv42PIpod-gtIasMU8f2WzgYqVdB9mZlFvc129yMGW5M5GOTE5RTNUxSx4RKNpx2w43_HMdFijkjsVnXsjq9WKLE-jS6sadsWwH86475tWaX7QhhHyIfF0pT09icUd5YlwupxNYpUDsZo5SULJbqgGbqKLjdLbrTx1s1mXtr6jHuXDwKJNjpNea3vOXmD57xTVKzlIJDCDcWCGeghKUncgbGX77IkRWp-8KgVeApyrPfMhFpnH74FqbDn092ZCrOthzI8hOGlu1HPAcA9rxxs2i7L90J86WKsaKjSYepHU4dMkS2mjVO4xJoKe05d3tg
+      Host:
+      - management.azure.com
   response:
     status:
       code: 200
@@ -2077,34 +2343,36 @@ http_interactions:
       - "-1"
       Vary:
       - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/GetOperation3Min;49977,Microsoft.Compute/GetOperation30Min;249977
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131599701143261070
       X-Ms-Request-Id:
-      - df967679-4d4c-4d11-abec-19a23017359c
+      - 926a2b73-6a4d-46b1-b04c-643c76505c23
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14911'
+      - '14860'
       X-Ms-Correlation-Request-Id:
-      - d5c4bfde-bf57-4a2b-bb2c-ff665f137e22
+      - 35b5055e-da54-4c59-b635-9531c0559141
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214147Z:d5c4bfde-bf57-4a2b-bb2c-ff665f137e22
+      - WESTUS:20180123T200726Z:35b5055e-da54-4c59-b635-9531c0559141
       Date:
-      - Fri, 22 Sep 2017 21:41:46 GMT
+      - Tue, 23 Jan 2018 20:07:26 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-22T21:41:48.0574635+00:00\",\r\n  \"endTime\":
-        \"2017-09-22T21:41:48.2162393+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=641d18d6-8fe5-4023-9d31-f1f209e7ed48&sig=amflQ53Pr%2BaHg2JIkhbNR0qHc%2BCZbvV4TDuqIZjQH3o%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"da68c226-01b6-45a7-a0f1-159e65965942\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2018-01-23T20:07:27.1694382+00:00\",\r\n  \"endTime\":
+        \"2018-01-23T20:07:27.40382+00:00\",\r\n  \"status\": \"Succeeded\",\r\n  \"properties\":
+        {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=8466f513-85ff-4288-9d4d-d9daa9e13022&sig=hCtv9GJbdKBHVYeENPxxHp6KXUvAn5%2FWoM526E0YZNw%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"b3bfc721-45b6-4443-b5e6-bc4103769f64\"\r\n}"
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:41:47 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:28 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/da68c226-01b6-45a7-a0f1-159e65965942?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/b3bfc721-45b6-4443-b5e6-bc4103769f64?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -2118,7 +2386,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMDMsIm5iZiI6MTUwNjExNjIwMywiZXhwIjoxNTA2MTIwMTAzLCJhaW8iOiJZMlZnWVBDVnFid3k0MUdUOWhQeFIvczVwZlJlQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiT29zV1E5alMzRU80dnBzR1lnQUxBQSIsInZlciI6IjEuMCJ9.qW2dETkABqLKjPpG1kNgiKjWDSGCrK2O436_yOUSiUEbgpEPPUqJy_4XcMu7FneQJg1gaLLLIl7ViyzJVBs_rftEdrJmuoUjufj8MetXeIaJQUh8hx-fNOrb9UEYpwK4mSK01HfRe3U-A3DT-6POIQFwbLf78M_nXJohlijBYEL0WZ02Vx2ZRqGVwpGQ8Jo--Iqcf3IELsE8RSuhDJAbLk4JAjxIen7f04U3S4dU4DxvN87n0tODuGTOD58uuY-Fsk8JMGfg47p_OQrhhZI8rg6qLu4vGVlZk_JjDqzFaVbRBWgB1QnwqnHjUqrtgjD9AsVlhuvWgUvG1swYo97bCQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3NDQsIm5iZiI6MTUxNjczNzc0NCwiZXhwIjoxNTE2NzQxNjQ0LCJhaW8iOiJZMk5nWURBTjFDdDJkcHEzYjE1K2V1Lys2UnRMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiaTgxdXM4M3pSRWFZRVlsRzV2SUFBQSIsInZlciI6IjEuMCJ9.bhuZbwr_DUbUHhY7EeZI_nzv42PIpod-gtIasMU8f2WzgYqVdB9mZlFvc129yMGW5M5GOTE5RTNUxSx4RKNpx2w43_HMdFijkjsVnXsjq9WKLE-jS6sadsWwH86475tWaX7QhhHyIfF0pT09icUd5YlwupxNYpUDsZo5SULJbqgGbqKLjdLbrTx1s1mXtr6jHuXDwKJNjpNea3vOXmD57xTVKzlIJDCDcWCGeghKUncgbGX77IkRWp-8KgVeApyrPfMhFpnH74FqbDn092ZCrOthzI8hOGlu1HPAcA9rxxs2i7L90J86WKsaKjSYepHU4dMkS2mjVO4xJoKe05d3tg
+      Host:
+      - management.azure.com
   response:
     status:
       code: 200
@@ -2136,34 +2406,36 @@ http_interactions:
       - "-1"
       Vary:
       - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/GetOperation3Min;49976,Microsoft.Compute/GetOperation30Min;249976
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131599701143261070
       X-Ms-Request-Id:
-      - 7be82a89-3410-4a72-aafd-6db42ed7868f
+      - bbe2a8dd-122b-4820-b8a7-6791cfd3f7d3
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14904'
+      - '14850'
       X-Ms-Correlation-Request-Id:
-      - 3c9771e1-2d83-4c34-a6c6-b2e8f89d194e
+      - 7e8b5eab-ec6a-4303-9eaf-218d8111a413
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214148Z:3c9771e1-2d83-4c34-a6c6-b2e8f89d194e
+      - WESTUS:20180123T200727Z:7e8b5eab-ec6a-4303-9eaf-218d8111a413
       Date:
-      - Fri, 22 Sep 2017 21:41:48 GMT
+      - Tue, 23 Jan 2018 20:07:26 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-22T21:41:48.0574635+00:00\",\r\n  \"endTime\":
-        \"2017-09-22T21:41:48.2162393+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=641d18d6-8fe5-4023-9d31-f1f209e7ed48&sig=amflQ53Pr%2BaHg2JIkhbNR0qHc%2BCZbvV4TDuqIZjQH3o%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"da68c226-01b6-45a7-a0f1-159e65965942\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2018-01-23T20:07:27.1694382+00:00\",\r\n  \"endTime\":
+        \"2018-01-23T20:07:27.40382+00:00\",\r\n  \"status\": \"Succeeded\",\r\n  \"properties\":
+        {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=8466f513-85ff-4288-9d4d-d9daa9e13022&sig=hCtv9GJbdKBHVYeENPxxHp6KXUvAn5%2FWoM526E0YZNw%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"b3bfc721-45b6-4443-b5e6-bc4103769f64\"\r\n}"
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:41:48 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:29 GMT
 - request:
     method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=641d18d6-8fe5-4023-9d31-f1f209e7ed48&sig=amflQ53Pr%2BaHg2JIkhbNR0qHc%2BCZbvV4TDuqIZjQH3o=&sr=b&sv=2016-05-31
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=8466f513-85ff-4288-9d4d-d9daa9e13022&sig=hCtv9GJbdKBHVYeENPxxHp6KXUvAn5/WoM526E0YZNw=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2176,6 +2448,8 @@ http_interactions:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
       X-Ms-Range:
       - bytes=0-0
+      Host:
+      - md-t4jdgqqlgszp.blob.core.windows.net
   response:
     status:
       code: 206
@@ -2188,15 +2462,15 @@ http_interactions:
       Content-Range:
       - bytes 0-0/34359738880
       Last-Modified:
-      - Sat, 15 Jul 2017 14:23:07 GMT
+      - Tue, 23 Jan 2018 20:04:26 GMT
       Accept-Ranges:
       - bytes
       Etag:
-      - '"0x8D4CB8D039FC699"'
+      - '"0x8D5629C811B65EB"'
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 7e6fa2da-001e-00cb-3deb-33331d000000
+      - 256b54fb-001e-0041-4185-94893e000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2208,7 +2482,7 @@ http_interactions:
       X-Ms-Blob-Type:
       - PageBlob
       X-Ms-Blob-Sequence-Number:
-      - '20'
+      - '30'
       X-Ms-Copy-Id:
       - 30cedd78-548a-4fd8-967e-f8344f587e3c
       X-Ms-Copy-Source:
@@ -2222,250 +2496,16 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Fri, 22 Sep 2017 21:41:48 GMT
+      - Tue, 23 Jan 2018 20:07:28 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         6w==
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:41:48 GMT
-- request:
-    method: post
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/EndGetAccess?api-version=2017-03-30
-    body:
-      encoding: ASCII-8BIT
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMDMsIm5iZiI6MTUwNjExNjIwMywiZXhwIjoxNTA2MTIwMTAzLCJhaW8iOiJZMlZnWVBDVnFid3k0MUdUOWhQeFIvczVwZlJlQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiT29zV1E5alMzRU80dnBzR1lnQUxBQSIsInZlciI6IjEuMCJ9.qW2dETkABqLKjPpG1kNgiKjWDSGCrK2O436_yOUSiUEbgpEPPUqJy_4XcMu7FneQJg1gaLLLIl7ViyzJVBs_rftEdrJmuoUjufj8MetXeIaJQUh8hx-fNOrb9UEYpwK4mSK01HfRe3U-A3DT-6POIQFwbLf78M_nXJohlijBYEL0WZ02Vx2ZRqGVwpGQ8Jo--Iqcf3IELsE8RSuhDJAbLk4JAjxIen7f04U3S4dU4DxvN87n0tODuGTOD58uuY-Fsk8JMGfg47p_OQrhhZI8rg6qLu4vGVlZk_JjDqzFaVbRBWgB1QnwqnHjUqrtgjD9AsVlhuvWgUvG1swYo97bCQ
-      Content-Length:
-      - '0'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '0'
-      Expires:
-      - "-1"
-      Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/af30100b-1bb4-466a-a212-52e724af9005?monitor=true&api-version=2017-03-30
-      Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/af30100b-1bb4-466a-a212-52e724af9005?api-version=2017-03-30
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - af30100b-1bb4-466a-a212-52e724af9005
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1181'
-      X-Ms-Correlation-Request-Id:
-      - bb3a0c1f-cb97-40ac-959a-124556dbb591
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214150Z:bb3a0c1f-cb97-40ac-959a-124556dbb591
-      Date:
-      - Fri, 22 Sep 2017 21:41:49 GMT
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:41:49 GMT
-- request:
-    method: post
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
-    body:
-      encoding: UTF-8
-      string: '{"access":"read","durationInSeconds":3600}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMDMsIm5iZiI6MTUwNjExNjIwMywiZXhwIjoxNTA2MTIwMTAzLCJhaW8iOiJZMlZnWVBDVnFid3k0MUdUOWhQeFIvczVwZlJlQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiT29zV1E5alMzRU80dnBzR1lnQUxBQSIsInZlciI6IjEuMCJ9.qW2dETkABqLKjPpG1kNgiKjWDSGCrK2O436_yOUSiUEbgpEPPUqJy_4XcMu7FneQJg1gaLLLIl7ViyzJVBs_rftEdrJmuoUjufj8MetXeIaJQUh8hx-fNOrb9UEYpwK4mSK01HfRe3U-A3DT-6POIQFwbLf78M_nXJohlijBYEL0WZ02Vx2ZRqGVwpGQ8Jo--Iqcf3IELsE8RSuhDJAbLk4JAjxIen7f04U3S4dU4DxvN87n0tODuGTOD58uuY-Fsk8JMGfg47p_OQrhhZI8rg6qLu4vGVlZk_JjDqzFaVbRBWgB1QnwqnHjUqrtgjD9AsVlhuvWgUvG1swYo97bCQ
-      Content-Length:
-      - '42'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '0'
-      Expires:
-      - "-1"
-      Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/69dbf036-9cf5-408c-af0e-57893cf89c56?monitor=true&api-version=2017-03-30
-      Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/69dbf036-9cf5-408c-af0e-57893cf89c56?api-version=2017-03-30
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - 69dbf036-9cf5-408c-af0e-57893cf89c56
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1186'
-      X-Ms-Correlation-Request-Id:
-      - d6096a60-f768-4d53-8f35-c08a5a448e6d
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214150Z:d6096a60-f768-4d53-8f35-c08a5a448e6d
-      Date:
-      - Fri, 22 Sep 2017 21:41:50 GMT
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:41:50 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:29 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/69dbf036-9cf5-408c-af0e-57893cf89c56?api-version=2017-03-30
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMDMsIm5iZiI6MTUwNjExNjIwMywiZXhwIjoxNTA2MTIwMTAzLCJhaW8iOiJZMlZnWVBDVnFid3k0MUdUOWhQeFIvczVwZlJlQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiT29zV1E5alMzRU80dnBzR1lnQUxBQSIsInZlciI6IjEuMCJ9.qW2dETkABqLKjPpG1kNgiKjWDSGCrK2O436_yOUSiUEbgpEPPUqJy_4XcMu7FneQJg1gaLLLIl7ViyzJVBs_rftEdrJmuoUjufj8MetXeIaJQUh8hx-fNOrb9UEYpwK4mSK01HfRe3U-A3DT-6POIQFwbLf78M_nXJohlijBYEL0WZ02Vx2ZRqGVwpGQ8Jo--Iqcf3IELsE8RSuhDJAbLk4JAjxIen7f04U3S4dU4DxvN87n0tODuGTOD58uuY-Fsk8JMGfg47p_OQrhhZI8rg6qLu4vGVlZk_JjDqzFaVbRBWgB1QnwqnHjUqrtgjD9AsVlhuvWgUvG1swYo97bCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - ec5da85e-f8d8-4eb4-9199-3e8c46a49a84
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14921'
-      X-Ms-Correlation-Request-Id:
-      - c6476883-0fb2-4034-b111-de7a6963d900
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214151Z:c6476883-0fb2-4034-b111-de7a6963d900
-      Date:
-      - Fri, 22 Sep 2017 21:41:51 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-22T21:41:52.3581004+00:00\",\r\n  \"endTime\":
-        \"2017-09-22T21:41:52.594276+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=64852b9d-2a51-461d-b415-c28bb8520816&sig=loSy7VN2kupGTjvGgsMKM6ryuAMtabEV0llH2wqtn%2FI%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"69dbf036-9cf5-408c-af0e-57893cf89c56\"\r\n}"
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:41:51 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/69dbf036-9cf5-408c-af0e-57893cf89c56?api-version=2017-03-30
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMDMsIm5iZiI6MTUwNjExNjIwMywiZXhwIjoxNTA2MTIwMTAzLCJhaW8iOiJZMlZnWVBDVnFid3k0MUdUOWhQeFIvczVwZlJlQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiT29zV1E5alMzRU80dnBzR1lnQUxBQSIsInZlciI6IjEuMCJ9.qW2dETkABqLKjPpG1kNgiKjWDSGCrK2O436_yOUSiUEbgpEPPUqJy_4XcMu7FneQJg1gaLLLIl7ViyzJVBs_rftEdrJmuoUjufj8MetXeIaJQUh8hx-fNOrb9UEYpwK4mSK01HfRe3U-A3DT-6POIQFwbLf78M_nXJohlijBYEL0WZ02Vx2ZRqGVwpGQ8Jo--Iqcf3IELsE8RSuhDJAbLk4JAjxIen7f04U3S4dU4DxvN87n0tODuGTOD58uuY-Fsk8JMGfg47p_OQrhhZI8rg6qLu4vGVlZk_JjDqzFaVbRBWgB1QnwqnHjUqrtgjD9AsVlhuvWgUvG1swYo97bCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - 1b5fda29-11ff-43e7-9459-30718b5f8347
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14914'
-      X-Ms-Correlation-Request-Id:
-      - 37e7686c-e36f-4d46-b075-0b46e34dbc57
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214152Z:37e7686c-e36f-4d46-b075-0b46e34dbc57
-      Date:
-      - Fri, 22 Sep 2017 21:41:51 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-22T21:41:52.3581004+00:00\",\r\n  \"endTime\":
-        \"2017-09-22T21:41:52.594276+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=64852b9d-2a51-461d-b415-c28bb8520816&sig=loSy7VN2kupGTjvGgsMKM6ryuAMtabEV0llH2wqtn%2FI%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"69dbf036-9cf5-408c-af0e-57893cf89c56\"\r\n}"
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:41:52 GMT
-- request:
-    method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=64852b9d-2a51-461d-b415-c28bb8520816&sig=loSy7VN2kupGTjvGgsMKM6ryuAMtabEV0llH2wqtn/I=&sr=b&sv=2016-05-31
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=8466f513-85ff-4288-9d4d-d9daa9e13022&sig=hCtv9GJbdKBHVYeENPxxHp6KXUvAn5/WoM526E0YZNw=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2478,6 +2518,8 @@ http_interactions:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
       X-Ms-Range:
       - bytes=440-443
+      Host:
+      - md-t4jdgqqlgszp.blob.core.windows.net
   response:
     status:
       code: 206
@@ -2490,15 +2532,15 @@ http_interactions:
       Content-Range:
       - bytes 440-443/34359738880
       Last-Modified:
-      - Sat, 15 Jul 2017 14:23:07 GMT
+      - Tue, 23 Jan 2018 20:04:26 GMT
       Accept-Ranges:
       - bytes
       Etag:
-      - '"0x8D4CB8D039FC699"'
+      - '"0x8D5629C811B65EB"'
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - d6dcc4ad-001e-0027-23eb-333b64000000
+      - f5be7952-001e-0059-7b85-94a4ab000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2510,7 +2552,7 @@ http_interactions:
       X-Ms-Blob-Type:
       - PageBlob
       X-Ms-Blob-Sequence-Number:
-      - '20'
+      - '30'
       X-Ms-Copy-Id:
       - 30cedd78-548a-4fd8-967e-f8344f587e3c
       X-Ms-Copy-Source:
@@ -2524,69 +2566,11 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Fri, 22 Sep 2017 21:41:52 GMT
+      - Tue, 23 Jan 2018 20:07:28 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         U5MJAA==
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:41:52 GMT
-- request:
-    method: post
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/EndGetAccess?api-version=2017-03-30
-    body:
-      encoding: ASCII-8BIT
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMDMsIm5iZiI6MTUwNjExNjIwMywiZXhwIjoxNTA2MTIwMTAzLCJhaW8iOiJZMlZnWVBDVnFid3k0MUdUOWhQeFIvczVwZlJlQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiT29zV1E5alMzRU80dnBzR1lnQUxBQSIsInZlciI6IjEuMCJ9.qW2dETkABqLKjPpG1kNgiKjWDSGCrK2O436_yOUSiUEbgpEPPUqJy_4XcMu7FneQJg1gaLLLIl7ViyzJVBs_rftEdrJmuoUjufj8MetXeIaJQUh8hx-fNOrb9UEYpwK4mSK01HfRe3U-A3DT-6POIQFwbLf78M_nXJohlijBYEL0WZ02Vx2ZRqGVwpGQ8Jo--Iqcf3IELsE8RSuhDJAbLk4JAjxIen7f04U3S4dU4DxvN87n0tODuGTOD58uuY-Fsk8JMGfg47p_OQrhhZI8rg6qLu4vGVlZk_JjDqzFaVbRBWgB1QnwqnHjUqrtgjD9AsVlhuvWgUvG1swYo97bCQ
-      Content-Length:
-      - '0'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '0'
-      Expires:
-      - "-1"
-      Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/e35bd637-4d5b-4888-9943-f3b9903baedd?monitor=true&api-version=2017-03-30
-      Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/e35bd637-4d5b-4888-9943-f3b9903baedd?api-version=2017-03-30
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - e35bd637-4d5b-4888-9943-f3b9903baedd
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1182'
-      X-Ms-Correlation-Request-Id:
-      - 79de296e-0ffd-40e6-aab8-2f1345edf33f
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214153Z:79de296e-0ffd-40e6-aab8-2f1345edf33f
-      Date:
-      - Fri, 22 Sep 2017 21:41:53 GMT
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:41:53 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:29 GMT
 recorded_with: VCR 3.0.3

--- a/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_lbaStart-1.yml
+++ b/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_lbaStart-1.yml
@@ -17,6 +17,8 @@ http_interactions:
       - '186'
       Content-Type:
       - application/x-www-form-urlencoded
+      Host:
+      - login.microsoftonline.com
   response:
     status:
       code: 200
@@ -37,25 +39,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - c44a7350-236a-4714-b889-f8c46b9f0c00
+      - c26d75b1-c04a-46e9-899a-98b3303f0000
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAAABlDrqfEFlSaui6xnRjX5Eq3yr1efzPbR178z4MbrDBH2hCMrgrd4h-1MtyOfWCMSyz3Wj_3B8Zdyxl2klCYcF1LkptIMNnjq4ikDUtbGjUQ_YNouKumjFgv0NrllNDsqZJJUcHPEkuI8SL4dMrZE2BJKxmIMLUET5i7q343DvV8LFcGtQQnHJeGn4gq4Qg1AgAA;
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzXPzSVVgtqsEXPJIxqKD6aEY_Odf2lXo9L15hGk38B8QaqFdxi7OR-AuZmx_e9SO1pcJ2E_e4dcN9KGUWRVeagXpLp-M215gNoemG_wk7sPTMaE9D2t3I_IC65vMOqNcXGryU1nhjq4EutjQFTNJUTxnRA7XI-X1iaFJsGJkNe9EgAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=007; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=005; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Fri, 22 Sep 2017 21:42:16 GMT
+      - Tue, 23 Jan 2018 20:07:05 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1506120137","not_before":"1506116237","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMzcsIm5iZiI6MTUwNjExNjIzNywiZXhwIjoxNTA2MTIwMTM3LCJhaW8iOiJZMlZnWUNpcG5ibDUwYk83RmV0ZjNTdFh5VlpLQmdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUhOS3hHb2pGRWU0aWZqRWE1OE1BQSIsInZlciI6IjEuMCJ9.YoVpr2T3l2iTzavKGXCTyf7I6tpWQ7zFH1yhWYBQeIjEzRiKEt0bBk2ImDTlqEedvQtTrES-7Py8sCKgj9fjeCAnXzOh2dl5fd2Z7U7DjzkPWeE33qylquZMhYOugI7yymgGAvh-EouKAflV3rJuYyo8ftiuQ1rHPv7D0KHuBqxSiNvYnlVf84-CepHlNUP5x_lJ7sX8rsZRWwjVLCoWU-Twz3VmqbQYyyeyqlpGBzfKns130Wa5vLLkwKoT5IxtKtW47uk1gL4M5PwZaxJIkm3bWSiOGebmzKEMSu8nWSSc2O_ZdI0XFMjKeDlOgX0CwCgzTrQpXeJ7lospdprQ8w"}'
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1516741628","not_before":"1516737728","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3MjgsIm5iZiI6MTUxNjczNzcyOCwiZXhwIjoxNTE2NzQxNjI4LCJhaW8iOiJZMk5nWU1qSWM2bzNQeTByYmRIUSsrVHp5VzRYQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoic1hWdHdrckE2VWFKbXBpek1EOEFBQSIsInZlciI6IjEuMCJ9.St2ItYfDyH8CewqUPtKhrugcHgnzUNJY6_hHjdRrKFQKwHszokh2S-JXzmhVvqu4Liyv_I0T2yDdtCwYu8tBAOLpcUgsUfsnZfUGJ8RowWsoBFVBZickn-jMBZj9MFRCIz4hREyx0zPpwvy5V3UqiQW_AkovjDUrNsHMcUuwc7QT7-4RGbWqMfbpb2wWPyzCJIHFzJNDGpOgkKkHNuxITRJMhfSikC2K5zpheghTHaDlsNjqK04kTTn4Q8ziE0eZ1c68k66quQeFeTBvnG5Qw--Jw2j6eNcJX4sQ9HkdAKzVpQj9kpbKNGF8r6-mVmCql2aAmBUrCgmCeDgok-JMow"}'
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:16 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:07 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -72,7 +74,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMzcsIm5iZiI6MTUwNjExNjIzNywiZXhwIjoxNTA2MTIwMTM3LCJhaW8iOiJZMlZnWUNpcG5ibDUwYk83RmV0ZjNTdFh5VlpLQmdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUhOS3hHb2pGRWU0aWZqRWE1OE1BQSIsInZlciI6IjEuMCJ9.YoVpr2T3l2iTzavKGXCTyf7I6tpWQ7zFH1yhWYBQeIjEzRiKEt0bBk2ImDTlqEedvQtTrES-7Py8sCKgj9fjeCAnXzOh2dl5fd2Z7U7DjzkPWeE33qylquZMhYOugI7yymgGAvh-EouKAflV3rJuYyo8ftiuQ1rHPv7D0KHuBqxSiNvYnlVf84-CepHlNUP5x_lJ7sX8rsZRWwjVLCoWU-Twz3VmqbQYyyeyqlpGBzfKns130Wa5vLLkwKoT5IxtKtW47uk1gL4M5PwZaxJIkm3bWSiOGebmzKEMSu8nWSSc2O_ZdI0XFMjKeDlOgX0CwCgzTrQpXeJ7lospdprQ8w
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3MjgsIm5iZiI6MTUxNjczNzcyOCwiZXhwIjoxNTE2NzQxNjI4LCJhaW8iOiJZMk5nWU1qSWM2bzNQeTByYmRIUSsrVHp5VzRYQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoic1hWdHdrckE2VWFKbXBpek1EOEFBQSIsInZlciI6IjEuMCJ9.St2ItYfDyH8CewqUPtKhrugcHgnzUNJY6_hHjdRrKFQKwHszokh2S-JXzmhVvqu4Liyv_I0T2yDdtCwYu8tBAOLpcUgsUfsnZfUGJ8RowWsoBFVBZickn-jMBZj9MFRCIz4hREyx0zPpwvy5V3UqiQW_AkovjDUrNsHMcUuwc7QT7-4RGbWqMfbpb2wWPyzCJIHFzJNDGpOgkKkHNuxITRJMhfSikC2K5zpheghTHaDlsNjqK04kTTn4Q8ziE0eZ1c68k66quQeFeTBvnG5Qw--Jw2j6eNcJX4sQ9HkdAKzVpQj9kpbKNGF8r6-mVmCql2aAmBUrCgmCeDgok-JMow
+      Host:
+      - management.azure.com
   response:
     status:
       code: 200
@@ -93,21 +97,22 @@ http_interactions:
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
       - '14999'
       X-Ms-Request-Id:
-      - f7a987b3-e327-4447-8c86-e8a80358410c
+      - ee6fdd59-925e-43d3-aaf0-29be3ce48d75
       X-Ms-Correlation-Request-Id:
-      - f7a987b3-e327-4447-8c86-e8a80358410c
+      - ee6fdd59-925e-43d3-aaf0-29be3ce48d75
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214218Z:f7a987b3-e327-4447-8c86-e8a80358410c
+      - WESTUS:20180123T200708Z:ee6fdd59-925e-43d3-aaf0-29be3ce48d75
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 22 Sep 2017 21:42:17 GMT
+      - Tue, 23 Jan 2018 20:07:07 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
-        Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
+      string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
+        Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
+        Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:17 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:08 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/azure_subscription_id/providers?api-version=2015-01-01
@@ -124,7 +129,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMzcsIm5iZiI6MTUwNjExNjIzNywiZXhwIjoxNTA2MTIwMTM3LCJhaW8iOiJZMlZnWUNpcG5ibDUwYk83RmV0ZjNTdFh5VlpLQmdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUhOS3hHb2pGRWU0aWZqRWE1OE1BQSIsInZlciI6IjEuMCJ9.YoVpr2T3l2iTzavKGXCTyf7I6tpWQ7zFH1yhWYBQeIjEzRiKEt0bBk2ImDTlqEedvQtTrES-7Py8sCKgj9fjeCAnXzOh2dl5fd2Z7U7DjzkPWeE33qylquZMhYOugI7yymgGAvh-EouKAflV3rJuYyo8ftiuQ1rHPv7D0KHuBqxSiNvYnlVf84-CepHlNUP5x_lJ7sX8rsZRWwjVLCoWU-Twz3VmqbQYyyeyqlpGBzfKns130Wa5vLLkwKoT5IxtKtW47uk1gL4M5PwZaxJIkm3bWSiOGebmzKEMSu8nWSSc2O_ZdI0XFMjKeDlOgX0CwCgzTrQpXeJ7lospdprQ8w
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3MjgsIm5iZiI6MTUxNjczNzcyOCwiZXhwIjoxNTE2NzQxNjI4LCJhaW8iOiJZMk5nWU1qSWM2bzNQeTByYmRIUSsrVHp5VzRYQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoic1hWdHdrckE2VWFKbXBpek1EOEFBQSIsInZlciI6IjEuMCJ9.St2ItYfDyH8CewqUPtKhrugcHgnzUNJY6_hHjdRrKFQKwHszokh2S-JXzmhVvqu4Liyv_I0T2yDdtCwYu8tBAOLpcUgsUfsnZfUGJ8RowWsoBFVBZickn-jMBZj9MFRCIz4hREyx0zPpwvy5V3UqiQW_AkovjDUrNsHMcUuwc7QT7-4RGbWqMfbpb2wWPyzCJIHFzJNDGpOgkKkHNuxITRJMhfSikC2K5zpheghTHaDlsNjqK04kTTn4Q8ziE0eZ1c68k66quQeFeTBvnG5Qw--Jw2j6eNcJX4sQ9HkdAKzVpQj9kpbKNGF8r6-mVmCql2aAmBUrCgmCeDgok-JMow
+      Host:
+      - management.azure.com
   response:
     status:
       code: 200
@@ -141,19 +148,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14908'
+      - '14854'
       X-Ms-Request-Id:
-      - 4b688839-35e8-4277-a471-18d97a0a4f62
+      - 385e205d-fc15-4010-b2ff-9f6bf095dc71
       X-Ms-Correlation-Request-Id:
-      - 4b688839-35e8-4277-a471-18d97a0a4f62
+      - 385e205d-fc15-4010-b2ff-9f6bf095dc71
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214219Z:4b688839-35e8-4277-a471-18d97a0a4f62
+      - WESTUS:20180123T200709Z:385e205d-fc15-4010-b2ff-9f6bf095dc71
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 22 Sep 2017 21:42:18 GMT
+      - Tue, 23 Jan 2018 20:07:08 GMT
       Content-Length:
-      - '254785'
+      - '293551'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
@@ -176,7 +183,7 @@ http_interactions:
         Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
         Central US","North Central US","Japan East","Japan West","Brazil South","Central
         India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
+        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-04-19","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-04-19","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-04-19","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-04-19","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","North Central
         US","South Central US","West Central US","West US","West US 2","Canada Central","Canada
         East","North Europe","West Europe","UK South","UK West","East Asia","Southeast
@@ -184,20 +191,26 @@ http_interactions:
         India","South India","West India"],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"validateServiceName","locations":[],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"checkServiceNameAvailability","locations":[],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"reportFeedback","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"checkFeedbackRequired","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Automation","namespace":"Microsoft.Automation","authorizations":[{"applicationId":"fc75330b-179d-49af-87dd-3b1acf6827fa","roleDefinitionId":"95fd5de3-d071-4362-92bf-cf341c1de832"}],"resourceTypes":[{"resourceType":"automationAccounts","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
         South","UK South","West Central US","North Europe","Canada Central","Australia
-        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/runbooks","locations":["Japan
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/runbooks","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
         South","UK South","West Central US","North Europe","Canada Central","Australia
-        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/configurations","locations":["Japan
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/configurations","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","North
-        Central US","Brazil South","UK South","West Central US","Central India","Australia
-        Southeast","Canada Central","North Europe"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/webhooks","locations":["Japan
+        Central US","Korea Central","East US","West US 2","Brazil South","UK South","West
+        Central US","Central India","Australia Southeast","Canada Central","North
+        Europe"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/webhooks","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
         South","UK South","West Central US","North Europe","Canada Central","Australia
-        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"operations","locations":["South
-        Central US"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/softwareUpdateConfigurations","locations":["Japan
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"operations","locations":["South
+        Central US"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/softwareUpdateConfigurations","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
         South","UK South","West Central US","North Europe","Canada Central","Australia
-        Southeast","Central India"],"apiVersions":["2017-05-15-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Backup","namespace":"Microsoft.Backup","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"BackupVault","locations":["West
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview"]},{"resourceType":"automationAccounts/jobs","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
+        South","UK South","West Central US","North Europe","Canada Central","Australia
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureActiveDirectory","namespace":"Microsoft.AzureActiveDirectory","resourceTypes":[{"resourceType":"b2cDirectories","locations":["Global","United
+        States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]},{"resourceType":"operations","locations":["Global","United
+        States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]}],"registrationState":"Unregistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Backup","namespace":"Microsoft.Backup","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"BackupVault","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
@@ -206,22 +219,22 @@ http_interactions:
         Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
         West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
         East","South India","Central India","Canada Central","Canada East","UK South","UK
-        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01","2015-07-01","2014-05-01-privatepreview"]},{"resourceType":"operations","locations":["West
+        West","West Central US","West US 2"],"apiVersions":["2017-09-01","2017-05-01","2017-01-01","2015-12-01","2015-09-01","2015-07-01","2014-05-01-privatepreview"]},{"resourceType":"operations","locations":["West
         Europe","East US","East US 2","West US","North Central US","Brazil South","North
         Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
         West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
         East","South India","Central India","Canada Central","Canada East","UK South","UK
-        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations/quotas","locations":["West
+        West","West Central US","West US 2"],"apiVersions":["2017-09-01","2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01","2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations/quotas","locations":["West
         Europe","East US","East US 2","West US","North Central US","Brazil South","North
         Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
         West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
         East","South India","Central India","Canada Central","Canada East","UK South","UK
-        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]}],"registrationState":"Unregistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicCompute","namespace":"Microsoft.ClassicCompute","resourceTypes":[{"resourceType":"domainNames","locations":["East
+        West","West Central US","West US 2"],"apiVersions":["2017-09-01","2017-05-01","2017-01-01","2015-12-01","2015-09-01"]}],"registrationState":"Unregistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicCompute","namespace":"Microsoft.ClassicCompute","resourceTypes":[{"resourceType":"domainNames","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
@@ -256,7 +269,7 @@ http_interactions:
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -296,92 +309,92 @@ http_interactions:
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30"]},{"resourceType":"locations/usages","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations/usages","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
+        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
@@ -411,76 +424,138 @@ http_interactions:
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
+        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
         US","East US","South Central US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
         Central","Central US","East US 2","North Central US","West Central US","West
-        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/webhooks","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/ping","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/getCallbackConfig","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/listEvents","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"locations","locations":["South
-        Central US","East US","West US","Central US","East US 2","North Central US","West
-        Central US","West US 2","Brazil South","Canada East","Canada Central","West
-        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
-        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"locations/operationResults","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/GetCredentials","locations":["West
+        US 2"],"apiVersions":["2017-10-01","2017-03-01"]},{"resourceType":"registries/replications","locations":["South
+        Central US","West Central US","East US","West Europe","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/webhooks","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/webhooks/ping","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/webhooks/getCallbackConfig","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/webhooks/listEvents","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"locations/operationResults","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/GetCredentials","locations":["West
         US","East US","South Central US","West Europe"],"apiVersions":["2016-06-27-preview"]},{"resourceType":"registries/listCredentials","locations":["South
         Central US","East US","West US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
         Central","Central US","East US 2","North Central US","West Central US","West
-        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/regenerateCredential","locations":["South
+        US 2"],"apiVersions":["2017-10-01","2017-03-01"]},{"resourceType":"registries/regenerateCredential","locations":["South
         Central US","West US","East US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
         Central","Central US","East US 2","North Central US","West Central US","West
-        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/listUsages","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/regenerateCredentials","locations":["West
+        US 2"],"apiVersions":["2017-10-01","2017-03-01"]},{"resourceType":"registries/listUsages","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/regenerateCredentials","locations":["West
         US","East US","South Central US","West Europe"],"apiVersions":["2016-06-27-preview"]},{"resourceType":"checkNameAvailability","locations":["South
         Central US","East US","West US","Central US","East US 2","North Central US","West
         Central US","West US 2","Brazil South","Canada East","Canada Central","West
         Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
-        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview","2017-03-01","2016-06-27-preview"]},{"resourceType":"operations","locations":["South
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-10-01","2017-06-01-preview","2017-03-01","2016-06-27-preview"]},{"resourceType":"operations","locations":["South
         Central US","East US","West US","Central US","East US 2","North Central US","West
         Central US","West US 2","Brazil South","Canada East","Canada Central","West
         Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
-        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview","2017-03-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerService","namespace":"Microsoft.ContainerService","authorization":{"applicationId":"7319c514-987d-4e9b-ac3d-d38c4f427f4c","roleDefinitionId":"1b4a0c7f-2217-416f-acfa-cf73452fdc1c"},"resourceTypes":[{"resourceType":"containerServices","locations":["Japan
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-10-01","2017-06-01-preview","2017-03-01"]},{"resourceType":"locations","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-10-01","2017-06-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerService","namespace":"Microsoft.ContainerService","authorization":{"applicationId":"7319c514-987d-4e9b-ac3d-d38c4f427f4c","roleDefinitionId":"1b4a0c7f-2217-416f-acfa-cf73452fdc1c","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"containerServices","locations":["Japan
         East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
         Central US","West US 2","South India","Central India","West India","Canada
-        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
+        East","Canada Central","Korea South","Korea Central"],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"managedClusters","locations":["East
+        US","West Europe","Central US","Canada Central","Canada East"],"apiVersions":["2017-08-31"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
         East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
         Central US","West US 2","South India","Central India","West India","Canada
-        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DevTestLab","namespace":"Microsoft.DevTestLab","authorization":{"applicationId":"1a14be2a-e903-4cec-99cf-b2e209259a0f","roleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525"},"resourceTypes":[{"resourceType":"labs","locations":["West
+        East","Canada Central","Korea South","Korea Central"],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/orchestrators","locations":["UK
+        West","West US 2","East US","West Europe","Central US"],"apiVersions":["2017-09-30"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DevTestLab","namespace":"Microsoft.DevTestLab","authorization":{"applicationId":"1a14be2a-e903-4cec-99cf-b2e209259a0f","roleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525","managedByRoleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525"},"resourceTypes":[{"resourceType":"labs","locations":["West
         Central US","Japan East","West US","Australia Southeast","Canada Central","Central
         India","Central US","East Asia","Korea Central","North Europe","South Central
-        US","UK West","Australia East","Brazil South","Canada East","East US","East
-        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        US","UK West","West India","Australia East","Brazil South","Canada East","East
+        US","East US 2","Japan West","Korea South","North Central US","South India","Southeast
         Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"schedules","locations":["West
         Central US","Japan East","West US","Australia Southeast","Canada Central","Central
         India","Central US","East Asia","Korea Central","North Europe","South Central
-        US","UK West","Australia East","Brazil South","Canada East","East US","East
-        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        US","UK West","West India","Australia East","Brazil South","Canada East","East
+        US","East US 2","Japan West","Korea South","North Central US","South India","Southeast
         Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"labs/virtualMachines","locations":["West
         Central US","Japan East","West US","Australia Southeast","Canada Central","Central
         India","Central US","East Asia","Korea Central","North Europe","South Central
-        US","UK West","Australia East","Brazil South","Canada East","East US","East
-        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        US","UK West","West India","Australia East","Brazil South","Canada East","East
+        US","East US 2","Japan West","Korea South","North Central US","South India","Southeast
         Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"labs/serviceRunners","locations":["Central
         US","East US 2","South Central US"],"apiVersions":["2017-04-26-preview","2016-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"locations/operations","locations":["West
         Central US","Japan East","West US","Australia Southeast","Canada Central","Central
         India","Central US","East Asia","Korea Central","North Europe","South Central
-        US","UK West","Australia East","Brazil South","Canada East","East US","East
-        US 2","Japan West","Korea South","North Central US","South India","Southeast
-        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"}],"resourceTypes":[{"resourceType":"components","locations":["East
-        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
-        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01","2014-04-01"]},{"resourceType":"queries","locations":["East
-        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
+        US","UK West","West India","Australia East","Brazil South","Canada East","East
+        US","East US 2","Japan West","Korea South","North Central US","South India","Southeast
+        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","authorizations":[{"applicationId":"57c0fc58-a83a-41d0-8ae9-08952659bdfd","roleDefinitionId":"FFFD5CF5-FFD3-4B24-B0E2-0715ADD4C282"}],"resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"databaseAccountNames","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"operationResults","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"},{"applicationId":"f5c26e74-f226-4ae8-85f0-b4af0080ac9e","roleDefinitionId":"529d7ae6-e892-4d43-809d-8547aeb90643"}],"resourceTypes":[{"resourceType":"components","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2015-05-01","2014-08-01","2014-04-01"]},{"resourceType":"queries","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"components/pricingPlans","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"migrateToNewPricingModel","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"rollbackToLegacyPricingModel","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"listMigrationdate","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
@@ -516,7 +591,7 @@ http_interactions:
         West","North Central US","South Central US","East US 2","Canada East","Canada
         Central","Central US","Australia East","Australia Southeast","Brazil South","South
         India","Central India","West India","North Europe","West US 2","West Central
-        US","Korea South","Korea Central","UK South","UK West","Global"],"apiVersions":["2017-05-01-preview","2016-03-01","2015-07-01"]},{"resourceType":"logDefinitions","locations":["West
+        US","Korea South","Korea Central","UK South","UK West","Global"],"apiVersions":["2017-09-01-preview","2017-05-01-preview","2016-03-01","2015-07-01"]},{"resourceType":"logDefinitions","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
@@ -526,7 +601,7 @@ http_interactions:
         West","North Central US","South Central US","East US 2","Canada East","Canada
         Central","Central US","Australia East","Australia Southeast","Brazil South","South
         India","Central India","West India","North Europe","West US 2","West Central
-        US","Korea South","Korea Central","UK South","UK West"],"apiVersions":["2017-05-01-preview","2016-09-01","2016-06-01"]},{"resourceType":"actiongroups","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]},{"resourceType":"activityLogAlerts","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.KeyVault","namespace":"Microsoft.KeyVault","resourceTypes":[{"resourceType":"vaults","locations":["North
+        US","Korea South","Korea Central","UK South","UK West"],"apiVersions":["2017-09-01-preview","2017-05-01-preview","2016-09-01","2016-06-01"]},{"resourceType":"actiongroups","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]},{"resourceType":"activityLogAlerts","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.KeyVault","namespace":"Microsoft.KeyVault","resourceTypes":[{"resourceType":"vaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
@@ -556,126 +631,153 @@ http_interactions:
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorizations":[{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},{"applicationId":"7c33bfcb-8d33-48d6-8e60-dc6404003489","roleDefinitionId":"ad6261e4-fa9a-4642-aa5f-104f1b67e9e3"},{"applicationId":"1e3e4475-288f-4018-a376-df66fd7fac5f","roleDefinitionId":"1d538b69-3d87-4e56-8ff8-25786fd48261"},{"applicationId":"a0be0c72-870e-46f0-9c49-c98333a996f7","roleDefinitionId":"7ce22727-ffce-45a9-930c-ddb2e56fa131"}],"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","West Central US"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"operations","locations":["South
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations","locations":["South
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operations","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"commitmentPlans","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"Registering"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorizations":[{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},{"applicationId":"7c33bfcb-8d33-48d6-8e60-dc6404003489","roleDefinitionId":"ad6261e4-fa9a-4642-aa5f-104f1b67e9e3"},{"applicationId":"1e3e4475-288f-4018-a376-df66fd7fac5f","roleDefinitionId":"1d538b69-3d87-4e56-8ff8-25786fd48261"},{"applicationId":"a0be0c72-870e-46f0-9c49-c98333a996f7","roleDefinitionId":"7ce22727-ffce-45a9-930c-ddb2e56fa131"}],"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
-        Central US"],"apiVersions":["2017-09-01"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
-        East","UK South","Central India","Canada Central"],"apiVersions":["2017-04-26-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"]},{"resourceType":"workspaces/dataSources","locations":["East
+        East","UK South","Central India","Canada Central"],"apiVersions":["2017-04-26-preview","2017-03-15-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"]},{"resourceType":"workspaces/query","locations":["West
+        Central US","Australia Southeast","West Europe","East US","Southeast Asia","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2017-10-01"]},{"resourceType":"workspaces/dataSources","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
         East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"storageInsightConfigs","locations":[],"apiVersions":["2014-10-10"]},{"resourceType":"workspaces/linkedServices","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
         East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"linkTargets","locations":["East
         US"],"apiVersions":["2015-03-20"]},{"resourceType":"operations","locations":[],"apiVersions":["2014-11-10"]},{"resourceType":"devices","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationsManagement","namespace":"Microsoft.OperationsManagement","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"aa249101-6816-4966-aafa-08175d795f14"},"resourceTypes":[{"resourceType":"solutions","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
-        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Portal","namespace":"Microsoft.Portal","resourceTypes":[{"resourceType":"dashboards","locations":["Central
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"managementconfigurations","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"managementassociations","locations":[],"apiVersions":["2015-11-01-preview"]},{"resourceType":"views","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2017-08-21-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Portal","namespace":"Microsoft.Portal","resourceTypes":[{"resourceType":"dashboards","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
@@ -687,9 +789,9 @@ http_interactions:
         East","West India","South India","Central India","Canada Central","Canada
         East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"consoles","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/consoles","locations":["West
         US","East US","Central India","North Europe","West Europe","South Central
-        US","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
+        US","Southeast Asia","East US 2","Central US"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
         US","East US","Central India","North Europe","West Europe","South Central
-        US","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
+        US","Southeast Asia","East US 2","Central US"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
@@ -710,7 +812,17 @@ http_interactions:
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ResourceHealth","namespace":"Microsoft.ResourceHealth","authorization":{"applicationId":"8bdebf23-c0fe-4187-a378-717ad86f6a53","roleDefinitionId":"cc026344-c8b1-4561-83ba-59eba84b27cc"},"resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2017-07-01","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"notifications","locations":["Australia
+        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]},{"resourceType":"locations/backupValidateFeatures","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-07-01"]},{"resourceType":"locations/backupPreValidateProtection","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-07-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ResourceHealth","namespace":"Microsoft.ResourceHealth","authorization":{"applicationId":"8bdebf23-c0fe-4187-a378-717ad86f6a53","roleDefinitionId":"cc026344-c8b1-4561-83ba-59eba84b27cc"},"resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2017-07-01","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"notifications","locations":["Australia
         Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Security","namespace":"Microsoft.Security","authorization":{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatuses","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/virtualMachines","locations":["Central
@@ -743,10 +855,14 @@ http_interactions:
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securitySolutionsReferenceData","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/securitySolutionsReferenceData","locations":["Central
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"jitNetworkAccessPolicies","locations":["Central
-        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/jitNetworkAccessPolicies","locations":["Central
-        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations","locations":["Central
+        US","East US","North Europe","West Europe","UK South","UK West","West Central
+        US","West US 2"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/jitNetworkAccessPolicies","locations":["Central
+        US","East US","North Europe","West Europe","UK South","UK West","West Central
+        US","West US 2"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatusesSummaries","locations":["Central
-        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/alerts","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"applicationWhitelistings","locations":["Central
+        US","East US","West Central US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/applicationWhitelistings","locations":["Central
+        US","West Central US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/alerts","locations":["Central
         US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/tasks","locations":["Central
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"externalSecuritySolutions","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/externalSecuritySolutions","locations":["Central
@@ -769,7 +885,17 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/databaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/databaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -814,7 +940,7 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01","2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -829,7 +955,7 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -859,12 +985,17 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/geoBackupPolicies","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -879,12 +1010,12 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/firewallrules","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/backupLongTermRetentionPolicies","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -999,6 +1130,16 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
         US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
@@ -1034,7 +1175,22 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -1144,7 +1300,47 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -1159,7 +1355,17 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/administratorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -1179,52 +1385,52 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorization":{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorizations":[{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},{"applicationId":"e406a681-f3d4-42a8-90b6-c2b029497af1"}],"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
         US","West US","West Europe","North Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","South India","Central
@@ -1234,7 +1440,19 @@ http_interactions:
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Web","namespace":"Microsoft.Web","authorization":{"applicationId":"abfa0a7c-a6b6-4736-8310-5855508787cd","roleDefinitionId":"f47ed98b-b063-4a5b-9e10-4b9b44fa7735"},"resourceTypes":[{"resourceType":"sites/extensions","locations":["South
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/project","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/extension","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"checkNameAvailability","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Web","namespace":"Microsoft.Web","authorization":{"applicationId":"abfa0a7c-a6b6-4736-8310-5855508787cd","roleDefinitionId":"f47ed98b-b063-4a5b-9e10-4b9b44fa7735"},"resourceTypes":[{"resourceType":"sites/extensions","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
         South","West US","East US","Japan West","Japan East","East Asia","East US
         2","North Central US","Central US","Brazil South","Australia East","Australia
@@ -1339,7 +1557,7 @@ http_interactions:
         South","West US","East US","Japan West","Japan East","East Asia","East US
         2","North Central US","Central US","Brazil South","Australia East","Australia
         Southeast","West India","Central India","South India","Canada Central","Canada
-        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms/workers","locations":["South
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms/workers","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
         South","West US","East US","Japan West","Japan East","East Asia","East US
         2","North Central US","Central US","Brazil South","Australia East","Australia
@@ -1394,7 +1612,17 @@ http_interactions:
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","West US 2","West Central US","Canada Central","Canada
-        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/managedApis","locations":["North
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/listWsdlInterfaces","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/extractApiDefinitionFromWsdl","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/managedApis","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
@@ -1445,8 +1673,11 @@ http_interactions:
         US","North Europe","Japan West","Japan East","East Asia","West Europe","East
         US","Southeast Asia","Central US"],"apiVersions":["2016-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Lombiq.DotNest","namespace":"Lombiq.DotNest","resourceTypes":[{"resourceType":"sites","locations":["East
         US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Mailjet.Email","namespace":"Mailjet.Email","resourceTypes":[{"resourceType":"services","locations":["West
-        US"],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
-        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
+        US","West Europe"],"apiVersions":["2017-10-01","2017-02-03"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-10-01","2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-10-01","2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]},{"resourceType":"diagnosticSettings","locations":[],"apiVersions":["2017-04-01"]},{"resourceType":"diagnosticSettingsCategories","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Addons","namespace":"Microsoft.Addons","authorization":{"applicationId":"24d3987b-be4a-48e0-a3e7-11c186f39e41","roleDefinitionId":"8004BAAB-A4CB-4981-8571-F7E44D039D93"},"resourceTypes":[{"resourceType":"supportProviders","locations":["West
+        Central US","South Central US","East US","West Europe"],"apiVersions":["2017-05-15"]},{"resourceType":"operations","locations":["West
+        Central US","South Central US","East US","West Europe"],"apiVersions":["2017-05-15"]},{"resourceType":"operationResults","locations":["West
+        Central US","South Central US","East US","West Europe"],"apiVersions":["2017-05-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"addsservices","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"configuration","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"operations","locations":["West
@@ -1456,51 +1687,45 @@ http_interactions:
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"servicehealthmetrics","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"logs","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"anonymousapiusers","locations":["West
-        US"],"apiVersions":["2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AnalysisServices","namespace":"Microsoft.AnalysisServices","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"servers","locations":["West
+        US"],"apiVersions":["2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AlertsManagement","namespace":"Microsoft.AlertsManagement","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-11-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AnalysisServices","namespace":"Microsoft.AnalysisServices","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"servers","locations":["West
         US","North Europe","South Central US","West Europe","West Central US","Southeast
         Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
-        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/checkNameAvailability","locations":["West
+        Southeast","Japan East","UK South","West India","West US 2","East US"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"locations/checkNameAvailability","locations":["West
         US","North Europe","South Central US","West Europe","West Central US","Southeast
         Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
-        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationresults","locations":["West
+        Southeast","Japan East","UK South","West India","West US 2","East US"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationresults","locations":["West
         US","North Europe","South Central US","West Europe","West Central US","Southeast
         Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
-        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationstatuses","locations":["West
+        Southeast","Japan East","UK South","West India","West US 2","East US"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationstatuses","locations":["West
         US","North Europe","South Central US","West Europe","West Central US","Southeast
         Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
-        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"operations","locations":["East
-        US 2","West Central US"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AppService","namespace":"Microsoft.AppService","authorization":{"applicationId":"dee7ba80-6a55-4f3b-a86c-746a9231ae49","roleDefinitionId":"6715d172-49c4-46f6-bb21-60512a8689dc"},"resourceTypes":[{"resourceType":"apiapps","locations":["East
-        US","West US","South Central US","North Europe","East Asia","Japan East","West
-        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
-        South","East US 2","Australia Southeast","Australia East","West India","South
-        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"appIdentities","locations":["East
-        US","West US","South Central US","North Europe","East Asia","Japan East","West
-        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
-        South","East US 2","Australia Southeast","Australia East","West India","South
-        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"gateways","locations":["East
-        US","West US","South Central US","North Europe","East Asia","Japan East","West
-        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
-        South","East US 2","Australia Southeast","Australia East","West India","South
-        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"deploymenttemplates","locations":[],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Authorization","namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"roleDefinitions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"classicAdministrators","locations":[],"apiVersions":["2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"permissions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"locks","locations":[],"apiVersions":["2017-04-01","2016-09-01","2015-06-01","2015-05-01-preview","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-01-01","2014-10-01-preview","2014-06-01"]},{"resourceType":"policyDefinitions","locations":[],"apiVersions":["2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"policySetDefinitions","locations":[],"apiVersions":["2017-06-01-preview"]},{"resourceType":"policyAssignments","locations":[],"apiVersions":["2017-06-01-preview","2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"providerOperations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01-preview","2015-07-01"]},{"resourceType":"elevateAccess","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureActiveDirectory","namespace":"Microsoft.AzureActiveDirectory","resourceTypes":[{"resourceType":"b2cDirectories","locations":["Global","United
-        States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureStack","namespace":"Microsoft.AzureStack","resourceTypes":[{"resourceType":"operations","locations":["Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations","locations":["West
+        Southeast","Japan East","UK South","West India","West US 2","East US"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"operations","locations":["East
+        US 2","West Central US","West US 2"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Authorization","namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[],"apiVersions":["2017-10-01-preview","2017-09-01","2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"roleDefinitions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"classicAdministrators","locations":[],"apiVersions":["2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"permissions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"locks","locations":[],"apiVersions":["2017-04-01","2016-09-01","2015-06-01","2015-05-01-preview","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-01-01","2014-10-01-preview","2014-06-01"]},{"resourceType":"policyDefinitions","locations":[],"apiVersions":["2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"policySetDefinitions","locations":[],"apiVersions":["2017-06-01-preview"]},{"resourceType":"policyAssignments","locations":[],"apiVersions":["2017-06-01-preview","2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"providerOperations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01-preview","2015-07-01"]},{"resourceType":"elevateAccess","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"checkAccess","locations":[],"apiVersions":["2017-10-01-preview","2017-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureStack","namespace":"Microsoft.AzureStack","resourceTypes":[{"resourceType":"operations","locations":["Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations","locations":["West
         Central US","Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations/products","locations":["West
-        Central US","Global"],"apiVersions":["2017-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Billing","namespace":"Microsoft.Billing","resourceTypes":[{"resourceType":"BillingPeriods","locations":["Central
+        Central US","Global"],"apiVersions":["2017-06-01","2016-01-01"]},{"resourceType":"registrations/customerSubscriptions","locations":["West
+        Central US","Global"],"apiVersions":["2017-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BatchAI","namespace":"Microsoft.BatchAI","authorization":{"applicationId":"9fcb3732-5f52-4135-8c08-9d4bbaf203ea","roleDefinitionId":"703B89C7-CE2C-431B-BDD8-FA34E39AF696","managedByRoleDefinitionId":"90B8E153-EBFF-4073-A95F-4DAD56B14C78"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"jobs","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"fileservers","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"operations","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01-preview"]},{"resourceType":"locations/operationresults","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Billing","namespace":"Microsoft.Billing","resourceTypes":[{"resourceType":"BillingPeriods","locations":["Central
         US"],"apiVersions":["2017-04-24-preview"]},{"resourceType":"Invoices","locations":["Central
         US"],"apiVersions":["2017-04-24-preview","2017-02-27-preview"]},{"resourceType":"operations","locations":["Central
         US"],"apiVersions":["2017-04-24-preview","2017-02-27-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BingMaps","namespace":"Microsoft.BingMaps","resourceTypes":[{"resourceType":"mapApis","locations":["West
         US"],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-18","2015-07-02"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BizTalkServices","namespace":"Microsoft.BizTalkServices","resourceTypes":[{"resourceType":"BizTalk","locations":["East
         US","West US","North Europe","West Europe","Southeast Asia","East Asia","North
-        Central US","Japan West","Japan East","South Central US"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Cache","namespace":"Microsoft.Cache","authorization":{"applicationId":"96231a05-34ce-4eb4-aa6a-70759cbb5e83","roleDefinitionId":"4f731528-ba85-45c7-acfb-cd0a9b3cf31b"},"resourceTypes":[{"resourceType":"Redis","locations":["North
+        Central US","Japan West","Japan East","South Central US"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BotService","namespace":"Microsoft.BotService","resourceTypes":[{"resourceType":"botServices","locations":["Global"],"apiVersions":["2017-12-01"]},{"resourceType":"checkNameAvailability","locations":["Global"],"apiVersions":["2017-12-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Cache","namespace":"Microsoft.Cache","authorization":{"applicationId":"96231a05-34ce-4eb4-aa6a-70759cbb5e83","roleDefinitionId":"4f731528-ba85-45c7-acfb-cd0a9b3cf31b"},"resourceTypes":[{"resourceType":"Redis","locations":["North
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","Canada Central","Canada East","UK South","UK West","West US 2","West
-        Central US","South India","Korea Central","Korea South"],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","South India","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","South India","Canada Central","Canada East","UK South","UK West","West
-        US 2","West Central US","Korea Central","Korea South"],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01"]},{"resourceType":"Redis/metricDefinitions","locations":["North
+        US 2","West Central US","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01"]},{"resourceType":"Redis/metricDefinitions","locations":["North
         Central US","South Central US","East US","East US 2","West US","Central US","East
         Asia","Southeast Asia","North Europe","West Europe","Japan East","Japan West","Brazil
         South","Australia Southeast","Australia East","Central India","West India","South
@@ -1514,59 +1739,59 @@ http_interactions:
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/origins","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/origins","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/customdomains","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/customdomains","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/originresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/originresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/customdomainresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/customdomainresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkResourceUsage","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkResourceUsage","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02"]},{"resourceType":"validateProbe","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02"]},{"resourceType":"validateProbe","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02"]},{"resourceType":"operations","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02"]},{"resourceType":"operations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"edgenodes","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"edgenodes","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CertificateRegistration","namespace":"Microsoft.CertificateRegistration","authorization":{"applicationId":"f3c21649-0979-4721-ac85-b0216b2cf413","roleDefinitionId":"933fba7e-2ed3-4da8-973d-8bd8298a9b40"},"resourceTypes":[{"resourceType":"certificateOrders","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"certificateOrders/certificates","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"validateCertificateRegistrationInformation","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicSubscription","namespace":"Microsoft.ClassicSubscription","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicInfrastructureMigrate","namespace":"Microsoft.ClassicInfrastructureMigrate","authorization":{"applicationId":"5e5abe2b-83cd-4786-826a-a05653ebb103","roleDefinitionId":"766c4d9b-ef83-4f73-8352-1450a506a69b"},"resourceTypes":[{"resourceType":"classicInfrastructureResources","locations":["East
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CertificateRegistration","namespace":"Microsoft.CertificateRegistration","authorization":{"applicationId":"f3c21649-0979-4721-ac85-b0216b2cf413","roleDefinitionId":"933fba7e-2ed3-4da8-973d-8bd8298a9b40"},"resourceTypes":[{"resourceType":"certificateOrders","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"certificateOrders/certificates","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"validateCertificateRegistrationInformation","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicSubscription","namespace":"Microsoft.ClassicSubscription","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-09-01","2017-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicInfrastructureMigrate","namespace":"Microsoft.ClassicInfrastructureMigrate","authorization":{"applicationId":"5e5abe2b-83cd-4786-826a-a05653ebb103","roleDefinitionId":"766c4d9b-ef83-4f73-8352-1450a506a69b"},"resourceTypes":[{"resourceType":"classicInfrastructureResources","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
         Central US","Central US","North Europe","West Europe","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","West
@@ -1584,8 +1809,9 @@ http_interactions:
         Asia","East Asia","West Central US","South Central US","East US","East US
         2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/updateAccountsCreationSettings","locations":["West
         US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/accountsCreationSettings","locations":["West
-        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2016-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Commerce","namespace":"Microsoft.Commerce","resourceTypes":[{"resourceType":"UsageAggregates","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]},{"resourceType":"RateCard","locations":[],"apiVersions":["2016-08-31-preview","2015-06-01-preview","2015-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Consumption","namespace":"Microsoft.Consumption","resourceTypes":[{"resourceType":"reservationsummaries","locations":[],"apiVersions":["2017-01-30"]},{"resourceType":"reservationdetails","locations":[],"apiVersions":["2017-01-30"]},{"resourceType":"UsageDetails","locations":[],"apiVersions":["2017-06-30-preview","2017-04-24-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-30-preview","2017-04-24-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","resourceTypes":[{"resourceType":"containerGroups","locations":["West
-        US","East US","West Europe"],"apiVersions":["2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
+        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2016-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Commerce","namespace":"Microsoft.Commerce","resourceTypes":[{"resourceType":"UsageAggregates","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]},{"resourceType":"RateCard","locations":[],"apiVersions":["2016-08-31-preview","2015-06-01-preview","2015-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Consumption","namespace":"Microsoft.Consumption","resourceTypes":[{"resourceType":"ReservationSummaries","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationTransactions","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"Balances","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"Pricesheets","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationDetails","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"Budgets","locations":[],"apiVersions":["2017-12-30-preview"]},{"resourceType":"Terms","locations":[],"apiVersions":["2017-12-30-preview"]},{"resourceType":"UsageDetails","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview","2017-04-24-preview"]},{"resourceType":"Operations","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview","2017-04-24-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","resourceTypes":[{"resourceType":"containerGroups","locations":["West
+        US","East US","West Europe","Southeast Asia"],"apiVersions":["2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US","East US","West Europe","Southeast Asia"],"apiVersions":["2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
         US"],"apiVersions":["2016-04-08"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CustomerInsights","namespace":"Microsoft.CustomerInsights","authorization":{"applicationId":"38c77d00-5fcb-4cce-9d93-af4738258e3c","roleDefinitionId":"E006F9C7-F333-477C-8AD6-1F3A9FE87F55"},"resourceTypes":[{"resourceType":"hubs","locations":["East
         US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/profiles","locations":["East
         US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/interactions","locations":["East
@@ -1608,8 +1834,8 @@ http_interactions:
         US","West US","Australia East","West Europe","North Europe","Southeast Asia","West
         Central US"],"apiVersions":["2016-03-30","2015-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataFactory","namespace":"Microsoft.DataFactory","resourceTypes":[{"resourceType":"dataFactories","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview","2014-04-01"]},{"resourceType":"factories","locations":["East
-        US","East US 2"],"apiVersions":["2017-09-01-preview","2017-03-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
-        US","East US 2"],"apiVersions":["2017-09-01-preview","2017-03-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
+        US","East US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
+        US","East US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
         Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"dataFactories/metricDefinitions","locations":["North
         Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"checkDataFactoryNameAvailability","locations":[],"apiVersions":["2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"checkAzureDataFactoryNameAvailability","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"dataFactorySchema","locations":["West
@@ -1621,69 +1847,71 @@ http_interactions:
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers/listSasTokens","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeStore","namespace":"Microsoft.DataLakeStore","authorization":{"applicationId":"e9f49c6b-5ce5-44c8-925d-015017e9f7ad","roleDefinitionId":"17eb9cca-f08a-4499-b2d3-852d175f614f"},"resourceTypes":[{"resourceType":"accounts","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/firewallRules","locations":["East
-        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","resourceTypes":[{"resourceType":"operations","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforPostgreSQL","namespace":"Microsoft.DBforPostgreSQL","resourceTypes":[{"resourceType":"operations","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"checkProvisioningServiceNameAvailability","locations":[],"apiVersions":["2017-08-21-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataMigration","namespace":"Microsoft.DataMigration","authorization":{"applicationId":"a4bad4aa-bf02-4631-9f78-a64ffdba8150","roleDefinitionId":"b831a21d-db98-4760-89cb-bef871952df1","managedByRoleDefinitionId":"6256fb55-9e59-4018-a9e1-76b11c0a4c89"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services/projects","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationStatuses","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforPostgreSQL","namespace":"Microsoft.DBforPostgreSQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"checkProvisioningServiceNameAvailability","locations":[],"apiVersions":["2017-11-15","2017-08-21-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
         US","North Europe","East Asia","East US","West Europe","Southeast Asia","Japan
         East","Japan West","Australia East","Australia Southeast","West US 2","West
         Central US","East US 2","Central US","UK South","UK West","South India","Central
-        India","Canada Central","Canada East"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"ProvisioningServices","locations":["East
-        US","West Europe","Southeast Asia"],"apiVersions":["2017-08-21-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
-        East","Australia Southeast","Canada Central","Canada East","Central India","Central
-        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
-        US","North Europe","South Central US","South India","Southeast Asia","West
-        Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"databaseAccountNames","locations":["Australia
-        East","Australia Southeast","Canada Central","Canada East","Central India","Central
-        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
-        US","North Europe","South Central US","South India","Southeast Asia","West
-        Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"operations","locations":["Australia
-        East","Australia Southeast","Canada Central","Canada East","Central India","Central
-        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
-        US","North Europe","South Central US","South India","Southeast Asia","West
-        Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DomainRegistration","namespace":"Microsoft.DomainRegistration","authorization":{"applicationId":"ea2f600a-4980-45b7-89bf-d34da487bda1","roleDefinitionId":"54d7f2e3-5040-48a7-ae90-eebf629cfa0b"},"resourceTypes":[{"resourceType":"domains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"domains/domainOwnershipIdentifiers","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"topLevelDomains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"checkDomainAvailability","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"listDomainRecommendations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"validateDomainRegistrationInformation","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"generateSsoRequest","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DynamicsLcs","namespace":"Microsoft.DynamicsLcs","resourceTypes":[{"resourceType":"lcsprojects","locations":["Brazil
+        India","Canada Central","Canada East","Brazil South","South Central US"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs/eventGridFilters","locations":["West
+        US","East US","West US 2","West Central US","East US 2","Central US"],"apiVersions":["2018-01-15-preview"]},{"resourceType":"ProvisioningServices","locations":["East
+        US","West US","West Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2017-11-15","2017-08-21-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DomainRegistration","namespace":"Microsoft.DomainRegistration","authorization":{"applicationId":"ea2f600a-4980-45b7-89bf-d34da487bda1","roleDefinitionId":"54d7f2e3-5040-48a7-ae90-eebf629cfa0b"},"resourceTypes":[{"resourceType":"domains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"domains/domainOwnershipIdentifiers","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"topLevelDomains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"checkDomainAvailability","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"listDomainRecommendations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"validateDomainRegistrationInformation","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"generateSsoRequest","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DynamicsLcs","namespace":"Microsoft.DynamicsLcs","resourceTypes":[{"resourceType":"lcsprojects","locations":["Brazil
         South","East Asia","East US","Japan East","Japan West","North Central US","North
         Europe","South Central US","West Europe","West US","Southeast Asia","Central
         US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"lcsprojects/connectors","locations":["Brazil
@@ -1695,21 +1923,21 @@ http_interactions:
         US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"operations","locations":["Brazil
         South","East Asia","East US","Japan East","Japan West","North Central US","North
         Europe","South Central US","West Europe","West US","Southeast Asia","Central
-        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topics","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operations","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topics","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operations","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","West
         US 2","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
         India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/consumergroups","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
         US","East US 2","West US","South Central US","Central US","Australia East","Australia
         Southeast","Central India","West Central US","West US 2","Canada East","Canada
         Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
@@ -1754,23 +1982,23 @@ http_interactions:
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations","locations":["Australia
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations/operationResults","locations":["Australia
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations/operationResults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"operations","locations":["Australia
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"operations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Logic","namespace":"Microsoft.Logic","authorization":{"applicationId":"7cd684f4-8a78-49b0-91ec-6a35d38739ba","roleDefinitionId":"cb3ef1fb-6e31-49e2-9d87-ed821053fe58"},"resourceTypes":[{"resourceType":"workflows","locations":["North
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.LocationBasedServices","namespace":"Microsoft.LocationBasedServices","resourceTypes":[{"resourceType":"accounts","locations":["Global"],"apiVersions":["2017-01-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Logic","namespace":"Microsoft.Logic","authorization":{"applicationId":"7cd684f4-8a78-49b0-91ec-6a35d38739ba","roleDefinitionId":"cb3ef1fb-6e31-49e2-9d87-ed821053fe58"},"resourceTypes":[{"resourceType":"workflows","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
@@ -1791,60 +2019,78 @@ http_interactions:
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada Central","Canada East","West US 2","West Central
-        US","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","West Central US"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"operations","locations":["South
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations","locations":["South
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operations","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"commitmentPlans","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningExperimentation","namespace":"Microsoft.MachineLearningExperimentation","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"accounts","locations":["Australia
-        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces","locations":["Australia
-        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces/projects","locations":["Australia
-        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningCompute","namespace":"Microsoft.MachineLearningCompute","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"376aa7d7-51a9-463d-bd4d-7e1691345612","managedByRoleDefinitionId":"91d00862-cf55-46a5-9dce-260bbd92ce25"},"resourceTypes":[{"resourceType":"operationalizationClusters","locations":["East
-        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"operations","locations":["East
+        US","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningExperimentation","namespace":"Microsoft.MachineLearningExperimentation","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"accounts","locations":["Australia
+        East","East US 2","West Central US","Southeast Asia","West Europe"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces","locations":["Australia
+        East","East US 2","West Central US","Southeast Asia","West Europe"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces/projects","locations":["Australia
+        East","East US 2","West Central US","Southeast Asia","West Europe"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"teamAccounts","locations":["Australia
+        East","West Central US","East US 2"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"teamAccounts/workspaces","locations":["Australia
+        East","West Central US","East US 2"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"teamAccounts/workspaces/projects","locations":["Australia
+        East","West Central US","East US 2"],"apiVersions":["2017-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningCompute","namespace":"Microsoft.MachineLearningCompute","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"376aa7d7-51a9-463d-bd4d-7e1691345612","managedByRoleDefinitionId":"91d00862-cf55-46a5-9dce-260bbd92ce25"},"resourceTypes":[{"resourceType":"operationalizationClusters","locations":["East
+        US 2","West Central US","Australia East","West Europe","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"operations","locations":["East
         US 2"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations","locations":["East
         US 2"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operations","locations":["East
-        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["East
-        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningModelManagement","namespace":"Microsoft.MachineLearningModelManagement","resourceTypes":[{"resourceType":"accounts","locations":["East
-        US 2","West Central US","Australia East"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"operations","locations":["West
-        Central US"],"apiVersions":["2017-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
+        US 2","West Central US","Australia East","West Europe","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["East
+        US 2","West Central US","Australia East","West Europe","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningModelManagement","namespace":"Microsoft.MachineLearningModelManagement","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US 2","West Central US","Australia East","West Europe","Southeast Asia"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"operations","locations":["West
+        Central US"],"apiVersions":["2017-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ManagedIdentity","namespace":"Microsoft.ManagedIdentity","resourceTypes":[{"resourceType":"Identities","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Brazil South","Central
+        India","West India","South India","Japan West","Japan East","East Asia","Southeast
+        Asia","Korea Central","Korea South","North Europe","West Europe","UK West","UK
+        South","Central US","North Central US","East US","East US 2","South Central
+        US","West US","West US 2","West Central US"],"apiVersions":["2015-08-31-PREVIEW"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Brazil South","Central
+        India","West India","South India","Japan West","Japan East","East Asia","Southeast
+        Asia","Korea Central","Korea South","North Europe","West Europe","UK West","UK
+        South","Central US","North Central US","East US","East US 2","South Central
+        US","West US","West US 2","West Central US"],"apiVersions":["2015-08-31-PREVIEW"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Management","namespace":"Microsoft.Management","authorization":{"applicationId":"f2c304cf-8e7e-4c3f-8164-16299ad9d272","roleDefinitionId":"c1cf3708-588a-4647-be7f-f400bbe214cf"},"resourceTypes":[{"resourceType":"resources","locations":[],"apiVersions":["2017-11-01-preview","2017-08-31-preview","2017-06-30-preview","2017-05-31-preview"]},{"resourceType":"managementGroups","locations":[],"apiVersions":["2017-11-01-preview","2017-08-31-preview","2017-06-30-preview","2017-05-31-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01-preview","2017-08-31-preview","2017-06-30-preview","2017-05-31-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceApps","namespace":"Microsoft.MarketplaceApps","resourceTypes":[{"resourceType":"classicDevServices","locations":["Northwest
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","Central US","North
+        Europe","West Europe","Japan East","Japan West","Brazil South","Australia
+        East","Australia Southeast","South India","Central India","Canada Central","Canada
+        East"],"apiVersions":["2017-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
         Central US","West US"],"apiVersions":["2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01"]},{"resourceType":"offertypes","locations":["South
         Central US","West US"],"apiVersions":["2015-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Media","namespace":"Microsoft.Media","authorization":{"applicationId":"374b2a64-3b6b-436b-934c-b820eacca870","roleDefinitionId":"aab70789-0cec-44b5-95d7-84b64c9487af"},"resourceTypes":[{"resourceType":"mediaservices","locations":["Japan
         West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
         US","West US","Australia East","Australia Southeast","Central US","Brazil
         South","Central India","West India","South India","South Central US","Canada
-        Central","Canada East","West Central US"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
+        Central","Canada East","West Central US","West US 2"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
+        Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"operations","locations":["West
+        Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
+        Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PolicyInsights","namespace":"Microsoft.PolicyInsights","authorization":{"applicationId":"1d78a85d-813d-46f0-b496-dd72f50a3ec0","roleDefinitionId":"63d2b225-4c34-4641-8768-21a1f7c68ce8"},"resourceTypes":[{"resourceType":"policyEvents","locations":[],"apiVersions":["2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"policyStates","locations":[],"apiVersions":["2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-17-preview","2017-08-09-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
         Central US","North Central US","East US 2","West US","West Europe","North
         Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
         East","UK South","West India"],"apiVersions":["2016-01-29"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-01-29"]},{"resourceType":"locations/checkNameAvailability","locations":["South
         Central US","North Central US","East US 2","West US","West Europe","North
         Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
-        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"capacities","locations":["West
-        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
-        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationresults","locations":["West
-        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
-        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"operations","locations":["East
-        US 2"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Relay","namespace":"Microsoft.Relay","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"capacities","locations":["Australia
+        Southeast","Brazil South","Canada Central","East Asia","East US","East US
+        2","West India","Japan East","West Central US","North Central US","North Europe","South
+        Central US","Southeast Asia","UK South","West Europe","West US","West US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":["Australia
+        Southeast","Brazil South","Canada Central","East Asia","East US","East US
+        2","West India","Japan East","West Central US","North Central US","North Europe","South
+        Central US","Southeast Asia","UK South","West Europe","West US","West US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationresults","locations":["Australia
+        Southeast","Brazil South","Canada Central","East Asia","East US","East US
+        2","West India","Japan East","West Central US","North Central US","North Europe","South
+        Central US","Southeast Asia","UK South","West Europe","West US","West US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["Australia
+        Southeast","Brazil South","Canada Central","East Asia","East US","East US
+        2","West India","Japan East","West Central US","North Central US","North Europe","South
+        Central US","Southeast Asia","UK South","West Europe","West US","West US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"operations","locations":["East
+        US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Relay","namespace":"Microsoft.Relay","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US 2","West
         US","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
         India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2017-08-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkPolicyCompliance","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/hybridconnections","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/hybridconnections/authorizationrules","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/wcfrelays","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/wcfrelays/authorizationrules","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkPolicyCompliance","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
         Central US","South Central US","North Europe","West Europe","East Asia","Southeast
         Asia","West US","East US","Japan West","Japan East","Brazil South","Central
         US","East US 2","Australia East","Australia Southeast","South India","Central
@@ -1868,12 +2114,12 @@ http_interactions:
         India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19","2015-02-28"]},{"resourceType":"checkServiceNameAvailability","locations":[],"apiVersions":["2015-02-28","2014-07-31-Preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2015-08-19"]},{"resourceType":"resourceHealthMetadata","locations":["West
         US","East US","North Europe","West Europe","Southeast Asia","East Asia","North
         Central US","South Central US","Japan West","Australia East","Brazil South","Central
-        India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","authorization":{"applicationId":"80a10ef9-8168-493d-abf9-3297c4ef6e3c","roleDefinitionId":"2b7763f7-bbe2-4e19-befe-28c79f1cf7f7"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US 2","West
         US","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
         India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"premiumMessagingRegions","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceFabric","namespace":"Microsoft.ServiceFabric","authorization":{"applicationId":"74cb6831-0dbb-4be1-8206-fd4df301cdc2","roleDefinitionId":"e55cc65f-6903-4917-b4ef-f8d4640b57f5"},"resourceTypes":[{"resourceType":"clusters","locations":["West
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/queues","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/queues/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/topics","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/topics/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/topics/subscriptions","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/topics/subscriptions/rules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"premiumMessagingRegions","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceFabric","namespace":"Microsoft.ServiceFabric","authorization":{"applicationId":"74cb6831-0dbb-4be1-8206-fd4df301cdc2","roleDefinitionId":"e55cc65f-6903-4917-b4ef-f8d4640b57f5"},"resourceTypes":[{"resourceType":"clusters","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
@@ -1887,17 +2133,43 @@ http_interactions:
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
-        India","West India","Central India","Brazil South","South Central US","Canada
-        Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
         Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
         Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applianceDefinitions","locations":["West
-        Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"locations","locations":["West
-        Central US"],"apiVersions":["2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
-        Central US"],"apiVersions":["2017-09-01","2016-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
+        Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applications","locations":["South
+        Central US","North Central US","West Central US","West US","West US 2","East
+        US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
+        Asia","Brazil South","Japan West","Japan East","Australia East","Australia
+        Southeast","South India","West India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
+        Central US","North Central US","West Central US","West US","West US 2","East
+        US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
+        Asia","Brazil South","Japan West","Japan East","Australia East","Australia
+        Southeast","South India","West India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
+        Central US"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
+        Central US","North Central US","West Central US","West US","West US 2","East
+        US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
+        Asia","Brazil South","Japan West","Japan East","Australia East","Australia
+        Southeast","South India","West India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/cloudEndpoints","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/serverEndpoints","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/registeredServers","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/workflows","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","West Central US","Japan East","Japan West","Australia East","Australia
         Southeast"],"apiVersions":["2017-06-01","2017-05-15","2017-01-01","2016-10-01","2016-06-01","2015-03-15","2014-09-01"]},{"resourceType":"operations","locations":["West
@@ -1928,23 +2200,11 @@ http_interactions:
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast"],"apiVersions":["2015-07-01-Preview","2015-03-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.TimeSeriesInsights","namespace":"Microsoft.TimeSeriesInsights","authorizations":[{"applicationId":"120d688d-1518-4cf7-bd38-182f158850b6","roleDefinitionId":"5a43abdf-bb87-42c4-9e56-1c24bf364150"}],"resourceTypes":[{"resourceType":"environments","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/eventsources","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/referenceDataSets","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/accessPolicies","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"operations","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
-        Central US","South Central US","East US","West US","Central US","North Europe","West
-        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
-        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/project","locations":["North
-        Central US","South Central US","East US","West US","Central US","North Europe","West
-        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
-        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/extension","locations":["North
-        Central US","South Central US","East US","West US","Central US","North Europe","West
-        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
-        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"checkNameAvailability","locations":["North
-        Central US","South Central US","East US","West US","Central US","North Europe","West
-        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
-        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Myget.PackageManagement","namespace":"Myget.PackageManagement","resourceTypes":[{"resourceType":"services","locations":["West
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]},{"resourceType":"environments/eventsources","locations":["East
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]},{"resourceType":"environments/referenceDataSets","locations":["East
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]},{"resourceType":"environments/accessPolicies","locations":["East
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]},{"resourceType":"operations","locations":["East
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Myget.PackageManagement","namespace":"Myget.PackageManagement","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/NewRelic.APM","namespace":"NewRelic.APM","authorization":{"allowedThirdPartyExtensions":[{"name":"NewRelic_AzurePortal_APM"}]},"resourceTypes":[{"resourceType":"accounts","locations":["North
         Central US","South Central US","West US","East US","North Europe","West Europe","Southeast
         Asia","East Asia","Japan East","Japan West"],"apiVersions":["2014-10-01","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/nuubit.nextgencdn","namespace":"nuubit.nextgencdn","resourceTypes":[{"resourceType":"accounts","locations":["East
@@ -1984,7 +2244,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:18 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:09 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
@@ -2001,9 +2261,11 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMzcsIm5iZiI6MTUwNjExNjIzNywiZXhwIjoxNTA2MTIwMTM3LCJhaW8iOiJZMlZnWUNpcG5ibDUwYk83RmV0ZjNTdFh5VlpLQmdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUhOS3hHb2pGRWU0aWZqRWE1OE1BQSIsInZlciI6IjEuMCJ9.YoVpr2T3l2iTzavKGXCTyf7I6tpWQ7zFH1yhWYBQeIjEzRiKEt0bBk2ImDTlqEedvQtTrES-7Py8sCKgj9fjeCAnXzOh2dl5fd2Z7U7DjzkPWeE33qylquZMhYOugI7yymgGAvh-EouKAflV3rJuYyo8ftiuQ1rHPv7D0KHuBqxSiNvYnlVf84-CepHlNUP5x_lJ7sX8rsZRWwjVLCoWU-Twz3VmqbQYyyeyqlpGBzfKns130Wa5vLLkwKoT5IxtKtW47uk1gL4M5PwZaxJIkm3bWSiOGebmzKEMSu8nWSSc2O_ZdI0XFMjKeDlOgX0CwCgzTrQpXeJ7lospdprQ8w
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3MjgsIm5iZiI6MTUxNjczNzcyOCwiZXhwIjoxNTE2NzQxNjI4LCJhaW8iOiJZMk5nWU1qSWM2bzNQeTByYmRIUSsrVHp5VzRYQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoic1hWdHdrckE2VWFKbXBpek1EOEFBQSIsInZlciI6IjEuMCJ9.St2ItYfDyH8CewqUPtKhrugcHgnzUNJY6_hHjdRrKFQKwHszokh2S-JXzmhVvqu4Liyv_I0T2yDdtCwYu8tBAOLpcUgsUfsnZfUGJ8RowWsoBFVBZickn-jMBZj9MFRCIz4hREyx0zPpwvy5V3UqiQW_AkovjDUrNsHMcUuwc7QT7-4RGbWqMfbpb2wWPyzCJIHFzJNDGpOgkKkHNuxITRJMhfSikC2K5zpheghTHaDlsNjqK04kTTn4Q8ziE0eZ1c68k66quQeFeTBvnG5Qw--Jw2j6eNcJX4sQ9HkdAKzVpQj9kpbKNGF8r6-mVmCql2aAmBUrCgmCeDgok-JMow
       Content-Length:
       - '42'
+      Host:
+      - management.azure.com
   response:
     status:
       code: 202
@@ -2013,39 +2275,41 @@ http_interactions:
       - no-cache
       Pragma:
       - no-cache
-      Content-Length:
-      - '0'
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/1fc03e7c-56c6-4c4a-a6ff-8b7ef21827fb?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/c89df73e-db73-413e-86c5-919524e3c981?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/1fc03e7c-56c6-4c4a-a6ff-8b7ef21827fb?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/c89df73e-db73-413e-86c5-919524e3c981?api-version=2017-03-30
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/HighCostHydrate3Min;234,Microsoft.Compute/HighCostHydrate30Min;1161
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131599701143261070
       X-Ms-Request-Id:
-      - 1fc03e7c-56c6-4c4a-a6ff-8b7ef21827fb
+      - c89df73e-db73-413e-86c5-919524e3c981
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1182'
+      - '1154'
       X-Ms-Correlation-Request-Id:
-      - 836f77e4-cdd0-436c-9b76-d0e51e146ff7
+      - 290cf5f4-1558-467b-8474-75b46a895f68
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214220Z:836f77e4-cdd0-436c-9b76-d0e51e146ff7
+      - WESTUS:20180123T200710Z:290cf5f4-1558-467b-8474-75b46a895f68
       Date:
-      - Fri, 22 Sep 2017 21:42:20 GMT
+      - Tue, 23 Jan 2018 20:07:10 GMT
+      Content-Length:
+      - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:20 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:10 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/1fc03e7c-56c6-4c4a-a6ff-8b7ef21827fb?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/c89df73e-db73-413e-86c5-919524e3c981?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -2059,7 +2323,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMzcsIm5iZiI6MTUwNjExNjIzNywiZXhwIjoxNTA2MTIwMTM3LCJhaW8iOiJZMlZnWUNpcG5ibDUwYk83RmV0ZjNTdFh5VlpLQmdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUhOS3hHb2pGRWU0aWZqRWE1OE1BQSIsInZlciI6IjEuMCJ9.YoVpr2T3l2iTzavKGXCTyf7I6tpWQ7zFH1yhWYBQeIjEzRiKEt0bBk2ImDTlqEedvQtTrES-7Py8sCKgj9fjeCAnXzOh2dl5fd2Z7U7DjzkPWeE33qylquZMhYOugI7yymgGAvh-EouKAflV3rJuYyo8ftiuQ1rHPv7D0KHuBqxSiNvYnlVf84-CepHlNUP5x_lJ7sX8rsZRWwjVLCoWU-Twz3VmqbQYyyeyqlpGBzfKns130Wa5vLLkwKoT5IxtKtW47uk1gL4M5PwZaxJIkm3bWSiOGebmzKEMSu8nWSSc2O_ZdI0XFMjKeDlOgX0CwCgzTrQpXeJ7lospdprQ8w
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3MjgsIm5iZiI6MTUxNjczNzcyOCwiZXhwIjoxNTE2NzQxNjI4LCJhaW8iOiJZMk5nWU1qSWM2bzNQeTByYmRIUSsrVHp5VzRYQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoic1hWdHdrckE2VWFKbXBpek1EOEFBQSIsInZlciI6IjEuMCJ9.St2ItYfDyH8CewqUPtKhrugcHgnzUNJY6_hHjdRrKFQKwHszokh2S-JXzmhVvqu4Liyv_I0T2yDdtCwYu8tBAOLpcUgsUfsnZfUGJ8RowWsoBFVBZickn-jMBZj9MFRCIz4hREyx0zPpwvy5V3UqiQW_AkovjDUrNsHMcUuwc7QT7-4RGbWqMfbpb2wWPyzCJIHFzJNDGpOgkKkHNuxITRJMhfSikC2K5zpheghTHaDlsNjqK04kTTn4Q8ziE0eZ1c68k66quQeFeTBvnG5Qw--Jw2j6eNcJX4sQ9HkdAKzVpQj9kpbKNGF8r6-mVmCql2aAmBUrCgmCeDgok-JMow
+      Host:
+      - management.azure.com
   response:
     status:
       code: 200
@@ -2077,34 +2343,36 @@ http_interactions:
       - "-1"
       Vary:
       - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/GetOperation3Min;49985,Microsoft.Compute/GetOperation30Min;249985
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131599701143261070
       X-Ms-Request-Id:
-      - ebf45581-67ea-47f8-b9d0-c726e55f13eb
+      - 3b5e929b-233d-4fc3-a254-33e62df71727
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14926'
+      - '14866'
       X-Ms-Correlation-Request-Id:
-      - eb92bb95-1a2f-4ab2-a42a-168c42d387b5
+      - 3c2b30a4-245a-48a8-97b8-1e2ec2fb6f0a
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214221Z:eb92bb95-1a2f-4ab2-a42a-168c42d387b5
+      - WESTUS:20180123T200711Z:3c2b30a4-245a-48a8-97b8-1e2ec2fb6f0a
       Date:
-      - Fri, 22 Sep 2017 21:42:21 GMT
+      - Tue, 23 Jan 2018 20:07:10 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-22T21:42:22.2770117+00:00\",\r\n  \"endTime\":
-        \"2017-09-22T21:42:22.4957963+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=8c3fd0d4-af3e-492a-a165-b6c714523fc7&sig=XOviiyOJG%2FRmyir%2BMLy6b9XxHEkYHTZ9xxhIV8SwG3w%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"1fc03e7c-56c6-4c4a-a6ff-8b7ef21827fb\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2018-01-23T20:07:10.0803715+00:00\",\r\n  \"endTime\":
+        \"2018-01-23T20:07:10.361641+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=71abd58b-75ab-48e9-80b0-ea130e75c712&sig=ltXp8%2FeXd%2F%2F7kCeZB9TYai4WeRcPgnnnuZtPMPZxNyQ%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"c89df73e-db73-413e-86c5-919524e3c981\"\r\n}"
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:21 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:11 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/1fc03e7c-56c6-4c4a-a6ff-8b7ef21827fb?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/c89df73e-db73-413e-86c5-919524e3c981?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -2118,7 +2386,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMzcsIm5iZiI6MTUwNjExNjIzNywiZXhwIjoxNTA2MTIwMTM3LCJhaW8iOiJZMlZnWUNpcG5ibDUwYk83RmV0ZjNTdFh5VlpLQmdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUhOS3hHb2pGRWU0aWZqRWE1OE1BQSIsInZlciI6IjEuMCJ9.YoVpr2T3l2iTzavKGXCTyf7I6tpWQ7zFH1yhWYBQeIjEzRiKEt0bBk2ImDTlqEedvQtTrES-7Py8sCKgj9fjeCAnXzOh2dl5fd2Z7U7DjzkPWeE33qylquZMhYOugI7yymgGAvh-EouKAflV3rJuYyo8ftiuQ1rHPv7D0KHuBqxSiNvYnlVf84-CepHlNUP5x_lJ7sX8rsZRWwjVLCoWU-Twz3VmqbQYyyeyqlpGBzfKns130Wa5vLLkwKoT5IxtKtW47uk1gL4M5PwZaxJIkm3bWSiOGebmzKEMSu8nWSSc2O_ZdI0XFMjKeDlOgX0CwCgzTrQpXeJ7lospdprQ8w
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3MjgsIm5iZiI6MTUxNjczNzcyOCwiZXhwIjoxNTE2NzQxNjI4LCJhaW8iOiJZMk5nWU1qSWM2bzNQeTByYmRIUSsrVHp5VzRYQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoic1hWdHdrckE2VWFKbXBpek1EOEFBQSIsInZlciI6IjEuMCJ9.St2ItYfDyH8CewqUPtKhrugcHgnzUNJY6_hHjdRrKFQKwHszokh2S-JXzmhVvqu4Liyv_I0T2yDdtCwYu8tBAOLpcUgsUfsnZfUGJ8RowWsoBFVBZickn-jMBZj9MFRCIz4hREyx0zPpwvy5V3UqiQW_AkovjDUrNsHMcUuwc7QT7-4RGbWqMfbpb2wWPyzCJIHFzJNDGpOgkKkHNuxITRJMhfSikC2K5zpheghTHaDlsNjqK04kTTn4Q8ziE0eZ1c68k66quQeFeTBvnG5Qw--Jw2j6eNcJX4sQ9HkdAKzVpQj9kpbKNGF8r6-mVmCql2aAmBUrCgmCeDgok-JMow
+      Host:
+      - management.azure.com
   response:
     status:
       code: 200
@@ -2136,34 +2406,36 @@ http_interactions:
       - "-1"
       Vary:
       - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/GetOperation3Min;49984,Microsoft.Compute/GetOperation30Min;249984
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131599701143261070
       X-Ms-Request-Id:
-      - 9e979d98-d0d1-464a-9953-f9432a019bc5
+      - b769a8d6-8d31-41f1-8433-d87968200ffd
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14926'
+      - '14862'
       X-Ms-Correlation-Request-Id:
-      - 43403207-4162-40f2-a508-a0fb38d5411b
+      - dfbf89be-4c95-423a-94e1-b74f52e33b56
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214223Z:43403207-4162-40f2-a508-a0fb38d5411b
+      - WESTUS:20180123T200712Z:dfbf89be-4c95-423a-94e1-b74f52e33b56
       Date:
-      - Fri, 22 Sep 2017 21:42:22 GMT
+      - Tue, 23 Jan 2018 20:07:11 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-22T21:42:22.2770117+00:00\",\r\n  \"endTime\":
-        \"2017-09-22T21:42:22.4957963+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=8c3fd0d4-af3e-492a-a165-b6c714523fc7&sig=XOviiyOJG%2FRmyir%2BMLy6b9XxHEkYHTZ9xxhIV8SwG3w%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"1fc03e7c-56c6-4c4a-a6ff-8b7ef21827fb\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2018-01-23T20:07:10.0803715+00:00\",\r\n  \"endTime\":
+        \"2018-01-23T20:07:10.361641+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=71abd58b-75ab-48e9-80b0-ea130e75c712&sig=ltXp8%2FeXd%2F%2F7kCeZB9TYai4WeRcPgnnnuZtPMPZxNyQ%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"c89df73e-db73-413e-86c5-919524e3c981\"\r\n}"
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:22 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:12 GMT
 - request:
     method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=8c3fd0d4-af3e-492a-a165-b6c714523fc7&sig=XOviiyOJG/Rmyir%2BMLy6b9XxHEkYHTZ9xxhIV8SwG3w=&sr=b&sv=2016-05-31
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=71abd58b-75ab-48e9-80b0-ea130e75c712&sig=ltXp8/eXd//7kCeZB9TYai4WeRcPgnnnuZtPMPZxNyQ=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2176,6 +2448,8 @@ http_interactions:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
       X-Ms-Range:
       - bytes=0-0
+      Host:
+      - md-t4jdgqqlgszp.blob.core.windows.net
   response:
     status:
       code: 206
@@ -2188,15 +2462,15 @@ http_interactions:
       Content-Range:
       - bytes 0-0/34359738880
       Last-Modified:
-      - Sat, 15 Jul 2017 14:23:07 GMT
+      - Tue, 23 Jan 2018 20:04:26 GMT
       Accept-Ranges:
       - bytes
       Etag:
-      - '"0x8D4CB8D039FC699"'
+      - '"0x8D5629C811B65EB"'
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 49bb9997-001e-008b-4beb-331af3000000
+      - 3a4a5b22-001e-00bf-5885-94b55b000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2208,7 +2482,7 @@ http_interactions:
       X-Ms-Blob-Type:
       - PageBlob
       X-Ms-Blob-Sequence-Number:
-      - '20'
+      - '30'
       X-Ms-Copy-Id:
       - 30cedd78-548a-4fd8-967e-f8344f587e3c
       X-Ms-Copy-Source:
@@ -2222,250 +2496,16 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Fri, 22 Sep 2017 21:42:23 GMT
+      - Tue, 23 Jan 2018 20:07:12 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         6w==
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:22 GMT
-- request:
-    method: post
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/EndGetAccess?api-version=2017-03-30
-    body:
-      encoding: ASCII-8BIT
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMzcsIm5iZiI6MTUwNjExNjIzNywiZXhwIjoxNTA2MTIwMTM3LCJhaW8iOiJZMlZnWUNpcG5ibDUwYk83RmV0ZjNTdFh5VlpLQmdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUhOS3hHb2pGRWU0aWZqRWE1OE1BQSIsInZlciI6IjEuMCJ9.YoVpr2T3l2iTzavKGXCTyf7I6tpWQ7zFH1yhWYBQeIjEzRiKEt0bBk2ImDTlqEedvQtTrES-7Py8sCKgj9fjeCAnXzOh2dl5fd2Z7U7DjzkPWeE33qylquZMhYOugI7yymgGAvh-EouKAflV3rJuYyo8ftiuQ1rHPv7D0KHuBqxSiNvYnlVf84-CepHlNUP5x_lJ7sX8rsZRWwjVLCoWU-Twz3VmqbQYyyeyqlpGBzfKns130Wa5vLLkwKoT5IxtKtW47uk1gL4M5PwZaxJIkm3bWSiOGebmzKEMSu8nWSSc2O_ZdI0XFMjKeDlOgX0CwCgzTrQpXeJ7lospdprQ8w
-      Content-Length:
-      - '0'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '0'
-      Expires:
-      - "-1"
-      Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/fc8dcbdd-56cd-43e3-aeb5-1207bfad20c7?monitor=true&api-version=2017-03-30
-      Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/fc8dcbdd-56cd-43e3-aeb5-1207bfad20c7?api-version=2017-03-30
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - fc8dcbdd-56cd-43e3-aeb5-1207bfad20c7
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1180'
-      X-Ms-Correlation-Request-Id:
-      - 1d360859-9e52-41df-aa87-8672e859fc03
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214224Z:1d360859-9e52-41df-aa87-8672e859fc03
-      Date:
-      - Fri, 22 Sep 2017 21:42:23 GMT
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:23 GMT
-- request:
-    method: post
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
-    body:
-      encoding: UTF-8
-      string: '{"access":"read","durationInSeconds":3600}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMzcsIm5iZiI6MTUwNjExNjIzNywiZXhwIjoxNTA2MTIwMTM3LCJhaW8iOiJZMlZnWUNpcG5ibDUwYk83RmV0ZjNTdFh5VlpLQmdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUhOS3hHb2pGRWU0aWZqRWE1OE1BQSIsInZlciI6IjEuMCJ9.YoVpr2T3l2iTzavKGXCTyf7I6tpWQ7zFH1yhWYBQeIjEzRiKEt0bBk2ImDTlqEedvQtTrES-7Py8sCKgj9fjeCAnXzOh2dl5fd2Z7U7DjzkPWeE33qylquZMhYOugI7yymgGAvh-EouKAflV3rJuYyo8ftiuQ1rHPv7D0KHuBqxSiNvYnlVf84-CepHlNUP5x_lJ7sX8rsZRWwjVLCoWU-Twz3VmqbQYyyeyqlpGBzfKns130Wa5vLLkwKoT5IxtKtW47uk1gL4M5PwZaxJIkm3bWSiOGebmzKEMSu8nWSSc2O_ZdI0XFMjKeDlOgX0CwCgzTrQpXeJ7lospdprQ8w
-      Content-Length:
-      - '42'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '0'
-      Expires:
-      - "-1"
-      Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/2048457c-601a-4e3a-974a-36c6ad1134c0?monitor=true&api-version=2017-03-30
-      Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/2048457c-601a-4e3a-974a-36c6ad1134c0?api-version=2017-03-30
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - 2048457c-601a-4e3a-974a-36c6ad1134c0
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1183'
-      X-Ms-Correlation-Request-Id:
-      - d699cb9e-93c0-42fd-bd1c-a7282016c9f6
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214224Z:d699cb9e-93c0-42fd-bd1c-a7282016c9f6
-      Date:
-      - Fri, 22 Sep 2017 21:42:24 GMT
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:24 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:12 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/2048457c-601a-4e3a-974a-36c6ad1134c0?api-version=2017-03-30
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMzcsIm5iZiI6MTUwNjExNjIzNywiZXhwIjoxNTA2MTIwMTM3LCJhaW8iOiJZMlZnWUNpcG5ibDUwYk83RmV0ZjNTdFh5VlpLQmdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUhOS3hHb2pGRWU0aWZqRWE1OE1BQSIsInZlciI6IjEuMCJ9.YoVpr2T3l2iTzavKGXCTyf7I6tpWQ7zFH1yhWYBQeIjEzRiKEt0bBk2ImDTlqEedvQtTrES-7Py8sCKgj9fjeCAnXzOh2dl5fd2Z7U7DjzkPWeE33qylquZMhYOugI7yymgGAvh-EouKAflV3rJuYyo8ftiuQ1rHPv7D0KHuBqxSiNvYnlVf84-CepHlNUP5x_lJ7sX8rsZRWwjVLCoWU-Twz3VmqbQYyyeyqlpGBzfKns130Wa5vLLkwKoT5IxtKtW47uk1gL4M5PwZaxJIkm3bWSiOGebmzKEMSu8nWSSc2O_ZdI0XFMjKeDlOgX0CwCgzTrQpXeJ7lospdprQ8w
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - 419f00ed-c5ac-4df9-8ea9-9c6c52f4834a
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14928'
-      X-Ms-Correlation-Request-Id:
-      - 495e8477-0ab0-4f1d-8672-e6fef55c2d5f
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214225Z:495e8477-0ab0-4f1d-8672-e6fef55c2d5f
-      Date:
-      - Fri, 22 Sep 2017 21:42:25 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-22T21:42:26.371799+00:00\",\r\n  \"endTime\":
-        \"2017-09-22T21:42:26.5906056+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=933cf519-c18c-41c9-b869-296ad550c8ec&sig=ySPlelOr4JnSGD3oVObmAUGkFA3bE%2Fdh4AHc9QiseCQ%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"2048457c-601a-4e3a-974a-36c6ad1134c0\"\r\n}"
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:25 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/2048457c-601a-4e3a-974a-36c6ad1134c0?api-version=2017-03-30
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMzcsIm5iZiI6MTUwNjExNjIzNywiZXhwIjoxNTA2MTIwMTM3LCJhaW8iOiJZMlZnWUNpcG5ibDUwYk83RmV0ZjNTdFh5VlpLQmdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUhOS3hHb2pGRWU0aWZqRWE1OE1BQSIsInZlciI6IjEuMCJ9.YoVpr2T3l2iTzavKGXCTyf7I6tpWQ7zFH1yhWYBQeIjEzRiKEt0bBk2ImDTlqEedvQtTrES-7Py8sCKgj9fjeCAnXzOh2dl5fd2Z7U7DjzkPWeE33qylquZMhYOugI7yymgGAvh-EouKAflV3rJuYyo8ftiuQ1rHPv7D0KHuBqxSiNvYnlVf84-CepHlNUP5x_lJ7sX8rsZRWwjVLCoWU-Twz3VmqbQYyyeyqlpGBzfKns130Wa5vLLkwKoT5IxtKtW47uk1gL4M5PwZaxJIkm3bWSiOGebmzKEMSu8nWSSc2O_ZdI0XFMjKeDlOgX0CwCgzTrQpXeJ7lospdprQ8w
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - 50473a99-076e-40c3-adac-b93ccca7066f
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14943'
-      X-Ms-Correlation-Request-Id:
-      - 2b602f54-51f3-490a-985e-f2228f898e82
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214226Z:2b602f54-51f3-490a-985e-f2228f898e82
-      Date:
-      - Fri, 22 Sep 2017 21:42:26 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-22T21:42:26.371799+00:00\",\r\n  \"endTime\":
-        \"2017-09-22T21:42:26.5906056+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=933cf519-c18c-41c9-b869-296ad550c8ec&sig=ySPlelOr4JnSGD3oVObmAUGkFA3bE%2Fdh4AHc9QiseCQ%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"2048457c-601a-4e3a-974a-36c6ad1134c0\"\r\n}"
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:26 GMT
-- request:
-    method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=933cf519-c18c-41c9-b869-296ad550c8ec&sig=ySPlelOr4JnSGD3oVObmAUGkFA3bE/dh4AHc9QiseCQ=&sr=b&sv=2016-05-31
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=71abd58b-75ab-48e9-80b0-ea130e75c712&sig=ltXp8/eXd//7kCeZB9TYai4WeRcPgnnnuZtPMPZxNyQ=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2478,6 +2518,8 @@ http_interactions:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
       X-Ms-Range:
       - bytes=440-443
+      Host:
+      - md-t4jdgqqlgszp.blob.core.windows.net
   response:
     status:
       code: 206
@@ -2490,15 +2532,15 @@ http_interactions:
       Content-Range:
       - bytes 440-443/34359738880
       Last-Modified:
-      - Sat, 15 Jul 2017 14:23:07 GMT
+      - Tue, 23 Jan 2018 20:04:26 GMT
       Accept-Ranges:
       - bytes
       Etag:
-      - '"0x8D4CB8D039FC699"'
+      - '"0x8D5629C811B65EB"'
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 80c8611f-001e-009b-33eb-332c15000000
+      - 6f8f47ee-001e-0055-7385-944a5a000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2510,7 +2552,7 @@ http_interactions:
       X-Ms-Blob-Type:
       - PageBlob
       X-Ms-Blob-Sequence-Number:
-      - '20'
+      - '30'
       X-Ms-Copy-Id:
       - 30cedd78-548a-4fd8-967e-f8344f587e3c
       X-Ms-Copy-Source:
@@ -2524,69 +2566,11 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Fri, 22 Sep 2017 21:42:30 GMT
+      - Tue, 23 Jan 2018 20:07:12 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         U5MJAA==
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:29 GMT
-- request:
-    method: post
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/EndGetAccess?api-version=2017-03-30
-    body:
-      encoding: ASCII-8BIT
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMzcsIm5iZiI6MTUwNjExNjIzNywiZXhwIjoxNTA2MTIwMTM3LCJhaW8iOiJZMlZnWUNpcG5ibDUwYk83RmV0ZjNTdFh5VlpLQmdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVUhOS3hHb2pGRWU0aWZqRWE1OE1BQSIsInZlciI6IjEuMCJ9.YoVpr2T3l2iTzavKGXCTyf7I6tpWQ7zFH1yhWYBQeIjEzRiKEt0bBk2ImDTlqEedvQtTrES-7Py8sCKgj9fjeCAnXzOh2dl5fd2Z7U7DjzkPWeE33qylquZMhYOugI7yymgGAvh-EouKAflV3rJuYyo8ftiuQ1rHPv7D0KHuBqxSiNvYnlVf84-CepHlNUP5x_lJ7sX8rsZRWwjVLCoWU-Twz3VmqbQYyyeyqlpGBzfKns130Wa5vLLkwKoT5IxtKtW47uk1gL4M5PwZaxJIkm3bWSiOGebmzKEMSu8nWSSc2O_ZdI0XFMjKeDlOgX0CwCgzTrQpXeJ7lospdprQ8w
-      Content-Length:
-      - '0'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '0'
-      Expires:
-      - "-1"
-      Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/9b522a12-b704-48e5-9efc-7920d493d8dc?monitor=true&api-version=2017-03-30
-      Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/9b522a12-b704-48e5-9efc-7920d493d8dc?api-version=2017-03-30
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - 9b522a12-b704-48e5-9efc-7920d493d8dc
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1177'
-      X-Ms-Correlation-Request-Id:
-      - 3302db5f-a03d-4ebc-81c4-8fbffe218f30
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214230Z:3302db5f-a03d-4ebc-81c4-8fbffe218f30
-      Date:
-      - Fri, 22 Sep 2017 21:42:30 GMT
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:30 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:12 GMT
 recorded_with: VCR 3.0.3

--- a/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_new-1.yml
+++ b/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_new-1.yml
@@ -17,6 +17,8 @@ http_interactions:
       - '186'
       Content-Type:
       - application/x-www-form-urlencoded
+      Host:
+      - login.microsoftonline.com
   response:
     status:
       code: 200
@@ -37,25 +39,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - ed511c08-abee-4123-8e41-a93724010d00
+      - 601ef352-a493-4e18-a653-b659054f4d00
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAAABlDrqfEFlSaui6xnRjX5EGo42CVlw-l8Ik8h_hIG2vsbGvVhULffsyLnvqL5qizJrtQBv2VBrB-gb58b5zlttn8rlb8fOU8JXWwpHVBsRZKQupn2jP_O6xXtVw9kfb_1vJMHhIKn_IIjxOrju6roV_YACL1wU57J8Q-CsKFc2IY2p63EP75HZNOmN6pCXmaUgAA;
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzo314kmTjZuqxVOhhSmf3KnARTaur1KbM1Tlwjd2ZhauYufpOOKR_J0gMuk0FvBQcaQKYC4Zwxs4WW9xVOPYOo2hyI59Od1F5_nhsPie1IDXzAZAfjUffZBLrUtXMPdq5yp7V3CPfQuOlYzEcwCNDa683voi2WfYCsqrNzVpi7GogAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=005; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=007; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Fri, 22 Sep 2017 21:43:39 GMT
+      - Tue, 23 Jan 2018 20:07:47 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1506120220","not_before":"1506116320","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYzMjAsIm5iZiI6MTUwNjExNjMyMCwiZXhwIjoxNTA2MTIwMjIwLCJhaW8iOiJZMlZnWU9nNGtxRHdabVYwQUYvY0RITmpzOWh5QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ0J4UjdlNnJJMEdPUWFrM0pBRU5BQSIsInZlciI6IjEuMCJ9.WcnPWRma_ZSUbEE2NtUD-qb0F63lFLuWHSnqlmMMY9EfGNjuB1Uin2svpt-lMGI2Yw36TYTE7KGdgYQsJKVDNfW1UuAii49CZVAFrV-4Shz7Xui_AHFNhqWSJhq_sniUWJO9WZpH5x86cp1kWVIPUfpEO0YO3ec69N_7FFK_rE4v8uTrXCxoMP2G_FQQrC3wKwghy6aLWgvP0e1mDGajn52q7AG7PQwDSFAkefAKGMs53rWOwYVc5iv0voFziAe0gp1vZDFxyPfkbxueJQNpyC8EbFbcpZorzRMIwm3qMFIU162wiFZf-qFJ3ni_BWs_wzR1NFjLow-PxaMumIsl9w"}'
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1516741667","not_before":"1516737767","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3NjcsIm5iZiI6MTUxNjczNzc2NywiZXhwIjoxNTE2NzQxNjY3LCJhaW8iOiJZMk5nWU5oYjVhbzdSMDlkSitxQVdmL3REY0VuQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVXZNZVlKT2tHRTZtVTdaWkJVOU5BQSIsInZlciI6IjEuMCJ9.clPB6sCVYpuOWFnlu3LL9lLjMZIJ3Ma-Na0jgG0KNVS02hHw-xjbs1gclLAiXaisqVAasGYoUQPv0UBc_-M88SU6TU5MxTgmaTOV2Hs7tIqyZbq8iL_Xn8RAORVxAFvgqW7Z2slTxFioBGbMVKY810ocNgtou-OMpgCSmb5C3uleWhejOhpBlMrunEUqCgDD7kTqnyv4t3Z0NbeCoQqVIOBu16Wu2idYdTrUsi04s7IkNGtpjiYDihngnKWHrbH338kjSxrI022d4MW-NXGTLdJk9Zgym3USe1hWNsvCZJAl8kvHo4JvuiPwCUpruRfjMsbjVOIl3jonvzAypxy38g"}'
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:43:39 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:47 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -72,7 +74,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYzMjAsIm5iZiI6MTUwNjExNjMyMCwiZXhwIjoxNTA2MTIwMjIwLCJhaW8iOiJZMlZnWU9nNGtxRHdabVYwQUYvY0RITmpzOWh5QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ0J4UjdlNnJJMEdPUWFrM0pBRU5BQSIsInZlciI6IjEuMCJ9.WcnPWRma_ZSUbEE2NtUD-qb0F63lFLuWHSnqlmMMY9EfGNjuB1Uin2svpt-lMGI2Yw36TYTE7KGdgYQsJKVDNfW1UuAii49CZVAFrV-4Shz7Xui_AHFNhqWSJhq_sniUWJO9WZpH5x86cp1kWVIPUfpEO0YO3ec69N_7FFK_rE4v8uTrXCxoMP2G_FQQrC3wKwghy6aLWgvP0e1mDGajn52q7AG7PQwDSFAkefAKGMs53rWOwYVc5iv0voFziAe0gp1vZDFxyPfkbxueJQNpyC8EbFbcpZorzRMIwm3qMFIU162wiFZf-qFJ3ni_BWs_wzR1NFjLow-PxaMumIsl9w
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3NjcsIm5iZiI6MTUxNjczNzc2NywiZXhwIjoxNTE2NzQxNjY3LCJhaW8iOiJZMk5nWU5oYjVhbzdSMDlkSitxQVdmL3REY0VuQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVXZNZVlKT2tHRTZtVTdaWkJVOU5BQSIsInZlciI6IjEuMCJ9.clPB6sCVYpuOWFnlu3LL9lLjMZIJ3Ma-Na0jgG0KNVS02hHw-xjbs1gclLAiXaisqVAasGYoUQPv0UBc_-M88SU6TU5MxTgmaTOV2Hs7tIqyZbq8iL_Xn8RAORVxAFvgqW7Z2slTxFioBGbMVKY810ocNgtou-OMpgCSmb5C3uleWhejOhpBlMrunEUqCgDD7kTqnyv4t3Z0NbeCoQqVIOBu16Wu2idYdTrUsi04s7IkNGtpjiYDihngnKWHrbH338kjSxrI022d4MW-NXGTLdJk9Zgym3USe1hWNsvCZJAl8kvHo4JvuiPwCUpruRfjMsbjVOIl3jonvzAypxy38g
+      Host:
+      - management.azure.com
   response:
     status:
       code: 200
@@ -93,21 +97,22 @@ http_interactions:
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
       - '14998'
       X-Ms-Request-Id:
-      - 97633e9d-7cce-4701-8248-e5ccd7e0cde3
+      - '08eb0977-8389-47fc-afdc-07457ae216fc'
       X-Ms-Correlation-Request-Id:
-      - 97633e9d-7cce-4701-8248-e5ccd7e0cde3
+      - '08eb0977-8389-47fc-afdc-07457ae216fc'
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214340Z:97633e9d-7cce-4701-8248-e5ccd7e0cde3
+      - WESTUS:20180123T200748Z:08eb0977-8389-47fc-afdc-07457ae216fc
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 22 Sep 2017 21:43:40 GMT
+      - Tue, 23 Jan 2018 20:07:48 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
-        Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
+      string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
+        Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
+        Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:43:40 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:48 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/azure_subscription_id/providers?api-version=2015-01-01
@@ -124,7 +129,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYzMjAsIm5iZiI6MTUwNjExNjMyMCwiZXhwIjoxNTA2MTIwMjIwLCJhaW8iOiJZMlZnWU9nNGtxRHdabVYwQUYvY0RITmpzOWh5QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ0J4UjdlNnJJMEdPUWFrM0pBRU5BQSIsInZlciI6IjEuMCJ9.WcnPWRma_ZSUbEE2NtUD-qb0F63lFLuWHSnqlmMMY9EfGNjuB1Uin2svpt-lMGI2Yw36TYTE7KGdgYQsJKVDNfW1UuAii49CZVAFrV-4Shz7Xui_AHFNhqWSJhq_sniUWJO9WZpH5x86cp1kWVIPUfpEO0YO3ec69N_7FFK_rE4v8uTrXCxoMP2G_FQQrC3wKwghy6aLWgvP0e1mDGajn52q7AG7PQwDSFAkefAKGMs53rWOwYVc5iv0voFziAe0gp1vZDFxyPfkbxueJQNpyC8EbFbcpZorzRMIwm3qMFIU162wiFZf-qFJ3ni_BWs_wzR1NFjLow-PxaMumIsl9w
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3NjcsIm5iZiI6MTUxNjczNzc2NywiZXhwIjoxNTE2NzQxNjY3LCJhaW8iOiJZMk5nWU5oYjVhbzdSMDlkSitxQVdmL3REY0VuQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVXZNZVlKT2tHRTZtVTdaWkJVOU5BQSIsInZlciI6IjEuMCJ9.clPB6sCVYpuOWFnlu3LL9lLjMZIJ3Ma-Na0jgG0KNVS02hHw-xjbs1gclLAiXaisqVAasGYoUQPv0UBc_-M88SU6TU5MxTgmaTOV2Hs7tIqyZbq8iL_Xn8RAORVxAFvgqW7Z2slTxFioBGbMVKY810ocNgtou-OMpgCSmb5C3uleWhejOhpBlMrunEUqCgDD7kTqnyv4t3Z0NbeCoQqVIOBu16Wu2idYdTrUsi04s7IkNGtpjiYDihngnKWHrbH338kjSxrI022d4MW-NXGTLdJk9Zgym3USe1hWNsvCZJAl8kvHo4JvuiPwCUpruRfjMsbjVOIl3jonvzAypxy38g
+      Host:
+      - management.azure.com
   response:
     status:
       code: 200
@@ -141,19 +148,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14917'
+      - '14860'
       X-Ms-Request-Id:
-      - 8cca1ef7-7c62-4981-afe2-326cfcd07981
+      - 520b3ecb-cf71-4b8d-8f7b-96fcf727d3c0
       X-Ms-Correlation-Request-Id:
-      - 8cca1ef7-7c62-4981-afe2-326cfcd07981
+      - 520b3ecb-cf71-4b8d-8f7b-96fcf727d3c0
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214341Z:8cca1ef7-7c62-4981-afe2-326cfcd07981
+      - WESTUS:20180123T200749Z:520b3ecb-cf71-4b8d-8f7b-96fcf727d3c0
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 22 Sep 2017 21:43:41 GMT
+      - Tue, 23 Jan 2018 20:07:49 GMT
       Content-Length:
-      - '254785'
+      - '293551'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
@@ -176,7 +183,7 @@ http_interactions:
         Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
         Central US","North Central US","Japan East","Japan West","Brazil South","Central
         India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
+        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-04-19","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-04-19","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-04-19","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-04-19","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","North Central
         US","South Central US","West Central US","West US","West US 2","Canada Central","Canada
         East","North Europe","West Europe","UK South","UK West","East Asia","Southeast
@@ -184,20 +191,26 @@ http_interactions:
         India","South India","West India"],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"validateServiceName","locations":[],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"checkServiceNameAvailability","locations":[],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"reportFeedback","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"checkFeedbackRequired","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Automation","namespace":"Microsoft.Automation","authorizations":[{"applicationId":"fc75330b-179d-49af-87dd-3b1acf6827fa","roleDefinitionId":"95fd5de3-d071-4362-92bf-cf341c1de832"}],"resourceTypes":[{"resourceType":"automationAccounts","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
         South","UK South","West Central US","North Europe","Canada Central","Australia
-        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/runbooks","locations":["Japan
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/runbooks","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
         South","UK South","West Central US","North Europe","Canada Central","Australia
-        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/configurations","locations":["Japan
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/configurations","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","North
-        Central US","Brazil South","UK South","West Central US","Central India","Australia
-        Southeast","Canada Central","North Europe"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/webhooks","locations":["Japan
+        Central US","Korea Central","East US","West US 2","Brazil South","UK South","West
+        Central US","Central India","Australia Southeast","Canada Central","North
+        Europe"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/webhooks","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
         South","UK South","West Central US","North Europe","Canada Central","Australia
-        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"operations","locations":["South
-        Central US"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/softwareUpdateConfigurations","locations":["Japan
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"operations","locations":["South
+        Central US"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/softwareUpdateConfigurations","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
         South","UK South","West Central US","North Europe","Canada Central","Australia
-        Southeast","Central India"],"apiVersions":["2017-05-15-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Backup","namespace":"Microsoft.Backup","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"BackupVault","locations":["West
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview"]},{"resourceType":"automationAccounts/jobs","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
+        South","UK South","West Central US","North Europe","Canada Central","Australia
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureActiveDirectory","namespace":"Microsoft.AzureActiveDirectory","resourceTypes":[{"resourceType":"b2cDirectories","locations":["Global","United
+        States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]},{"resourceType":"operations","locations":["Global","United
+        States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]}],"registrationState":"Unregistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Backup","namespace":"Microsoft.Backup","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"BackupVault","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
@@ -206,22 +219,22 @@ http_interactions:
         Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
         West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
         East","South India","Central India","Canada Central","Canada East","UK South","UK
-        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01","2015-07-01","2014-05-01-privatepreview"]},{"resourceType":"operations","locations":["West
+        West","West Central US","West US 2"],"apiVersions":["2017-09-01","2017-05-01","2017-01-01","2015-12-01","2015-09-01","2015-07-01","2014-05-01-privatepreview"]},{"resourceType":"operations","locations":["West
         Europe","East US","East US 2","West US","North Central US","Brazil South","North
         Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
         West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
         East","South India","Central India","Canada Central","Canada East","UK South","UK
-        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations/quotas","locations":["West
+        West","West Central US","West US 2"],"apiVersions":["2017-09-01","2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01","2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations/quotas","locations":["West
         Europe","East US","East US 2","West US","North Central US","Brazil South","North
         Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
         West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
         East","South India","Central India","Canada Central","Canada East","UK South","UK
-        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]}],"registrationState":"Unregistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicCompute","namespace":"Microsoft.ClassicCompute","resourceTypes":[{"resourceType":"domainNames","locations":["East
+        West","West Central US","West US 2"],"apiVersions":["2017-09-01","2017-05-01","2017-01-01","2015-12-01","2015-09-01"]}],"registrationState":"Unregistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicCompute","namespace":"Microsoft.ClassicCompute","resourceTypes":[{"resourceType":"domainNames","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
@@ -256,7 +269,7 @@ http_interactions:
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -296,92 +309,92 @@ http_interactions:
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30"]},{"resourceType":"locations/usages","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations/usages","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
+        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
@@ -411,76 +424,138 @@ http_interactions:
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
+        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
         US","East US","South Central US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
         Central","Central US","East US 2","North Central US","West Central US","West
-        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/webhooks","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/ping","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/getCallbackConfig","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/listEvents","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"locations","locations":["South
-        Central US","East US","West US","Central US","East US 2","North Central US","West
-        Central US","West US 2","Brazil South","Canada East","Canada Central","West
-        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
-        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"locations/operationResults","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/GetCredentials","locations":["West
+        US 2"],"apiVersions":["2017-10-01","2017-03-01"]},{"resourceType":"registries/replications","locations":["South
+        Central US","West Central US","East US","West Europe","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/webhooks","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/webhooks/ping","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/webhooks/getCallbackConfig","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/webhooks/listEvents","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"locations/operationResults","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/GetCredentials","locations":["West
         US","East US","South Central US","West Europe"],"apiVersions":["2016-06-27-preview"]},{"resourceType":"registries/listCredentials","locations":["South
         Central US","East US","West US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
         Central","Central US","East US 2","North Central US","West Central US","West
-        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/regenerateCredential","locations":["South
+        US 2"],"apiVersions":["2017-10-01","2017-03-01"]},{"resourceType":"registries/regenerateCredential","locations":["South
         Central US","West US","East US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
         Central","Central US","East US 2","North Central US","West Central US","West
-        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/listUsages","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/regenerateCredentials","locations":["West
+        US 2"],"apiVersions":["2017-10-01","2017-03-01"]},{"resourceType":"registries/listUsages","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/regenerateCredentials","locations":["West
         US","East US","South Central US","West Europe"],"apiVersions":["2016-06-27-preview"]},{"resourceType":"checkNameAvailability","locations":["South
         Central US","East US","West US","Central US","East US 2","North Central US","West
         Central US","West US 2","Brazil South","Canada East","Canada Central","West
         Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
-        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview","2017-03-01","2016-06-27-preview"]},{"resourceType":"operations","locations":["South
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-10-01","2017-06-01-preview","2017-03-01","2016-06-27-preview"]},{"resourceType":"operations","locations":["South
         Central US","East US","West US","Central US","East US 2","North Central US","West
         Central US","West US 2","Brazil South","Canada East","Canada Central","West
         Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
-        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview","2017-03-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerService","namespace":"Microsoft.ContainerService","authorization":{"applicationId":"7319c514-987d-4e9b-ac3d-d38c4f427f4c","roleDefinitionId":"1b4a0c7f-2217-416f-acfa-cf73452fdc1c"},"resourceTypes":[{"resourceType":"containerServices","locations":["Japan
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-10-01","2017-06-01-preview","2017-03-01"]},{"resourceType":"locations","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-10-01","2017-06-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerService","namespace":"Microsoft.ContainerService","authorization":{"applicationId":"7319c514-987d-4e9b-ac3d-d38c4f427f4c","roleDefinitionId":"1b4a0c7f-2217-416f-acfa-cf73452fdc1c","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"containerServices","locations":["Japan
         East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
         Central US","West US 2","South India","Central India","West India","Canada
-        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
+        East","Canada Central","Korea South","Korea Central"],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"managedClusters","locations":["East
+        US","West Europe","Central US","Canada Central","Canada East"],"apiVersions":["2017-08-31"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
         East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
         Central US","West US 2","South India","Central India","West India","Canada
-        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DevTestLab","namespace":"Microsoft.DevTestLab","authorization":{"applicationId":"1a14be2a-e903-4cec-99cf-b2e209259a0f","roleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525"},"resourceTypes":[{"resourceType":"labs","locations":["West
+        East","Canada Central","Korea South","Korea Central"],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/orchestrators","locations":["UK
+        West","West US 2","East US","West Europe","Central US"],"apiVersions":["2017-09-30"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DevTestLab","namespace":"Microsoft.DevTestLab","authorization":{"applicationId":"1a14be2a-e903-4cec-99cf-b2e209259a0f","roleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525","managedByRoleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525"},"resourceTypes":[{"resourceType":"labs","locations":["West
         Central US","Japan East","West US","Australia Southeast","Canada Central","Central
         India","Central US","East Asia","Korea Central","North Europe","South Central
-        US","UK West","Australia East","Brazil South","Canada East","East US","East
-        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        US","UK West","West India","Australia East","Brazil South","Canada East","East
+        US","East US 2","Japan West","Korea South","North Central US","South India","Southeast
         Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"schedules","locations":["West
         Central US","Japan East","West US","Australia Southeast","Canada Central","Central
         India","Central US","East Asia","Korea Central","North Europe","South Central
-        US","UK West","Australia East","Brazil South","Canada East","East US","East
-        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        US","UK West","West India","Australia East","Brazil South","Canada East","East
+        US","East US 2","Japan West","Korea South","North Central US","South India","Southeast
         Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"labs/virtualMachines","locations":["West
         Central US","Japan East","West US","Australia Southeast","Canada Central","Central
         India","Central US","East Asia","Korea Central","North Europe","South Central
-        US","UK West","Australia East","Brazil South","Canada East","East US","East
-        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        US","UK West","West India","Australia East","Brazil South","Canada East","East
+        US","East US 2","Japan West","Korea South","North Central US","South India","Southeast
         Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"labs/serviceRunners","locations":["Central
         US","East US 2","South Central US"],"apiVersions":["2017-04-26-preview","2016-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"locations/operations","locations":["West
         Central US","Japan East","West US","Australia Southeast","Canada Central","Central
         India","Central US","East Asia","Korea Central","North Europe","South Central
-        US","UK West","Australia East","Brazil South","Canada East","East US","East
-        US 2","Japan West","Korea South","North Central US","South India","Southeast
-        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"}],"resourceTypes":[{"resourceType":"components","locations":["East
-        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
-        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01","2014-04-01"]},{"resourceType":"queries","locations":["East
-        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
+        US","UK West","West India","Australia East","Brazil South","Canada East","East
+        US","East US 2","Japan West","Korea South","North Central US","South India","Southeast
+        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","authorizations":[{"applicationId":"57c0fc58-a83a-41d0-8ae9-08952659bdfd","roleDefinitionId":"FFFD5CF5-FFD3-4B24-B0E2-0715ADD4C282"}],"resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"databaseAccountNames","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"operationResults","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"},{"applicationId":"f5c26e74-f226-4ae8-85f0-b4af0080ac9e","roleDefinitionId":"529d7ae6-e892-4d43-809d-8547aeb90643"}],"resourceTypes":[{"resourceType":"components","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2015-05-01","2014-08-01","2014-04-01"]},{"resourceType":"queries","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"components/pricingPlans","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"migrateToNewPricingModel","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"rollbackToLegacyPricingModel","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"listMigrationdate","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
@@ -516,7 +591,7 @@ http_interactions:
         West","North Central US","South Central US","East US 2","Canada East","Canada
         Central","Central US","Australia East","Australia Southeast","Brazil South","South
         India","Central India","West India","North Europe","West US 2","West Central
-        US","Korea South","Korea Central","UK South","UK West","Global"],"apiVersions":["2017-05-01-preview","2016-03-01","2015-07-01"]},{"resourceType":"logDefinitions","locations":["West
+        US","Korea South","Korea Central","UK South","UK West","Global"],"apiVersions":["2017-09-01-preview","2017-05-01-preview","2016-03-01","2015-07-01"]},{"resourceType":"logDefinitions","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
@@ -526,7 +601,7 @@ http_interactions:
         West","North Central US","South Central US","East US 2","Canada East","Canada
         Central","Central US","Australia East","Australia Southeast","Brazil South","South
         India","Central India","West India","North Europe","West US 2","West Central
-        US","Korea South","Korea Central","UK South","UK West"],"apiVersions":["2017-05-01-preview","2016-09-01","2016-06-01"]},{"resourceType":"actiongroups","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]},{"resourceType":"activityLogAlerts","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.KeyVault","namespace":"Microsoft.KeyVault","resourceTypes":[{"resourceType":"vaults","locations":["North
+        US","Korea South","Korea Central","UK South","UK West"],"apiVersions":["2017-09-01-preview","2017-05-01-preview","2016-09-01","2016-06-01"]},{"resourceType":"actiongroups","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]},{"resourceType":"activityLogAlerts","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.KeyVault","namespace":"Microsoft.KeyVault","resourceTypes":[{"resourceType":"vaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
@@ -556,126 +631,153 @@ http_interactions:
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorizations":[{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},{"applicationId":"7c33bfcb-8d33-48d6-8e60-dc6404003489","roleDefinitionId":"ad6261e4-fa9a-4642-aa5f-104f1b67e9e3"},{"applicationId":"1e3e4475-288f-4018-a376-df66fd7fac5f","roleDefinitionId":"1d538b69-3d87-4e56-8ff8-25786fd48261"},{"applicationId":"a0be0c72-870e-46f0-9c49-c98333a996f7","roleDefinitionId":"7ce22727-ffce-45a9-930c-ddb2e56fa131"}],"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","West Central US"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"operations","locations":["South
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations","locations":["South
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operations","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"commitmentPlans","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"Registering"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorizations":[{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},{"applicationId":"7c33bfcb-8d33-48d6-8e60-dc6404003489","roleDefinitionId":"ad6261e4-fa9a-4642-aa5f-104f1b67e9e3"},{"applicationId":"1e3e4475-288f-4018-a376-df66fd7fac5f","roleDefinitionId":"1d538b69-3d87-4e56-8ff8-25786fd48261"},{"applicationId":"a0be0c72-870e-46f0-9c49-c98333a996f7","roleDefinitionId":"7ce22727-ffce-45a9-930c-ddb2e56fa131"}],"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
-        Central US"],"apiVersions":["2017-09-01"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
-        East","UK South","Central India","Canada Central"],"apiVersions":["2017-04-26-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"]},{"resourceType":"workspaces/dataSources","locations":["East
+        East","UK South","Central India","Canada Central"],"apiVersions":["2017-04-26-preview","2017-03-15-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"]},{"resourceType":"workspaces/query","locations":["West
+        Central US","Australia Southeast","West Europe","East US","Southeast Asia","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2017-10-01"]},{"resourceType":"workspaces/dataSources","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
         East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"storageInsightConfigs","locations":[],"apiVersions":["2014-10-10"]},{"resourceType":"workspaces/linkedServices","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
         East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"linkTargets","locations":["East
         US"],"apiVersions":["2015-03-20"]},{"resourceType":"operations","locations":[],"apiVersions":["2014-11-10"]},{"resourceType":"devices","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationsManagement","namespace":"Microsoft.OperationsManagement","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"aa249101-6816-4966-aafa-08175d795f14"},"resourceTypes":[{"resourceType":"solutions","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
-        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Portal","namespace":"Microsoft.Portal","resourceTypes":[{"resourceType":"dashboards","locations":["Central
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"managementconfigurations","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"managementassociations","locations":[],"apiVersions":["2015-11-01-preview"]},{"resourceType":"views","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2017-08-21-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Portal","namespace":"Microsoft.Portal","resourceTypes":[{"resourceType":"dashboards","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
@@ -687,9 +789,9 @@ http_interactions:
         East","West India","South India","Central India","Canada Central","Canada
         East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"consoles","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/consoles","locations":["West
         US","East US","Central India","North Europe","West Europe","South Central
-        US","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
+        US","Southeast Asia","East US 2","Central US"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
         US","East US","Central India","North Europe","West Europe","South Central
-        US","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
+        US","Southeast Asia","East US 2","Central US"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
@@ -710,7 +812,17 @@ http_interactions:
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ResourceHealth","namespace":"Microsoft.ResourceHealth","authorization":{"applicationId":"8bdebf23-c0fe-4187-a378-717ad86f6a53","roleDefinitionId":"cc026344-c8b1-4561-83ba-59eba84b27cc"},"resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2017-07-01","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"notifications","locations":["Australia
+        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]},{"resourceType":"locations/backupValidateFeatures","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-07-01"]},{"resourceType":"locations/backupPreValidateProtection","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-07-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ResourceHealth","namespace":"Microsoft.ResourceHealth","authorization":{"applicationId":"8bdebf23-c0fe-4187-a378-717ad86f6a53","roleDefinitionId":"cc026344-c8b1-4561-83ba-59eba84b27cc"},"resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2017-07-01","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"notifications","locations":["Australia
         Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Security","namespace":"Microsoft.Security","authorization":{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatuses","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/virtualMachines","locations":["Central
@@ -743,10 +855,14 @@ http_interactions:
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securitySolutionsReferenceData","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/securitySolutionsReferenceData","locations":["Central
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"jitNetworkAccessPolicies","locations":["Central
-        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/jitNetworkAccessPolicies","locations":["Central
-        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations","locations":["Central
+        US","East US","North Europe","West Europe","UK South","UK West","West Central
+        US","West US 2"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/jitNetworkAccessPolicies","locations":["Central
+        US","East US","North Europe","West Europe","UK South","UK West","West Central
+        US","West US 2"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatusesSummaries","locations":["Central
-        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/alerts","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"applicationWhitelistings","locations":["Central
+        US","East US","West Central US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/applicationWhitelistings","locations":["Central
+        US","West Central US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/alerts","locations":["Central
         US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/tasks","locations":["Central
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"externalSecuritySolutions","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/externalSecuritySolutions","locations":["Central
@@ -769,7 +885,17 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/databaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/databaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -814,7 +940,7 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01","2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -829,7 +955,7 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -859,12 +985,17 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/geoBackupPolicies","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -879,12 +1010,12 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/firewallrules","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/backupLongTermRetentionPolicies","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -999,6 +1130,16 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
         US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
@@ -1034,7 +1175,22 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -1144,7 +1300,47 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -1159,7 +1355,17 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/administratorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -1179,52 +1385,52 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorization":{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorizations":[{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},{"applicationId":"e406a681-f3d4-42a8-90b6-c2b029497af1"}],"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
         US","West US","West Europe","North Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","South India","Central
@@ -1234,7 +1440,19 @@ http_interactions:
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Web","namespace":"Microsoft.Web","authorization":{"applicationId":"abfa0a7c-a6b6-4736-8310-5855508787cd","roleDefinitionId":"f47ed98b-b063-4a5b-9e10-4b9b44fa7735"},"resourceTypes":[{"resourceType":"sites/extensions","locations":["South
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/project","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/extension","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"checkNameAvailability","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Web","namespace":"Microsoft.Web","authorization":{"applicationId":"abfa0a7c-a6b6-4736-8310-5855508787cd","roleDefinitionId":"f47ed98b-b063-4a5b-9e10-4b9b44fa7735"},"resourceTypes":[{"resourceType":"sites/extensions","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
         South","West US","East US","Japan West","Japan East","East Asia","East US
         2","North Central US","Central US","Brazil South","Australia East","Australia
@@ -1339,7 +1557,7 @@ http_interactions:
         South","West US","East US","Japan West","Japan East","East Asia","East US
         2","North Central US","Central US","Brazil South","Australia East","Australia
         Southeast","West India","Central India","South India","Canada Central","Canada
-        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms/workers","locations":["South
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms/workers","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
         South","West US","East US","Japan West","Japan East","East Asia","East US
         2","North Central US","Central US","Brazil South","Australia East","Australia
@@ -1394,7 +1612,17 @@ http_interactions:
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","West US 2","West Central US","Canada Central","Canada
-        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/managedApis","locations":["North
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/listWsdlInterfaces","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/extractApiDefinitionFromWsdl","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/managedApis","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
@@ -1445,8 +1673,11 @@ http_interactions:
         US","North Europe","Japan West","Japan East","East Asia","West Europe","East
         US","Southeast Asia","Central US"],"apiVersions":["2016-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Lombiq.DotNest","namespace":"Lombiq.DotNest","resourceTypes":[{"resourceType":"sites","locations":["East
         US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Mailjet.Email","namespace":"Mailjet.Email","resourceTypes":[{"resourceType":"services","locations":["West
-        US"],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
-        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
+        US","West Europe"],"apiVersions":["2017-10-01","2017-02-03"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-10-01","2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-10-01","2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]},{"resourceType":"diagnosticSettings","locations":[],"apiVersions":["2017-04-01"]},{"resourceType":"diagnosticSettingsCategories","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Addons","namespace":"Microsoft.Addons","authorization":{"applicationId":"24d3987b-be4a-48e0-a3e7-11c186f39e41","roleDefinitionId":"8004BAAB-A4CB-4981-8571-F7E44D039D93"},"resourceTypes":[{"resourceType":"supportProviders","locations":["West
+        Central US","South Central US","East US","West Europe"],"apiVersions":["2017-05-15"]},{"resourceType":"operations","locations":["West
+        Central US","South Central US","East US","West Europe"],"apiVersions":["2017-05-15"]},{"resourceType":"operationResults","locations":["West
+        Central US","South Central US","East US","West Europe"],"apiVersions":["2017-05-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"addsservices","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"configuration","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"operations","locations":["West
@@ -1456,51 +1687,45 @@ http_interactions:
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"servicehealthmetrics","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"logs","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"anonymousapiusers","locations":["West
-        US"],"apiVersions":["2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AnalysisServices","namespace":"Microsoft.AnalysisServices","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"servers","locations":["West
+        US"],"apiVersions":["2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AlertsManagement","namespace":"Microsoft.AlertsManagement","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-11-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AnalysisServices","namespace":"Microsoft.AnalysisServices","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"servers","locations":["West
         US","North Europe","South Central US","West Europe","West Central US","Southeast
         Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
-        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/checkNameAvailability","locations":["West
+        Southeast","Japan East","UK South","West India","West US 2","East US"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"locations/checkNameAvailability","locations":["West
         US","North Europe","South Central US","West Europe","West Central US","Southeast
         Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
-        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationresults","locations":["West
+        Southeast","Japan East","UK South","West India","West US 2","East US"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationresults","locations":["West
         US","North Europe","South Central US","West Europe","West Central US","Southeast
         Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
-        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationstatuses","locations":["West
+        Southeast","Japan East","UK South","West India","West US 2","East US"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationstatuses","locations":["West
         US","North Europe","South Central US","West Europe","West Central US","Southeast
         Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
-        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"operations","locations":["East
-        US 2","West Central US"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AppService","namespace":"Microsoft.AppService","authorization":{"applicationId":"dee7ba80-6a55-4f3b-a86c-746a9231ae49","roleDefinitionId":"6715d172-49c4-46f6-bb21-60512a8689dc"},"resourceTypes":[{"resourceType":"apiapps","locations":["East
-        US","West US","South Central US","North Europe","East Asia","Japan East","West
-        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
-        South","East US 2","Australia Southeast","Australia East","West India","South
-        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"appIdentities","locations":["East
-        US","West US","South Central US","North Europe","East Asia","Japan East","West
-        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
-        South","East US 2","Australia Southeast","Australia East","West India","South
-        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"gateways","locations":["East
-        US","West US","South Central US","North Europe","East Asia","Japan East","West
-        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
-        South","East US 2","Australia Southeast","Australia East","West India","South
-        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"deploymenttemplates","locations":[],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Authorization","namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"roleDefinitions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"classicAdministrators","locations":[],"apiVersions":["2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"permissions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"locks","locations":[],"apiVersions":["2017-04-01","2016-09-01","2015-06-01","2015-05-01-preview","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-01-01","2014-10-01-preview","2014-06-01"]},{"resourceType":"policyDefinitions","locations":[],"apiVersions":["2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"policySetDefinitions","locations":[],"apiVersions":["2017-06-01-preview"]},{"resourceType":"policyAssignments","locations":[],"apiVersions":["2017-06-01-preview","2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"providerOperations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01-preview","2015-07-01"]},{"resourceType":"elevateAccess","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureActiveDirectory","namespace":"Microsoft.AzureActiveDirectory","resourceTypes":[{"resourceType":"b2cDirectories","locations":["Global","United
-        States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureStack","namespace":"Microsoft.AzureStack","resourceTypes":[{"resourceType":"operations","locations":["Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations","locations":["West
+        Southeast","Japan East","UK South","West India","West US 2","East US"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"operations","locations":["East
+        US 2","West Central US","West US 2"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Authorization","namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[],"apiVersions":["2017-10-01-preview","2017-09-01","2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"roleDefinitions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"classicAdministrators","locations":[],"apiVersions":["2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"permissions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"locks","locations":[],"apiVersions":["2017-04-01","2016-09-01","2015-06-01","2015-05-01-preview","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-01-01","2014-10-01-preview","2014-06-01"]},{"resourceType":"policyDefinitions","locations":[],"apiVersions":["2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"policySetDefinitions","locations":[],"apiVersions":["2017-06-01-preview"]},{"resourceType":"policyAssignments","locations":[],"apiVersions":["2017-06-01-preview","2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"providerOperations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01-preview","2015-07-01"]},{"resourceType":"elevateAccess","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"checkAccess","locations":[],"apiVersions":["2017-10-01-preview","2017-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureStack","namespace":"Microsoft.AzureStack","resourceTypes":[{"resourceType":"operations","locations":["Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations","locations":["West
         Central US","Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations/products","locations":["West
-        Central US","Global"],"apiVersions":["2017-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Billing","namespace":"Microsoft.Billing","resourceTypes":[{"resourceType":"BillingPeriods","locations":["Central
+        Central US","Global"],"apiVersions":["2017-06-01","2016-01-01"]},{"resourceType":"registrations/customerSubscriptions","locations":["West
+        Central US","Global"],"apiVersions":["2017-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BatchAI","namespace":"Microsoft.BatchAI","authorization":{"applicationId":"9fcb3732-5f52-4135-8c08-9d4bbaf203ea","roleDefinitionId":"703B89C7-CE2C-431B-BDD8-FA34E39AF696","managedByRoleDefinitionId":"90B8E153-EBFF-4073-A95F-4DAD56B14C78"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"jobs","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"fileservers","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"operations","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01-preview"]},{"resourceType":"locations/operationresults","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Billing","namespace":"Microsoft.Billing","resourceTypes":[{"resourceType":"BillingPeriods","locations":["Central
         US"],"apiVersions":["2017-04-24-preview"]},{"resourceType":"Invoices","locations":["Central
         US"],"apiVersions":["2017-04-24-preview","2017-02-27-preview"]},{"resourceType":"operations","locations":["Central
         US"],"apiVersions":["2017-04-24-preview","2017-02-27-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BingMaps","namespace":"Microsoft.BingMaps","resourceTypes":[{"resourceType":"mapApis","locations":["West
         US"],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-18","2015-07-02"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BizTalkServices","namespace":"Microsoft.BizTalkServices","resourceTypes":[{"resourceType":"BizTalk","locations":["East
         US","West US","North Europe","West Europe","Southeast Asia","East Asia","North
-        Central US","Japan West","Japan East","South Central US"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Cache","namespace":"Microsoft.Cache","authorization":{"applicationId":"96231a05-34ce-4eb4-aa6a-70759cbb5e83","roleDefinitionId":"4f731528-ba85-45c7-acfb-cd0a9b3cf31b"},"resourceTypes":[{"resourceType":"Redis","locations":["North
+        Central US","Japan West","Japan East","South Central US"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BotService","namespace":"Microsoft.BotService","resourceTypes":[{"resourceType":"botServices","locations":["Global"],"apiVersions":["2017-12-01"]},{"resourceType":"checkNameAvailability","locations":["Global"],"apiVersions":["2017-12-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Cache","namespace":"Microsoft.Cache","authorization":{"applicationId":"96231a05-34ce-4eb4-aa6a-70759cbb5e83","roleDefinitionId":"4f731528-ba85-45c7-acfb-cd0a9b3cf31b"},"resourceTypes":[{"resourceType":"Redis","locations":["North
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","Canada Central","Canada East","UK South","UK West","West US 2","West
-        Central US","South India","Korea Central","Korea South"],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","South India","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","South India","Canada Central","Canada East","UK South","UK West","West
-        US 2","West Central US","Korea Central","Korea South"],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01"]},{"resourceType":"Redis/metricDefinitions","locations":["North
+        US 2","West Central US","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01"]},{"resourceType":"Redis/metricDefinitions","locations":["North
         Central US","South Central US","East US","East US 2","West US","Central US","East
         Asia","Southeast Asia","North Europe","West Europe","Japan East","Japan West","Brazil
         South","Australia Southeast","Australia East","Central India","West India","South
@@ -1514,59 +1739,59 @@ http_interactions:
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/origins","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/origins","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/customdomains","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/customdomains","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/originresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/originresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/customdomainresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/customdomainresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkResourceUsage","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkResourceUsage","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02"]},{"resourceType":"validateProbe","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02"]},{"resourceType":"validateProbe","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02"]},{"resourceType":"operations","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02"]},{"resourceType":"operations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"edgenodes","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"edgenodes","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CertificateRegistration","namespace":"Microsoft.CertificateRegistration","authorization":{"applicationId":"f3c21649-0979-4721-ac85-b0216b2cf413","roleDefinitionId":"933fba7e-2ed3-4da8-973d-8bd8298a9b40"},"resourceTypes":[{"resourceType":"certificateOrders","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"certificateOrders/certificates","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"validateCertificateRegistrationInformation","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicSubscription","namespace":"Microsoft.ClassicSubscription","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicInfrastructureMigrate","namespace":"Microsoft.ClassicInfrastructureMigrate","authorization":{"applicationId":"5e5abe2b-83cd-4786-826a-a05653ebb103","roleDefinitionId":"766c4d9b-ef83-4f73-8352-1450a506a69b"},"resourceTypes":[{"resourceType":"classicInfrastructureResources","locations":["East
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CertificateRegistration","namespace":"Microsoft.CertificateRegistration","authorization":{"applicationId":"f3c21649-0979-4721-ac85-b0216b2cf413","roleDefinitionId":"933fba7e-2ed3-4da8-973d-8bd8298a9b40"},"resourceTypes":[{"resourceType":"certificateOrders","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"certificateOrders/certificates","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"validateCertificateRegistrationInformation","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicSubscription","namespace":"Microsoft.ClassicSubscription","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-09-01","2017-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicInfrastructureMigrate","namespace":"Microsoft.ClassicInfrastructureMigrate","authorization":{"applicationId":"5e5abe2b-83cd-4786-826a-a05653ebb103","roleDefinitionId":"766c4d9b-ef83-4f73-8352-1450a506a69b"},"resourceTypes":[{"resourceType":"classicInfrastructureResources","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
         Central US","Central US","North Europe","West Europe","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","West
@@ -1584,8 +1809,9 @@ http_interactions:
         Asia","East Asia","West Central US","South Central US","East US","East US
         2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/updateAccountsCreationSettings","locations":["West
         US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/accountsCreationSettings","locations":["West
-        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2016-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Commerce","namespace":"Microsoft.Commerce","resourceTypes":[{"resourceType":"UsageAggregates","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]},{"resourceType":"RateCard","locations":[],"apiVersions":["2016-08-31-preview","2015-06-01-preview","2015-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Consumption","namespace":"Microsoft.Consumption","resourceTypes":[{"resourceType":"reservationsummaries","locations":[],"apiVersions":["2017-01-30"]},{"resourceType":"reservationdetails","locations":[],"apiVersions":["2017-01-30"]},{"resourceType":"UsageDetails","locations":[],"apiVersions":["2017-06-30-preview","2017-04-24-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-30-preview","2017-04-24-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","resourceTypes":[{"resourceType":"containerGroups","locations":["West
-        US","East US","West Europe"],"apiVersions":["2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
+        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2016-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Commerce","namespace":"Microsoft.Commerce","resourceTypes":[{"resourceType":"UsageAggregates","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]},{"resourceType":"RateCard","locations":[],"apiVersions":["2016-08-31-preview","2015-06-01-preview","2015-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Consumption","namespace":"Microsoft.Consumption","resourceTypes":[{"resourceType":"ReservationSummaries","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationTransactions","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"Balances","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"Pricesheets","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationDetails","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"Budgets","locations":[],"apiVersions":["2017-12-30-preview"]},{"resourceType":"Terms","locations":[],"apiVersions":["2017-12-30-preview"]},{"resourceType":"UsageDetails","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview","2017-04-24-preview"]},{"resourceType":"Operations","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview","2017-04-24-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","resourceTypes":[{"resourceType":"containerGroups","locations":["West
+        US","East US","West Europe","Southeast Asia"],"apiVersions":["2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US","East US","West Europe","Southeast Asia"],"apiVersions":["2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
         US"],"apiVersions":["2016-04-08"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CustomerInsights","namespace":"Microsoft.CustomerInsights","authorization":{"applicationId":"38c77d00-5fcb-4cce-9d93-af4738258e3c","roleDefinitionId":"E006F9C7-F333-477C-8AD6-1F3A9FE87F55"},"resourceTypes":[{"resourceType":"hubs","locations":["East
         US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/profiles","locations":["East
         US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/interactions","locations":["East
@@ -1608,8 +1834,8 @@ http_interactions:
         US","West US","Australia East","West Europe","North Europe","Southeast Asia","West
         Central US"],"apiVersions":["2016-03-30","2015-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataFactory","namespace":"Microsoft.DataFactory","resourceTypes":[{"resourceType":"dataFactories","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview","2014-04-01"]},{"resourceType":"factories","locations":["East
-        US","East US 2"],"apiVersions":["2017-09-01-preview","2017-03-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
-        US","East US 2"],"apiVersions":["2017-09-01-preview","2017-03-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
+        US","East US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
+        US","East US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
         Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"dataFactories/metricDefinitions","locations":["North
         Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"checkDataFactoryNameAvailability","locations":[],"apiVersions":["2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"checkAzureDataFactoryNameAvailability","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"dataFactorySchema","locations":["West
@@ -1621,69 +1847,71 @@ http_interactions:
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers/listSasTokens","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeStore","namespace":"Microsoft.DataLakeStore","authorization":{"applicationId":"e9f49c6b-5ce5-44c8-925d-015017e9f7ad","roleDefinitionId":"17eb9cca-f08a-4499-b2d3-852d175f614f"},"resourceTypes":[{"resourceType":"accounts","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/firewallRules","locations":["East
-        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","resourceTypes":[{"resourceType":"operations","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforPostgreSQL","namespace":"Microsoft.DBforPostgreSQL","resourceTypes":[{"resourceType":"operations","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"checkProvisioningServiceNameAvailability","locations":[],"apiVersions":["2017-08-21-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataMigration","namespace":"Microsoft.DataMigration","authorization":{"applicationId":"a4bad4aa-bf02-4631-9f78-a64ffdba8150","roleDefinitionId":"b831a21d-db98-4760-89cb-bef871952df1","managedByRoleDefinitionId":"6256fb55-9e59-4018-a9e1-76b11c0a4c89"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services/projects","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationStatuses","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforPostgreSQL","namespace":"Microsoft.DBforPostgreSQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"checkProvisioningServiceNameAvailability","locations":[],"apiVersions":["2017-11-15","2017-08-21-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
         US","North Europe","East Asia","East US","West Europe","Southeast Asia","Japan
         East","Japan West","Australia East","Australia Southeast","West US 2","West
         Central US","East US 2","Central US","UK South","UK West","South India","Central
-        India","Canada Central","Canada East"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"ProvisioningServices","locations":["East
-        US","West Europe","Southeast Asia"],"apiVersions":["2017-08-21-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
-        East","Australia Southeast","Canada Central","Canada East","Central India","Central
-        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
-        US","North Europe","South Central US","South India","Southeast Asia","West
-        Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"databaseAccountNames","locations":["Australia
-        East","Australia Southeast","Canada Central","Canada East","Central India","Central
-        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
-        US","North Europe","South Central US","South India","Southeast Asia","West
-        Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"operations","locations":["Australia
-        East","Australia Southeast","Canada Central","Canada East","Central India","Central
-        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
-        US","North Europe","South Central US","South India","Southeast Asia","West
-        Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DomainRegistration","namespace":"Microsoft.DomainRegistration","authorization":{"applicationId":"ea2f600a-4980-45b7-89bf-d34da487bda1","roleDefinitionId":"54d7f2e3-5040-48a7-ae90-eebf629cfa0b"},"resourceTypes":[{"resourceType":"domains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"domains/domainOwnershipIdentifiers","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"topLevelDomains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"checkDomainAvailability","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"listDomainRecommendations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"validateDomainRegistrationInformation","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"generateSsoRequest","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DynamicsLcs","namespace":"Microsoft.DynamicsLcs","resourceTypes":[{"resourceType":"lcsprojects","locations":["Brazil
+        India","Canada Central","Canada East","Brazil South","South Central US"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs/eventGridFilters","locations":["West
+        US","East US","West US 2","West Central US","East US 2","Central US"],"apiVersions":["2018-01-15-preview"]},{"resourceType":"ProvisioningServices","locations":["East
+        US","West US","West Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2017-11-15","2017-08-21-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DomainRegistration","namespace":"Microsoft.DomainRegistration","authorization":{"applicationId":"ea2f600a-4980-45b7-89bf-d34da487bda1","roleDefinitionId":"54d7f2e3-5040-48a7-ae90-eebf629cfa0b"},"resourceTypes":[{"resourceType":"domains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"domains/domainOwnershipIdentifiers","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"topLevelDomains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"checkDomainAvailability","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"listDomainRecommendations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"validateDomainRegistrationInformation","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"generateSsoRequest","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DynamicsLcs","namespace":"Microsoft.DynamicsLcs","resourceTypes":[{"resourceType":"lcsprojects","locations":["Brazil
         South","East Asia","East US","Japan East","Japan West","North Central US","North
         Europe","South Central US","West Europe","West US","Southeast Asia","Central
         US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"lcsprojects/connectors","locations":["Brazil
@@ -1695,21 +1923,21 @@ http_interactions:
         US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"operations","locations":["Brazil
         South","East Asia","East US","Japan East","Japan West","North Central US","North
         Europe","South Central US","West Europe","West US","Southeast Asia","Central
-        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topics","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operations","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topics","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operations","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","West
         US 2","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
         India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/consumergroups","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
         US","East US 2","West US","South Central US","Central US","Australia East","Australia
         Southeast","Central India","West Central US","West US 2","Canada East","Canada
         Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
@@ -1754,23 +1982,23 @@ http_interactions:
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations","locations":["Australia
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations/operationResults","locations":["Australia
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations/operationResults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"operations","locations":["Australia
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"operations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Logic","namespace":"Microsoft.Logic","authorization":{"applicationId":"7cd684f4-8a78-49b0-91ec-6a35d38739ba","roleDefinitionId":"cb3ef1fb-6e31-49e2-9d87-ed821053fe58"},"resourceTypes":[{"resourceType":"workflows","locations":["North
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.LocationBasedServices","namespace":"Microsoft.LocationBasedServices","resourceTypes":[{"resourceType":"accounts","locations":["Global"],"apiVersions":["2017-01-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Logic","namespace":"Microsoft.Logic","authorization":{"applicationId":"7cd684f4-8a78-49b0-91ec-6a35d38739ba","roleDefinitionId":"cb3ef1fb-6e31-49e2-9d87-ed821053fe58"},"resourceTypes":[{"resourceType":"workflows","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
@@ -1791,60 +2019,78 @@ http_interactions:
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada Central","Canada East","West US 2","West Central
-        US","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","West Central US"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"operations","locations":["South
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations","locations":["South
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operations","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"commitmentPlans","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningExperimentation","namespace":"Microsoft.MachineLearningExperimentation","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"accounts","locations":["Australia
-        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces","locations":["Australia
-        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces/projects","locations":["Australia
-        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningCompute","namespace":"Microsoft.MachineLearningCompute","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"376aa7d7-51a9-463d-bd4d-7e1691345612","managedByRoleDefinitionId":"91d00862-cf55-46a5-9dce-260bbd92ce25"},"resourceTypes":[{"resourceType":"operationalizationClusters","locations":["East
-        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"operations","locations":["East
+        US","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningExperimentation","namespace":"Microsoft.MachineLearningExperimentation","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"accounts","locations":["Australia
+        East","East US 2","West Central US","Southeast Asia","West Europe"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces","locations":["Australia
+        East","East US 2","West Central US","Southeast Asia","West Europe"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces/projects","locations":["Australia
+        East","East US 2","West Central US","Southeast Asia","West Europe"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"teamAccounts","locations":["Australia
+        East","West Central US","East US 2"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"teamAccounts/workspaces","locations":["Australia
+        East","West Central US","East US 2"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"teamAccounts/workspaces/projects","locations":["Australia
+        East","West Central US","East US 2"],"apiVersions":["2017-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningCompute","namespace":"Microsoft.MachineLearningCompute","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"376aa7d7-51a9-463d-bd4d-7e1691345612","managedByRoleDefinitionId":"91d00862-cf55-46a5-9dce-260bbd92ce25"},"resourceTypes":[{"resourceType":"operationalizationClusters","locations":["East
+        US 2","West Central US","Australia East","West Europe","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"operations","locations":["East
         US 2"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations","locations":["East
         US 2"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operations","locations":["East
-        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["East
-        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningModelManagement","namespace":"Microsoft.MachineLearningModelManagement","resourceTypes":[{"resourceType":"accounts","locations":["East
-        US 2","West Central US","Australia East"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"operations","locations":["West
-        Central US"],"apiVersions":["2017-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
+        US 2","West Central US","Australia East","West Europe","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["East
+        US 2","West Central US","Australia East","West Europe","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningModelManagement","namespace":"Microsoft.MachineLearningModelManagement","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US 2","West Central US","Australia East","West Europe","Southeast Asia"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"operations","locations":["West
+        Central US"],"apiVersions":["2017-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ManagedIdentity","namespace":"Microsoft.ManagedIdentity","resourceTypes":[{"resourceType":"Identities","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Brazil South","Central
+        India","West India","South India","Japan West","Japan East","East Asia","Southeast
+        Asia","Korea Central","Korea South","North Europe","West Europe","UK West","UK
+        South","Central US","North Central US","East US","East US 2","South Central
+        US","West US","West US 2","West Central US"],"apiVersions":["2015-08-31-PREVIEW"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Brazil South","Central
+        India","West India","South India","Japan West","Japan East","East Asia","Southeast
+        Asia","Korea Central","Korea South","North Europe","West Europe","UK West","UK
+        South","Central US","North Central US","East US","East US 2","South Central
+        US","West US","West US 2","West Central US"],"apiVersions":["2015-08-31-PREVIEW"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Management","namespace":"Microsoft.Management","authorization":{"applicationId":"f2c304cf-8e7e-4c3f-8164-16299ad9d272","roleDefinitionId":"c1cf3708-588a-4647-be7f-f400bbe214cf"},"resourceTypes":[{"resourceType":"resources","locations":[],"apiVersions":["2017-11-01-preview","2017-08-31-preview","2017-06-30-preview","2017-05-31-preview"]},{"resourceType":"managementGroups","locations":[],"apiVersions":["2017-11-01-preview","2017-08-31-preview","2017-06-30-preview","2017-05-31-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01-preview","2017-08-31-preview","2017-06-30-preview","2017-05-31-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceApps","namespace":"Microsoft.MarketplaceApps","resourceTypes":[{"resourceType":"classicDevServices","locations":["Northwest
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","Central US","North
+        Europe","West Europe","Japan East","Japan West","Brazil South","Australia
+        East","Australia Southeast","South India","Central India","Canada Central","Canada
+        East"],"apiVersions":["2017-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
         Central US","West US"],"apiVersions":["2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01"]},{"resourceType":"offertypes","locations":["South
         Central US","West US"],"apiVersions":["2015-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Media","namespace":"Microsoft.Media","authorization":{"applicationId":"374b2a64-3b6b-436b-934c-b820eacca870","roleDefinitionId":"aab70789-0cec-44b5-95d7-84b64c9487af"},"resourceTypes":[{"resourceType":"mediaservices","locations":["Japan
         West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
         US","West US","Australia East","Australia Southeast","Central US","Brazil
         South","Central India","West India","South India","South Central US","Canada
-        Central","Canada East","West Central US"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
+        Central","Canada East","West Central US","West US 2"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
+        Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"operations","locations":["West
+        Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
+        Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PolicyInsights","namespace":"Microsoft.PolicyInsights","authorization":{"applicationId":"1d78a85d-813d-46f0-b496-dd72f50a3ec0","roleDefinitionId":"63d2b225-4c34-4641-8768-21a1f7c68ce8"},"resourceTypes":[{"resourceType":"policyEvents","locations":[],"apiVersions":["2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"policyStates","locations":[],"apiVersions":["2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-17-preview","2017-08-09-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
         Central US","North Central US","East US 2","West US","West Europe","North
         Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
         East","UK South","West India"],"apiVersions":["2016-01-29"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-01-29"]},{"resourceType":"locations/checkNameAvailability","locations":["South
         Central US","North Central US","East US 2","West US","West Europe","North
         Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
-        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"capacities","locations":["West
-        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
-        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationresults","locations":["West
-        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
-        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"operations","locations":["East
-        US 2"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Relay","namespace":"Microsoft.Relay","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"capacities","locations":["Australia
+        Southeast","Brazil South","Canada Central","East Asia","East US","East US
+        2","West India","Japan East","West Central US","North Central US","North Europe","South
+        Central US","Southeast Asia","UK South","West Europe","West US","West US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":["Australia
+        Southeast","Brazil South","Canada Central","East Asia","East US","East US
+        2","West India","Japan East","West Central US","North Central US","North Europe","South
+        Central US","Southeast Asia","UK South","West Europe","West US","West US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationresults","locations":["Australia
+        Southeast","Brazil South","Canada Central","East Asia","East US","East US
+        2","West India","Japan East","West Central US","North Central US","North Europe","South
+        Central US","Southeast Asia","UK South","West Europe","West US","West US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["Australia
+        Southeast","Brazil South","Canada Central","East Asia","East US","East US
+        2","West India","Japan East","West Central US","North Central US","North Europe","South
+        Central US","Southeast Asia","UK South","West Europe","West US","West US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"operations","locations":["East
+        US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Relay","namespace":"Microsoft.Relay","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US 2","West
         US","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
         India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2017-08-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkPolicyCompliance","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/hybridconnections","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/hybridconnections/authorizationrules","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/wcfrelays","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/wcfrelays/authorizationrules","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkPolicyCompliance","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
         Central US","South Central US","North Europe","West Europe","East Asia","Southeast
         Asia","West US","East US","Japan West","Japan East","Brazil South","Central
         US","East US 2","Australia East","Australia Southeast","South India","Central
@@ -1868,12 +2114,12 @@ http_interactions:
         India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19","2015-02-28"]},{"resourceType":"checkServiceNameAvailability","locations":[],"apiVersions":["2015-02-28","2014-07-31-Preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2015-08-19"]},{"resourceType":"resourceHealthMetadata","locations":["West
         US","East US","North Europe","West Europe","Southeast Asia","East Asia","North
         Central US","South Central US","Japan West","Australia East","Brazil South","Central
-        India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","authorization":{"applicationId":"80a10ef9-8168-493d-abf9-3297c4ef6e3c","roleDefinitionId":"2b7763f7-bbe2-4e19-befe-28c79f1cf7f7"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US 2","West
         US","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
         India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"premiumMessagingRegions","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceFabric","namespace":"Microsoft.ServiceFabric","authorization":{"applicationId":"74cb6831-0dbb-4be1-8206-fd4df301cdc2","roleDefinitionId":"e55cc65f-6903-4917-b4ef-f8d4640b57f5"},"resourceTypes":[{"resourceType":"clusters","locations":["West
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/queues","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/queues/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/topics","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/topics/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/topics/subscriptions","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/topics/subscriptions/rules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"premiumMessagingRegions","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceFabric","namespace":"Microsoft.ServiceFabric","authorization":{"applicationId":"74cb6831-0dbb-4be1-8206-fd4df301cdc2","roleDefinitionId":"e55cc65f-6903-4917-b4ef-f8d4640b57f5"},"resourceTypes":[{"resourceType":"clusters","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
@@ -1887,17 +2133,43 @@ http_interactions:
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
-        India","West India","Central India","Brazil South","South Central US","Canada
-        Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
         Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
         Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applianceDefinitions","locations":["West
-        Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"locations","locations":["West
-        Central US"],"apiVersions":["2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
-        Central US"],"apiVersions":["2017-09-01","2016-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
+        Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applications","locations":["South
+        Central US","North Central US","West Central US","West US","West US 2","East
+        US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
+        Asia","Brazil South","Japan West","Japan East","Australia East","Australia
+        Southeast","South India","West India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
+        Central US","North Central US","West Central US","West US","West US 2","East
+        US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
+        Asia","Brazil South","Japan West","Japan East","Australia East","Australia
+        Southeast","South India","West India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
+        Central US"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
+        Central US","North Central US","West Central US","West US","West US 2","East
+        US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
+        Asia","Brazil South","Japan West","Japan East","Australia East","Australia
+        Southeast","South India","West India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/cloudEndpoints","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/serverEndpoints","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/registeredServers","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/workflows","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","West Central US","Japan East","Japan West","Australia East","Australia
         Southeast"],"apiVersions":["2017-06-01","2017-05-15","2017-01-01","2016-10-01","2016-06-01","2015-03-15","2014-09-01"]},{"resourceType":"operations","locations":["West
@@ -1928,23 +2200,11 @@ http_interactions:
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast"],"apiVersions":["2015-07-01-Preview","2015-03-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.TimeSeriesInsights","namespace":"Microsoft.TimeSeriesInsights","authorizations":[{"applicationId":"120d688d-1518-4cf7-bd38-182f158850b6","roleDefinitionId":"5a43abdf-bb87-42c4-9e56-1c24bf364150"}],"resourceTypes":[{"resourceType":"environments","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/eventsources","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/referenceDataSets","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/accessPolicies","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"operations","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
-        Central US","South Central US","East US","West US","Central US","North Europe","West
-        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
-        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/project","locations":["North
-        Central US","South Central US","East US","West US","Central US","North Europe","West
-        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
-        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/extension","locations":["North
-        Central US","South Central US","East US","West US","Central US","North Europe","West
-        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
-        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"checkNameAvailability","locations":["North
-        Central US","South Central US","East US","West US","Central US","North Europe","West
-        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
-        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Myget.PackageManagement","namespace":"Myget.PackageManagement","resourceTypes":[{"resourceType":"services","locations":["West
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]},{"resourceType":"environments/eventsources","locations":["East
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]},{"resourceType":"environments/referenceDataSets","locations":["East
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]},{"resourceType":"environments/accessPolicies","locations":["East
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]},{"resourceType":"operations","locations":["East
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Myget.PackageManagement","namespace":"Myget.PackageManagement","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/NewRelic.APM","namespace":"NewRelic.APM","authorization":{"allowedThirdPartyExtensions":[{"name":"NewRelic_AzurePortal_APM"}]},"resourceTypes":[{"resourceType":"accounts","locations":["North
         Central US","South Central US","West US","East US","North Europe","West Europe","Southeast
         Asia","East Asia","Japan East","Japan West"],"apiVersions":["2014-10-01","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/nuubit.nextgencdn","namespace":"nuubit.nextgencdn","resourceTypes":[{"resourceType":"accounts","locations":["East
@@ -1984,7 +2244,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:43:41 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:50 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/this_is_not_a_disk_name/BeginGetAccess?api-version=2017-03-30
@@ -2001,9 +2261,11 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYzMjAsIm5iZiI6MTUwNjExNjMyMCwiZXhwIjoxNTA2MTIwMjIwLCJhaW8iOiJZMlZnWU9nNGtxRHdabVYwQUYvY0RITmpzOWh5QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ0J4UjdlNnJJMEdPUWFrM0pBRU5BQSIsInZlciI6IjEuMCJ9.WcnPWRma_ZSUbEE2NtUD-qb0F63lFLuWHSnqlmMMY9EfGNjuB1Uin2svpt-lMGI2Yw36TYTE7KGdgYQsJKVDNfW1UuAii49CZVAFrV-4Shz7Xui_AHFNhqWSJhq_sniUWJO9WZpH5x86cp1kWVIPUfpEO0YO3ec69N_7FFK_rE4v8uTrXCxoMP2G_FQQrC3wKwghy6aLWgvP0e1mDGajn52q7AG7PQwDSFAkefAKGMs53rWOwYVc5iv0voFziAe0gp1vZDFxyPfkbxueJQNpyC8EbFbcpZorzRMIwm3qMFIU162wiFZf-qFJ3ni_BWs_wzR1NFjLow-PxaMumIsl9w
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3NjcsIm5iZiI6MTUxNjczNzc2NywiZXhwIjoxNTE2NzQxNjY3LCJhaW8iOiJZMk5nWU5oYjVhbzdSMDlkSitxQVdmL3REY0VuQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVXZNZVlKT2tHRTZtVTdaWkJVOU5BQSIsInZlciI6IjEuMCJ9.clPB6sCVYpuOWFnlu3LL9lLjMZIJ3Ma-Na0jgG0KNVS02hHw-xjbs1gclLAiXaisqVAasGYoUQPv0UBc_-M88SU6TU5MxTgmaTOV2Hs7tIqyZbq8iL_Xn8RAORVxAFvgqW7Z2slTxFioBGbMVKY810ocNgtou-OMpgCSmb5C3uleWhejOhpBlMrunEUqCgDD7kTqnyv4t3Z0NbeCoQqVIOBu16Wu2idYdTrUsi04s7IkNGtpjiYDihngnKWHrbH338kjSxrI022d4MW-NXGTLdJk9Zgym3USe1hWNsvCZJAl8kvHo4JvuiPwCUpruRfjMsbjVOIl3jonvzAypxy38g
       Content-Length:
       - '42'
+      Host:
+      - management.azure.com
   response:
     status:
       code: 404
@@ -2020,15 +2282,15 @@ http_interactions:
       X-Ms-Failure-Cause:
       - gateway
       X-Ms-Request-Id:
-      - db3ba159-d7d3-4d38-89df-62a5e755332e
+      - c2569b57-c325-4fb4-8be0-2ff7322dd8b1
       X-Ms-Correlation-Request-Id:
-      - db3ba159-d7d3-4d38-89df-62a5e755332e
+      - c2569b57-c325-4fb4-8be0-2ff7322dd8b1
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214343Z:db3ba159-d7d3-4d38-89df-62a5e755332e
+      - WESTUS:20180123T200750Z:c2569b57-c325-4fb4-8be0-2ff7322dd8b1
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 22 Sep 2017 21:43:43 GMT
+      - Tue, 23 Jan 2018 20:07:50 GMT
       Content-Length:
       - '166'
     body:
@@ -2036,5 +2298,5 @@ http_interactions:
       string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Compute/disks/this_is_not_a_disk_name''
         under resource group ''my-azure-resource-group'' was not found."}}'
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:43:42 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:50 GMT
 recorded_with: VCR 3.0.3

--- a/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_new-2.yml
+++ b/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_new-2.yml
@@ -17,6 +17,8 @@ http_interactions:
       - '186'
       Content-Type:
       - application/x-www-form-urlencoded
+      Host:
+      - login.microsoftonline.com
   response:
     status:
       code: 200
@@ -37,25 +39,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - a59a9509-a849-4fbf-a344-1598ca2d0c00
+      - 2cb47264-549f-4f09-9e84-743b204f0000
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAAABlDrqfEFlSaui6xnRjX5EUiQpzAckYBLeZhmfBUgUM68usW6qb34PWlmBZ4jmtdfSNy-wULLCKDKoVGcaowAxYut8ZyR39xJX7j4jPDGPiog2k3cdI4jNm8iyfklPCpcUr4Gqgvgj8d-zoYq-zTHbtyhlcBvsJ04LKIFf0HRsqoCfJUqORGoB-jjhFY5_BssgAA;
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzXyxq2S-ar8Em5eFUZyQfs3EKCZsS7wVmh1wduCaqzxGiNJYlno9CoDBlWeaEiv1zwnvsTgxuu8yA9JeLEl_7aKQS7jOK0jVteqbj2yozb5uVa-5Z7ahIhKhtyrpKjZzEEtJWd22NmDfOKiDYdEt9v3XkClWMdDMjolbbdi14HZkgAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=007; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=005; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Fri, 22 Sep 2017 21:43:27 GMT
+      - Tue, 23 Jan 2018 20:07:42 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3600","ext_expires_in":"0","expires_on":"1506120208","not_before":"1506116308","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYzMDgsIm5iZiI6MTUwNjExNjMwOCwiZXhwIjoxNTA2MTIwMjA4LCJhaW8iOiJZMlZnWUZELys4NzZrY3hyOWJ5d0x2NGdHOTJiQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ1pXYXBVbW92MC1qUkJXWXlpME1BQSIsInZlciI6IjEuMCJ9.Jl8LBRzHw1JW6L_k40ZwqM7HM82e2tGTkWajlzMMoLesa04Ha-HCpzvzk-w4v-vQcPDl67S3dygKPu-luwtN4zN4ktalhxTcyEayD7-vBEv2QY1rCpaIbGvvXYWW4oKoJVu2iWhsk1p7sxucpRclKb7F-CshnuE4ysJvWA97KS3zIBouFfNIqA9_4kUA02qk186ey2JALUFGKdxcv9R_C5Lx2FpGQ5UXQe3Zb7yjlfrH6PB_wgyyFvs4N-2z3YC6G1EAIPiRgI_j-R0RZnM0X8TrHk_u6-8WtjJOL7VLyEz5VRl3qRRGp1UgYh5MkIkxX7_LRjaPi4raJiM0DfLXhA"}'
+      string: '{"token_type":"Bearer","expires_in":"3600","ext_expires_in":"0","expires_on":"1516741662","not_before":"1516737762","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3NjIsIm5iZiI6MTUxNjczNzc2MiwiZXhwIjoxNTE2NzQxNjYyLCJhaW8iOiJZMk5nWUNnTldYSnBWZFNwRjhXOWg5K1ZYem5LQkFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWkhLMExKOVVDVS1laEhRN0lFOEFBQSIsInZlciI6IjEuMCJ9.d5kXm5QdQk1sZsML_GLNiXwkZVqGB1QwpuAfM4YFLM9D8wEFxFPyvMY6Jgvu6sUCDa4HVHNEq9SWWZiW-v9lSOhFN_AH2qaWbOGGpH4M2FI6YQ8-yc7TtbwsrAgYSVLawBSC0kGj0MhNxb3nxrobEwbCIfbLsuTujHXaAMLBhYtTWGOvvCqbGvoclHjDpL7BUVv7-8ljpqo4O5H5UnGpNMmKWhxVkQrXRnYAl4HnCIgMjzum3j3X9Sg7Mzjwkk6K4-1tduOCiYpHfd4MEi4Q5FJGI1AUZoRHik9XWowGMe_QWeklOt9I2_5-meCRZWBv1RA3m22pn5T2O8Ak9i8Tuw"}'
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:43:28 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:42 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -72,7 +74,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYzMDgsIm5iZiI6MTUwNjExNjMwOCwiZXhwIjoxNTA2MTIwMjA4LCJhaW8iOiJZMlZnWUZELys4NzZrY3hyOWJ5d0x2NGdHOTJiQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ1pXYXBVbW92MC1qUkJXWXlpME1BQSIsInZlciI6IjEuMCJ9.Jl8LBRzHw1JW6L_k40ZwqM7HM82e2tGTkWajlzMMoLesa04Ha-HCpzvzk-w4v-vQcPDl67S3dygKPu-luwtN4zN4ktalhxTcyEayD7-vBEv2QY1rCpaIbGvvXYWW4oKoJVu2iWhsk1p7sxucpRclKb7F-CshnuE4ysJvWA97KS3zIBouFfNIqA9_4kUA02qk186ey2JALUFGKdxcv9R_C5Lx2FpGQ5UXQe3Zb7yjlfrH6PB_wgyyFvs4N-2z3YC6G1EAIPiRgI_j-R0RZnM0X8TrHk_u6-8WtjJOL7VLyEz5VRl3qRRGp1UgYh5MkIkxX7_LRjaPi4raJiM0DfLXhA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3NjIsIm5iZiI6MTUxNjczNzc2MiwiZXhwIjoxNTE2NzQxNjYyLCJhaW8iOiJZMk5nWUNnTldYSnBWZFNwRjhXOWg5K1ZYem5LQkFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWkhLMExKOVVDVS1laEhRN0lFOEFBQSIsInZlciI6IjEuMCJ9.d5kXm5QdQk1sZsML_GLNiXwkZVqGB1QwpuAfM4YFLM9D8wEFxFPyvMY6Jgvu6sUCDa4HVHNEq9SWWZiW-v9lSOhFN_AH2qaWbOGGpH4M2FI6YQ8-yc7TtbwsrAgYSVLawBSC0kGj0MhNxb3nxrobEwbCIfbLsuTujHXaAMLBhYtTWGOvvCqbGvoclHjDpL7BUVv7-8ljpqo4O5H5UnGpNMmKWhxVkQrXRnYAl4HnCIgMjzum3j3X9Sg7Mzjwkk6K4-1tduOCiYpHfd4MEi4Q5FJGI1AUZoRHik9XWowGMe_QWeklOt9I2_5-meCRZWBv1RA3m22pn5T2O8Ak9i8Tuw
+      Host:
+      - management.azure.com
   response:
     status:
       code: 200
@@ -93,21 +97,22 @@ http_interactions:
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
       - '14999'
       X-Ms-Request-Id:
-      - f598ffd4-1707-41e8-88fa-bfb1ecb374a6
+      - 0301ce8a-8265-40c8-ae4e-05a6c6deed7c
       X-Ms-Correlation-Request-Id:
-      - f598ffd4-1707-41e8-88fa-bfb1ecb374a6
+      - 0301ce8a-8265-40c8-ae4e-05a6c6deed7c
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214329Z:f598ffd4-1707-41e8-88fa-bfb1ecb374a6
+      - WESTUS:20180123T200742Z:0301ce8a-8265-40c8-ae4e-05a6c6deed7c
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 22 Sep 2017 21:43:28 GMT
+      - Tue, 23 Jan 2018 20:07:41 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
-        Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
+      string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
+        Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
+        Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:43:29 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:42 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/azure_subscription_id/providers?api-version=2015-01-01
@@ -124,7 +129,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYzMDgsIm5iZiI6MTUwNjExNjMwOCwiZXhwIjoxNTA2MTIwMjA4LCJhaW8iOiJZMlZnWUZELys4NzZrY3hyOWJ5d0x2NGdHOTJiQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ1pXYXBVbW92MC1qUkJXWXlpME1BQSIsInZlciI6IjEuMCJ9.Jl8LBRzHw1JW6L_k40ZwqM7HM82e2tGTkWajlzMMoLesa04Ha-HCpzvzk-w4v-vQcPDl67S3dygKPu-luwtN4zN4ktalhxTcyEayD7-vBEv2QY1rCpaIbGvvXYWW4oKoJVu2iWhsk1p7sxucpRclKb7F-CshnuE4ysJvWA97KS3zIBouFfNIqA9_4kUA02qk186ey2JALUFGKdxcv9R_C5Lx2FpGQ5UXQe3Zb7yjlfrH6PB_wgyyFvs4N-2z3YC6G1EAIPiRgI_j-R0RZnM0X8TrHk_u6-8WtjJOL7VLyEz5VRl3qRRGp1UgYh5MkIkxX7_LRjaPi4raJiM0DfLXhA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3NjIsIm5iZiI6MTUxNjczNzc2MiwiZXhwIjoxNTE2NzQxNjYyLCJhaW8iOiJZMk5nWUNnTldYSnBWZFNwRjhXOWg5K1ZYem5LQkFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWkhLMExKOVVDVS1laEhRN0lFOEFBQSIsInZlciI6IjEuMCJ9.d5kXm5QdQk1sZsML_GLNiXwkZVqGB1QwpuAfM4YFLM9D8wEFxFPyvMY6Jgvu6sUCDa4HVHNEq9SWWZiW-v9lSOhFN_AH2qaWbOGGpH4M2FI6YQ8-yc7TtbwsrAgYSVLawBSC0kGj0MhNxb3nxrobEwbCIfbLsuTujHXaAMLBhYtTWGOvvCqbGvoclHjDpL7BUVv7-8ljpqo4O5H5UnGpNMmKWhxVkQrXRnYAl4HnCIgMjzum3j3X9Sg7Mzjwkk6K4-1tduOCiYpHfd4MEi4Q5FJGI1AUZoRHik9XWowGMe_QWeklOt9I2_5-meCRZWBv1RA3m22pn5T2O8Ak9i8Tuw
+      Host:
+      - management.azure.com
   response:
     status:
       code: 200
@@ -141,19 +148,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14922'
+      - '14857'
       X-Ms-Request-Id:
-      - 05a30e2f-68d5-403f-994a-2173a0fb5450
+      - 80199522-801e-4749-b1f7-46c167d06cf0
       X-Ms-Correlation-Request-Id:
-      - 05a30e2f-68d5-403f-994a-2173a0fb5450
+      - 80199522-801e-4749-b1f7-46c167d06cf0
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214330Z:05a30e2f-68d5-403f-994a-2173a0fb5450
+      - WESTUS:20180123T200743Z:80199522-801e-4749-b1f7-46c167d06cf0
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 22 Sep 2017 21:43:30 GMT
+      - Tue, 23 Jan 2018 20:07:43 GMT
       Content-Length:
-      - '254785'
+      - '293551'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
@@ -176,7 +183,7 @@ http_interactions:
         Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
         Central US","North Central US","Japan East","Japan West","Brazil South","Central
         India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
+        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-04-19","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-04-19","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-04-19","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-04-19","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","North Central
         US","South Central US","West Central US","West US","West US 2","Canada Central","Canada
         East","North Europe","West Europe","UK South","UK West","East Asia","Southeast
@@ -184,20 +191,26 @@ http_interactions:
         India","South India","West India"],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"validateServiceName","locations":[],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"checkServiceNameAvailability","locations":[],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"reportFeedback","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"checkFeedbackRequired","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Automation","namespace":"Microsoft.Automation","authorizations":[{"applicationId":"fc75330b-179d-49af-87dd-3b1acf6827fa","roleDefinitionId":"95fd5de3-d071-4362-92bf-cf341c1de832"}],"resourceTypes":[{"resourceType":"automationAccounts","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
         South","UK South","West Central US","North Europe","Canada Central","Australia
-        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/runbooks","locations":["Japan
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/runbooks","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
         South","UK South","West Central US","North Europe","Canada Central","Australia
-        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/configurations","locations":["Japan
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/configurations","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","North
-        Central US","Brazil South","UK South","West Central US","Central India","Australia
-        Southeast","Canada Central","North Europe"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/webhooks","locations":["Japan
+        Central US","Korea Central","East US","West US 2","Brazil South","UK South","West
+        Central US","Central India","Australia Southeast","Canada Central","North
+        Europe"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/webhooks","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
         South","UK South","West Central US","North Europe","Canada Central","Australia
-        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"operations","locations":["South
-        Central US"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/softwareUpdateConfigurations","locations":["Japan
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"operations","locations":["South
+        Central US"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/softwareUpdateConfigurations","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
         South","UK South","West Central US","North Europe","Canada Central","Australia
-        Southeast","Central India"],"apiVersions":["2017-05-15-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Backup","namespace":"Microsoft.Backup","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"BackupVault","locations":["West
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview"]},{"resourceType":"automationAccounts/jobs","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
+        South","UK South","West Central US","North Europe","Canada Central","Australia
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureActiveDirectory","namespace":"Microsoft.AzureActiveDirectory","resourceTypes":[{"resourceType":"b2cDirectories","locations":["Global","United
+        States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]},{"resourceType":"operations","locations":["Global","United
+        States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]}],"registrationState":"Unregistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Backup","namespace":"Microsoft.Backup","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"BackupVault","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
@@ -206,22 +219,22 @@ http_interactions:
         Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
         West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
         East","South India","Central India","Canada Central","Canada East","UK South","UK
-        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01","2015-07-01","2014-05-01-privatepreview"]},{"resourceType":"operations","locations":["West
+        West","West Central US","West US 2"],"apiVersions":["2017-09-01","2017-05-01","2017-01-01","2015-12-01","2015-09-01","2015-07-01","2014-05-01-privatepreview"]},{"resourceType":"operations","locations":["West
         Europe","East US","East US 2","West US","North Central US","Brazil South","North
         Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
         West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
         East","South India","Central India","Canada Central","Canada East","UK South","UK
-        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations/quotas","locations":["West
+        West","West Central US","West US 2"],"apiVersions":["2017-09-01","2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01","2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations/quotas","locations":["West
         Europe","East US","East US 2","West US","North Central US","Brazil South","North
         Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
         West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
         East","South India","Central India","Canada Central","Canada East","UK South","UK
-        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]}],"registrationState":"Unregistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicCompute","namespace":"Microsoft.ClassicCompute","resourceTypes":[{"resourceType":"domainNames","locations":["East
+        West","West Central US","West US 2"],"apiVersions":["2017-09-01","2017-05-01","2017-01-01","2015-12-01","2015-09-01"]}],"registrationState":"Unregistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicCompute","namespace":"Microsoft.ClassicCompute","resourceTypes":[{"resourceType":"domainNames","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
@@ -256,7 +269,7 @@ http_interactions:
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -296,92 +309,92 @@ http_interactions:
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30"]},{"resourceType":"locations/usages","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations/usages","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
+        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
@@ -411,76 +424,138 @@ http_interactions:
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
+        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
         US","East US","South Central US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
         Central","Central US","East US 2","North Central US","West Central US","West
-        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/webhooks","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/ping","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/getCallbackConfig","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/listEvents","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"locations","locations":["South
-        Central US","East US","West US","Central US","East US 2","North Central US","West
-        Central US","West US 2","Brazil South","Canada East","Canada Central","West
-        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
-        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"locations/operationResults","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/GetCredentials","locations":["West
+        US 2"],"apiVersions":["2017-10-01","2017-03-01"]},{"resourceType":"registries/replications","locations":["South
+        Central US","West Central US","East US","West Europe","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/webhooks","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/webhooks/ping","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/webhooks/getCallbackConfig","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/webhooks/listEvents","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"locations/operationResults","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/GetCredentials","locations":["West
         US","East US","South Central US","West Europe"],"apiVersions":["2016-06-27-preview"]},{"resourceType":"registries/listCredentials","locations":["South
         Central US","East US","West US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
         Central","Central US","East US 2","North Central US","West Central US","West
-        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/regenerateCredential","locations":["South
+        US 2"],"apiVersions":["2017-10-01","2017-03-01"]},{"resourceType":"registries/regenerateCredential","locations":["South
         Central US","West US","East US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
         Central","Central US","East US 2","North Central US","West Central US","West
-        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/listUsages","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/regenerateCredentials","locations":["West
+        US 2"],"apiVersions":["2017-10-01","2017-03-01"]},{"resourceType":"registries/listUsages","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/regenerateCredentials","locations":["West
         US","East US","South Central US","West Europe"],"apiVersions":["2016-06-27-preview"]},{"resourceType":"checkNameAvailability","locations":["South
         Central US","East US","West US","Central US","East US 2","North Central US","West
         Central US","West US 2","Brazil South","Canada East","Canada Central","West
         Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
-        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview","2017-03-01","2016-06-27-preview"]},{"resourceType":"operations","locations":["South
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-10-01","2017-06-01-preview","2017-03-01","2016-06-27-preview"]},{"resourceType":"operations","locations":["South
         Central US","East US","West US","Central US","East US 2","North Central US","West
         Central US","West US 2","Brazil South","Canada East","Canada Central","West
         Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
-        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview","2017-03-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerService","namespace":"Microsoft.ContainerService","authorization":{"applicationId":"7319c514-987d-4e9b-ac3d-d38c4f427f4c","roleDefinitionId":"1b4a0c7f-2217-416f-acfa-cf73452fdc1c"},"resourceTypes":[{"resourceType":"containerServices","locations":["Japan
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-10-01","2017-06-01-preview","2017-03-01"]},{"resourceType":"locations","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-10-01","2017-06-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerService","namespace":"Microsoft.ContainerService","authorization":{"applicationId":"7319c514-987d-4e9b-ac3d-d38c4f427f4c","roleDefinitionId":"1b4a0c7f-2217-416f-acfa-cf73452fdc1c","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"containerServices","locations":["Japan
         East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
         Central US","West US 2","South India","Central India","West India","Canada
-        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
+        East","Canada Central","Korea South","Korea Central"],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"managedClusters","locations":["East
+        US","West Europe","Central US","Canada Central","Canada East"],"apiVersions":["2017-08-31"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
         East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
         Central US","West US 2","South India","Central India","West India","Canada
-        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DevTestLab","namespace":"Microsoft.DevTestLab","authorization":{"applicationId":"1a14be2a-e903-4cec-99cf-b2e209259a0f","roleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525"},"resourceTypes":[{"resourceType":"labs","locations":["West
+        East","Canada Central","Korea South","Korea Central"],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/orchestrators","locations":["UK
+        West","West US 2","East US","West Europe","Central US"],"apiVersions":["2017-09-30"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DevTestLab","namespace":"Microsoft.DevTestLab","authorization":{"applicationId":"1a14be2a-e903-4cec-99cf-b2e209259a0f","roleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525","managedByRoleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525"},"resourceTypes":[{"resourceType":"labs","locations":["West
         Central US","Japan East","West US","Australia Southeast","Canada Central","Central
         India","Central US","East Asia","Korea Central","North Europe","South Central
-        US","UK West","Australia East","Brazil South","Canada East","East US","East
-        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        US","UK West","West India","Australia East","Brazil South","Canada East","East
+        US","East US 2","Japan West","Korea South","North Central US","South India","Southeast
         Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"schedules","locations":["West
         Central US","Japan East","West US","Australia Southeast","Canada Central","Central
         India","Central US","East Asia","Korea Central","North Europe","South Central
-        US","UK West","Australia East","Brazil South","Canada East","East US","East
-        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        US","UK West","West India","Australia East","Brazil South","Canada East","East
+        US","East US 2","Japan West","Korea South","North Central US","South India","Southeast
         Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"labs/virtualMachines","locations":["West
         Central US","Japan East","West US","Australia Southeast","Canada Central","Central
         India","Central US","East Asia","Korea Central","North Europe","South Central
-        US","UK West","Australia East","Brazil South","Canada East","East US","East
-        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        US","UK West","West India","Australia East","Brazil South","Canada East","East
+        US","East US 2","Japan West","Korea South","North Central US","South India","Southeast
         Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"labs/serviceRunners","locations":["Central
         US","East US 2","South Central US"],"apiVersions":["2017-04-26-preview","2016-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"locations/operations","locations":["West
         Central US","Japan East","West US","Australia Southeast","Canada Central","Central
         India","Central US","East Asia","Korea Central","North Europe","South Central
-        US","UK West","Australia East","Brazil South","Canada East","East US","East
-        US 2","Japan West","Korea South","North Central US","South India","Southeast
-        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"}],"resourceTypes":[{"resourceType":"components","locations":["East
-        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
-        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01","2014-04-01"]},{"resourceType":"queries","locations":["East
-        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
+        US","UK West","West India","Australia East","Brazil South","Canada East","East
+        US","East US 2","Japan West","Korea South","North Central US","South India","Southeast
+        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","authorizations":[{"applicationId":"57c0fc58-a83a-41d0-8ae9-08952659bdfd","roleDefinitionId":"FFFD5CF5-FFD3-4B24-B0E2-0715ADD4C282"}],"resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"databaseAccountNames","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"operationResults","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"},{"applicationId":"f5c26e74-f226-4ae8-85f0-b4af0080ac9e","roleDefinitionId":"529d7ae6-e892-4d43-809d-8547aeb90643"}],"resourceTypes":[{"resourceType":"components","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2015-05-01","2014-08-01","2014-04-01"]},{"resourceType":"queries","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"components/pricingPlans","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"migrateToNewPricingModel","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"rollbackToLegacyPricingModel","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"listMigrationdate","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
@@ -516,7 +591,7 @@ http_interactions:
         West","North Central US","South Central US","East US 2","Canada East","Canada
         Central","Central US","Australia East","Australia Southeast","Brazil South","South
         India","Central India","West India","North Europe","West US 2","West Central
-        US","Korea South","Korea Central","UK South","UK West","Global"],"apiVersions":["2017-05-01-preview","2016-03-01","2015-07-01"]},{"resourceType":"logDefinitions","locations":["West
+        US","Korea South","Korea Central","UK South","UK West","Global"],"apiVersions":["2017-09-01-preview","2017-05-01-preview","2016-03-01","2015-07-01"]},{"resourceType":"logDefinitions","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
@@ -526,7 +601,7 @@ http_interactions:
         West","North Central US","South Central US","East US 2","Canada East","Canada
         Central","Central US","Australia East","Australia Southeast","Brazil South","South
         India","Central India","West India","North Europe","West US 2","West Central
-        US","Korea South","Korea Central","UK South","UK West"],"apiVersions":["2017-05-01-preview","2016-09-01","2016-06-01"]},{"resourceType":"actiongroups","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]},{"resourceType":"activityLogAlerts","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.KeyVault","namespace":"Microsoft.KeyVault","resourceTypes":[{"resourceType":"vaults","locations":["North
+        US","Korea South","Korea Central","UK South","UK West"],"apiVersions":["2017-09-01-preview","2017-05-01-preview","2016-09-01","2016-06-01"]},{"resourceType":"actiongroups","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]},{"resourceType":"activityLogAlerts","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.KeyVault","namespace":"Microsoft.KeyVault","resourceTypes":[{"resourceType":"vaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
@@ -556,126 +631,153 @@ http_interactions:
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorizations":[{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},{"applicationId":"7c33bfcb-8d33-48d6-8e60-dc6404003489","roleDefinitionId":"ad6261e4-fa9a-4642-aa5f-104f1b67e9e3"},{"applicationId":"1e3e4475-288f-4018-a376-df66fd7fac5f","roleDefinitionId":"1d538b69-3d87-4e56-8ff8-25786fd48261"},{"applicationId":"a0be0c72-870e-46f0-9c49-c98333a996f7","roleDefinitionId":"7ce22727-ffce-45a9-930c-ddb2e56fa131"}],"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","West Central US"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"operations","locations":["South
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations","locations":["South
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operations","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"commitmentPlans","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"Registering"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorizations":[{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},{"applicationId":"7c33bfcb-8d33-48d6-8e60-dc6404003489","roleDefinitionId":"ad6261e4-fa9a-4642-aa5f-104f1b67e9e3"},{"applicationId":"1e3e4475-288f-4018-a376-df66fd7fac5f","roleDefinitionId":"1d538b69-3d87-4e56-8ff8-25786fd48261"},{"applicationId":"a0be0c72-870e-46f0-9c49-c98333a996f7","roleDefinitionId":"7ce22727-ffce-45a9-930c-ddb2e56fa131"}],"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
-        Central US"],"apiVersions":["2017-09-01"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
-        East","UK South","Central India","Canada Central"],"apiVersions":["2017-04-26-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"]},{"resourceType":"workspaces/dataSources","locations":["East
+        East","UK South","Central India","Canada Central"],"apiVersions":["2017-04-26-preview","2017-03-15-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"]},{"resourceType":"workspaces/query","locations":["West
+        Central US","Australia Southeast","West Europe","East US","Southeast Asia","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2017-10-01"]},{"resourceType":"workspaces/dataSources","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
         East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"storageInsightConfigs","locations":[],"apiVersions":["2014-10-10"]},{"resourceType":"workspaces/linkedServices","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
         East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"linkTargets","locations":["East
         US"],"apiVersions":["2015-03-20"]},{"resourceType":"operations","locations":[],"apiVersions":["2014-11-10"]},{"resourceType":"devices","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationsManagement","namespace":"Microsoft.OperationsManagement","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"aa249101-6816-4966-aafa-08175d795f14"},"resourceTypes":[{"resourceType":"solutions","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
-        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Portal","namespace":"Microsoft.Portal","resourceTypes":[{"resourceType":"dashboards","locations":["Central
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"managementconfigurations","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"managementassociations","locations":[],"apiVersions":["2015-11-01-preview"]},{"resourceType":"views","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2017-08-21-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Portal","namespace":"Microsoft.Portal","resourceTypes":[{"resourceType":"dashboards","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
@@ -687,9 +789,9 @@ http_interactions:
         East","West India","South India","Central India","Canada Central","Canada
         East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"consoles","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/consoles","locations":["West
         US","East US","Central India","North Europe","West Europe","South Central
-        US","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
+        US","Southeast Asia","East US 2","Central US"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
         US","East US","Central India","North Europe","West Europe","South Central
-        US","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
+        US","Southeast Asia","East US 2","Central US"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
@@ -710,7 +812,17 @@ http_interactions:
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ResourceHealth","namespace":"Microsoft.ResourceHealth","authorization":{"applicationId":"8bdebf23-c0fe-4187-a378-717ad86f6a53","roleDefinitionId":"cc026344-c8b1-4561-83ba-59eba84b27cc"},"resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2017-07-01","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"notifications","locations":["Australia
+        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]},{"resourceType":"locations/backupValidateFeatures","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-07-01"]},{"resourceType":"locations/backupPreValidateProtection","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-07-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ResourceHealth","namespace":"Microsoft.ResourceHealth","authorization":{"applicationId":"8bdebf23-c0fe-4187-a378-717ad86f6a53","roleDefinitionId":"cc026344-c8b1-4561-83ba-59eba84b27cc"},"resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2017-07-01","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"notifications","locations":["Australia
         Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Security","namespace":"Microsoft.Security","authorization":{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatuses","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/virtualMachines","locations":["Central
@@ -743,10 +855,14 @@ http_interactions:
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securitySolutionsReferenceData","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/securitySolutionsReferenceData","locations":["Central
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"jitNetworkAccessPolicies","locations":["Central
-        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/jitNetworkAccessPolicies","locations":["Central
-        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations","locations":["Central
+        US","East US","North Europe","West Europe","UK South","UK West","West Central
+        US","West US 2"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/jitNetworkAccessPolicies","locations":["Central
+        US","East US","North Europe","West Europe","UK South","UK West","West Central
+        US","West US 2"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatusesSummaries","locations":["Central
-        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/alerts","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"applicationWhitelistings","locations":["Central
+        US","East US","West Central US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/applicationWhitelistings","locations":["Central
+        US","West Central US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/alerts","locations":["Central
         US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/tasks","locations":["Central
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"externalSecuritySolutions","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/externalSecuritySolutions","locations":["Central
@@ -769,7 +885,17 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/databaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/databaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -814,7 +940,7 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01","2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -829,7 +955,7 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -859,12 +985,17 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/geoBackupPolicies","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -879,12 +1010,12 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/firewallrules","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/backupLongTermRetentionPolicies","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -999,6 +1130,16 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
         US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
@@ -1034,7 +1175,22 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -1144,7 +1300,47 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -1159,7 +1355,17 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/administratorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -1179,52 +1385,52 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorization":{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorizations":[{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},{"applicationId":"e406a681-f3d4-42a8-90b6-c2b029497af1"}],"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
         US","West US","West Europe","North Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","South India","Central
@@ -1234,7 +1440,19 @@ http_interactions:
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Web","namespace":"Microsoft.Web","authorization":{"applicationId":"abfa0a7c-a6b6-4736-8310-5855508787cd","roleDefinitionId":"f47ed98b-b063-4a5b-9e10-4b9b44fa7735"},"resourceTypes":[{"resourceType":"sites/extensions","locations":["South
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/project","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/extension","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"checkNameAvailability","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Web","namespace":"Microsoft.Web","authorization":{"applicationId":"abfa0a7c-a6b6-4736-8310-5855508787cd","roleDefinitionId":"f47ed98b-b063-4a5b-9e10-4b9b44fa7735"},"resourceTypes":[{"resourceType":"sites/extensions","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
         South","West US","East US","Japan West","Japan East","East Asia","East US
         2","North Central US","Central US","Brazil South","Australia East","Australia
@@ -1339,7 +1557,7 @@ http_interactions:
         South","West US","East US","Japan West","Japan East","East Asia","East US
         2","North Central US","Central US","Brazil South","Australia East","Australia
         Southeast","West India","Central India","South India","Canada Central","Canada
-        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms/workers","locations":["South
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms/workers","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
         South","West US","East US","Japan West","Japan East","East Asia","East US
         2","North Central US","Central US","Brazil South","Australia East","Australia
@@ -1394,7 +1612,17 @@ http_interactions:
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","West US 2","West Central US","Canada Central","Canada
-        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/managedApis","locations":["North
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/listWsdlInterfaces","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/extractApiDefinitionFromWsdl","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/managedApis","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
@@ -1445,8 +1673,11 @@ http_interactions:
         US","North Europe","Japan West","Japan East","East Asia","West Europe","East
         US","Southeast Asia","Central US"],"apiVersions":["2016-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Lombiq.DotNest","namespace":"Lombiq.DotNest","resourceTypes":[{"resourceType":"sites","locations":["East
         US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Mailjet.Email","namespace":"Mailjet.Email","resourceTypes":[{"resourceType":"services","locations":["West
-        US"],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
-        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
+        US","West Europe"],"apiVersions":["2017-10-01","2017-02-03"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-10-01","2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-10-01","2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]},{"resourceType":"diagnosticSettings","locations":[],"apiVersions":["2017-04-01"]},{"resourceType":"diagnosticSettingsCategories","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Addons","namespace":"Microsoft.Addons","authorization":{"applicationId":"24d3987b-be4a-48e0-a3e7-11c186f39e41","roleDefinitionId":"8004BAAB-A4CB-4981-8571-F7E44D039D93"},"resourceTypes":[{"resourceType":"supportProviders","locations":["West
+        Central US","South Central US","East US","West Europe"],"apiVersions":["2017-05-15"]},{"resourceType":"operations","locations":["West
+        Central US","South Central US","East US","West Europe"],"apiVersions":["2017-05-15"]},{"resourceType":"operationResults","locations":["West
+        Central US","South Central US","East US","West Europe"],"apiVersions":["2017-05-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"addsservices","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"configuration","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"operations","locations":["West
@@ -1456,51 +1687,45 @@ http_interactions:
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"servicehealthmetrics","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"logs","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"anonymousapiusers","locations":["West
-        US"],"apiVersions":["2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AnalysisServices","namespace":"Microsoft.AnalysisServices","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"servers","locations":["West
+        US"],"apiVersions":["2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AlertsManagement","namespace":"Microsoft.AlertsManagement","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-11-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AnalysisServices","namespace":"Microsoft.AnalysisServices","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"servers","locations":["West
         US","North Europe","South Central US","West Europe","West Central US","Southeast
         Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
-        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/checkNameAvailability","locations":["West
+        Southeast","Japan East","UK South","West India","West US 2","East US"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"locations/checkNameAvailability","locations":["West
         US","North Europe","South Central US","West Europe","West Central US","Southeast
         Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
-        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationresults","locations":["West
+        Southeast","Japan East","UK South","West India","West US 2","East US"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationresults","locations":["West
         US","North Europe","South Central US","West Europe","West Central US","Southeast
         Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
-        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationstatuses","locations":["West
+        Southeast","Japan East","UK South","West India","West US 2","East US"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationstatuses","locations":["West
         US","North Europe","South Central US","West Europe","West Central US","Southeast
         Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
-        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"operations","locations":["East
-        US 2","West Central US"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AppService","namespace":"Microsoft.AppService","authorization":{"applicationId":"dee7ba80-6a55-4f3b-a86c-746a9231ae49","roleDefinitionId":"6715d172-49c4-46f6-bb21-60512a8689dc"},"resourceTypes":[{"resourceType":"apiapps","locations":["East
-        US","West US","South Central US","North Europe","East Asia","Japan East","West
-        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
-        South","East US 2","Australia Southeast","Australia East","West India","South
-        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"appIdentities","locations":["East
-        US","West US","South Central US","North Europe","East Asia","Japan East","West
-        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
-        South","East US 2","Australia Southeast","Australia East","West India","South
-        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"gateways","locations":["East
-        US","West US","South Central US","North Europe","East Asia","Japan East","West
-        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
-        South","East US 2","Australia Southeast","Australia East","West India","South
-        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"deploymenttemplates","locations":[],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Authorization","namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"roleDefinitions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"classicAdministrators","locations":[],"apiVersions":["2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"permissions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"locks","locations":[],"apiVersions":["2017-04-01","2016-09-01","2015-06-01","2015-05-01-preview","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-01-01","2014-10-01-preview","2014-06-01"]},{"resourceType":"policyDefinitions","locations":[],"apiVersions":["2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"policySetDefinitions","locations":[],"apiVersions":["2017-06-01-preview"]},{"resourceType":"policyAssignments","locations":[],"apiVersions":["2017-06-01-preview","2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"providerOperations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01-preview","2015-07-01"]},{"resourceType":"elevateAccess","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureActiveDirectory","namespace":"Microsoft.AzureActiveDirectory","resourceTypes":[{"resourceType":"b2cDirectories","locations":["Global","United
-        States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureStack","namespace":"Microsoft.AzureStack","resourceTypes":[{"resourceType":"operations","locations":["Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations","locations":["West
+        Southeast","Japan East","UK South","West India","West US 2","East US"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"operations","locations":["East
+        US 2","West Central US","West US 2"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Authorization","namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[],"apiVersions":["2017-10-01-preview","2017-09-01","2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"roleDefinitions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"classicAdministrators","locations":[],"apiVersions":["2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"permissions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"locks","locations":[],"apiVersions":["2017-04-01","2016-09-01","2015-06-01","2015-05-01-preview","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-01-01","2014-10-01-preview","2014-06-01"]},{"resourceType":"policyDefinitions","locations":[],"apiVersions":["2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"policySetDefinitions","locations":[],"apiVersions":["2017-06-01-preview"]},{"resourceType":"policyAssignments","locations":[],"apiVersions":["2017-06-01-preview","2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"providerOperations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01-preview","2015-07-01"]},{"resourceType":"elevateAccess","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"checkAccess","locations":[],"apiVersions":["2017-10-01-preview","2017-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureStack","namespace":"Microsoft.AzureStack","resourceTypes":[{"resourceType":"operations","locations":["Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations","locations":["West
         Central US","Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations/products","locations":["West
-        Central US","Global"],"apiVersions":["2017-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Billing","namespace":"Microsoft.Billing","resourceTypes":[{"resourceType":"BillingPeriods","locations":["Central
+        Central US","Global"],"apiVersions":["2017-06-01","2016-01-01"]},{"resourceType":"registrations/customerSubscriptions","locations":["West
+        Central US","Global"],"apiVersions":["2017-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BatchAI","namespace":"Microsoft.BatchAI","authorization":{"applicationId":"9fcb3732-5f52-4135-8c08-9d4bbaf203ea","roleDefinitionId":"703B89C7-CE2C-431B-BDD8-FA34E39AF696","managedByRoleDefinitionId":"90B8E153-EBFF-4073-A95F-4DAD56B14C78"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"jobs","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"fileservers","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"operations","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01-preview"]},{"resourceType":"locations/operationresults","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Billing","namespace":"Microsoft.Billing","resourceTypes":[{"resourceType":"BillingPeriods","locations":["Central
         US"],"apiVersions":["2017-04-24-preview"]},{"resourceType":"Invoices","locations":["Central
         US"],"apiVersions":["2017-04-24-preview","2017-02-27-preview"]},{"resourceType":"operations","locations":["Central
         US"],"apiVersions":["2017-04-24-preview","2017-02-27-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BingMaps","namespace":"Microsoft.BingMaps","resourceTypes":[{"resourceType":"mapApis","locations":["West
         US"],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-18","2015-07-02"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BizTalkServices","namespace":"Microsoft.BizTalkServices","resourceTypes":[{"resourceType":"BizTalk","locations":["East
         US","West US","North Europe","West Europe","Southeast Asia","East Asia","North
-        Central US","Japan West","Japan East","South Central US"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Cache","namespace":"Microsoft.Cache","authorization":{"applicationId":"96231a05-34ce-4eb4-aa6a-70759cbb5e83","roleDefinitionId":"4f731528-ba85-45c7-acfb-cd0a9b3cf31b"},"resourceTypes":[{"resourceType":"Redis","locations":["North
+        Central US","Japan West","Japan East","South Central US"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BotService","namespace":"Microsoft.BotService","resourceTypes":[{"resourceType":"botServices","locations":["Global"],"apiVersions":["2017-12-01"]},{"resourceType":"checkNameAvailability","locations":["Global"],"apiVersions":["2017-12-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Cache","namespace":"Microsoft.Cache","authorization":{"applicationId":"96231a05-34ce-4eb4-aa6a-70759cbb5e83","roleDefinitionId":"4f731528-ba85-45c7-acfb-cd0a9b3cf31b"},"resourceTypes":[{"resourceType":"Redis","locations":["North
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","Canada Central","Canada East","UK South","UK West","West US 2","West
-        Central US","South India","Korea Central","Korea South"],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","South India","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","South India","Canada Central","Canada East","UK South","UK West","West
-        US 2","West Central US","Korea Central","Korea South"],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01"]},{"resourceType":"Redis/metricDefinitions","locations":["North
+        US 2","West Central US","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01"]},{"resourceType":"Redis/metricDefinitions","locations":["North
         Central US","South Central US","East US","East US 2","West US","Central US","East
         Asia","Southeast Asia","North Europe","West Europe","Japan East","Japan West","Brazil
         South","Australia Southeast","Australia East","Central India","West India","South
@@ -1514,59 +1739,59 @@ http_interactions:
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/origins","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/origins","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/customdomains","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/customdomains","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/originresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/originresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/customdomainresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/customdomainresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkResourceUsage","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkResourceUsage","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02"]},{"resourceType":"validateProbe","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02"]},{"resourceType":"validateProbe","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02"]},{"resourceType":"operations","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02"]},{"resourceType":"operations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"edgenodes","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"edgenodes","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CertificateRegistration","namespace":"Microsoft.CertificateRegistration","authorization":{"applicationId":"f3c21649-0979-4721-ac85-b0216b2cf413","roleDefinitionId":"933fba7e-2ed3-4da8-973d-8bd8298a9b40"},"resourceTypes":[{"resourceType":"certificateOrders","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"certificateOrders/certificates","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"validateCertificateRegistrationInformation","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicSubscription","namespace":"Microsoft.ClassicSubscription","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicInfrastructureMigrate","namespace":"Microsoft.ClassicInfrastructureMigrate","authorization":{"applicationId":"5e5abe2b-83cd-4786-826a-a05653ebb103","roleDefinitionId":"766c4d9b-ef83-4f73-8352-1450a506a69b"},"resourceTypes":[{"resourceType":"classicInfrastructureResources","locations":["East
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CertificateRegistration","namespace":"Microsoft.CertificateRegistration","authorization":{"applicationId":"f3c21649-0979-4721-ac85-b0216b2cf413","roleDefinitionId":"933fba7e-2ed3-4da8-973d-8bd8298a9b40"},"resourceTypes":[{"resourceType":"certificateOrders","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"certificateOrders/certificates","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"validateCertificateRegistrationInformation","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicSubscription","namespace":"Microsoft.ClassicSubscription","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-09-01","2017-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicInfrastructureMigrate","namespace":"Microsoft.ClassicInfrastructureMigrate","authorization":{"applicationId":"5e5abe2b-83cd-4786-826a-a05653ebb103","roleDefinitionId":"766c4d9b-ef83-4f73-8352-1450a506a69b"},"resourceTypes":[{"resourceType":"classicInfrastructureResources","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
         Central US","Central US","North Europe","West Europe","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","West
@@ -1584,8 +1809,9 @@ http_interactions:
         Asia","East Asia","West Central US","South Central US","East US","East US
         2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/updateAccountsCreationSettings","locations":["West
         US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/accountsCreationSettings","locations":["West
-        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2016-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Commerce","namespace":"Microsoft.Commerce","resourceTypes":[{"resourceType":"UsageAggregates","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]},{"resourceType":"RateCard","locations":[],"apiVersions":["2016-08-31-preview","2015-06-01-preview","2015-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Consumption","namespace":"Microsoft.Consumption","resourceTypes":[{"resourceType":"reservationsummaries","locations":[],"apiVersions":["2017-01-30"]},{"resourceType":"reservationdetails","locations":[],"apiVersions":["2017-01-30"]},{"resourceType":"UsageDetails","locations":[],"apiVersions":["2017-06-30-preview","2017-04-24-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-30-preview","2017-04-24-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","resourceTypes":[{"resourceType":"containerGroups","locations":["West
-        US","East US","West Europe"],"apiVersions":["2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
+        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2016-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Commerce","namespace":"Microsoft.Commerce","resourceTypes":[{"resourceType":"UsageAggregates","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]},{"resourceType":"RateCard","locations":[],"apiVersions":["2016-08-31-preview","2015-06-01-preview","2015-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Consumption","namespace":"Microsoft.Consumption","resourceTypes":[{"resourceType":"ReservationSummaries","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationTransactions","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"Balances","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"Pricesheets","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationDetails","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"Budgets","locations":[],"apiVersions":["2017-12-30-preview"]},{"resourceType":"Terms","locations":[],"apiVersions":["2017-12-30-preview"]},{"resourceType":"UsageDetails","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview","2017-04-24-preview"]},{"resourceType":"Operations","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview","2017-04-24-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","resourceTypes":[{"resourceType":"containerGroups","locations":["West
+        US","East US","West Europe","Southeast Asia"],"apiVersions":["2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US","East US","West Europe","Southeast Asia"],"apiVersions":["2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
         US"],"apiVersions":["2016-04-08"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CustomerInsights","namespace":"Microsoft.CustomerInsights","authorization":{"applicationId":"38c77d00-5fcb-4cce-9d93-af4738258e3c","roleDefinitionId":"E006F9C7-F333-477C-8AD6-1F3A9FE87F55"},"resourceTypes":[{"resourceType":"hubs","locations":["East
         US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/profiles","locations":["East
         US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/interactions","locations":["East
@@ -1608,8 +1834,8 @@ http_interactions:
         US","West US","Australia East","West Europe","North Europe","Southeast Asia","West
         Central US"],"apiVersions":["2016-03-30","2015-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataFactory","namespace":"Microsoft.DataFactory","resourceTypes":[{"resourceType":"dataFactories","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview","2014-04-01"]},{"resourceType":"factories","locations":["East
-        US","East US 2"],"apiVersions":["2017-09-01-preview","2017-03-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
-        US","East US 2"],"apiVersions":["2017-09-01-preview","2017-03-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
+        US","East US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
+        US","East US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
         Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"dataFactories/metricDefinitions","locations":["North
         Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"checkDataFactoryNameAvailability","locations":[],"apiVersions":["2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"checkAzureDataFactoryNameAvailability","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"dataFactorySchema","locations":["West
@@ -1621,69 +1847,71 @@ http_interactions:
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers/listSasTokens","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeStore","namespace":"Microsoft.DataLakeStore","authorization":{"applicationId":"e9f49c6b-5ce5-44c8-925d-015017e9f7ad","roleDefinitionId":"17eb9cca-f08a-4499-b2d3-852d175f614f"},"resourceTypes":[{"resourceType":"accounts","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/firewallRules","locations":["East
-        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","resourceTypes":[{"resourceType":"operations","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforPostgreSQL","namespace":"Microsoft.DBforPostgreSQL","resourceTypes":[{"resourceType":"operations","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"checkProvisioningServiceNameAvailability","locations":[],"apiVersions":["2017-08-21-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataMigration","namespace":"Microsoft.DataMigration","authorization":{"applicationId":"a4bad4aa-bf02-4631-9f78-a64ffdba8150","roleDefinitionId":"b831a21d-db98-4760-89cb-bef871952df1","managedByRoleDefinitionId":"6256fb55-9e59-4018-a9e1-76b11c0a4c89"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services/projects","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationStatuses","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforPostgreSQL","namespace":"Microsoft.DBforPostgreSQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"checkProvisioningServiceNameAvailability","locations":[],"apiVersions":["2017-11-15","2017-08-21-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
         US","North Europe","East Asia","East US","West Europe","Southeast Asia","Japan
         East","Japan West","Australia East","Australia Southeast","West US 2","West
         Central US","East US 2","Central US","UK South","UK West","South India","Central
-        India","Canada Central","Canada East"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"ProvisioningServices","locations":["East
-        US","West Europe","Southeast Asia"],"apiVersions":["2017-08-21-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
-        East","Australia Southeast","Canada Central","Canada East","Central India","Central
-        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
-        US","North Europe","South Central US","South India","Southeast Asia","West
-        Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"databaseAccountNames","locations":["Australia
-        East","Australia Southeast","Canada Central","Canada East","Central India","Central
-        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
-        US","North Europe","South Central US","South India","Southeast Asia","West
-        Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"operations","locations":["Australia
-        East","Australia Southeast","Canada Central","Canada East","Central India","Central
-        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
-        US","North Europe","South Central US","South India","Southeast Asia","West
-        Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DomainRegistration","namespace":"Microsoft.DomainRegistration","authorization":{"applicationId":"ea2f600a-4980-45b7-89bf-d34da487bda1","roleDefinitionId":"54d7f2e3-5040-48a7-ae90-eebf629cfa0b"},"resourceTypes":[{"resourceType":"domains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"domains/domainOwnershipIdentifiers","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"topLevelDomains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"checkDomainAvailability","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"listDomainRecommendations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"validateDomainRegistrationInformation","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"generateSsoRequest","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DynamicsLcs","namespace":"Microsoft.DynamicsLcs","resourceTypes":[{"resourceType":"lcsprojects","locations":["Brazil
+        India","Canada Central","Canada East","Brazil South","South Central US"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs/eventGridFilters","locations":["West
+        US","East US","West US 2","West Central US","East US 2","Central US"],"apiVersions":["2018-01-15-preview"]},{"resourceType":"ProvisioningServices","locations":["East
+        US","West US","West Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2017-11-15","2017-08-21-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DomainRegistration","namespace":"Microsoft.DomainRegistration","authorization":{"applicationId":"ea2f600a-4980-45b7-89bf-d34da487bda1","roleDefinitionId":"54d7f2e3-5040-48a7-ae90-eebf629cfa0b"},"resourceTypes":[{"resourceType":"domains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"domains/domainOwnershipIdentifiers","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"topLevelDomains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"checkDomainAvailability","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"listDomainRecommendations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"validateDomainRegistrationInformation","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"generateSsoRequest","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DynamicsLcs","namespace":"Microsoft.DynamicsLcs","resourceTypes":[{"resourceType":"lcsprojects","locations":["Brazil
         South","East Asia","East US","Japan East","Japan West","North Central US","North
         Europe","South Central US","West Europe","West US","Southeast Asia","Central
         US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"lcsprojects/connectors","locations":["Brazil
@@ -1695,21 +1923,21 @@ http_interactions:
         US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"operations","locations":["Brazil
         South","East Asia","East US","Japan East","Japan West","North Central US","North
         Europe","South Central US","West Europe","West US","Southeast Asia","Central
-        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topics","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operations","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topics","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operations","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","West
         US 2","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
         India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/consumergroups","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
         US","East US 2","West US","South Central US","Central US","Australia East","Australia
         Southeast","Central India","West Central US","West US 2","Canada East","Canada
         Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
@@ -1754,23 +1982,23 @@ http_interactions:
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations","locations":["Australia
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations/operationResults","locations":["Australia
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations/operationResults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"operations","locations":["Australia
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"operations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Logic","namespace":"Microsoft.Logic","authorization":{"applicationId":"7cd684f4-8a78-49b0-91ec-6a35d38739ba","roleDefinitionId":"cb3ef1fb-6e31-49e2-9d87-ed821053fe58"},"resourceTypes":[{"resourceType":"workflows","locations":["North
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.LocationBasedServices","namespace":"Microsoft.LocationBasedServices","resourceTypes":[{"resourceType":"accounts","locations":["Global"],"apiVersions":["2017-01-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Logic","namespace":"Microsoft.Logic","authorization":{"applicationId":"7cd684f4-8a78-49b0-91ec-6a35d38739ba","roleDefinitionId":"cb3ef1fb-6e31-49e2-9d87-ed821053fe58"},"resourceTypes":[{"resourceType":"workflows","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
@@ -1791,60 +2019,78 @@ http_interactions:
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada Central","Canada East","West US 2","West Central
-        US","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","West Central US"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"operations","locations":["South
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations","locations":["South
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operations","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"commitmentPlans","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningExperimentation","namespace":"Microsoft.MachineLearningExperimentation","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"accounts","locations":["Australia
-        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces","locations":["Australia
-        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces/projects","locations":["Australia
-        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningCompute","namespace":"Microsoft.MachineLearningCompute","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"376aa7d7-51a9-463d-bd4d-7e1691345612","managedByRoleDefinitionId":"91d00862-cf55-46a5-9dce-260bbd92ce25"},"resourceTypes":[{"resourceType":"operationalizationClusters","locations":["East
-        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"operations","locations":["East
+        US","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningExperimentation","namespace":"Microsoft.MachineLearningExperimentation","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"accounts","locations":["Australia
+        East","East US 2","West Central US","Southeast Asia","West Europe"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces","locations":["Australia
+        East","East US 2","West Central US","Southeast Asia","West Europe"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces/projects","locations":["Australia
+        East","East US 2","West Central US","Southeast Asia","West Europe"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"teamAccounts","locations":["Australia
+        East","West Central US","East US 2"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"teamAccounts/workspaces","locations":["Australia
+        East","West Central US","East US 2"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"teamAccounts/workspaces/projects","locations":["Australia
+        East","West Central US","East US 2"],"apiVersions":["2017-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningCompute","namespace":"Microsoft.MachineLearningCompute","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"376aa7d7-51a9-463d-bd4d-7e1691345612","managedByRoleDefinitionId":"91d00862-cf55-46a5-9dce-260bbd92ce25"},"resourceTypes":[{"resourceType":"operationalizationClusters","locations":["East
+        US 2","West Central US","Australia East","West Europe","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"operations","locations":["East
         US 2"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations","locations":["East
         US 2"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operations","locations":["East
-        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["East
-        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningModelManagement","namespace":"Microsoft.MachineLearningModelManagement","resourceTypes":[{"resourceType":"accounts","locations":["East
-        US 2","West Central US","Australia East"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"operations","locations":["West
-        Central US"],"apiVersions":["2017-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
+        US 2","West Central US","Australia East","West Europe","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["East
+        US 2","West Central US","Australia East","West Europe","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningModelManagement","namespace":"Microsoft.MachineLearningModelManagement","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US 2","West Central US","Australia East","West Europe","Southeast Asia"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"operations","locations":["West
+        Central US"],"apiVersions":["2017-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ManagedIdentity","namespace":"Microsoft.ManagedIdentity","resourceTypes":[{"resourceType":"Identities","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Brazil South","Central
+        India","West India","South India","Japan West","Japan East","East Asia","Southeast
+        Asia","Korea Central","Korea South","North Europe","West Europe","UK West","UK
+        South","Central US","North Central US","East US","East US 2","South Central
+        US","West US","West US 2","West Central US"],"apiVersions":["2015-08-31-PREVIEW"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Brazil South","Central
+        India","West India","South India","Japan West","Japan East","East Asia","Southeast
+        Asia","Korea Central","Korea South","North Europe","West Europe","UK West","UK
+        South","Central US","North Central US","East US","East US 2","South Central
+        US","West US","West US 2","West Central US"],"apiVersions":["2015-08-31-PREVIEW"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Management","namespace":"Microsoft.Management","authorization":{"applicationId":"f2c304cf-8e7e-4c3f-8164-16299ad9d272","roleDefinitionId":"c1cf3708-588a-4647-be7f-f400bbe214cf"},"resourceTypes":[{"resourceType":"resources","locations":[],"apiVersions":["2017-11-01-preview","2017-08-31-preview","2017-06-30-preview","2017-05-31-preview"]},{"resourceType":"managementGroups","locations":[],"apiVersions":["2017-11-01-preview","2017-08-31-preview","2017-06-30-preview","2017-05-31-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01-preview","2017-08-31-preview","2017-06-30-preview","2017-05-31-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceApps","namespace":"Microsoft.MarketplaceApps","resourceTypes":[{"resourceType":"classicDevServices","locations":["Northwest
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","Central US","North
+        Europe","West Europe","Japan East","Japan West","Brazil South","Australia
+        East","Australia Southeast","South India","Central India","Canada Central","Canada
+        East"],"apiVersions":["2017-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
         Central US","West US"],"apiVersions":["2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01"]},{"resourceType":"offertypes","locations":["South
         Central US","West US"],"apiVersions":["2015-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Media","namespace":"Microsoft.Media","authorization":{"applicationId":"374b2a64-3b6b-436b-934c-b820eacca870","roleDefinitionId":"aab70789-0cec-44b5-95d7-84b64c9487af"},"resourceTypes":[{"resourceType":"mediaservices","locations":["Japan
         West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
         US","West US","Australia East","Australia Southeast","Central US","Brazil
         South","Central India","West India","South India","South Central US","Canada
-        Central","Canada East","West Central US"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
+        Central","Canada East","West Central US","West US 2"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
+        Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"operations","locations":["West
+        Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
+        Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PolicyInsights","namespace":"Microsoft.PolicyInsights","authorization":{"applicationId":"1d78a85d-813d-46f0-b496-dd72f50a3ec0","roleDefinitionId":"63d2b225-4c34-4641-8768-21a1f7c68ce8"},"resourceTypes":[{"resourceType":"policyEvents","locations":[],"apiVersions":["2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"policyStates","locations":[],"apiVersions":["2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-17-preview","2017-08-09-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
         Central US","North Central US","East US 2","West US","West Europe","North
         Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
         East","UK South","West India"],"apiVersions":["2016-01-29"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-01-29"]},{"resourceType":"locations/checkNameAvailability","locations":["South
         Central US","North Central US","East US 2","West US","West Europe","North
         Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
-        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"capacities","locations":["West
-        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
-        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationresults","locations":["West
-        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
-        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"operations","locations":["East
-        US 2"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Relay","namespace":"Microsoft.Relay","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"capacities","locations":["Australia
+        Southeast","Brazil South","Canada Central","East Asia","East US","East US
+        2","West India","Japan East","West Central US","North Central US","North Europe","South
+        Central US","Southeast Asia","UK South","West Europe","West US","West US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":["Australia
+        Southeast","Brazil South","Canada Central","East Asia","East US","East US
+        2","West India","Japan East","West Central US","North Central US","North Europe","South
+        Central US","Southeast Asia","UK South","West Europe","West US","West US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationresults","locations":["Australia
+        Southeast","Brazil South","Canada Central","East Asia","East US","East US
+        2","West India","Japan East","West Central US","North Central US","North Europe","South
+        Central US","Southeast Asia","UK South","West Europe","West US","West US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["Australia
+        Southeast","Brazil South","Canada Central","East Asia","East US","East US
+        2","West India","Japan East","West Central US","North Central US","North Europe","South
+        Central US","Southeast Asia","UK South","West Europe","West US","West US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"operations","locations":["East
+        US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Relay","namespace":"Microsoft.Relay","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US 2","West
         US","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
         India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2017-08-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkPolicyCompliance","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/hybridconnections","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/hybridconnections/authorizationrules","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/wcfrelays","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/wcfrelays/authorizationrules","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkPolicyCompliance","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
         Central US","South Central US","North Europe","West Europe","East Asia","Southeast
         Asia","West US","East US","Japan West","Japan East","Brazil South","Central
         US","East US 2","Australia East","Australia Southeast","South India","Central
@@ -1868,12 +2114,12 @@ http_interactions:
         India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19","2015-02-28"]},{"resourceType":"checkServiceNameAvailability","locations":[],"apiVersions":["2015-02-28","2014-07-31-Preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2015-08-19"]},{"resourceType":"resourceHealthMetadata","locations":["West
         US","East US","North Europe","West Europe","Southeast Asia","East Asia","North
         Central US","South Central US","Japan West","Australia East","Brazil South","Central
-        India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","authorization":{"applicationId":"80a10ef9-8168-493d-abf9-3297c4ef6e3c","roleDefinitionId":"2b7763f7-bbe2-4e19-befe-28c79f1cf7f7"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US 2","West
         US","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
         India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"premiumMessagingRegions","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceFabric","namespace":"Microsoft.ServiceFabric","authorization":{"applicationId":"74cb6831-0dbb-4be1-8206-fd4df301cdc2","roleDefinitionId":"e55cc65f-6903-4917-b4ef-f8d4640b57f5"},"resourceTypes":[{"resourceType":"clusters","locations":["West
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/queues","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/queues/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/topics","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/topics/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/topics/subscriptions","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/topics/subscriptions/rules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"premiumMessagingRegions","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceFabric","namespace":"Microsoft.ServiceFabric","authorization":{"applicationId":"74cb6831-0dbb-4be1-8206-fd4df301cdc2","roleDefinitionId":"e55cc65f-6903-4917-b4ef-f8d4640b57f5"},"resourceTypes":[{"resourceType":"clusters","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
@@ -1887,17 +2133,43 @@ http_interactions:
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
-        India","West India","Central India","Brazil South","South Central US","Canada
-        Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
         Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
         Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applianceDefinitions","locations":["West
-        Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"locations","locations":["West
-        Central US"],"apiVersions":["2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
-        Central US"],"apiVersions":["2017-09-01","2016-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
+        Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applications","locations":["South
+        Central US","North Central US","West Central US","West US","West US 2","East
+        US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
+        Asia","Brazil South","Japan West","Japan East","Australia East","Australia
+        Southeast","South India","West India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
+        Central US","North Central US","West Central US","West US","West US 2","East
+        US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
+        Asia","Brazil South","Japan West","Japan East","Australia East","Australia
+        Southeast","South India","West India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
+        Central US"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
+        Central US","North Central US","West Central US","West US","West US 2","East
+        US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
+        Asia","Brazil South","Japan West","Japan East","Australia East","Australia
+        Southeast","South India","West India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/cloudEndpoints","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/serverEndpoints","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/registeredServers","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/workflows","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","West Central US","Japan East","Japan West","Australia East","Australia
         Southeast"],"apiVersions":["2017-06-01","2017-05-15","2017-01-01","2016-10-01","2016-06-01","2015-03-15","2014-09-01"]},{"resourceType":"operations","locations":["West
@@ -1928,23 +2200,11 @@ http_interactions:
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast"],"apiVersions":["2015-07-01-Preview","2015-03-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.TimeSeriesInsights","namespace":"Microsoft.TimeSeriesInsights","authorizations":[{"applicationId":"120d688d-1518-4cf7-bd38-182f158850b6","roleDefinitionId":"5a43abdf-bb87-42c4-9e56-1c24bf364150"}],"resourceTypes":[{"resourceType":"environments","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/eventsources","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/referenceDataSets","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/accessPolicies","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"operations","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
-        Central US","South Central US","East US","West US","Central US","North Europe","West
-        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
-        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/project","locations":["North
-        Central US","South Central US","East US","West US","Central US","North Europe","West
-        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
-        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/extension","locations":["North
-        Central US","South Central US","East US","West US","Central US","North Europe","West
-        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
-        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"checkNameAvailability","locations":["North
-        Central US","South Central US","East US","West US","Central US","North Europe","West
-        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
-        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Myget.PackageManagement","namespace":"Myget.PackageManagement","resourceTypes":[{"resourceType":"services","locations":["West
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]},{"resourceType":"environments/eventsources","locations":["East
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]},{"resourceType":"environments/referenceDataSets","locations":["East
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]},{"resourceType":"environments/accessPolicies","locations":["East
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]},{"resourceType":"operations","locations":["East
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Myget.PackageManagement","namespace":"Myget.PackageManagement","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/NewRelic.APM","namespace":"NewRelic.APM","authorization":{"allowedThirdPartyExtensions":[{"name":"NewRelic_AzurePortal_APM"}]},"resourceTypes":[{"resourceType":"accounts","locations":["North
         Central US","South Central US","West US","East US","North Europe","West Europe","Southeast
         Asia","East Asia","Japan East","Japan West"],"apiVersions":["2014-10-01","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/nuubit.nextgencdn","namespace":"nuubit.nextgencdn","resourceTypes":[{"resourceType":"accounts","locations":["East
@@ -1984,7 +2244,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:43:30 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:44 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
@@ -2001,9 +2261,11 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYzMDgsIm5iZiI6MTUwNjExNjMwOCwiZXhwIjoxNTA2MTIwMjA4LCJhaW8iOiJZMlZnWUZELys4NzZrY3hyOWJ5d0x2NGdHOTJiQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ1pXYXBVbW92MC1qUkJXWXlpME1BQSIsInZlciI6IjEuMCJ9.Jl8LBRzHw1JW6L_k40ZwqM7HM82e2tGTkWajlzMMoLesa04Ha-HCpzvzk-w4v-vQcPDl67S3dygKPu-luwtN4zN4ktalhxTcyEayD7-vBEv2QY1rCpaIbGvvXYWW4oKoJVu2iWhsk1p7sxucpRclKb7F-CshnuE4ysJvWA97KS3zIBouFfNIqA9_4kUA02qk186ey2JALUFGKdxcv9R_C5Lx2FpGQ5UXQe3Zb7yjlfrH6PB_wgyyFvs4N-2z3YC6G1EAIPiRgI_j-R0RZnM0X8TrHk_u6-8WtjJOL7VLyEz5VRl3qRRGp1UgYh5MkIkxX7_LRjaPi4raJiM0DfLXhA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3NjIsIm5iZiI6MTUxNjczNzc2MiwiZXhwIjoxNTE2NzQxNjYyLCJhaW8iOiJZMk5nWUNnTldYSnBWZFNwRjhXOWg5K1ZYem5LQkFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWkhLMExKOVVDVS1laEhRN0lFOEFBQSIsInZlciI6IjEuMCJ9.d5kXm5QdQk1sZsML_GLNiXwkZVqGB1QwpuAfM4YFLM9D8wEFxFPyvMY6Jgvu6sUCDa4HVHNEq9SWWZiW-v9lSOhFN_AH2qaWbOGGpH4M2FI6YQ8-yc7TtbwsrAgYSVLawBSC0kGj0MhNxb3nxrobEwbCIfbLsuTujHXaAMLBhYtTWGOvvCqbGvoclHjDpL7BUVv7-8ljpqo4O5H5UnGpNMmKWhxVkQrXRnYAl4HnCIgMjzum3j3X9Sg7Mzjwkk6K4-1tduOCiYpHfd4MEi4Q5FJGI1AUZoRHik9XWowGMe_QWeklOt9I2_5-meCRZWBv1RA3m22pn5T2O8Ak9i8Tuw
       Content-Length:
       - '42'
+      Host:
+      - management.azure.com
   response:
     status:
       code: 202
@@ -2013,39 +2275,41 @@ http_interactions:
       - no-cache
       Pragma:
       - no-cache
-      Content-Length:
-      - '0'
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/d94ca538-dc9c-4582-91bf-e1beb060944f?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/379332bf-2674-43b8-b0a1-363360c2bf0c?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/d94ca538-dc9c-4582-91bf-e1beb060944f?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/379332bf-2674-43b8-b0a1-363360c2bf0c?api-version=2017-03-30
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/HighCostHydrate3Min;228,Microsoft.Compute/HighCostHydrate30Min;1155
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131599701143261070
       X-Ms-Request-Id:
-      - d94ca538-dc9c-4582-91bf-e1beb060944f
+      - 379332bf-2674-43b8-b0a1-363360c2bf0c
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1180'
+      - '1163'
       X-Ms-Correlation-Request-Id:
-      - 66844874-7f7d-4ce0-85af-e3bd2a76d7f8
+      - 22b3c2f4-268d-47a1-9ca9-ce5589e9c66f
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214332Z:66844874-7f7d-4ce0-85af-e3bd2a76d7f8
+      - WESTUS:20180123T200745Z:22b3c2f4-268d-47a1-9ca9-ce5589e9c66f
       Date:
-      - Fri, 22 Sep 2017 21:43:31 GMT
+      - Tue, 23 Jan 2018 20:07:44 GMT
+      Content-Length:
+      - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:43:31 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:45 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/d94ca538-dc9c-4582-91bf-e1beb060944f?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/379332bf-2674-43b8-b0a1-363360c2bf0c?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -2059,7 +2323,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYzMDgsIm5iZiI6MTUwNjExNjMwOCwiZXhwIjoxNTA2MTIwMjA4LCJhaW8iOiJZMlZnWUZELys4NzZrY3hyOWJ5d0x2NGdHOTJiQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ1pXYXBVbW92MC1qUkJXWXlpME1BQSIsInZlciI6IjEuMCJ9.Jl8LBRzHw1JW6L_k40ZwqM7HM82e2tGTkWajlzMMoLesa04Ha-HCpzvzk-w4v-vQcPDl67S3dygKPu-luwtN4zN4ktalhxTcyEayD7-vBEv2QY1rCpaIbGvvXYWW4oKoJVu2iWhsk1p7sxucpRclKb7F-CshnuE4ysJvWA97KS3zIBouFfNIqA9_4kUA02qk186ey2JALUFGKdxcv9R_C5Lx2FpGQ5UXQe3Zb7yjlfrH6PB_wgyyFvs4N-2z3YC6G1EAIPiRgI_j-R0RZnM0X8TrHk_u6-8WtjJOL7VLyEz5VRl3qRRGp1UgYh5MkIkxX7_LRjaPi4raJiM0DfLXhA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3NjIsIm5iZiI6MTUxNjczNzc2MiwiZXhwIjoxNTE2NzQxNjYyLCJhaW8iOiJZMk5nWUNnTldYSnBWZFNwRjhXOWg5K1ZYem5LQkFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWkhLMExKOVVDVS1laEhRN0lFOEFBQSIsInZlciI6IjEuMCJ9.d5kXm5QdQk1sZsML_GLNiXwkZVqGB1QwpuAfM4YFLM9D8wEFxFPyvMY6Jgvu6sUCDa4HVHNEq9SWWZiW-v9lSOhFN_AH2qaWbOGGpH4M2FI6YQ8-yc7TtbwsrAgYSVLawBSC0kGj0MhNxb3nxrobEwbCIfbLsuTujHXaAMLBhYtTWGOvvCqbGvoclHjDpL7BUVv7-8ljpqo4O5H5UnGpNMmKWhxVkQrXRnYAl4HnCIgMjzum3j3X9Sg7Mzjwkk6K4-1tduOCiYpHfd4MEi4Q5FJGI1AUZoRHik9XWowGMe_QWeklOt9I2_5-meCRZWBv1RA3m22pn5T2O8Ak9i8Tuw
+      Host:
+      - management.azure.com
   response:
     status:
       code: 200
@@ -2077,34 +2343,36 @@ http_interactions:
       - "-1"
       Vary:
       - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/GetOperation3Min;49968,Microsoft.Compute/GetOperation30Min;249968
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131599701143261070
       X-Ms-Request-Id:
-      - 328151af-0e62-4654-8495-9f6ecddf55b0
+      - 285a5784-62dc-4678-b448-b3d22f8ed859
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14938'
+      - '14856'
       X-Ms-Correlation-Request-Id:
-      - d3ab743f-801d-40ac-a854-c34a76639d4e
+      - 54b889e5-50a8-4580-97c9-28b6a37a5e26
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214332Z:d3ab743f-801d-40ac-a854-c34a76639d4e
+      - WESTUS:20180123T200745Z:54b889e5-50a8-4580-97c9-28b6a37a5e26
       Date:
-      - Fri, 22 Sep 2017 21:43:32 GMT
+      - Tue, 23 Jan 2018 20:07:45 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-22T21:43:33.4720872+00:00\",\r\n  \"endTime\":
-        \"2017-09-22T21:43:33.7065363+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=5116297c-32cb-44ad-9687-6454756a885c&sig=G67U0CODLeGIHBDB3pLurMAlBNW9Wc%2FGz%2FHN3LOClbQ%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"d94ca538-dc9c-4582-91bf-e1beb060944f\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2018-01-23T20:07:44.5541199+00:00\",\r\n  \"endTime\":
+        \"2018-01-23T20:07:44.8199013+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=7c20a076-f1fc-418f-912b-8c140cfa8b64&sig=%2BQN49AsXOCqs1tMnv7p7tDOvia2aO7Ut68LR0Gz3i3Y%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"379332bf-2674-43b8-b0a1-363360c2bf0c\"\r\n}"
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:43:32 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:46 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/d94ca538-dc9c-4582-91bf-e1beb060944f?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/379332bf-2674-43b8-b0a1-363360c2bf0c?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -2118,7 +2386,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYzMDgsIm5iZiI6MTUwNjExNjMwOCwiZXhwIjoxNTA2MTIwMjA4LCJhaW8iOiJZMlZnWUZELys4NzZrY3hyOWJ5d0x2NGdHOTJiQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ1pXYXBVbW92MC1qUkJXWXlpME1BQSIsInZlciI6IjEuMCJ9.Jl8LBRzHw1JW6L_k40ZwqM7HM82e2tGTkWajlzMMoLesa04Ha-HCpzvzk-w4v-vQcPDl67S3dygKPu-luwtN4zN4ktalhxTcyEayD7-vBEv2QY1rCpaIbGvvXYWW4oKoJVu2iWhsk1p7sxucpRclKb7F-CshnuE4ysJvWA97KS3zIBouFfNIqA9_4kUA02qk186ey2JALUFGKdxcv9R_C5Lx2FpGQ5UXQe3Zb7yjlfrH6PB_wgyyFvs4N-2z3YC6G1EAIPiRgI_j-R0RZnM0X8TrHk_u6-8WtjJOL7VLyEz5VRl3qRRGp1UgYh5MkIkxX7_LRjaPi4raJiM0DfLXhA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3NjIsIm5iZiI6MTUxNjczNzc2MiwiZXhwIjoxNTE2NzQxNjYyLCJhaW8iOiJZMk5nWUNnTldYSnBWZFNwRjhXOWg5K1ZYem5LQkFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWkhLMExKOVVDVS1laEhRN0lFOEFBQSIsInZlciI6IjEuMCJ9.d5kXm5QdQk1sZsML_GLNiXwkZVqGB1QwpuAfM4YFLM9D8wEFxFPyvMY6Jgvu6sUCDa4HVHNEq9SWWZiW-v9lSOhFN_AH2qaWbOGGpH4M2FI6YQ8-yc7TtbwsrAgYSVLawBSC0kGj0MhNxb3nxrobEwbCIfbLsuTujHXaAMLBhYtTWGOvvCqbGvoclHjDpL7BUVv7-8ljpqo4O5H5UnGpNMmKWhxVkQrXRnYAl4HnCIgMjzum3j3X9Sg7Mzjwkk6K4-1tduOCiYpHfd4MEi4Q5FJGI1AUZoRHik9XWowGMe_QWeklOt9I2_5-meCRZWBv1RA3m22pn5T2O8Ak9i8Tuw
+      Host:
+      - management.azure.com
   response:
     status:
       code: 200
@@ -2136,34 +2406,36 @@ http_interactions:
       - "-1"
       Vary:
       - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/GetOperation3Min;49967,Microsoft.Compute/GetOperation30Min;249967
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131599701143261070
       X-Ms-Request-Id:
-      - bcccd8c2-712b-40cf-9c35-c9facd75227d
+      - 2289369a-5c31-40b8-b0b5-2bcbc789bebb
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14995'
+      - '14851'
       X-Ms-Correlation-Request-Id:
-      - a6c2f1bb-8c64-4876-aa27-020c921bb3d4
+      - 36ec7045-7686-4198-97e4-36343f76fcf2
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214333Z:a6c2f1bb-8c64-4876-aa27-020c921bb3d4
+      - WESTUS:20180123T200746Z:36ec7045-7686-4198-97e4-36343f76fcf2
       Date:
-      - Fri, 22 Sep 2017 21:43:33 GMT
+      - Tue, 23 Jan 2018 20:07:45 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-22T21:43:33.4720872+00:00\",\r\n  \"endTime\":
-        \"2017-09-22T21:43:33.7065363+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=5116297c-32cb-44ad-9687-6454756a885c&sig=G67U0CODLeGIHBDB3pLurMAlBNW9Wc%2FGz%2FHN3LOClbQ%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"d94ca538-dc9c-4582-91bf-e1beb060944f\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2018-01-23T20:07:44.5541199+00:00\",\r\n  \"endTime\":
+        \"2018-01-23T20:07:44.8199013+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=7c20a076-f1fc-418f-912b-8c140cfa8b64&sig=%2BQN49AsXOCqs1tMnv7p7tDOvia2aO7Ut68LR0Gz3i3Y%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"379332bf-2674-43b8-b0a1-363360c2bf0c\"\r\n}"
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:43:33 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:47 GMT
 - request:
     method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=5116297c-32cb-44ad-9687-6454756a885c&sig=G67U0CODLeGIHBDB3pLurMAlBNW9Wc/Gz/HN3LOClbQ=&sr=b&sv=2016-05-31
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=7c20a076-f1fc-418f-912b-8c140cfa8b64&sig=%2BQN49AsXOCqs1tMnv7p7tDOvia2aO7Ut68LR0Gz3i3Y=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2176,6 +2448,8 @@ http_interactions:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
       X-Ms-Range:
       - bytes=0-0
+      Host:
+      - md-t4jdgqqlgszp.blob.core.windows.net
   response:
     status:
       code: 206
@@ -2188,15 +2462,15 @@ http_interactions:
       Content-Range:
       - bytes 0-0/34359738880
       Last-Modified:
-      - Sat, 15 Jul 2017 14:23:07 GMT
+      - Tue, 23 Jan 2018 20:04:26 GMT
       Accept-Ranges:
       - bytes
       Etag:
-      - '"0x8D4CB8D039FC699"'
+      - '"0x8D5629C811B65EB"'
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - b837bff1-001e-00ac-72eb-3380ba000000
+      - cdf57066-001e-0066-5d85-941377000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2208,7 +2482,7 @@ http_interactions:
       X-Ms-Blob-Type:
       - PageBlob
       X-Ms-Blob-Sequence-Number:
-      - '20'
+      - '30'
       X-Ms-Copy-Id:
       - 30cedd78-548a-4fd8-967e-f8344f587e3c
       X-Ms-Copy-Source:
@@ -2222,250 +2496,16 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Fri, 22 Sep 2017 21:43:34 GMT
+      - Tue, 23 Jan 2018 20:07:46 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         6w==
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:43:33 GMT
-- request:
-    method: post
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/EndGetAccess?api-version=2017-03-30
-    body:
-      encoding: ASCII-8BIT
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYzMDgsIm5iZiI6MTUwNjExNjMwOCwiZXhwIjoxNTA2MTIwMjA4LCJhaW8iOiJZMlZnWUZELys4NzZrY3hyOWJ5d0x2NGdHOTJiQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ1pXYXBVbW92MC1qUkJXWXlpME1BQSIsInZlciI6IjEuMCJ9.Jl8LBRzHw1JW6L_k40ZwqM7HM82e2tGTkWajlzMMoLesa04Ha-HCpzvzk-w4v-vQcPDl67S3dygKPu-luwtN4zN4ktalhxTcyEayD7-vBEv2QY1rCpaIbGvvXYWW4oKoJVu2iWhsk1p7sxucpRclKb7F-CshnuE4ysJvWA97KS3zIBouFfNIqA9_4kUA02qk186ey2JALUFGKdxcv9R_C5Lx2FpGQ5UXQe3Zb7yjlfrH6PB_wgyyFvs4N-2z3YC6G1EAIPiRgI_j-R0RZnM0X8TrHk_u6-8WtjJOL7VLyEz5VRl3qRRGp1UgYh5MkIkxX7_LRjaPi4raJiM0DfLXhA
-      Content-Length:
-      - '0'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '0'
-      Expires:
-      - "-1"
-      Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/33569068-8e4e-428f-bb7d-4aea877ce8c0?monitor=true&api-version=2017-03-30
-      Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/33569068-8e4e-428f-bb7d-4aea877ce8c0?api-version=2017-03-30
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - 33569068-8e4e-428f-bb7d-4aea877ce8c0
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1185'
-      X-Ms-Correlation-Request-Id:
-      - 7049eacf-3168-4153-a66b-385268a1c57f
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214335Z:7049eacf-3168-4153-a66b-385268a1c57f
-      Date:
-      - Fri, 22 Sep 2017 21:43:34 GMT
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:43:34 GMT
-- request:
-    method: post
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
-    body:
-      encoding: UTF-8
-      string: '{"access":"read","durationInSeconds":3600}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYzMDgsIm5iZiI6MTUwNjExNjMwOCwiZXhwIjoxNTA2MTIwMjA4LCJhaW8iOiJZMlZnWUZELys4NzZrY3hyOWJ5d0x2NGdHOTJiQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ1pXYXBVbW92MC1qUkJXWXlpME1BQSIsInZlciI6IjEuMCJ9.Jl8LBRzHw1JW6L_k40ZwqM7HM82e2tGTkWajlzMMoLesa04Ha-HCpzvzk-w4v-vQcPDl67S3dygKPu-luwtN4zN4ktalhxTcyEayD7-vBEv2QY1rCpaIbGvvXYWW4oKoJVu2iWhsk1p7sxucpRclKb7F-CshnuE4ysJvWA97KS3zIBouFfNIqA9_4kUA02qk186ey2JALUFGKdxcv9R_C5Lx2FpGQ5UXQe3Zb7yjlfrH6PB_wgyyFvs4N-2z3YC6G1EAIPiRgI_j-R0RZnM0X8TrHk_u6-8WtjJOL7VLyEz5VRl3qRRGp1UgYh5MkIkxX7_LRjaPi4raJiM0DfLXhA
-      Content-Length:
-      - '42'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '0'
-      Expires:
-      - "-1"
-      Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/8d00b98e-979c-4428-b9d0-a5fae8bbb693?monitor=true&api-version=2017-03-30
-      Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/8d00b98e-979c-4428-b9d0-a5fae8bbb693?api-version=2017-03-30
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - 8d00b98e-979c-4428-b9d0-a5fae8bbb693
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1175'
-      X-Ms-Correlation-Request-Id:
-      - 6228290d-dc55-44a8-bcc7-88deff53c4c6
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214336Z:6228290d-dc55-44a8-bcc7-88deff53c4c6
-      Date:
-      - Fri, 22 Sep 2017 21:43:35 GMT
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:43:35 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:47 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/8d00b98e-979c-4428-b9d0-a5fae8bbb693?api-version=2017-03-30
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYzMDgsIm5iZiI6MTUwNjExNjMwOCwiZXhwIjoxNTA2MTIwMjA4LCJhaW8iOiJZMlZnWUZELys4NzZrY3hyOWJ5d0x2NGdHOTJiQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ1pXYXBVbW92MC1qUkJXWXlpME1BQSIsInZlciI6IjEuMCJ9.Jl8LBRzHw1JW6L_k40ZwqM7HM82e2tGTkWajlzMMoLesa04Ha-HCpzvzk-w4v-vQcPDl67S3dygKPu-luwtN4zN4ktalhxTcyEayD7-vBEv2QY1rCpaIbGvvXYWW4oKoJVu2iWhsk1p7sxucpRclKb7F-CshnuE4ysJvWA97KS3zIBouFfNIqA9_4kUA02qk186ey2JALUFGKdxcv9R_C5Lx2FpGQ5UXQe3Zb7yjlfrH6PB_wgyyFvs4N-2z3YC6G1EAIPiRgI_j-R0RZnM0X8TrHk_u6-8WtjJOL7VLyEz5VRl3qRRGp1UgYh5MkIkxX7_LRjaPi4raJiM0DfLXhA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - 615de0c9-1301-4fa1-8b51-9a2334b69d18
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14909'
-      X-Ms-Correlation-Request-Id:
-      - a50bb732-bc09-4ab9-93dc-357a25a12f38
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214336Z:a50bb732-bc09-4ab9-93dc-357a25a12f38
-      Date:
-      - Fri, 22 Sep 2017 21:43:35 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-22T21:43:37.5517003+00:00\",\r\n  \"endTime\":
-        \"2017-09-22T21:43:37.7705384+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=1b394f0c-0ac1-4baf-89ba-97c5dd8198ec&sig=U8ntZTm3PMHrOn1r6CXU1fPDuw%2FEQ%2B4N5QedNTDu9j0%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"8d00b98e-979c-4428-b9d0-a5fae8bbb693\"\r\n}"
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:43:36 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/8d00b98e-979c-4428-b9d0-a5fae8bbb693?api-version=2017-03-30
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYzMDgsIm5iZiI6MTUwNjExNjMwOCwiZXhwIjoxNTA2MTIwMjA4LCJhaW8iOiJZMlZnWUZELys4NzZrY3hyOWJ5d0x2NGdHOTJiQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ1pXYXBVbW92MC1qUkJXWXlpME1BQSIsInZlciI6IjEuMCJ9.Jl8LBRzHw1JW6L_k40ZwqM7HM82e2tGTkWajlzMMoLesa04Ha-HCpzvzk-w4v-vQcPDl67S3dygKPu-luwtN4zN4ktalhxTcyEayD7-vBEv2QY1rCpaIbGvvXYWW4oKoJVu2iWhsk1p7sxucpRclKb7F-CshnuE4ysJvWA97KS3zIBouFfNIqA9_4kUA02qk186ey2JALUFGKdxcv9R_C5Lx2FpGQ5UXQe3Zb7yjlfrH6PB_wgyyFvs4N-2z3YC6G1EAIPiRgI_j-R0RZnM0X8TrHk_u6-8WtjJOL7VLyEz5VRl3qRRGp1UgYh5MkIkxX7_LRjaPi4raJiM0DfLXhA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - 4204cd4f-08c5-41ff-8e47-49977fd065b3
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14897'
-      X-Ms-Correlation-Request-Id:
-      - fbacdac9-f65e-4719-b2bb-c70146e21c70
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214338Z:fbacdac9-f65e-4719-b2bb-c70146e21c70
-      Date:
-      - Fri, 22 Sep 2017 21:43:38 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-22T21:43:37.5517003+00:00\",\r\n  \"endTime\":
-        \"2017-09-22T21:43:37.7705384+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=1b394f0c-0ac1-4baf-89ba-97c5dd8198ec&sig=U8ntZTm3PMHrOn1r6CXU1fPDuw%2FEQ%2B4N5QedNTDu9j0%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"8d00b98e-979c-4428-b9d0-a5fae8bbb693\"\r\n}"
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:43:37 GMT
-- request:
-    method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=1b394f0c-0ac1-4baf-89ba-97c5dd8198ec&sig=U8ntZTm3PMHrOn1r6CXU1fPDuw/EQ%2B4N5QedNTDu9j0=&sr=b&sv=2016-05-31
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=7c20a076-f1fc-418f-912b-8c140cfa8b64&sig=%2BQN49AsXOCqs1tMnv7p7tDOvia2aO7Ut68LR0Gz3i3Y=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2478,6 +2518,8 @@ http_interactions:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
       X-Ms-Range:
       - bytes=440-443
+      Host:
+      - md-t4jdgqqlgszp.blob.core.windows.net
   response:
     status:
       code: 206
@@ -2490,15 +2532,15 @@ http_interactions:
       Content-Range:
       - bytes 440-443/34359738880
       Last-Modified:
-      - Sat, 15 Jul 2017 14:23:07 GMT
+      - Tue, 23 Jan 2018 20:04:26 GMT
       Accept-Ranges:
       - bytes
       Etag:
-      - '"0x8D4CB8D039FC699"'
+      - '"0x8D5629C811B65EB"'
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - eca6ae76-001e-00c2-28eb-332993000000
+      - 5cd5c1ff-001e-00aa-1485-9477c2000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2510,7 +2552,7 @@ http_interactions:
       X-Ms-Blob-Type:
       - PageBlob
       X-Ms-Blob-Sequence-Number:
-      - '20'
+      - '30'
       X-Ms-Copy-Id:
       - 30cedd78-548a-4fd8-967e-f8344f587e3c
       X-Ms-Copy-Source:
@@ -2524,69 +2566,11 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Fri, 22 Sep 2017 21:43:38 GMT
+      - Tue, 23 Jan 2018 20:07:47 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         U5MJAA==
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:43:37 GMT
-- request:
-    method: post
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/EndGetAccess?api-version=2017-03-30
-    body:
-      encoding: ASCII-8BIT
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYzMDgsIm5iZiI6MTUwNjExNjMwOCwiZXhwIjoxNTA2MTIwMjA4LCJhaW8iOiJZMlZnWUZELys4NzZrY3hyOWJ5d0x2NGdHOTJiQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ1pXYXBVbW92MC1qUkJXWXlpME1BQSIsInZlciI6IjEuMCJ9.Jl8LBRzHw1JW6L_k40ZwqM7HM82e2tGTkWajlzMMoLesa04Ha-HCpzvzk-w4v-vQcPDl67S3dygKPu-luwtN4zN4ktalhxTcyEayD7-vBEv2QY1rCpaIbGvvXYWW4oKoJVu2iWhsk1p7sxucpRclKb7F-CshnuE4ysJvWA97KS3zIBouFfNIqA9_4kUA02qk186ey2JALUFGKdxcv9R_C5Lx2FpGQ5UXQe3Zb7yjlfrH6PB_wgyyFvs4N-2z3YC6G1EAIPiRgI_j-R0RZnM0X8TrHk_u6-8WtjJOL7VLyEz5VRl3qRRGp1UgYh5MkIkxX7_LRjaPi4raJiM0DfLXhA
-      Content-Length:
-      - '0'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '0'
-      Expires:
-      - "-1"
-      Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/ac77e3a3-69d9-472a-b174-b67d754a0ee7?monitor=true&api-version=2017-03-30
-      Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/ac77e3a3-69d9-472a-b174-b67d754a0ee7?api-version=2017-03-30
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - ac77e3a3-69d9-472a-b174-b67d754a0ee7
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1180'
-      X-Ms-Correlation-Request-Id:
-      - 25c6824e-5748-4680-8c2a-53a9266e3dcd
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214339Z:25c6824e-5748-4680-8c2a-53a9266e3dcd
-      Date:
-      - Fri, 22 Sep 2017 21:43:38 GMT
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:43:39 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:47 GMT
 recorded_with: VCR 3.0.3

--- a/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_partNum-1.yml
+++ b/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_partNum-1.yml
@@ -17,6 +17,8 @@ http_interactions:
       - '186'
       Content-Type:
       - application/x-www-form-urlencoded
+      Host:
+      - login.microsoftonline.com
   response:
     status:
       code: 200
@@ -37,25 +39,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - f738d7f7-83e3-4dc7-bba5-c25180380d00
+      - 3cd62a66-6cb1-42b7-88ca-97f0605e1200
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAAABlDrqfEFlSaui6xnRjX5EXrtiQ1invhLWk75_uzj9A_UsNBd3Gq2ol3WJiwp4KKLXdxbajpme5uTAUCN38xtWy6I2DVkPiJxGxo5FPUPnesqu_RrHFe8NhyRX0dQ8D5n4pbBYvgQ8vVB4gHo2fd9Yu7qqegSgnK4pbtPBlSSwYlEDjlaopysaDgqxnNi_nLAgAA;
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzwXLbtMkedH31DW1LURzt3wTPzqhyn2K_SR7Yz4Y8CsThGMMFta48hBX_tYyjkqK_wgfOzmyEes9ABLim7gkmH1iHD42vVruDKo425re8cuEF-Oa86iOmV2jSgiqevjcegZnBSiudb8Ec4rFqP6DHQNTFZSZaV-8TxXRxVaXxOCwgAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=005; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=003; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Fri, 22 Sep 2017 21:43:07 GMT
+      - Tue, 23 Jan 2018 20:07:18 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1506120187","not_before":"1506116287","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyODcsIm5iZiI6MTUwNjExNjI4NywiZXhwIjoxNTA2MTIwMTg3LCJhaW8iOiJZMlZnWURBN2FjaFIvNVAvekU3TjI5dTc5V2VsQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiOTljNDktT0R4MDI3cGNKUmdEZ05BQSIsInZlciI6IjEuMCJ9.NVvVVwlnwXscLIZM4jdqDK2ouoMS2L5w7AjwjdDU2wodpK-G6FUfumZxjqKHGtihz2-o0Y6xbQBepjPMjIIiyASFXwHpAUJu4_yhjkeJPYTOVeoy-XCVDGUve-Lr4Mo10MKw1kK3jq3Fvoa8_YvcCAx9BkMTfbTjiTaBHtMKELmMSxoVHJGGXGyKQWPfL66ovHgwDUBo8XWmUeZ2J_msc0YeTMIkN30LYl456-UhmriXN2aggJZUHw8-4y7bhtCZeeXM6Wi6B1Duh0HKh8JZ4vea4mLk7Zu1yc3oCBNvsANa3Bgp7zQSZB4_WXI1in_6Phc52A4Myt_E9HodzFgRog"}'
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1516741638","not_before":"1516737738","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3MzgsIm5iZiI6MTUxNjczNzczOCwiZXhwIjoxNTE2NzQxNjM4LCJhaW8iOiJZMk5nWUhqcTllWThrOGFQU3hKUzh4NVc5OHdSQWdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWmlyV1BMRnN0MEtJeXBmd1lGNFNBQSIsInZlciI6IjEuMCJ9.aNBdN0csm5aTNbMwRU1i6jnOL79rSvGd6dzSg_Xb4A6g6h66UFSEA3eNyqW3RNqh0AWS0HRVR_VTgmUj3LAKLFrXoeHiGq3Ax6t2fB7c9Vx_76rwyhjo8ZpQHQMaTXwN8GQvYjqEQYwRr0t4PINuRlr7mvJSr_JTGapww7T0iKgSJy-BvH1UjkYPFpB-UimzD54C6N-9sjMYl1KNsUqEcLYzWpbmSGR9spjmTJU2z7-F-rxWVDogOV32MGHrZNpCp5zwxKD3i7hjF5QDXSeLE755YRo_xtl6j688epgc0FEKq6R-1W6Q6_XegTZmBKdDom0C92uIAOrHpd0JwWD4wQ"}'
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:43:07 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:18 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -72,7 +74,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyODcsIm5iZiI6MTUwNjExNjI4NywiZXhwIjoxNTA2MTIwMTg3LCJhaW8iOiJZMlZnWURBN2FjaFIvNVAvekU3TjI5dTc5V2VsQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiOTljNDktT0R4MDI3cGNKUmdEZ05BQSIsInZlciI6IjEuMCJ9.NVvVVwlnwXscLIZM4jdqDK2ouoMS2L5w7AjwjdDU2wodpK-G6FUfumZxjqKHGtihz2-o0Y6xbQBepjPMjIIiyASFXwHpAUJu4_yhjkeJPYTOVeoy-XCVDGUve-Lr4Mo10MKw1kK3jq3Fvoa8_YvcCAx9BkMTfbTjiTaBHtMKELmMSxoVHJGGXGyKQWPfL66ovHgwDUBo8XWmUeZ2J_msc0YeTMIkN30LYl456-UhmriXN2aggJZUHw8-4y7bhtCZeeXM6Wi6B1Duh0HKh8JZ4vea4mLk7Zu1yc3oCBNvsANa3Bgp7zQSZB4_WXI1in_6Phc52A4Myt_E9HodzFgRog
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3MzgsIm5iZiI6MTUxNjczNzczOCwiZXhwIjoxNTE2NzQxNjM4LCJhaW8iOiJZMk5nWUhqcTllWThrOGFQU3hKUzh4NVc5OHdSQWdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWmlyV1BMRnN0MEtJeXBmd1lGNFNBQSIsInZlciI6IjEuMCJ9.aNBdN0csm5aTNbMwRU1i6jnOL79rSvGd6dzSg_Xb4A6g6h66UFSEA3eNyqW3RNqh0AWS0HRVR_VTgmUj3LAKLFrXoeHiGq3Ax6t2fB7c9Vx_76rwyhjo8ZpQHQMaTXwN8GQvYjqEQYwRr0t4PINuRlr7mvJSr_JTGapww7T0iKgSJy-BvH1UjkYPFpB-UimzD54C6N-9sjMYl1KNsUqEcLYzWpbmSGR9spjmTJU2z7-F-rxWVDogOV32MGHrZNpCp5zwxKD3i7hjF5QDXSeLE755YRo_xtl6j688epgc0FEKq6R-1W6Q6_XegTZmBKdDom0C92uIAOrHpd0JwWD4wQ
+      Host:
+      - management.azure.com
   response:
     status:
       code: 200
@@ -93,21 +97,22 @@ http_interactions:
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
       - '14999'
       X-Ms-Request-Id:
-      - 1d85e7d7-1c08-4975-beab-598cfcad8873
+      - 88060922-6528-4d3f-9dcb-7f133acf95f4
       X-Ms-Correlation-Request-Id:
-      - 1d85e7d7-1c08-4975-beab-598cfcad8873
+      - 88060922-6528-4d3f-9dcb-7f133acf95f4
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214307Z:1d85e7d7-1c08-4975-beab-598cfcad8873
+      - WESTUS:20180123T200719Z:88060922-6528-4d3f-9dcb-7f133acf95f4
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 22 Sep 2017 21:43:07 GMT
+      - Tue, 23 Jan 2018 20:07:18 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
-        Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
+      string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
+        Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
+        Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:43:07 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:19 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/azure_subscription_id/providers?api-version=2015-01-01
@@ -124,7 +129,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyODcsIm5iZiI6MTUwNjExNjI4NywiZXhwIjoxNTA2MTIwMTg3LCJhaW8iOiJZMlZnWURBN2FjaFIvNVAvekU3TjI5dTc5V2VsQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiOTljNDktT0R4MDI3cGNKUmdEZ05BQSIsInZlciI6IjEuMCJ9.NVvVVwlnwXscLIZM4jdqDK2ouoMS2L5w7AjwjdDU2wodpK-G6FUfumZxjqKHGtihz2-o0Y6xbQBepjPMjIIiyASFXwHpAUJu4_yhjkeJPYTOVeoy-XCVDGUve-Lr4Mo10MKw1kK3jq3Fvoa8_YvcCAx9BkMTfbTjiTaBHtMKELmMSxoVHJGGXGyKQWPfL66ovHgwDUBo8XWmUeZ2J_msc0YeTMIkN30LYl456-UhmriXN2aggJZUHw8-4y7bhtCZeeXM6Wi6B1Duh0HKh8JZ4vea4mLk7Zu1yc3oCBNvsANa3Bgp7zQSZB4_WXI1in_6Phc52A4Myt_E9HodzFgRog
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3MzgsIm5iZiI6MTUxNjczNzczOCwiZXhwIjoxNTE2NzQxNjM4LCJhaW8iOiJZMk5nWUhqcTllWThrOGFQU3hKUzh4NVc5OHdSQWdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWmlyV1BMRnN0MEtJeXBmd1lGNFNBQSIsInZlciI6IjEuMCJ9.aNBdN0csm5aTNbMwRU1i6jnOL79rSvGd6dzSg_Xb4A6g6h66UFSEA3eNyqW3RNqh0AWS0HRVR_VTgmUj3LAKLFrXoeHiGq3Ax6t2fB7c9Vx_76rwyhjo8ZpQHQMaTXwN8GQvYjqEQYwRr0t4PINuRlr7mvJSr_JTGapww7T0iKgSJy-BvH1UjkYPFpB-UimzD54C6N-9sjMYl1KNsUqEcLYzWpbmSGR9spjmTJU2z7-F-rxWVDogOV32MGHrZNpCp5zwxKD3i7hjF5QDXSeLE755YRo_xtl6j688epgc0FEKq6R-1W6Q6_XegTZmBKdDom0C92uIAOrHpd0JwWD4wQ
+      Host:
+      - management.azure.com
   response:
     status:
       code: 200
@@ -141,19 +148,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14927'
+      - '14858'
       X-Ms-Request-Id:
-      - bec77f80-b0b6-4d30-b436-d4caf90d8a09
+      - 486a845f-c99e-4463-addb-20ce57bf6d2a
       X-Ms-Correlation-Request-Id:
-      - bec77f80-b0b6-4d30-b436-d4caf90d8a09
+      - 486a845f-c99e-4463-addb-20ce57bf6d2a
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214310Z:bec77f80-b0b6-4d30-b436-d4caf90d8a09
+      - WESTUS:20180123T200718Z:486a845f-c99e-4463-addb-20ce57bf6d2a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 22 Sep 2017 21:43:10 GMT
+      - Tue, 23 Jan 2018 20:07:17 GMT
       Content-Length:
-      - '254785'
+      - '293551'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
@@ -176,7 +183,7 @@ http_interactions:
         Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
         Central US","North Central US","Japan East","Japan West","Brazil South","Central
         India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
+        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-04-19","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-04-19","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-04-19","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-04-19","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","North Central
         US","South Central US","West Central US","West US","West US 2","Canada Central","Canada
         East","North Europe","West Europe","UK South","UK West","East Asia","Southeast
@@ -184,20 +191,26 @@ http_interactions:
         India","South India","West India"],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"validateServiceName","locations":[],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"checkServiceNameAvailability","locations":[],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"reportFeedback","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"checkFeedbackRequired","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Automation","namespace":"Microsoft.Automation","authorizations":[{"applicationId":"fc75330b-179d-49af-87dd-3b1acf6827fa","roleDefinitionId":"95fd5de3-d071-4362-92bf-cf341c1de832"}],"resourceTypes":[{"resourceType":"automationAccounts","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
         South","UK South","West Central US","North Europe","Canada Central","Australia
-        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/runbooks","locations":["Japan
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/runbooks","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
         South","UK South","West Central US","North Europe","Canada Central","Australia
-        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/configurations","locations":["Japan
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/configurations","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","North
-        Central US","Brazil South","UK South","West Central US","Central India","Australia
-        Southeast","Canada Central","North Europe"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/webhooks","locations":["Japan
+        Central US","Korea Central","East US","West US 2","Brazil South","UK South","West
+        Central US","Central India","Australia Southeast","Canada Central","North
+        Europe"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/webhooks","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
         South","UK South","West Central US","North Europe","Canada Central","Australia
-        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"operations","locations":["South
-        Central US"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/softwareUpdateConfigurations","locations":["Japan
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"operations","locations":["South
+        Central US"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/softwareUpdateConfigurations","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
         South","UK South","West Central US","North Europe","Canada Central","Australia
-        Southeast","Central India"],"apiVersions":["2017-05-15-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Backup","namespace":"Microsoft.Backup","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"BackupVault","locations":["West
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview"]},{"resourceType":"automationAccounts/jobs","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
+        South","UK South","West Central US","North Europe","Canada Central","Australia
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureActiveDirectory","namespace":"Microsoft.AzureActiveDirectory","resourceTypes":[{"resourceType":"b2cDirectories","locations":["Global","United
+        States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]},{"resourceType":"operations","locations":["Global","United
+        States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]}],"registrationState":"Unregistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Backup","namespace":"Microsoft.Backup","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"BackupVault","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
@@ -206,22 +219,22 @@ http_interactions:
         Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
         West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
         East","South India","Central India","Canada Central","Canada East","UK South","UK
-        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01","2015-07-01","2014-05-01-privatepreview"]},{"resourceType":"operations","locations":["West
+        West","West Central US","West US 2"],"apiVersions":["2017-09-01","2017-05-01","2017-01-01","2015-12-01","2015-09-01","2015-07-01","2014-05-01-privatepreview"]},{"resourceType":"operations","locations":["West
         Europe","East US","East US 2","West US","North Central US","Brazil South","North
         Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
         West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
         East","South India","Central India","Canada Central","Canada East","UK South","UK
-        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations/quotas","locations":["West
+        West","West Central US","West US 2"],"apiVersions":["2017-09-01","2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01","2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations/quotas","locations":["West
         Europe","East US","East US 2","West US","North Central US","Brazil South","North
         Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
         West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
         East","South India","Central India","Canada Central","Canada East","UK South","UK
-        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]}],"registrationState":"Unregistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicCompute","namespace":"Microsoft.ClassicCompute","resourceTypes":[{"resourceType":"domainNames","locations":["East
+        West","West Central US","West US 2"],"apiVersions":["2017-09-01","2017-05-01","2017-01-01","2015-12-01","2015-09-01"]}],"registrationState":"Unregistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicCompute","namespace":"Microsoft.ClassicCompute","resourceTypes":[{"resourceType":"domainNames","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
@@ -256,7 +269,7 @@ http_interactions:
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -296,92 +309,92 @@ http_interactions:
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30"]},{"resourceType":"locations/usages","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations/usages","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
+        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
@@ -411,76 +424,138 @@ http_interactions:
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
+        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
         US","East US","South Central US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
         Central","Central US","East US 2","North Central US","West Central US","West
-        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/webhooks","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/ping","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/getCallbackConfig","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/listEvents","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"locations","locations":["South
-        Central US","East US","West US","Central US","East US 2","North Central US","West
-        Central US","West US 2","Brazil South","Canada East","Canada Central","West
-        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
-        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"locations/operationResults","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/GetCredentials","locations":["West
+        US 2"],"apiVersions":["2017-10-01","2017-03-01"]},{"resourceType":"registries/replications","locations":["South
+        Central US","West Central US","East US","West Europe","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/webhooks","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/webhooks/ping","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/webhooks/getCallbackConfig","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/webhooks/listEvents","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"locations/operationResults","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/GetCredentials","locations":["West
         US","East US","South Central US","West Europe"],"apiVersions":["2016-06-27-preview"]},{"resourceType":"registries/listCredentials","locations":["South
         Central US","East US","West US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
         Central","Central US","East US 2","North Central US","West Central US","West
-        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/regenerateCredential","locations":["South
+        US 2"],"apiVersions":["2017-10-01","2017-03-01"]},{"resourceType":"registries/regenerateCredential","locations":["South
         Central US","West US","East US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
         Central","Central US","East US 2","North Central US","West Central US","West
-        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/listUsages","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/regenerateCredentials","locations":["West
+        US 2"],"apiVersions":["2017-10-01","2017-03-01"]},{"resourceType":"registries/listUsages","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/regenerateCredentials","locations":["West
         US","East US","South Central US","West Europe"],"apiVersions":["2016-06-27-preview"]},{"resourceType":"checkNameAvailability","locations":["South
         Central US","East US","West US","Central US","East US 2","North Central US","West
         Central US","West US 2","Brazil South","Canada East","Canada Central","West
         Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
-        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview","2017-03-01","2016-06-27-preview"]},{"resourceType":"operations","locations":["South
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-10-01","2017-06-01-preview","2017-03-01","2016-06-27-preview"]},{"resourceType":"operations","locations":["South
         Central US","East US","West US","Central US","East US 2","North Central US","West
         Central US","West US 2","Brazil South","Canada East","Canada Central","West
         Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
-        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview","2017-03-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerService","namespace":"Microsoft.ContainerService","authorization":{"applicationId":"7319c514-987d-4e9b-ac3d-d38c4f427f4c","roleDefinitionId":"1b4a0c7f-2217-416f-acfa-cf73452fdc1c"},"resourceTypes":[{"resourceType":"containerServices","locations":["Japan
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-10-01","2017-06-01-preview","2017-03-01"]},{"resourceType":"locations","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-10-01","2017-06-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerService","namespace":"Microsoft.ContainerService","authorization":{"applicationId":"7319c514-987d-4e9b-ac3d-d38c4f427f4c","roleDefinitionId":"1b4a0c7f-2217-416f-acfa-cf73452fdc1c","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"containerServices","locations":["Japan
         East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
         Central US","West US 2","South India","Central India","West India","Canada
-        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
+        East","Canada Central","Korea South","Korea Central"],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"managedClusters","locations":["East
+        US","West Europe","Central US","Canada Central","Canada East"],"apiVersions":["2017-08-31"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
         East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
         Central US","West US 2","South India","Central India","West India","Canada
-        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DevTestLab","namespace":"Microsoft.DevTestLab","authorization":{"applicationId":"1a14be2a-e903-4cec-99cf-b2e209259a0f","roleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525"},"resourceTypes":[{"resourceType":"labs","locations":["West
+        East","Canada Central","Korea South","Korea Central"],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/orchestrators","locations":["UK
+        West","West US 2","East US","West Europe","Central US"],"apiVersions":["2017-09-30"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DevTestLab","namespace":"Microsoft.DevTestLab","authorization":{"applicationId":"1a14be2a-e903-4cec-99cf-b2e209259a0f","roleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525","managedByRoleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525"},"resourceTypes":[{"resourceType":"labs","locations":["West
         Central US","Japan East","West US","Australia Southeast","Canada Central","Central
         India","Central US","East Asia","Korea Central","North Europe","South Central
-        US","UK West","Australia East","Brazil South","Canada East","East US","East
-        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        US","UK West","West India","Australia East","Brazil South","Canada East","East
+        US","East US 2","Japan West","Korea South","North Central US","South India","Southeast
         Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"schedules","locations":["West
         Central US","Japan East","West US","Australia Southeast","Canada Central","Central
         India","Central US","East Asia","Korea Central","North Europe","South Central
-        US","UK West","Australia East","Brazil South","Canada East","East US","East
-        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        US","UK West","West India","Australia East","Brazil South","Canada East","East
+        US","East US 2","Japan West","Korea South","North Central US","South India","Southeast
         Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"labs/virtualMachines","locations":["West
         Central US","Japan East","West US","Australia Southeast","Canada Central","Central
         India","Central US","East Asia","Korea Central","North Europe","South Central
-        US","UK West","Australia East","Brazil South","Canada East","East US","East
-        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        US","UK West","West India","Australia East","Brazil South","Canada East","East
+        US","East US 2","Japan West","Korea South","North Central US","South India","Southeast
         Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"labs/serviceRunners","locations":["Central
         US","East US 2","South Central US"],"apiVersions":["2017-04-26-preview","2016-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"locations/operations","locations":["West
         Central US","Japan East","West US","Australia Southeast","Canada Central","Central
         India","Central US","East Asia","Korea Central","North Europe","South Central
-        US","UK West","Australia East","Brazil South","Canada East","East US","East
-        US 2","Japan West","Korea South","North Central US","South India","Southeast
-        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"}],"resourceTypes":[{"resourceType":"components","locations":["East
-        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
-        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01","2014-04-01"]},{"resourceType":"queries","locations":["East
-        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
+        US","UK West","West India","Australia East","Brazil South","Canada East","East
+        US","East US 2","Japan West","Korea South","North Central US","South India","Southeast
+        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","authorizations":[{"applicationId":"57c0fc58-a83a-41d0-8ae9-08952659bdfd","roleDefinitionId":"FFFD5CF5-FFD3-4B24-B0E2-0715ADD4C282"}],"resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"databaseAccountNames","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"operationResults","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"},{"applicationId":"f5c26e74-f226-4ae8-85f0-b4af0080ac9e","roleDefinitionId":"529d7ae6-e892-4d43-809d-8547aeb90643"}],"resourceTypes":[{"resourceType":"components","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2015-05-01","2014-08-01","2014-04-01"]},{"resourceType":"queries","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"components/pricingPlans","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"migrateToNewPricingModel","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"rollbackToLegacyPricingModel","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"listMigrationdate","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
@@ -516,7 +591,7 @@ http_interactions:
         West","North Central US","South Central US","East US 2","Canada East","Canada
         Central","Central US","Australia East","Australia Southeast","Brazil South","South
         India","Central India","West India","North Europe","West US 2","West Central
-        US","Korea South","Korea Central","UK South","UK West","Global"],"apiVersions":["2017-05-01-preview","2016-03-01","2015-07-01"]},{"resourceType":"logDefinitions","locations":["West
+        US","Korea South","Korea Central","UK South","UK West","Global"],"apiVersions":["2017-09-01-preview","2017-05-01-preview","2016-03-01","2015-07-01"]},{"resourceType":"logDefinitions","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
@@ -526,7 +601,7 @@ http_interactions:
         West","North Central US","South Central US","East US 2","Canada East","Canada
         Central","Central US","Australia East","Australia Southeast","Brazil South","South
         India","Central India","West India","North Europe","West US 2","West Central
-        US","Korea South","Korea Central","UK South","UK West"],"apiVersions":["2017-05-01-preview","2016-09-01","2016-06-01"]},{"resourceType":"actiongroups","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]},{"resourceType":"activityLogAlerts","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.KeyVault","namespace":"Microsoft.KeyVault","resourceTypes":[{"resourceType":"vaults","locations":["North
+        US","Korea South","Korea Central","UK South","UK West"],"apiVersions":["2017-09-01-preview","2017-05-01-preview","2016-09-01","2016-06-01"]},{"resourceType":"actiongroups","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]},{"resourceType":"activityLogAlerts","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.KeyVault","namespace":"Microsoft.KeyVault","resourceTypes":[{"resourceType":"vaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
@@ -556,126 +631,153 @@ http_interactions:
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorizations":[{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},{"applicationId":"7c33bfcb-8d33-48d6-8e60-dc6404003489","roleDefinitionId":"ad6261e4-fa9a-4642-aa5f-104f1b67e9e3"},{"applicationId":"1e3e4475-288f-4018-a376-df66fd7fac5f","roleDefinitionId":"1d538b69-3d87-4e56-8ff8-25786fd48261"},{"applicationId":"a0be0c72-870e-46f0-9c49-c98333a996f7","roleDefinitionId":"7ce22727-ffce-45a9-930c-ddb2e56fa131"}],"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","West Central US"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"operations","locations":["South
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations","locations":["South
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operations","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"commitmentPlans","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"Registering"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorizations":[{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},{"applicationId":"7c33bfcb-8d33-48d6-8e60-dc6404003489","roleDefinitionId":"ad6261e4-fa9a-4642-aa5f-104f1b67e9e3"},{"applicationId":"1e3e4475-288f-4018-a376-df66fd7fac5f","roleDefinitionId":"1d538b69-3d87-4e56-8ff8-25786fd48261"},{"applicationId":"a0be0c72-870e-46f0-9c49-c98333a996f7","roleDefinitionId":"7ce22727-ffce-45a9-930c-ddb2e56fa131"}],"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
-        Central US"],"apiVersions":["2017-09-01"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
-        East","UK South","Central India","Canada Central"],"apiVersions":["2017-04-26-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"]},{"resourceType":"workspaces/dataSources","locations":["East
+        East","UK South","Central India","Canada Central"],"apiVersions":["2017-04-26-preview","2017-03-15-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"]},{"resourceType":"workspaces/query","locations":["West
+        Central US","Australia Southeast","West Europe","East US","Southeast Asia","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2017-10-01"]},{"resourceType":"workspaces/dataSources","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
         East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"storageInsightConfigs","locations":[],"apiVersions":["2014-10-10"]},{"resourceType":"workspaces/linkedServices","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
         East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"linkTargets","locations":["East
         US"],"apiVersions":["2015-03-20"]},{"resourceType":"operations","locations":[],"apiVersions":["2014-11-10"]},{"resourceType":"devices","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationsManagement","namespace":"Microsoft.OperationsManagement","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"aa249101-6816-4966-aafa-08175d795f14"},"resourceTypes":[{"resourceType":"solutions","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
-        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Portal","namespace":"Microsoft.Portal","resourceTypes":[{"resourceType":"dashboards","locations":["Central
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"managementconfigurations","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"managementassociations","locations":[],"apiVersions":["2015-11-01-preview"]},{"resourceType":"views","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2017-08-21-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Portal","namespace":"Microsoft.Portal","resourceTypes":[{"resourceType":"dashboards","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
@@ -687,9 +789,9 @@ http_interactions:
         East","West India","South India","Central India","Canada Central","Canada
         East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"consoles","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/consoles","locations":["West
         US","East US","Central India","North Europe","West Europe","South Central
-        US","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
+        US","Southeast Asia","East US 2","Central US"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
         US","East US","Central India","North Europe","West Europe","South Central
-        US","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
+        US","Southeast Asia","East US 2","Central US"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
@@ -710,7 +812,17 @@ http_interactions:
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ResourceHealth","namespace":"Microsoft.ResourceHealth","authorization":{"applicationId":"8bdebf23-c0fe-4187-a378-717ad86f6a53","roleDefinitionId":"cc026344-c8b1-4561-83ba-59eba84b27cc"},"resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2017-07-01","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"notifications","locations":["Australia
+        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]},{"resourceType":"locations/backupValidateFeatures","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-07-01"]},{"resourceType":"locations/backupPreValidateProtection","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-07-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ResourceHealth","namespace":"Microsoft.ResourceHealth","authorization":{"applicationId":"8bdebf23-c0fe-4187-a378-717ad86f6a53","roleDefinitionId":"cc026344-c8b1-4561-83ba-59eba84b27cc"},"resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2017-07-01","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"notifications","locations":["Australia
         Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Security","namespace":"Microsoft.Security","authorization":{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatuses","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/virtualMachines","locations":["Central
@@ -743,10 +855,14 @@ http_interactions:
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securitySolutionsReferenceData","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/securitySolutionsReferenceData","locations":["Central
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"jitNetworkAccessPolicies","locations":["Central
-        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/jitNetworkAccessPolicies","locations":["Central
-        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations","locations":["Central
+        US","East US","North Europe","West Europe","UK South","UK West","West Central
+        US","West US 2"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/jitNetworkAccessPolicies","locations":["Central
+        US","East US","North Europe","West Europe","UK South","UK West","West Central
+        US","West US 2"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatusesSummaries","locations":["Central
-        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/alerts","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"applicationWhitelistings","locations":["Central
+        US","East US","West Central US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/applicationWhitelistings","locations":["Central
+        US","West Central US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/alerts","locations":["Central
         US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/tasks","locations":["Central
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"externalSecuritySolutions","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/externalSecuritySolutions","locations":["Central
@@ -769,7 +885,17 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/databaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/databaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -814,7 +940,7 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01","2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -829,7 +955,7 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -859,12 +985,17 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/geoBackupPolicies","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -879,12 +1010,12 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/firewallrules","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/backupLongTermRetentionPolicies","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -999,6 +1130,16 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
         US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
@@ -1034,7 +1175,22 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -1144,7 +1300,47 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -1159,7 +1355,17 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/administratorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -1179,52 +1385,52 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorization":{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorizations":[{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},{"applicationId":"e406a681-f3d4-42a8-90b6-c2b029497af1"}],"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
         US","West US","West Europe","North Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","South India","Central
@@ -1234,7 +1440,19 @@ http_interactions:
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Web","namespace":"Microsoft.Web","authorization":{"applicationId":"abfa0a7c-a6b6-4736-8310-5855508787cd","roleDefinitionId":"f47ed98b-b063-4a5b-9e10-4b9b44fa7735"},"resourceTypes":[{"resourceType":"sites/extensions","locations":["South
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/project","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/extension","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"checkNameAvailability","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Web","namespace":"Microsoft.Web","authorization":{"applicationId":"abfa0a7c-a6b6-4736-8310-5855508787cd","roleDefinitionId":"f47ed98b-b063-4a5b-9e10-4b9b44fa7735"},"resourceTypes":[{"resourceType":"sites/extensions","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
         South","West US","East US","Japan West","Japan East","East Asia","East US
         2","North Central US","Central US","Brazil South","Australia East","Australia
@@ -1339,7 +1557,7 @@ http_interactions:
         South","West US","East US","Japan West","Japan East","East Asia","East US
         2","North Central US","Central US","Brazil South","Australia East","Australia
         Southeast","West India","Central India","South India","Canada Central","Canada
-        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms/workers","locations":["South
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms/workers","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
         South","West US","East US","Japan West","Japan East","East Asia","East US
         2","North Central US","Central US","Brazil South","Australia East","Australia
@@ -1394,7 +1612,17 @@ http_interactions:
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","West US 2","West Central US","Canada Central","Canada
-        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/managedApis","locations":["North
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/listWsdlInterfaces","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/extractApiDefinitionFromWsdl","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/managedApis","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
@@ -1445,8 +1673,11 @@ http_interactions:
         US","North Europe","Japan West","Japan East","East Asia","West Europe","East
         US","Southeast Asia","Central US"],"apiVersions":["2016-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Lombiq.DotNest","namespace":"Lombiq.DotNest","resourceTypes":[{"resourceType":"sites","locations":["East
         US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Mailjet.Email","namespace":"Mailjet.Email","resourceTypes":[{"resourceType":"services","locations":["West
-        US"],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
-        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
+        US","West Europe"],"apiVersions":["2017-10-01","2017-02-03"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-10-01","2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-10-01","2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]},{"resourceType":"diagnosticSettings","locations":[],"apiVersions":["2017-04-01"]},{"resourceType":"diagnosticSettingsCategories","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Addons","namespace":"Microsoft.Addons","authorization":{"applicationId":"24d3987b-be4a-48e0-a3e7-11c186f39e41","roleDefinitionId":"8004BAAB-A4CB-4981-8571-F7E44D039D93"},"resourceTypes":[{"resourceType":"supportProviders","locations":["West
+        Central US","South Central US","East US","West Europe"],"apiVersions":["2017-05-15"]},{"resourceType":"operations","locations":["West
+        Central US","South Central US","East US","West Europe"],"apiVersions":["2017-05-15"]},{"resourceType":"operationResults","locations":["West
+        Central US","South Central US","East US","West Europe"],"apiVersions":["2017-05-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"addsservices","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"configuration","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"operations","locations":["West
@@ -1456,51 +1687,45 @@ http_interactions:
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"servicehealthmetrics","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"logs","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"anonymousapiusers","locations":["West
-        US"],"apiVersions":["2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AnalysisServices","namespace":"Microsoft.AnalysisServices","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"servers","locations":["West
+        US"],"apiVersions":["2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AlertsManagement","namespace":"Microsoft.AlertsManagement","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-11-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AnalysisServices","namespace":"Microsoft.AnalysisServices","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"servers","locations":["West
         US","North Europe","South Central US","West Europe","West Central US","Southeast
         Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
-        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/checkNameAvailability","locations":["West
+        Southeast","Japan East","UK South","West India","West US 2","East US"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"locations/checkNameAvailability","locations":["West
         US","North Europe","South Central US","West Europe","West Central US","Southeast
         Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
-        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationresults","locations":["West
+        Southeast","Japan East","UK South","West India","West US 2","East US"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationresults","locations":["West
         US","North Europe","South Central US","West Europe","West Central US","Southeast
         Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
-        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationstatuses","locations":["West
+        Southeast","Japan East","UK South","West India","West US 2","East US"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationstatuses","locations":["West
         US","North Europe","South Central US","West Europe","West Central US","Southeast
         Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
-        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"operations","locations":["East
-        US 2","West Central US"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AppService","namespace":"Microsoft.AppService","authorization":{"applicationId":"dee7ba80-6a55-4f3b-a86c-746a9231ae49","roleDefinitionId":"6715d172-49c4-46f6-bb21-60512a8689dc"},"resourceTypes":[{"resourceType":"apiapps","locations":["East
-        US","West US","South Central US","North Europe","East Asia","Japan East","West
-        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
-        South","East US 2","Australia Southeast","Australia East","West India","South
-        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"appIdentities","locations":["East
-        US","West US","South Central US","North Europe","East Asia","Japan East","West
-        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
-        South","East US 2","Australia Southeast","Australia East","West India","South
-        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"gateways","locations":["East
-        US","West US","South Central US","North Europe","East Asia","Japan East","West
-        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
-        South","East US 2","Australia Southeast","Australia East","West India","South
-        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"deploymenttemplates","locations":[],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Authorization","namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"roleDefinitions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"classicAdministrators","locations":[],"apiVersions":["2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"permissions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"locks","locations":[],"apiVersions":["2017-04-01","2016-09-01","2015-06-01","2015-05-01-preview","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-01-01","2014-10-01-preview","2014-06-01"]},{"resourceType":"policyDefinitions","locations":[],"apiVersions":["2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"policySetDefinitions","locations":[],"apiVersions":["2017-06-01-preview"]},{"resourceType":"policyAssignments","locations":[],"apiVersions":["2017-06-01-preview","2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"providerOperations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01-preview","2015-07-01"]},{"resourceType":"elevateAccess","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureActiveDirectory","namespace":"Microsoft.AzureActiveDirectory","resourceTypes":[{"resourceType":"b2cDirectories","locations":["Global","United
-        States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureStack","namespace":"Microsoft.AzureStack","resourceTypes":[{"resourceType":"operations","locations":["Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations","locations":["West
+        Southeast","Japan East","UK South","West India","West US 2","East US"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"operations","locations":["East
+        US 2","West Central US","West US 2"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Authorization","namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[],"apiVersions":["2017-10-01-preview","2017-09-01","2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"roleDefinitions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"classicAdministrators","locations":[],"apiVersions":["2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"permissions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"locks","locations":[],"apiVersions":["2017-04-01","2016-09-01","2015-06-01","2015-05-01-preview","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-01-01","2014-10-01-preview","2014-06-01"]},{"resourceType":"policyDefinitions","locations":[],"apiVersions":["2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"policySetDefinitions","locations":[],"apiVersions":["2017-06-01-preview"]},{"resourceType":"policyAssignments","locations":[],"apiVersions":["2017-06-01-preview","2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"providerOperations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01-preview","2015-07-01"]},{"resourceType":"elevateAccess","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"checkAccess","locations":[],"apiVersions":["2017-10-01-preview","2017-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureStack","namespace":"Microsoft.AzureStack","resourceTypes":[{"resourceType":"operations","locations":["Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations","locations":["West
         Central US","Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations/products","locations":["West
-        Central US","Global"],"apiVersions":["2017-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Billing","namespace":"Microsoft.Billing","resourceTypes":[{"resourceType":"BillingPeriods","locations":["Central
+        Central US","Global"],"apiVersions":["2017-06-01","2016-01-01"]},{"resourceType":"registrations/customerSubscriptions","locations":["West
+        Central US","Global"],"apiVersions":["2017-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BatchAI","namespace":"Microsoft.BatchAI","authorization":{"applicationId":"9fcb3732-5f52-4135-8c08-9d4bbaf203ea","roleDefinitionId":"703B89C7-CE2C-431B-BDD8-FA34E39AF696","managedByRoleDefinitionId":"90B8E153-EBFF-4073-A95F-4DAD56B14C78"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"jobs","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"fileservers","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"operations","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01-preview"]},{"resourceType":"locations/operationresults","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Billing","namespace":"Microsoft.Billing","resourceTypes":[{"resourceType":"BillingPeriods","locations":["Central
         US"],"apiVersions":["2017-04-24-preview"]},{"resourceType":"Invoices","locations":["Central
         US"],"apiVersions":["2017-04-24-preview","2017-02-27-preview"]},{"resourceType":"operations","locations":["Central
         US"],"apiVersions":["2017-04-24-preview","2017-02-27-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BingMaps","namespace":"Microsoft.BingMaps","resourceTypes":[{"resourceType":"mapApis","locations":["West
         US"],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-18","2015-07-02"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BizTalkServices","namespace":"Microsoft.BizTalkServices","resourceTypes":[{"resourceType":"BizTalk","locations":["East
         US","West US","North Europe","West Europe","Southeast Asia","East Asia","North
-        Central US","Japan West","Japan East","South Central US"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Cache","namespace":"Microsoft.Cache","authorization":{"applicationId":"96231a05-34ce-4eb4-aa6a-70759cbb5e83","roleDefinitionId":"4f731528-ba85-45c7-acfb-cd0a9b3cf31b"},"resourceTypes":[{"resourceType":"Redis","locations":["North
+        Central US","Japan West","Japan East","South Central US"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BotService","namespace":"Microsoft.BotService","resourceTypes":[{"resourceType":"botServices","locations":["Global"],"apiVersions":["2017-12-01"]},{"resourceType":"checkNameAvailability","locations":["Global"],"apiVersions":["2017-12-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Cache","namespace":"Microsoft.Cache","authorization":{"applicationId":"96231a05-34ce-4eb4-aa6a-70759cbb5e83","roleDefinitionId":"4f731528-ba85-45c7-acfb-cd0a9b3cf31b"},"resourceTypes":[{"resourceType":"Redis","locations":["North
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","Canada Central","Canada East","UK South","UK West","West US 2","West
-        Central US","South India","Korea Central","Korea South"],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","South India","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","South India","Canada Central","Canada East","UK South","UK West","West
-        US 2","West Central US","Korea Central","Korea South"],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01"]},{"resourceType":"Redis/metricDefinitions","locations":["North
+        US 2","West Central US","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01"]},{"resourceType":"Redis/metricDefinitions","locations":["North
         Central US","South Central US","East US","East US 2","West US","Central US","East
         Asia","Southeast Asia","North Europe","West Europe","Japan East","Japan West","Brazil
         South","Australia Southeast","Australia East","Central India","West India","South
@@ -1514,59 +1739,59 @@ http_interactions:
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/origins","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/origins","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/customdomains","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/customdomains","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/originresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/originresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/customdomainresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/customdomainresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkResourceUsage","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkResourceUsage","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02"]},{"resourceType":"validateProbe","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02"]},{"resourceType":"validateProbe","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02"]},{"resourceType":"operations","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02"]},{"resourceType":"operations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"edgenodes","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"edgenodes","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CertificateRegistration","namespace":"Microsoft.CertificateRegistration","authorization":{"applicationId":"f3c21649-0979-4721-ac85-b0216b2cf413","roleDefinitionId":"933fba7e-2ed3-4da8-973d-8bd8298a9b40"},"resourceTypes":[{"resourceType":"certificateOrders","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"certificateOrders/certificates","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"validateCertificateRegistrationInformation","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicSubscription","namespace":"Microsoft.ClassicSubscription","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicInfrastructureMigrate","namespace":"Microsoft.ClassicInfrastructureMigrate","authorization":{"applicationId":"5e5abe2b-83cd-4786-826a-a05653ebb103","roleDefinitionId":"766c4d9b-ef83-4f73-8352-1450a506a69b"},"resourceTypes":[{"resourceType":"classicInfrastructureResources","locations":["East
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CertificateRegistration","namespace":"Microsoft.CertificateRegistration","authorization":{"applicationId":"f3c21649-0979-4721-ac85-b0216b2cf413","roleDefinitionId":"933fba7e-2ed3-4da8-973d-8bd8298a9b40"},"resourceTypes":[{"resourceType":"certificateOrders","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"certificateOrders/certificates","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"validateCertificateRegistrationInformation","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicSubscription","namespace":"Microsoft.ClassicSubscription","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-09-01","2017-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicInfrastructureMigrate","namespace":"Microsoft.ClassicInfrastructureMigrate","authorization":{"applicationId":"5e5abe2b-83cd-4786-826a-a05653ebb103","roleDefinitionId":"766c4d9b-ef83-4f73-8352-1450a506a69b"},"resourceTypes":[{"resourceType":"classicInfrastructureResources","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
         Central US","Central US","North Europe","West Europe","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","West
@@ -1584,8 +1809,9 @@ http_interactions:
         Asia","East Asia","West Central US","South Central US","East US","East US
         2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/updateAccountsCreationSettings","locations":["West
         US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/accountsCreationSettings","locations":["West
-        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2016-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Commerce","namespace":"Microsoft.Commerce","resourceTypes":[{"resourceType":"UsageAggregates","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]},{"resourceType":"RateCard","locations":[],"apiVersions":["2016-08-31-preview","2015-06-01-preview","2015-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Consumption","namespace":"Microsoft.Consumption","resourceTypes":[{"resourceType":"reservationsummaries","locations":[],"apiVersions":["2017-01-30"]},{"resourceType":"reservationdetails","locations":[],"apiVersions":["2017-01-30"]},{"resourceType":"UsageDetails","locations":[],"apiVersions":["2017-06-30-preview","2017-04-24-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-30-preview","2017-04-24-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","resourceTypes":[{"resourceType":"containerGroups","locations":["West
-        US","East US","West Europe"],"apiVersions":["2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
+        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2016-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Commerce","namespace":"Microsoft.Commerce","resourceTypes":[{"resourceType":"UsageAggregates","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]},{"resourceType":"RateCard","locations":[],"apiVersions":["2016-08-31-preview","2015-06-01-preview","2015-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Consumption","namespace":"Microsoft.Consumption","resourceTypes":[{"resourceType":"ReservationSummaries","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationTransactions","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"Balances","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"Pricesheets","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationDetails","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"Budgets","locations":[],"apiVersions":["2017-12-30-preview"]},{"resourceType":"Terms","locations":[],"apiVersions":["2017-12-30-preview"]},{"resourceType":"UsageDetails","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview","2017-04-24-preview"]},{"resourceType":"Operations","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview","2017-04-24-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","resourceTypes":[{"resourceType":"containerGroups","locations":["West
+        US","East US","West Europe","Southeast Asia"],"apiVersions":["2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US","East US","West Europe","Southeast Asia"],"apiVersions":["2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
         US"],"apiVersions":["2016-04-08"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CustomerInsights","namespace":"Microsoft.CustomerInsights","authorization":{"applicationId":"38c77d00-5fcb-4cce-9d93-af4738258e3c","roleDefinitionId":"E006F9C7-F333-477C-8AD6-1F3A9FE87F55"},"resourceTypes":[{"resourceType":"hubs","locations":["East
         US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/profiles","locations":["East
         US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/interactions","locations":["East
@@ -1608,8 +1834,8 @@ http_interactions:
         US","West US","Australia East","West Europe","North Europe","Southeast Asia","West
         Central US"],"apiVersions":["2016-03-30","2015-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataFactory","namespace":"Microsoft.DataFactory","resourceTypes":[{"resourceType":"dataFactories","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview","2014-04-01"]},{"resourceType":"factories","locations":["East
-        US","East US 2"],"apiVersions":["2017-09-01-preview","2017-03-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
-        US","East US 2"],"apiVersions":["2017-09-01-preview","2017-03-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
+        US","East US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
+        US","East US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
         Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"dataFactories/metricDefinitions","locations":["North
         Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"checkDataFactoryNameAvailability","locations":[],"apiVersions":["2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"checkAzureDataFactoryNameAvailability","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"dataFactorySchema","locations":["West
@@ -1621,69 +1847,71 @@ http_interactions:
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers/listSasTokens","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeStore","namespace":"Microsoft.DataLakeStore","authorization":{"applicationId":"e9f49c6b-5ce5-44c8-925d-015017e9f7ad","roleDefinitionId":"17eb9cca-f08a-4499-b2d3-852d175f614f"},"resourceTypes":[{"resourceType":"accounts","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/firewallRules","locations":["East
-        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","resourceTypes":[{"resourceType":"operations","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforPostgreSQL","namespace":"Microsoft.DBforPostgreSQL","resourceTypes":[{"resourceType":"operations","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"checkProvisioningServiceNameAvailability","locations":[],"apiVersions":["2017-08-21-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataMigration","namespace":"Microsoft.DataMigration","authorization":{"applicationId":"a4bad4aa-bf02-4631-9f78-a64ffdba8150","roleDefinitionId":"b831a21d-db98-4760-89cb-bef871952df1","managedByRoleDefinitionId":"6256fb55-9e59-4018-a9e1-76b11c0a4c89"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services/projects","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationStatuses","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforPostgreSQL","namespace":"Microsoft.DBforPostgreSQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"checkProvisioningServiceNameAvailability","locations":[],"apiVersions":["2017-11-15","2017-08-21-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
         US","North Europe","East Asia","East US","West Europe","Southeast Asia","Japan
         East","Japan West","Australia East","Australia Southeast","West US 2","West
         Central US","East US 2","Central US","UK South","UK West","South India","Central
-        India","Canada Central","Canada East"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"ProvisioningServices","locations":["East
-        US","West Europe","Southeast Asia"],"apiVersions":["2017-08-21-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
-        East","Australia Southeast","Canada Central","Canada East","Central India","Central
-        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
-        US","North Europe","South Central US","South India","Southeast Asia","West
-        Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"databaseAccountNames","locations":["Australia
-        East","Australia Southeast","Canada Central","Canada East","Central India","Central
-        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
-        US","North Europe","South Central US","South India","Southeast Asia","West
-        Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"operations","locations":["Australia
-        East","Australia Southeast","Canada Central","Canada East","Central India","Central
-        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
-        US","North Europe","South Central US","South India","Southeast Asia","West
-        Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DomainRegistration","namespace":"Microsoft.DomainRegistration","authorization":{"applicationId":"ea2f600a-4980-45b7-89bf-d34da487bda1","roleDefinitionId":"54d7f2e3-5040-48a7-ae90-eebf629cfa0b"},"resourceTypes":[{"resourceType":"domains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"domains/domainOwnershipIdentifiers","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"topLevelDomains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"checkDomainAvailability","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"listDomainRecommendations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"validateDomainRegistrationInformation","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"generateSsoRequest","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DynamicsLcs","namespace":"Microsoft.DynamicsLcs","resourceTypes":[{"resourceType":"lcsprojects","locations":["Brazil
+        India","Canada Central","Canada East","Brazil South","South Central US"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs/eventGridFilters","locations":["West
+        US","East US","West US 2","West Central US","East US 2","Central US"],"apiVersions":["2018-01-15-preview"]},{"resourceType":"ProvisioningServices","locations":["East
+        US","West US","West Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2017-11-15","2017-08-21-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DomainRegistration","namespace":"Microsoft.DomainRegistration","authorization":{"applicationId":"ea2f600a-4980-45b7-89bf-d34da487bda1","roleDefinitionId":"54d7f2e3-5040-48a7-ae90-eebf629cfa0b"},"resourceTypes":[{"resourceType":"domains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"domains/domainOwnershipIdentifiers","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"topLevelDomains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"checkDomainAvailability","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"listDomainRecommendations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"validateDomainRegistrationInformation","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"generateSsoRequest","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DynamicsLcs","namespace":"Microsoft.DynamicsLcs","resourceTypes":[{"resourceType":"lcsprojects","locations":["Brazil
         South","East Asia","East US","Japan East","Japan West","North Central US","North
         Europe","South Central US","West Europe","West US","Southeast Asia","Central
         US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"lcsprojects/connectors","locations":["Brazil
@@ -1695,21 +1923,21 @@ http_interactions:
         US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"operations","locations":["Brazil
         South","East Asia","East US","Japan East","Japan West","North Central US","North
         Europe","South Central US","West Europe","West US","Southeast Asia","Central
-        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topics","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operations","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topics","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operations","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","West
         US 2","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
         India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/consumergroups","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
         US","East US 2","West US","South Central US","Central US","Australia East","Australia
         Southeast","Central India","West Central US","West US 2","Canada East","Canada
         Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
@@ -1754,23 +1982,23 @@ http_interactions:
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations","locations":["Australia
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations/operationResults","locations":["Australia
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations/operationResults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"operations","locations":["Australia
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"operations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Logic","namespace":"Microsoft.Logic","authorization":{"applicationId":"7cd684f4-8a78-49b0-91ec-6a35d38739ba","roleDefinitionId":"cb3ef1fb-6e31-49e2-9d87-ed821053fe58"},"resourceTypes":[{"resourceType":"workflows","locations":["North
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.LocationBasedServices","namespace":"Microsoft.LocationBasedServices","resourceTypes":[{"resourceType":"accounts","locations":["Global"],"apiVersions":["2017-01-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Logic","namespace":"Microsoft.Logic","authorization":{"applicationId":"7cd684f4-8a78-49b0-91ec-6a35d38739ba","roleDefinitionId":"cb3ef1fb-6e31-49e2-9d87-ed821053fe58"},"resourceTypes":[{"resourceType":"workflows","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
@@ -1791,60 +2019,78 @@ http_interactions:
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada Central","Canada East","West US 2","West Central
-        US","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","West Central US"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"operations","locations":["South
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations","locations":["South
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operations","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"commitmentPlans","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningExperimentation","namespace":"Microsoft.MachineLearningExperimentation","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"accounts","locations":["Australia
-        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces","locations":["Australia
-        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces/projects","locations":["Australia
-        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningCompute","namespace":"Microsoft.MachineLearningCompute","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"376aa7d7-51a9-463d-bd4d-7e1691345612","managedByRoleDefinitionId":"91d00862-cf55-46a5-9dce-260bbd92ce25"},"resourceTypes":[{"resourceType":"operationalizationClusters","locations":["East
-        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"operations","locations":["East
+        US","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningExperimentation","namespace":"Microsoft.MachineLearningExperimentation","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"accounts","locations":["Australia
+        East","East US 2","West Central US","Southeast Asia","West Europe"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces","locations":["Australia
+        East","East US 2","West Central US","Southeast Asia","West Europe"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces/projects","locations":["Australia
+        East","East US 2","West Central US","Southeast Asia","West Europe"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"teamAccounts","locations":["Australia
+        East","West Central US","East US 2"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"teamAccounts/workspaces","locations":["Australia
+        East","West Central US","East US 2"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"teamAccounts/workspaces/projects","locations":["Australia
+        East","West Central US","East US 2"],"apiVersions":["2017-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningCompute","namespace":"Microsoft.MachineLearningCompute","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"376aa7d7-51a9-463d-bd4d-7e1691345612","managedByRoleDefinitionId":"91d00862-cf55-46a5-9dce-260bbd92ce25"},"resourceTypes":[{"resourceType":"operationalizationClusters","locations":["East
+        US 2","West Central US","Australia East","West Europe","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"operations","locations":["East
         US 2"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations","locations":["East
         US 2"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operations","locations":["East
-        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["East
-        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningModelManagement","namespace":"Microsoft.MachineLearningModelManagement","resourceTypes":[{"resourceType":"accounts","locations":["East
-        US 2","West Central US","Australia East"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"operations","locations":["West
-        Central US"],"apiVersions":["2017-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
+        US 2","West Central US","Australia East","West Europe","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["East
+        US 2","West Central US","Australia East","West Europe","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningModelManagement","namespace":"Microsoft.MachineLearningModelManagement","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US 2","West Central US","Australia East","West Europe","Southeast Asia"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"operations","locations":["West
+        Central US"],"apiVersions":["2017-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ManagedIdentity","namespace":"Microsoft.ManagedIdentity","resourceTypes":[{"resourceType":"Identities","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Brazil South","Central
+        India","West India","South India","Japan West","Japan East","East Asia","Southeast
+        Asia","Korea Central","Korea South","North Europe","West Europe","UK West","UK
+        South","Central US","North Central US","East US","East US 2","South Central
+        US","West US","West US 2","West Central US"],"apiVersions":["2015-08-31-PREVIEW"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Brazil South","Central
+        India","West India","South India","Japan West","Japan East","East Asia","Southeast
+        Asia","Korea Central","Korea South","North Europe","West Europe","UK West","UK
+        South","Central US","North Central US","East US","East US 2","South Central
+        US","West US","West US 2","West Central US"],"apiVersions":["2015-08-31-PREVIEW"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Management","namespace":"Microsoft.Management","authorization":{"applicationId":"f2c304cf-8e7e-4c3f-8164-16299ad9d272","roleDefinitionId":"c1cf3708-588a-4647-be7f-f400bbe214cf"},"resourceTypes":[{"resourceType":"resources","locations":[],"apiVersions":["2017-11-01-preview","2017-08-31-preview","2017-06-30-preview","2017-05-31-preview"]},{"resourceType":"managementGroups","locations":[],"apiVersions":["2017-11-01-preview","2017-08-31-preview","2017-06-30-preview","2017-05-31-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01-preview","2017-08-31-preview","2017-06-30-preview","2017-05-31-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceApps","namespace":"Microsoft.MarketplaceApps","resourceTypes":[{"resourceType":"classicDevServices","locations":["Northwest
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","Central US","North
+        Europe","West Europe","Japan East","Japan West","Brazil South","Australia
+        East","Australia Southeast","South India","Central India","Canada Central","Canada
+        East"],"apiVersions":["2017-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
         Central US","West US"],"apiVersions":["2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01"]},{"resourceType":"offertypes","locations":["South
         Central US","West US"],"apiVersions":["2015-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Media","namespace":"Microsoft.Media","authorization":{"applicationId":"374b2a64-3b6b-436b-934c-b820eacca870","roleDefinitionId":"aab70789-0cec-44b5-95d7-84b64c9487af"},"resourceTypes":[{"resourceType":"mediaservices","locations":["Japan
         West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
         US","West US","Australia East","Australia Southeast","Central US","Brazil
         South","Central India","West India","South India","South Central US","Canada
-        Central","Canada East","West Central US"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
+        Central","Canada East","West Central US","West US 2"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
+        Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"operations","locations":["West
+        Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
+        Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PolicyInsights","namespace":"Microsoft.PolicyInsights","authorization":{"applicationId":"1d78a85d-813d-46f0-b496-dd72f50a3ec0","roleDefinitionId":"63d2b225-4c34-4641-8768-21a1f7c68ce8"},"resourceTypes":[{"resourceType":"policyEvents","locations":[],"apiVersions":["2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"policyStates","locations":[],"apiVersions":["2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-17-preview","2017-08-09-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
         Central US","North Central US","East US 2","West US","West Europe","North
         Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
         East","UK South","West India"],"apiVersions":["2016-01-29"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-01-29"]},{"resourceType":"locations/checkNameAvailability","locations":["South
         Central US","North Central US","East US 2","West US","West Europe","North
         Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
-        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"capacities","locations":["West
-        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
-        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationresults","locations":["West
-        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
-        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"operations","locations":["East
-        US 2"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Relay","namespace":"Microsoft.Relay","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"capacities","locations":["Australia
+        Southeast","Brazil South","Canada Central","East Asia","East US","East US
+        2","West India","Japan East","West Central US","North Central US","North Europe","South
+        Central US","Southeast Asia","UK South","West Europe","West US","West US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":["Australia
+        Southeast","Brazil South","Canada Central","East Asia","East US","East US
+        2","West India","Japan East","West Central US","North Central US","North Europe","South
+        Central US","Southeast Asia","UK South","West Europe","West US","West US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationresults","locations":["Australia
+        Southeast","Brazil South","Canada Central","East Asia","East US","East US
+        2","West India","Japan East","West Central US","North Central US","North Europe","South
+        Central US","Southeast Asia","UK South","West Europe","West US","West US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["Australia
+        Southeast","Brazil South","Canada Central","East Asia","East US","East US
+        2","West India","Japan East","West Central US","North Central US","North Europe","South
+        Central US","Southeast Asia","UK South","West Europe","West US","West US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"operations","locations":["East
+        US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Relay","namespace":"Microsoft.Relay","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US 2","West
         US","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
         India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2017-08-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkPolicyCompliance","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/hybridconnections","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/hybridconnections/authorizationrules","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/wcfrelays","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/wcfrelays/authorizationrules","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkPolicyCompliance","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
         Central US","South Central US","North Europe","West Europe","East Asia","Southeast
         Asia","West US","East US","Japan West","Japan East","Brazil South","Central
         US","East US 2","Australia East","Australia Southeast","South India","Central
@@ -1868,12 +2114,12 @@ http_interactions:
         India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19","2015-02-28"]},{"resourceType":"checkServiceNameAvailability","locations":[],"apiVersions":["2015-02-28","2014-07-31-Preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2015-08-19"]},{"resourceType":"resourceHealthMetadata","locations":["West
         US","East US","North Europe","West Europe","Southeast Asia","East Asia","North
         Central US","South Central US","Japan West","Australia East","Brazil South","Central
-        India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","authorization":{"applicationId":"80a10ef9-8168-493d-abf9-3297c4ef6e3c","roleDefinitionId":"2b7763f7-bbe2-4e19-befe-28c79f1cf7f7"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US 2","West
         US","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
         India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"premiumMessagingRegions","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceFabric","namespace":"Microsoft.ServiceFabric","authorization":{"applicationId":"74cb6831-0dbb-4be1-8206-fd4df301cdc2","roleDefinitionId":"e55cc65f-6903-4917-b4ef-f8d4640b57f5"},"resourceTypes":[{"resourceType":"clusters","locations":["West
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/queues","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/queues/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/topics","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/topics/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/topics/subscriptions","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/topics/subscriptions/rules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"premiumMessagingRegions","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceFabric","namespace":"Microsoft.ServiceFabric","authorization":{"applicationId":"74cb6831-0dbb-4be1-8206-fd4df301cdc2","roleDefinitionId":"e55cc65f-6903-4917-b4ef-f8d4640b57f5"},"resourceTypes":[{"resourceType":"clusters","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
@@ -1887,17 +2133,43 @@ http_interactions:
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
-        India","West India","Central India","Brazil South","South Central US","Canada
-        Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
         Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
         Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applianceDefinitions","locations":["West
-        Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"locations","locations":["West
-        Central US"],"apiVersions":["2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
-        Central US"],"apiVersions":["2017-09-01","2016-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
+        Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applications","locations":["South
+        Central US","North Central US","West Central US","West US","West US 2","East
+        US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
+        Asia","Brazil South","Japan West","Japan East","Australia East","Australia
+        Southeast","South India","West India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
+        Central US","North Central US","West Central US","West US","West US 2","East
+        US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
+        Asia","Brazil South","Japan West","Japan East","Australia East","Australia
+        Southeast","South India","West India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
+        Central US"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
+        Central US","North Central US","West Central US","West US","West US 2","East
+        US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
+        Asia","Brazil South","Japan West","Japan East","Australia East","Australia
+        Southeast","South India","West India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/cloudEndpoints","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/serverEndpoints","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/registeredServers","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/workflows","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","West Central US","Japan East","Japan West","Australia East","Australia
         Southeast"],"apiVersions":["2017-06-01","2017-05-15","2017-01-01","2016-10-01","2016-06-01","2015-03-15","2014-09-01"]},{"resourceType":"operations","locations":["West
@@ -1928,23 +2200,11 @@ http_interactions:
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast"],"apiVersions":["2015-07-01-Preview","2015-03-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.TimeSeriesInsights","namespace":"Microsoft.TimeSeriesInsights","authorizations":[{"applicationId":"120d688d-1518-4cf7-bd38-182f158850b6","roleDefinitionId":"5a43abdf-bb87-42c4-9e56-1c24bf364150"}],"resourceTypes":[{"resourceType":"environments","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/eventsources","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/referenceDataSets","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/accessPolicies","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"operations","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
-        Central US","South Central US","East US","West US","Central US","North Europe","West
-        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
-        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/project","locations":["North
-        Central US","South Central US","East US","West US","Central US","North Europe","West
-        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
-        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/extension","locations":["North
-        Central US","South Central US","East US","West US","Central US","North Europe","West
-        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
-        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"checkNameAvailability","locations":["North
-        Central US","South Central US","East US","West US","Central US","North Europe","West
-        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
-        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Myget.PackageManagement","namespace":"Myget.PackageManagement","resourceTypes":[{"resourceType":"services","locations":["West
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]},{"resourceType":"environments/eventsources","locations":["East
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]},{"resourceType":"environments/referenceDataSets","locations":["East
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]},{"resourceType":"environments/accessPolicies","locations":["East
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]},{"resourceType":"operations","locations":["East
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Myget.PackageManagement","namespace":"Myget.PackageManagement","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/NewRelic.APM","namespace":"NewRelic.APM","authorization":{"allowedThirdPartyExtensions":[{"name":"NewRelic_AzurePortal_APM"}]},"resourceTypes":[{"resourceType":"accounts","locations":["North
         Central US","South Central US","West US","East US","North Europe","West Europe","Southeast
         Asia","East Asia","Japan East","Japan West"],"apiVersions":["2014-10-01","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/nuubit.nextgencdn","namespace":"nuubit.nextgencdn","resourceTypes":[{"resourceType":"accounts","locations":["East
@@ -1984,7 +2244,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:43:10 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:20 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
@@ -2001,9 +2261,11 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyODcsIm5iZiI6MTUwNjExNjI4NywiZXhwIjoxNTA2MTIwMTg3LCJhaW8iOiJZMlZnWURBN2FjaFIvNVAvekU3TjI5dTc5V2VsQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiOTljNDktT0R4MDI3cGNKUmdEZ05BQSIsInZlciI6IjEuMCJ9.NVvVVwlnwXscLIZM4jdqDK2ouoMS2L5w7AjwjdDU2wodpK-G6FUfumZxjqKHGtihz2-o0Y6xbQBepjPMjIIiyASFXwHpAUJu4_yhjkeJPYTOVeoy-XCVDGUve-Lr4Mo10MKw1kK3jq3Fvoa8_YvcCAx9BkMTfbTjiTaBHtMKELmMSxoVHJGGXGyKQWPfL66ovHgwDUBo8XWmUeZ2J_msc0YeTMIkN30LYl456-UhmriXN2aggJZUHw8-4y7bhtCZeeXM6Wi6B1Duh0HKh8JZ4vea4mLk7Zu1yc3oCBNvsANa3Bgp7zQSZB4_WXI1in_6Phc52A4Myt_E9HodzFgRog
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3MzgsIm5iZiI6MTUxNjczNzczOCwiZXhwIjoxNTE2NzQxNjM4LCJhaW8iOiJZMk5nWUhqcTllWThrOGFQU3hKUzh4NVc5OHdSQWdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWmlyV1BMRnN0MEtJeXBmd1lGNFNBQSIsInZlciI6IjEuMCJ9.aNBdN0csm5aTNbMwRU1i6jnOL79rSvGd6dzSg_Xb4A6g6h66UFSEA3eNyqW3RNqh0AWS0HRVR_VTgmUj3LAKLFrXoeHiGq3Ax6t2fB7c9Vx_76rwyhjo8ZpQHQMaTXwN8GQvYjqEQYwRr0t4PINuRlr7mvJSr_JTGapww7T0iKgSJy-BvH1UjkYPFpB-UimzD54C6N-9sjMYl1KNsUqEcLYzWpbmSGR9spjmTJU2z7-F-rxWVDogOV32MGHrZNpCp5zwxKD3i7hjF5QDXSeLE755YRo_xtl6j688epgc0FEKq6R-1W6Q6_XegTZmBKdDom0C92uIAOrHpd0JwWD4wQ
       Content-Length:
       - '42'
+      Host:
+      - management.azure.com
   response:
     status:
       code: 202
@@ -2013,39 +2275,41 @@ http_interactions:
       - no-cache
       Pragma:
       - no-cache
-      Content-Length:
-      - '0'
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/d4f0e2cb-0af9-4476-8ce6-c34b5ee08e1f?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/0ff27fff-4576-4d5a-9bae-5ca97ff20c93?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/d4f0e2cb-0af9-4476-8ce6-c34b5ee08e1f?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/0ff27fff-4576-4d5a-9bae-5ca97ff20c93?api-version=2017-03-30
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/HighCostHydrate3Min;232,Microsoft.Compute/HighCostHydrate30Min;1159
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131599701143261070
       X-Ms-Request-Id:
-      - d4f0e2cb-0af9-4476-8ce6-c34b5ee08e1f
+      - 0ff27fff-4576-4d5a-9bae-5ca97ff20c93
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1169'
+      - '1165'
       X-Ms-Correlation-Request-Id:
-      - 7f43fc9c-dcf8-45b7-a60b-dfdb6ac64de8
+      - 49691d94-1f95-4168-80c6-9de4d09500d8
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214311Z:7f43fc9c-dcf8-45b7-a60b-dfdb6ac64de8
+      - WESTUS:20180123T200722Z:49691d94-1f95-4168-80c6-9de4d09500d8
       Date:
-      - Fri, 22 Sep 2017 21:43:11 GMT
+      - Tue, 23 Jan 2018 20:07:21 GMT
+      Content-Length:
+      - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:43:11 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:22 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/d4f0e2cb-0af9-4476-8ce6-c34b5ee08e1f?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/0ff27fff-4576-4d5a-9bae-5ca97ff20c93?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -2059,7 +2323,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyODcsIm5iZiI6MTUwNjExNjI4NywiZXhwIjoxNTA2MTIwMTg3LCJhaW8iOiJZMlZnWURBN2FjaFIvNVAvekU3TjI5dTc5V2VsQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiOTljNDktT0R4MDI3cGNKUmdEZ05BQSIsInZlciI6IjEuMCJ9.NVvVVwlnwXscLIZM4jdqDK2ouoMS2L5w7AjwjdDU2wodpK-G6FUfumZxjqKHGtihz2-o0Y6xbQBepjPMjIIiyASFXwHpAUJu4_yhjkeJPYTOVeoy-XCVDGUve-Lr4Mo10MKw1kK3jq3Fvoa8_YvcCAx9BkMTfbTjiTaBHtMKELmMSxoVHJGGXGyKQWPfL66ovHgwDUBo8XWmUeZ2J_msc0YeTMIkN30LYl456-UhmriXN2aggJZUHw8-4y7bhtCZeeXM6Wi6B1Duh0HKh8JZ4vea4mLk7Zu1yc3oCBNvsANa3Bgp7zQSZB4_WXI1in_6Phc52A4Myt_E9HodzFgRog
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3MzgsIm5iZiI6MTUxNjczNzczOCwiZXhwIjoxNTE2NzQxNjM4LCJhaW8iOiJZMk5nWUhqcTllWThrOGFQU3hKUzh4NVc5OHdSQWdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWmlyV1BMRnN0MEtJeXBmd1lGNFNBQSIsInZlciI6IjEuMCJ9.aNBdN0csm5aTNbMwRU1i6jnOL79rSvGd6dzSg_Xb4A6g6h66UFSEA3eNyqW3RNqh0AWS0HRVR_VTgmUj3LAKLFrXoeHiGq3Ax6t2fB7c9Vx_76rwyhjo8ZpQHQMaTXwN8GQvYjqEQYwRr0t4PINuRlr7mvJSr_JTGapww7T0iKgSJy-BvH1UjkYPFpB-UimzD54C6N-9sjMYl1KNsUqEcLYzWpbmSGR9spjmTJU2z7-F-rxWVDogOV32MGHrZNpCp5zwxKD3i7hjF5QDXSeLE755YRo_xtl6j688epgc0FEKq6R-1W6Q6_XegTZmBKdDom0C92uIAOrHpd0JwWD4wQ
+      Host:
+      - management.azure.com
   response:
     status:
       code: 200
@@ -2077,34 +2343,36 @@ http_interactions:
       - "-1"
       Vary:
       - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/GetOperation3Min;49980,Microsoft.Compute/GetOperation30Min;249980
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131599701143261070
       X-Ms-Request-Id:
-      - 3e8584c1-8166-48de-898b-0c59965b823a
+      - 73014bd4-41e5-4307-8186-949752fe9156
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14987'
+      - '14865'
       X-Ms-Correlation-Request-Id:
-      - 518a9fa5-e4fc-4c6d-902e-f79152e67de1
+      - 95649138-527a-4ab2-8b26-5473fce26d8f
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214312Z:518a9fa5-e4fc-4c6d-902e-f79152e67de1
+      - WESTUS:20180123T200722Z:95649138-527a-4ab2-8b26-5473fce26d8f
       Date:
-      - Fri, 22 Sep 2017 21:43:12 GMT
+      - Tue, 23 Jan 2018 20:07:21 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-22T21:43:13.1794483+00:00\",\r\n  \"endTime\":
-        \"2017-09-22T21:43:13.3982845+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=bed63c44-b681-4b04-8749-15a1604dba88&sig=3DamxkhDnkQk5w7P9PiLUAVFolhGxatuoZwwZfq9%2Fq0%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"d4f0e2cb-0af9-4476-8ce6-c34b5ee08e1f\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2018-01-23T20:07:21.4261503+00:00\",\r\n  \"endTime\":
+        \"2018-01-23T20:07:21.6292448+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=9a628546-3f62-4191-8feb-0b911b9c0069&sig=nc1a11%2B98gYbHrgir9YBadaKE8S%2FLeyqRARZPqvqrlY%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"0ff27fff-4576-4d5a-9bae-5ca97ff20c93\"\r\n}"
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:43:12 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:22 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/d4f0e2cb-0af9-4476-8ce6-c34b5ee08e1f?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/0ff27fff-4576-4d5a-9bae-5ca97ff20c93?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -2118,7 +2386,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyODcsIm5iZiI6MTUwNjExNjI4NywiZXhwIjoxNTA2MTIwMTg3LCJhaW8iOiJZMlZnWURBN2FjaFIvNVAvekU3TjI5dTc5V2VsQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiOTljNDktT0R4MDI3cGNKUmdEZ05BQSIsInZlciI6IjEuMCJ9.NVvVVwlnwXscLIZM4jdqDK2ouoMS2L5w7AjwjdDU2wodpK-G6FUfumZxjqKHGtihz2-o0Y6xbQBepjPMjIIiyASFXwHpAUJu4_yhjkeJPYTOVeoy-XCVDGUve-Lr4Mo10MKw1kK3jq3Fvoa8_YvcCAx9BkMTfbTjiTaBHtMKELmMSxoVHJGGXGyKQWPfL66ovHgwDUBo8XWmUeZ2J_msc0YeTMIkN30LYl456-UhmriXN2aggJZUHw8-4y7bhtCZeeXM6Wi6B1Duh0HKh8JZ4vea4mLk7Zu1yc3oCBNvsANa3Bgp7zQSZB4_WXI1in_6Phc52A4Myt_E9HodzFgRog
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3MzgsIm5iZiI6MTUxNjczNzczOCwiZXhwIjoxNTE2NzQxNjM4LCJhaW8iOiJZMk5nWUhqcTllWThrOGFQU3hKUzh4NVc5OHdSQWdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWmlyV1BMRnN0MEtJeXBmd1lGNFNBQSIsInZlciI6IjEuMCJ9.aNBdN0csm5aTNbMwRU1i6jnOL79rSvGd6dzSg_Xb4A6g6h66UFSEA3eNyqW3RNqh0AWS0HRVR_VTgmUj3LAKLFrXoeHiGq3Ax6t2fB7c9Vx_76rwyhjo8ZpQHQMaTXwN8GQvYjqEQYwRr0t4PINuRlr7mvJSr_JTGapww7T0iKgSJy-BvH1UjkYPFpB-UimzD54C6N-9sjMYl1KNsUqEcLYzWpbmSGR9spjmTJU2z7-F-rxWVDogOV32MGHrZNpCp5zwxKD3i7hjF5QDXSeLE755YRo_xtl6j688epgc0FEKq6R-1W6Q6_XegTZmBKdDom0C92uIAOrHpd0JwWD4wQ
+      Host:
+      - management.azure.com
   response:
     status:
       code: 200
@@ -2136,34 +2406,36 @@ http_interactions:
       - "-1"
       Vary:
       - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/GetOperation3Min;49979,Microsoft.Compute/GetOperation30Min;249979
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131599701143261070
       X-Ms-Request-Id:
-      - 037bb834-cd91-4e84-98ab-56f7829a961e
+      - e5a1402a-e214-4a45-aa3c-867fc6f41515
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14922'
+      - '14869'
       X-Ms-Correlation-Request-Id:
-      - 2a2ed3f6-f958-4e75-9ca2-31922bbd03f8
+      - 347ae738-0aaa-43e7-8061-666f5ea03636
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214313Z:2a2ed3f6-f958-4e75-9ca2-31922bbd03f8
+      - WESTUS:20180123T200723Z:347ae738-0aaa-43e7-8061-666f5ea03636
       Date:
-      - Fri, 22 Sep 2017 21:43:12 GMT
+      - Tue, 23 Jan 2018 20:07:23 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-22T21:43:13.1794483+00:00\",\r\n  \"endTime\":
-        \"2017-09-22T21:43:13.3982845+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=bed63c44-b681-4b04-8749-15a1604dba88&sig=3DamxkhDnkQk5w7P9PiLUAVFolhGxatuoZwwZfq9%2Fq0%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"d4f0e2cb-0af9-4476-8ce6-c34b5ee08e1f\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2018-01-23T20:07:21.4261503+00:00\",\r\n  \"endTime\":
+        \"2018-01-23T20:07:21.6292448+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=9a628546-3f62-4191-8feb-0b911b9c0069&sig=nc1a11%2B98gYbHrgir9YBadaKE8S%2FLeyqRARZPqvqrlY%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"0ff27fff-4576-4d5a-9bae-5ca97ff20c93\"\r\n}"
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:43:13 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:23 GMT
 - request:
     method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=bed63c44-b681-4b04-8749-15a1604dba88&sig=3DamxkhDnkQk5w7P9PiLUAVFolhGxatuoZwwZfq9/q0=&sr=b&sv=2016-05-31
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=9a628546-3f62-4191-8feb-0b911b9c0069&sig=nc1a11%2B98gYbHrgir9YBadaKE8S/LeyqRARZPqvqrlY=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2176,6 +2448,8 @@ http_interactions:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
       X-Ms-Range:
       - bytes=0-0
+      Host:
+      - md-t4jdgqqlgszp.blob.core.windows.net
   response:
     status:
       code: 206
@@ -2188,15 +2462,15 @@ http_interactions:
       Content-Range:
       - bytes 0-0/34359738880
       Last-Modified:
-      - Sat, 15 Jul 2017 14:23:07 GMT
+      - Tue, 23 Jan 2018 20:04:26 GMT
       Accept-Ranges:
       - bytes
       Etag:
-      - '"0x8D4CB8D039FC699"'
+      - '"0x8D5629C811B65EB"'
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - ba85321c-001e-0066-29eb-331377000000
+      - 5faf350f-001e-003a-7085-94e28e000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2208,7 +2482,7 @@ http_interactions:
       X-Ms-Blob-Type:
       - PageBlob
       X-Ms-Blob-Sequence-Number:
-      - '20'
+      - '30'
       X-Ms-Copy-Id:
       - 30cedd78-548a-4fd8-967e-f8344f587e3c
       X-Ms-Copy-Source:
@@ -2222,250 +2496,16 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Fri, 22 Sep 2017 21:43:12 GMT
+      - Tue, 23 Jan 2018 20:07:23 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         6w==
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:43:13 GMT
-- request:
-    method: post
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/EndGetAccess?api-version=2017-03-30
-    body:
-      encoding: ASCII-8BIT
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyODcsIm5iZiI6MTUwNjExNjI4NywiZXhwIjoxNTA2MTIwMTg3LCJhaW8iOiJZMlZnWURBN2FjaFIvNVAvekU3TjI5dTc5V2VsQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiOTljNDktT0R4MDI3cGNKUmdEZ05BQSIsInZlciI6IjEuMCJ9.NVvVVwlnwXscLIZM4jdqDK2ouoMS2L5w7AjwjdDU2wodpK-G6FUfumZxjqKHGtihz2-o0Y6xbQBepjPMjIIiyASFXwHpAUJu4_yhjkeJPYTOVeoy-XCVDGUve-Lr4Mo10MKw1kK3jq3Fvoa8_YvcCAx9BkMTfbTjiTaBHtMKELmMSxoVHJGGXGyKQWPfL66ovHgwDUBo8XWmUeZ2J_msc0YeTMIkN30LYl456-UhmriXN2aggJZUHw8-4y7bhtCZeeXM6Wi6B1Duh0HKh8JZ4vea4mLk7Zu1yc3oCBNvsANa3Bgp7zQSZB4_WXI1in_6Phc52A4Myt_E9HodzFgRog
-      Content-Length:
-      - '0'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '0'
-      Expires:
-      - "-1"
-      Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/f3cf3587-ff3f-4f9f-8683-005466036707?monitor=true&api-version=2017-03-30
-      Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/f3cf3587-ff3f-4f9f-8683-005466036707?api-version=2017-03-30
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - f3cf3587-ff3f-4f9f-8683-005466036707
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1181'
-      X-Ms-Correlation-Request-Id:
-      - 9e5326b6-2d2e-4268-8981-da75f51594ac
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214314Z:9e5326b6-2d2e-4268-8981-da75f51594ac
-      Date:
-      - Fri, 22 Sep 2017 21:43:13 GMT
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:43:14 GMT
-- request:
-    method: post
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
-    body:
-      encoding: UTF-8
-      string: '{"access":"read","durationInSeconds":3600}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyODcsIm5iZiI6MTUwNjExNjI4NywiZXhwIjoxNTA2MTIwMTg3LCJhaW8iOiJZMlZnWURBN2FjaFIvNVAvekU3TjI5dTc5V2VsQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiOTljNDktT0R4MDI3cGNKUmdEZ05BQSIsInZlciI6IjEuMCJ9.NVvVVwlnwXscLIZM4jdqDK2ouoMS2L5w7AjwjdDU2wodpK-G6FUfumZxjqKHGtihz2-o0Y6xbQBepjPMjIIiyASFXwHpAUJu4_yhjkeJPYTOVeoy-XCVDGUve-Lr4Mo10MKw1kK3jq3Fvoa8_YvcCAx9BkMTfbTjiTaBHtMKELmMSxoVHJGGXGyKQWPfL66ovHgwDUBo8XWmUeZ2J_msc0YeTMIkN30LYl456-UhmriXN2aggJZUHw8-4y7bhtCZeeXM6Wi6B1Duh0HKh8JZ4vea4mLk7Zu1yc3oCBNvsANa3Bgp7zQSZB4_WXI1in_6Phc52A4Myt_E9HodzFgRog
-      Content-Length:
-      - '42'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '0'
-      Expires:
-      - "-1"
-      Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/a485b41f-641a-45fe-bc32-dc394255b4a7?monitor=true&api-version=2017-03-30
-      Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/a485b41f-641a-45fe-bc32-dc394255b4a7?api-version=2017-03-30
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - a485b41f-641a-45fe-bc32-dc394255b4a7
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1179'
-      X-Ms-Correlation-Request-Id:
-      - 19a48a4c-5b7e-4df7-a783-969823993b2a
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214315Z:19a48a4c-5b7e-4df7-a783-969823993b2a
-      Date:
-      - Fri, 22 Sep 2017 21:43:14 GMT
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:43:15 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:23 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/a485b41f-641a-45fe-bc32-dc394255b4a7?api-version=2017-03-30
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyODcsIm5iZiI6MTUwNjExNjI4NywiZXhwIjoxNTA2MTIwMTg3LCJhaW8iOiJZMlZnWURBN2FjaFIvNVAvekU3TjI5dTc5V2VsQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiOTljNDktT0R4MDI3cGNKUmdEZ05BQSIsInZlciI6IjEuMCJ9.NVvVVwlnwXscLIZM4jdqDK2ouoMS2L5w7AjwjdDU2wodpK-G6FUfumZxjqKHGtihz2-o0Y6xbQBepjPMjIIiyASFXwHpAUJu4_yhjkeJPYTOVeoy-XCVDGUve-Lr4Mo10MKw1kK3jq3Fvoa8_YvcCAx9BkMTfbTjiTaBHtMKELmMSxoVHJGGXGyKQWPfL66ovHgwDUBo8XWmUeZ2J_msc0YeTMIkN30LYl456-UhmriXN2aggJZUHw8-4y7bhtCZeeXM6Wi6B1Duh0HKh8JZ4vea4mLk7Zu1yc3oCBNvsANa3Bgp7zQSZB4_WXI1in_6Phc52A4Myt_E9HodzFgRog
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - eabcf23e-a468-4187-b66b-8c2d3e217802
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
-      X-Ms-Correlation-Request-Id:
-      - 34cdb2cc-4957-43ed-a19b-81447e969a65
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214315Z:34cdb2cc-4957-43ed-a19b-81447e969a65
-      Date:
-      - Fri, 22 Sep 2017 21:43:14 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-22T21:43:16.5958805+00:00\",\r\n  \"endTime\":
-        \"2017-09-22T21:43:16.8146963+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=7b2557de-903d-42d0-a8ec-c039e9e90e7e&sig=tgvF5VWb1fZkIH5AqMebKhIgNFeUdPuI5tYBCGfI%2FUU%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"a485b41f-641a-45fe-bc32-dc394255b4a7\"\r\n}"
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:43:15 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/a485b41f-641a-45fe-bc32-dc394255b4a7?api-version=2017-03-30
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyODcsIm5iZiI6MTUwNjExNjI4NywiZXhwIjoxNTA2MTIwMTg3LCJhaW8iOiJZMlZnWURBN2FjaFIvNVAvekU3TjI5dTc5V2VsQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiOTljNDktT0R4MDI3cGNKUmdEZ05BQSIsInZlciI6IjEuMCJ9.NVvVVwlnwXscLIZM4jdqDK2ouoMS2L5w7AjwjdDU2wodpK-G6FUfumZxjqKHGtihz2-o0Y6xbQBepjPMjIIiyASFXwHpAUJu4_yhjkeJPYTOVeoy-XCVDGUve-Lr4Mo10MKw1kK3jq3Fvoa8_YvcCAx9BkMTfbTjiTaBHtMKELmMSxoVHJGGXGyKQWPfL66ovHgwDUBo8XWmUeZ2J_msc0YeTMIkN30LYl456-UhmriXN2aggJZUHw8-4y7bhtCZeeXM6Wi6B1Duh0HKh8JZ4vea4mLk7Zu1yc3oCBNvsANa3Bgp7zQSZB4_WXI1in_6Phc52A4Myt_E9HodzFgRog
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - b4cb41e0-e998-4344-8884-97773cf45e70
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14910'
-      X-Ms-Correlation-Request-Id:
-      - 0625275f-c736-4b74-93a2-758917eeef6f
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214316Z:0625275f-c736-4b74-93a2-758917eeef6f
-      Date:
-      - Fri, 22 Sep 2017 21:43:15 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-22T21:43:16.5958805+00:00\",\r\n  \"endTime\":
-        \"2017-09-22T21:43:16.8146963+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=7b2557de-903d-42d0-a8ec-c039e9e90e7e&sig=tgvF5VWb1fZkIH5AqMebKhIgNFeUdPuI5tYBCGfI%2FUU%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"a485b41f-641a-45fe-bc32-dc394255b4a7\"\r\n}"
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:43:16 GMT
-- request:
-    method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=7b2557de-903d-42d0-a8ec-c039e9e90e7e&sig=tgvF5VWb1fZkIH5AqMebKhIgNFeUdPuI5tYBCGfI/UU=&sr=b&sv=2016-05-31
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=9a628546-3f62-4191-8feb-0b911b9c0069&sig=nc1a11%2B98gYbHrgir9YBadaKE8S/LeyqRARZPqvqrlY=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2478,6 +2518,8 @@ http_interactions:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
       X-Ms-Range:
       - bytes=440-443
+      Host:
+      - md-t4jdgqqlgszp.blob.core.windows.net
   response:
     status:
       code: 206
@@ -2490,15 +2532,15 @@ http_interactions:
       Content-Range:
       - bytes 440-443/34359738880
       Last-Modified:
-      - Sat, 15 Jul 2017 14:23:07 GMT
+      - Tue, 23 Jan 2018 20:04:26 GMT
       Accept-Ranges:
       - bytes
       Etag:
-      - '"0x8D4CB8D039FC699"'
+      - '"0x8D5629C811B65EB"'
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 653e129b-001e-00a4-1ceb-339bc9000000
+      - 48981a04-001e-0034-3185-940e85000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2510,7 +2552,7 @@ http_interactions:
       X-Ms-Blob-Type:
       - PageBlob
       X-Ms-Blob-Sequence-Number:
-      - '20'
+      - '30'
       X-Ms-Copy-Id:
       - 30cedd78-548a-4fd8-967e-f8344f587e3c
       X-Ms-Copy-Source:
@@ -2524,69 +2566,11 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Fri, 22 Sep 2017 21:43:16 GMT
+      - Tue, 23 Jan 2018 20:07:23 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         U5MJAA==
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:43:16 GMT
-- request:
-    method: post
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/EndGetAccess?api-version=2017-03-30
-    body:
-      encoding: ASCII-8BIT
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyODcsIm5iZiI6MTUwNjExNjI4NywiZXhwIjoxNTA2MTIwMTg3LCJhaW8iOiJZMlZnWURBN2FjaFIvNVAvekU3TjI5dTc5V2VsQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiOTljNDktT0R4MDI3cGNKUmdEZ05BQSIsInZlciI6IjEuMCJ9.NVvVVwlnwXscLIZM4jdqDK2ouoMS2L5w7AjwjdDU2wodpK-G6FUfumZxjqKHGtihz2-o0Y6xbQBepjPMjIIiyASFXwHpAUJu4_yhjkeJPYTOVeoy-XCVDGUve-Lr4Mo10MKw1kK3jq3Fvoa8_YvcCAx9BkMTfbTjiTaBHtMKELmMSxoVHJGGXGyKQWPfL66ovHgwDUBo8XWmUeZ2J_msc0YeTMIkN30LYl456-UhmriXN2aggJZUHw8-4y7bhtCZeeXM6Wi6B1Duh0HKh8JZ4vea4mLk7Zu1yc3oCBNvsANa3Bgp7zQSZB4_WXI1in_6Phc52A4Myt_E9HodzFgRog
-      Content-Length:
-      - '0'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '0'
-      Expires:
-      - "-1"
-      Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/0b374339-5ac4-4899-b11a-9a3c420ebf2d?monitor=true&api-version=2017-03-30
-      Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/0b374339-5ac4-4899-b11a-9a3c420ebf2d?api-version=2017-03-30
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - 0b374339-5ac4-4899-b11a-9a3c420ebf2d
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1176'
-      X-Ms-Correlation-Request-Id:
-      - 6ac9ad5d-f77f-43cc-a772-d751e9f3e2e7
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214317Z:6ac9ad5d-f77f-43cc-a772-d751e9f3e2e7
-      Date:
-      - Fri, 22 Sep 2017 21:43:16 GMT
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:43:17 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:24 GMT
 recorded_with: VCR 3.0.3

--- a/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_partType-1.yml
+++ b/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_partType-1.yml
@@ -17,6 +17,8 @@ http_interactions:
       - '186'
       Content-Type:
       - application/x-www-form-urlencoded
+      Host:
+      - login.microsoftonline.com
   response:
     status:
       code: 200
@@ -37,25 +39,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - def8d403-4f59-4754-ae4f-4363f3df0a00
+      - bb1fb887-77a2-491c-8421-ac7589920100
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAAABlDrqfEFlSaui6xnRjX5EDQ4x8Ke0WUTufcjKtoqrvq09B_EuuwcpqVfcZXNwP5ge2CObDYhbGp8r8ZdiDq36LCtEW-PBDieMr65GWFsStFCjdw0Bo7AZkXSnv3qVQnc83pGqq2BlOhHvp6YiVsJ69iaXLwtV407ZknJ34_kWVGgLvE9-3O1YFNL1LnS638EgAA;
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzA8WW-rEF8_VCXBe2JCLus22QbK1HT-KTh2BCqbRD1EiexGet6uqFmOmU2PNHsDI4ntXFugo5u4xDl6lOSlX38Fzlvw2ocUDBIHdtTNV8HvHK028hglK3JzHwe9D1PsU_MN817OdXDO73_tDo8kWNLRZIE5XXU5jtlawDP5uqfKogAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=004; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=008; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Fri, 22 Sep 2017 21:42:39 GMT
+      - Tue, 23 Jan 2018 20:06:55 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1506120160","not_before":"1506116260","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNjAsIm5iZiI6MTUwNjExNjI2MCwiZXhwIjoxNTA2MTIwMTYwLCJhaW8iOiJZMlZnWU5paE9LMDd2L1MyZGlDWHpkSkRPaXdUQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQTlUNDNsbFBWRWV1VDBOajg5OEtBQSIsInZlciI6IjEuMCJ9.m2q1UV9vV03MzAANTYje3G1TeuvrUD7j9xF9RFAZ5K8Zpn8tCFh_-CIuO8uYfW2iT7Dlf1wuo4SO_wd3QIEwibwUzO6Kvx8QfsYAguRT1SJ9c5wjNpPMn5fUsF9ekp2w8naEvHBnxZAaX_6in8ZrOt5lXh2Dye14W65OFYNHV6kHvbVIl70LTnkqkgQsPeKjuVfhFjBvYX6otE_QHiM7PH8IXaadkD4Hk7EIityoza6HM32SHGs2_TNlUKC3vNm_O1ovfa-3NxjyMH94QUIzn0pfoYTskhE3yyLLinP2mDW5sqNEBKrJMlJ7JAZNNMmAO9lIZxOfhOrN-WJuyVSuqg"}'
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1516741617","not_before":"1516737717","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3MTcsIm5iZiI6MTUxNjczNzcxNywiZXhwIjoxNTE2NzQxNjE3LCJhaW8iOiJZMk5nWUdCbFZFM242NXFhdkh0eDN4U2J5ZkVMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiaDdnZnU2SjNIRW1FSWF4MWlaSUJBQSIsInZlciI6IjEuMCJ9.PAWw9_8VQ4OiYbLMONchobMsu05eUq6JVzocHGf1zWEx8Yjp20nLBB_SS_rOq7r2aoZKYXAEeK2zfQqgo4RT2PijWZSJVwlFNAEJnVT2yvD0CXeWw4DdjjO2gvzovg76NN62OvN74xYYJL7BEVZlEiLpaAOssqydcZPxLxxJ-SfYAjxDw3ObwWE1j9iB7DC7DcNvsQhoIgkT1UuHjPxWyIUIQuYc5F_WQwZbdPu5qI722ZctZ9sBdYRCxZm0vdb1hAWpJ-Z3H8edOwBcLc5vvX0rngE6RaQQhbKiLN_yYDvwucdnfCpcQ-Flhh5DEutk-X-SxGY3E-TGpjv4fOPk9A"}'
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:39 GMT
+  recorded_at: Tue, 23 Jan 2018 20:06:57 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -72,7 +74,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNjAsIm5iZiI6MTUwNjExNjI2MCwiZXhwIjoxNTA2MTIwMTYwLCJhaW8iOiJZMlZnWU5paE9LMDd2L1MyZGlDWHpkSkRPaXdUQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQTlUNDNsbFBWRWV1VDBOajg5OEtBQSIsInZlciI6IjEuMCJ9.m2q1UV9vV03MzAANTYje3G1TeuvrUD7j9xF9RFAZ5K8Zpn8tCFh_-CIuO8uYfW2iT7Dlf1wuo4SO_wd3QIEwibwUzO6Kvx8QfsYAguRT1SJ9c5wjNpPMn5fUsF9ekp2w8naEvHBnxZAaX_6in8ZrOt5lXh2Dye14W65OFYNHV6kHvbVIl70LTnkqkgQsPeKjuVfhFjBvYX6otE_QHiM7PH8IXaadkD4Hk7EIityoza6HM32SHGs2_TNlUKC3vNm_O1ovfa-3NxjyMH94QUIzn0pfoYTskhE3yyLLinP2mDW5sqNEBKrJMlJ7JAZNNMmAO9lIZxOfhOrN-WJuyVSuqg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3MTcsIm5iZiI6MTUxNjczNzcxNywiZXhwIjoxNTE2NzQxNjE3LCJhaW8iOiJZMk5nWUdCbFZFM242NXFhdkh0eDN4U2J5ZkVMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiaDdnZnU2SjNIRW1FSWF4MWlaSUJBQSIsInZlciI6IjEuMCJ9.PAWw9_8VQ4OiYbLMONchobMsu05eUq6JVzocHGf1zWEx8Yjp20nLBB_SS_rOq7r2aoZKYXAEeK2zfQqgo4RT2PijWZSJVwlFNAEJnVT2yvD0CXeWw4DdjjO2gvzovg76NN62OvN74xYYJL7BEVZlEiLpaAOssqydcZPxLxxJ-SfYAjxDw3ObwWE1j9iB7DC7DcNvsQhoIgkT1UuHjPxWyIUIQuYc5F_WQwZbdPu5qI722ZctZ9sBdYRCxZm0vdb1hAWpJ-Z3H8edOwBcLc5vvX0rngE6RaQQhbKiLN_yYDvwucdnfCpcQ-Flhh5DEutk-X-SxGY3E-TGpjv4fOPk9A
+      Host:
+      - management.azure.com
   response:
     status:
       code: 200
@@ -93,21 +97,22 @@ http_interactions:
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
       - '14999'
       X-Ms-Request-Id:
-      - e375a0e9-5d78-4a9e-bf05-276e81aaf80d
+      - 2b3d7d6c-8f6e-4d15-9706-00e40937912f
       X-Ms-Correlation-Request-Id:
-      - e375a0e9-5d78-4a9e-bf05-276e81aaf80d
+      - 2b3d7d6c-8f6e-4d15-9706-00e40937912f
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214241Z:e375a0e9-5d78-4a9e-bf05-276e81aaf80d
+      - WESTUS:20180123T200658Z:2b3d7d6c-8f6e-4d15-9706-00e40937912f
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 22 Sep 2017 21:42:40 GMT
+      - Tue, 23 Jan 2018 20:06:57 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
-        Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
+      string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
+        Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
+        Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:40 GMT
+  recorded_at: Tue, 23 Jan 2018 20:06:58 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/azure_subscription_id/providers?api-version=2015-01-01
@@ -124,7 +129,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNjAsIm5iZiI6MTUwNjExNjI2MCwiZXhwIjoxNTA2MTIwMTYwLCJhaW8iOiJZMlZnWU5paE9LMDd2L1MyZGlDWHpkSkRPaXdUQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQTlUNDNsbFBWRWV1VDBOajg5OEtBQSIsInZlciI6IjEuMCJ9.m2q1UV9vV03MzAANTYje3G1TeuvrUD7j9xF9RFAZ5K8Zpn8tCFh_-CIuO8uYfW2iT7Dlf1wuo4SO_wd3QIEwibwUzO6Kvx8QfsYAguRT1SJ9c5wjNpPMn5fUsF9ekp2w8naEvHBnxZAaX_6in8ZrOt5lXh2Dye14W65OFYNHV6kHvbVIl70LTnkqkgQsPeKjuVfhFjBvYX6otE_QHiM7PH8IXaadkD4Hk7EIityoza6HM32SHGs2_TNlUKC3vNm_O1ovfa-3NxjyMH94QUIzn0pfoYTskhE3yyLLinP2mDW5sqNEBKrJMlJ7JAZNNMmAO9lIZxOfhOrN-WJuyVSuqg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3MTcsIm5iZiI6MTUxNjczNzcxNywiZXhwIjoxNTE2NzQxNjE3LCJhaW8iOiJZMk5nWUdCbFZFM242NXFhdkh0eDN4U2J5ZkVMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiaDdnZnU2SjNIRW1FSWF4MWlaSUJBQSIsInZlciI6IjEuMCJ9.PAWw9_8VQ4OiYbLMONchobMsu05eUq6JVzocHGf1zWEx8Yjp20nLBB_SS_rOq7r2aoZKYXAEeK2zfQqgo4RT2PijWZSJVwlFNAEJnVT2yvD0CXeWw4DdjjO2gvzovg76NN62OvN74xYYJL7BEVZlEiLpaAOssqydcZPxLxxJ-SfYAjxDw3ObwWE1j9iB7DC7DcNvsQhoIgkT1UuHjPxWyIUIQuYc5F_WQwZbdPu5qI722ZctZ9sBdYRCxZm0vdb1hAWpJ-Z3H8edOwBcLc5vvX0rngE6RaQQhbKiLN_yYDvwucdnfCpcQ-Flhh5DEutk-X-SxGY3E-TGpjv4fOPk9A
+      Host:
+      - management.azure.com
   response:
     status:
       code: 200
@@ -141,19 +148,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14910'
+      - '14866'
       X-Ms-Request-Id:
-      - 3149d3ca-4142-4c98-8971-3ddeac6facd4
+      - c9c6166f-cd8a-4c10-a6f8-6346838552ef
       X-Ms-Correlation-Request-Id:
-      - 3149d3ca-4142-4c98-8971-3ddeac6facd4
+      - c9c6166f-cd8a-4c10-a6f8-6346838552ef
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214242Z:3149d3ca-4142-4c98-8971-3ddeac6facd4
+      - WESTUS:20180123T200659Z:c9c6166f-cd8a-4c10-a6f8-6346838552ef
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 22 Sep 2017 21:42:41 GMT
+      - Tue, 23 Jan 2018 20:06:58 GMT
       Content-Length:
-      - '254785'
+      - '293551'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
@@ -176,7 +183,7 @@ http_interactions:
         Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
         Central US","North Central US","Japan East","Japan West","Brazil South","Central
         India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
+        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-04-19","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-04-19","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-04-19","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-04-19","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","North Central
         US","South Central US","West Central US","West US","West US 2","Canada Central","Canada
         East","North Europe","West Europe","UK South","UK West","East Asia","Southeast
@@ -184,20 +191,26 @@ http_interactions:
         India","South India","West India"],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"validateServiceName","locations":[],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"checkServiceNameAvailability","locations":[],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"reportFeedback","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"checkFeedbackRequired","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Automation","namespace":"Microsoft.Automation","authorizations":[{"applicationId":"fc75330b-179d-49af-87dd-3b1acf6827fa","roleDefinitionId":"95fd5de3-d071-4362-92bf-cf341c1de832"}],"resourceTypes":[{"resourceType":"automationAccounts","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
         South","UK South","West Central US","North Europe","Canada Central","Australia
-        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/runbooks","locations":["Japan
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/runbooks","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
         South","UK South","West Central US","North Europe","Canada Central","Australia
-        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/configurations","locations":["Japan
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/configurations","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","North
-        Central US","Brazil South","UK South","West Central US","Central India","Australia
-        Southeast","Canada Central","North Europe"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/webhooks","locations":["Japan
+        Central US","Korea Central","East US","West US 2","Brazil South","UK South","West
+        Central US","Central India","Australia Southeast","Canada Central","North
+        Europe"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/webhooks","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
         South","UK South","West Central US","North Europe","Canada Central","Australia
-        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"operations","locations":["South
-        Central US"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/softwareUpdateConfigurations","locations":["Japan
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"operations","locations":["South
+        Central US"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/softwareUpdateConfigurations","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
         South","UK South","West Central US","North Europe","Canada Central","Australia
-        Southeast","Central India"],"apiVersions":["2017-05-15-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Backup","namespace":"Microsoft.Backup","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"BackupVault","locations":["West
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview"]},{"resourceType":"automationAccounts/jobs","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
+        South","UK South","West Central US","North Europe","Canada Central","Australia
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureActiveDirectory","namespace":"Microsoft.AzureActiveDirectory","resourceTypes":[{"resourceType":"b2cDirectories","locations":["Global","United
+        States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]},{"resourceType":"operations","locations":["Global","United
+        States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]}],"registrationState":"Unregistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Backup","namespace":"Microsoft.Backup","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"BackupVault","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
@@ -206,22 +219,22 @@ http_interactions:
         Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
         West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
         East","South India","Central India","Canada Central","Canada East","UK South","UK
-        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01","2015-07-01","2014-05-01-privatepreview"]},{"resourceType":"operations","locations":["West
+        West","West Central US","West US 2"],"apiVersions":["2017-09-01","2017-05-01","2017-01-01","2015-12-01","2015-09-01","2015-07-01","2014-05-01-privatepreview"]},{"resourceType":"operations","locations":["West
         Europe","East US","East US 2","West US","North Central US","Brazil South","North
         Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
         West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
         East","South India","Central India","Canada Central","Canada East","UK South","UK
-        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations/quotas","locations":["West
+        West","West Central US","West US 2"],"apiVersions":["2017-09-01","2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01","2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations/quotas","locations":["West
         Europe","East US","East US 2","West US","North Central US","Brazil South","North
         Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
         West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
         East","South India","Central India","Canada Central","Canada East","UK South","UK
-        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]}],"registrationState":"Unregistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicCompute","namespace":"Microsoft.ClassicCompute","resourceTypes":[{"resourceType":"domainNames","locations":["East
+        West","West Central US","West US 2"],"apiVersions":["2017-09-01","2017-05-01","2017-01-01","2015-12-01","2015-09-01"]}],"registrationState":"Unregistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicCompute","namespace":"Microsoft.ClassicCompute","resourceTypes":[{"resourceType":"domainNames","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
@@ -256,7 +269,7 @@ http_interactions:
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -296,92 +309,92 @@ http_interactions:
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30"]},{"resourceType":"locations/usages","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations/usages","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
+        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
@@ -411,76 +424,138 @@ http_interactions:
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
+        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
         US","East US","South Central US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
         Central","Central US","East US 2","North Central US","West Central US","West
-        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/webhooks","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/ping","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/getCallbackConfig","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/listEvents","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"locations","locations":["South
-        Central US","East US","West US","Central US","East US 2","North Central US","West
-        Central US","West US 2","Brazil South","Canada East","Canada Central","West
-        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
-        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"locations/operationResults","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/GetCredentials","locations":["West
+        US 2"],"apiVersions":["2017-10-01","2017-03-01"]},{"resourceType":"registries/replications","locations":["South
+        Central US","West Central US","East US","West Europe","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/webhooks","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/webhooks/ping","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/webhooks/getCallbackConfig","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/webhooks/listEvents","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"locations/operationResults","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/GetCredentials","locations":["West
         US","East US","South Central US","West Europe"],"apiVersions":["2016-06-27-preview"]},{"resourceType":"registries/listCredentials","locations":["South
         Central US","East US","West US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
         Central","Central US","East US 2","North Central US","West Central US","West
-        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/regenerateCredential","locations":["South
+        US 2"],"apiVersions":["2017-10-01","2017-03-01"]},{"resourceType":"registries/regenerateCredential","locations":["South
         Central US","West US","East US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
         Central","Central US","East US 2","North Central US","West Central US","West
-        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/listUsages","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/regenerateCredentials","locations":["West
+        US 2"],"apiVersions":["2017-10-01","2017-03-01"]},{"resourceType":"registries/listUsages","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/regenerateCredentials","locations":["West
         US","East US","South Central US","West Europe"],"apiVersions":["2016-06-27-preview"]},{"resourceType":"checkNameAvailability","locations":["South
         Central US","East US","West US","Central US","East US 2","North Central US","West
         Central US","West US 2","Brazil South","Canada East","Canada Central","West
         Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
-        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview","2017-03-01","2016-06-27-preview"]},{"resourceType":"operations","locations":["South
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-10-01","2017-06-01-preview","2017-03-01","2016-06-27-preview"]},{"resourceType":"operations","locations":["South
         Central US","East US","West US","Central US","East US 2","North Central US","West
         Central US","West US 2","Brazil South","Canada East","Canada Central","West
         Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
-        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview","2017-03-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerService","namespace":"Microsoft.ContainerService","authorization":{"applicationId":"7319c514-987d-4e9b-ac3d-d38c4f427f4c","roleDefinitionId":"1b4a0c7f-2217-416f-acfa-cf73452fdc1c"},"resourceTypes":[{"resourceType":"containerServices","locations":["Japan
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-10-01","2017-06-01-preview","2017-03-01"]},{"resourceType":"locations","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-10-01","2017-06-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerService","namespace":"Microsoft.ContainerService","authorization":{"applicationId":"7319c514-987d-4e9b-ac3d-d38c4f427f4c","roleDefinitionId":"1b4a0c7f-2217-416f-acfa-cf73452fdc1c","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"containerServices","locations":["Japan
         East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
         Central US","West US 2","South India","Central India","West India","Canada
-        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
+        East","Canada Central","Korea South","Korea Central"],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"managedClusters","locations":["East
+        US","West Europe","Central US","Canada Central","Canada East"],"apiVersions":["2017-08-31"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
         East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
         Central US","West US 2","South India","Central India","West India","Canada
-        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DevTestLab","namespace":"Microsoft.DevTestLab","authorization":{"applicationId":"1a14be2a-e903-4cec-99cf-b2e209259a0f","roleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525"},"resourceTypes":[{"resourceType":"labs","locations":["West
+        East","Canada Central","Korea South","Korea Central"],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/orchestrators","locations":["UK
+        West","West US 2","East US","West Europe","Central US"],"apiVersions":["2017-09-30"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DevTestLab","namespace":"Microsoft.DevTestLab","authorization":{"applicationId":"1a14be2a-e903-4cec-99cf-b2e209259a0f","roleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525","managedByRoleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525"},"resourceTypes":[{"resourceType":"labs","locations":["West
         Central US","Japan East","West US","Australia Southeast","Canada Central","Central
         India","Central US","East Asia","Korea Central","North Europe","South Central
-        US","UK West","Australia East","Brazil South","Canada East","East US","East
-        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        US","UK West","West India","Australia East","Brazil South","Canada East","East
+        US","East US 2","Japan West","Korea South","North Central US","South India","Southeast
         Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"schedules","locations":["West
         Central US","Japan East","West US","Australia Southeast","Canada Central","Central
         India","Central US","East Asia","Korea Central","North Europe","South Central
-        US","UK West","Australia East","Brazil South","Canada East","East US","East
-        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        US","UK West","West India","Australia East","Brazil South","Canada East","East
+        US","East US 2","Japan West","Korea South","North Central US","South India","Southeast
         Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"labs/virtualMachines","locations":["West
         Central US","Japan East","West US","Australia Southeast","Canada Central","Central
         India","Central US","East Asia","Korea Central","North Europe","South Central
-        US","UK West","Australia East","Brazil South","Canada East","East US","East
-        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        US","UK West","West India","Australia East","Brazil South","Canada East","East
+        US","East US 2","Japan West","Korea South","North Central US","South India","Southeast
         Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"labs/serviceRunners","locations":["Central
         US","East US 2","South Central US"],"apiVersions":["2017-04-26-preview","2016-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"locations/operations","locations":["West
         Central US","Japan East","West US","Australia Southeast","Canada Central","Central
         India","Central US","East Asia","Korea Central","North Europe","South Central
-        US","UK West","Australia East","Brazil South","Canada East","East US","East
-        US 2","Japan West","Korea South","North Central US","South India","Southeast
-        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"}],"resourceTypes":[{"resourceType":"components","locations":["East
-        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
-        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01","2014-04-01"]},{"resourceType":"queries","locations":["East
-        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
+        US","UK West","West India","Australia East","Brazil South","Canada East","East
+        US","East US 2","Japan West","Korea South","North Central US","South India","Southeast
+        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","authorizations":[{"applicationId":"57c0fc58-a83a-41d0-8ae9-08952659bdfd","roleDefinitionId":"FFFD5CF5-FFD3-4B24-B0E2-0715ADD4C282"}],"resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"databaseAccountNames","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"operationResults","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"},{"applicationId":"f5c26e74-f226-4ae8-85f0-b4af0080ac9e","roleDefinitionId":"529d7ae6-e892-4d43-809d-8547aeb90643"}],"resourceTypes":[{"resourceType":"components","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2015-05-01","2014-08-01","2014-04-01"]},{"resourceType":"queries","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"components/pricingPlans","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"migrateToNewPricingModel","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"rollbackToLegacyPricingModel","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"listMigrationdate","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
@@ -516,7 +591,7 @@ http_interactions:
         West","North Central US","South Central US","East US 2","Canada East","Canada
         Central","Central US","Australia East","Australia Southeast","Brazil South","South
         India","Central India","West India","North Europe","West US 2","West Central
-        US","Korea South","Korea Central","UK South","UK West","Global"],"apiVersions":["2017-05-01-preview","2016-03-01","2015-07-01"]},{"resourceType":"logDefinitions","locations":["West
+        US","Korea South","Korea Central","UK South","UK West","Global"],"apiVersions":["2017-09-01-preview","2017-05-01-preview","2016-03-01","2015-07-01"]},{"resourceType":"logDefinitions","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
@@ -526,7 +601,7 @@ http_interactions:
         West","North Central US","South Central US","East US 2","Canada East","Canada
         Central","Central US","Australia East","Australia Southeast","Brazil South","South
         India","Central India","West India","North Europe","West US 2","West Central
-        US","Korea South","Korea Central","UK South","UK West"],"apiVersions":["2017-05-01-preview","2016-09-01","2016-06-01"]},{"resourceType":"actiongroups","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]},{"resourceType":"activityLogAlerts","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.KeyVault","namespace":"Microsoft.KeyVault","resourceTypes":[{"resourceType":"vaults","locations":["North
+        US","Korea South","Korea Central","UK South","UK West"],"apiVersions":["2017-09-01-preview","2017-05-01-preview","2016-09-01","2016-06-01"]},{"resourceType":"actiongroups","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]},{"resourceType":"activityLogAlerts","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.KeyVault","namespace":"Microsoft.KeyVault","resourceTypes":[{"resourceType":"vaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
@@ -556,126 +631,153 @@ http_interactions:
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorizations":[{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},{"applicationId":"7c33bfcb-8d33-48d6-8e60-dc6404003489","roleDefinitionId":"ad6261e4-fa9a-4642-aa5f-104f1b67e9e3"},{"applicationId":"1e3e4475-288f-4018-a376-df66fd7fac5f","roleDefinitionId":"1d538b69-3d87-4e56-8ff8-25786fd48261"},{"applicationId":"a0be0c72-870e-46f0-9c49-c98333a996f7","roleDefinitionId":"7ce22727-ffce-45a9-930c-ddb2e56fa131"}],"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","West Central US"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"operations","locations":["South
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations","locations":["South
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operations","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"commitmentPlans","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"Registering"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorizations":[{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},{"applicationId":"7c33bfcb-8d33-48d6-8e60-dc6404003489","roleDefinitionId":"ad6261e4-fa9a-4642-aa5f-104f1b67e9e3"},{"applicationId":"1e3e4475-288f-4018-a376-df66fd7fac5f","roleDefinitionId":"1d538b69-3d87-4e56-8ff8-25786fd48261"},{"applicationId":"a0be0c72-870e-46f0-9c49-c98333a996f7","roleDefinitionId":"7ce22727-ffce-45a9-930c-ddb2e56fa131"}],"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
-        Central US"],"apiVersions":["2017-09-01"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
-        East","UK South","Central India","Canada Central"],"apiVersions":["2017-04-26-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"]},{"resourceType":"workspaces/dataSources","locations":["East
+        East","UK South","Central India","Canada Central"],"apiVersions":["2017-04-26-preview","2017-03-15-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"]},{"resourceType":"workspaces/query","locations":["West
+        Central US","Australia Southeast","West Europe","East US","Southeast Asia","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2017-10-01"]},{"resourceType":"workspaces/dataSources","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
         East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"storageInsightConfigs","locations":[],"apiVersions":["2014-10-10"]},{"resourceType":"workspaces/linkedServices","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
         East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"linkTargets","locations":["East
         US"],"apiVersions":["2015-03-20"]},{"resourceType":"operations","locations":[],"apiVersions":["2014-11-10"]},{"resourceType":"devices","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationsManagement","namespace":"Microsoft.OperationsManagement","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"aa249101-6816-4966-aafa-08175d795f14"},"resourceTypes":[{"resourceType":"solutions","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
-        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Portal","namespace":"Microsoft.Portal","resourceTypes":[{"resourceType":"dashboards","locations":["Central
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"managementconfigurations","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"managementassociations","locations":[],"apiVersions":["2015-11-01-preview"]},{"resourceType":"views","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2017-08-21-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Portal","namespace":"Microsoft.Portal","resourceTypes":[{"resourceType":"dashboards","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
@@ -687,9 +789,9 @@ http_interactions:
         East","West India","South India","Central India","Canada Central","Canada
         East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"consoles","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/consoles","locations":["West
         US","East US","Central India","North Europe","West Europe","South Central
-        US","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
+        US","Southeast Asia","East US 2","Central US"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
         US","East US","Central India","North Europe","West Europe","South Central
-        US","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
+        US","Southeast Asia","East US 2","Central US"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
@@ -710,7 +812,17 @@ http_interactions:
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ResourceHealth","namespace":"Microsoft.ResourceHealth","authorization":{"applicationId":"8bdebf23-c0fe-4187-a378-717ad86f6a53","roleDefinitionId":"cc026344-c8b1-4561-83ba-59eba84b27cc"},"resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2017-07-01","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"notifications","locations":["Australia
+        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]},{"resourceType":"locations/backupValidateFeatures","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-07-01"]},{"resourceType":"locations/backupPreValidateProtection","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-07-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ResourceHealth","namespace":"Microsoft.ResourceHealth","authorization":{"applicationId":"8bdebf23-c0fe-4187-a378-717ad86f6a53","roleDefinitionId":"cc026344-c8b1-4561-83ba-59eba84b27cc"},"resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2017-07-01","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"notifications","locations":["Australia
         Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Security","namespace":"Microsoft.Security","authorization":{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatuses","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/virtualMachines","locations":["Central
@@ -743,10 +855,14 @@ http_interactions:
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securitySolutionsReferenceData","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/securitySolutionsReferenceData","locations":["Central
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"jitNetworkAccessPolicies","locations":["Central
-        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/jitNetworkAccessPolicies","locations":["Central
-        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations","locations":["Central
+        US","East US","North Europe","West Europe","UK South","UK West","West Central
+        US","West US 2"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/jitNetworkAccessPolicies","locations":["Central
+        US","East US","North Europe","West Europe","UK South","UK West","West Central
+        US","West US 2"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatusesSummaries","locations":["Central
-        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/alerts","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"applicationWhitelistings","locations":["Central
+        US","East US","West Central US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/applicationWhitelistings","locations":["Central
+        US","West Central US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/alerts","locations":["Central
         US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/tasks","locations":["Central
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"externalSecuritySolutions","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/externalSecuritySolutions","locations":["Central
@@ -769,7 +885,17 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/databaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/databaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -814,7 +940,7 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01","2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -829,7 +955,7 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -859,12 +985,17 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/geoBackupPolicies","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -879,12 +1010,12 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/firewallrules","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/backupLongTermRetentionPolicies","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -999,6 +1130,16 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
         US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
@@ -1034,7 +1175,22 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -1144,7 +1300,47 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -1159,7 +1355,17 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/administratorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -1179,52 +1385,52 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorization":{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorizations":[{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},{"applicationId":"e406a681-f3d4-42a8-90b6-c2b029497af1"}],"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
         US","West US","West Europe","North Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","South India","Central
@@ -1234,7 +1440,19 @@ http_interactions:
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Web","namespace":"Microsoft.Web","authorization":{"applicationId":"abfa0a7c-a6b6-4736-8310-5855508787cd","roleDefinitionId":"f47ed98b-b063-4a5b-9e10-4b9b44fa7735"},"resourceTypes":[{"resourceType":"sites/extensions","locations":["South
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/project","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/extension","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"checkNameAvailability","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Web","namespace":"Microsoft.Web","authorization":{"applicationId":"abfa0a7c-a6b6-4736-8310-5855508787cd","roleDefinitionId":"f47ed98b-b063-4a5b-9e10-4b9b44fa7735"},"resourceTypes":[{"resourceType":"sites/extensions","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
         South","West US","East US","Japan West","Japan East","East Asia","East US
         2","North Central US","Central US","Brazil South","Australia East","Australia
@@ -1339,7 +1557,7 @@ http_interactions:
         South","West US","East US","Japan West","Japan East","East Asia","East US
         2","North Central US","Central US","Brazil South","Australia East","Australia
         Southeast","West India","Central India","South India","Canada Central","Canada
-        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms/workers","locations":["South
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms/workers","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
         South","West US","East US","Japan West","Japan East","East Asia","East US
         2","North Central US","Central US","Brazil South","Australia East","Australia
@@ -1394,7 +1612,17 @@ http_interactions:
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","West US 2","West Central US","Canada Central","Canada
-        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/managedApis","locations":["North
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/listWsdlInterfaces","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/extractApiDefinitionFromWsdl","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/managedApis","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
@@ -1445,8 +1673,11 @@ http_interactions:
         US","North Europe","Japan West","Japan East","East Asia","West Europe","East
         US","Southeast Asia","Central US"],"apiVersions":["2016-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Lombiq.DotNest","namespace":"Lombiq.DotNest","resourceTypes":[{"resourceType":"sites","locations":["East
         US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Mailjet.Email","namespace":"Mailjet.Email","resourceTypes":[{"resourceType":"services","locations":["West
-        US"],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
-        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
+        US","West Europe"],"apiVersions":["2017-10-01","2017-02-03"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-10-01","2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-10-01","2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]},{"resourceType":"diagnosticSettings","locations":[],"apiVersions":["2017-04-01"]},{"resourceType":"diagnosticSettingsCategories","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Addons","namespace":"Microsoft.Addons","authorization":{"applicationId":"24d3987b-be4a-48e0-a3e7-11c186f39e41","roleDefinitionId":"8004BAAB-A4CB-4981-8571-F7E44D039D93"},"resourceTypes":[{"resourceType":"supportProviders","locations":["West
+        Central US","South Central US","East US","West Europe"],"apiVersions":["2017-05-15"]},{"resourceType":"operations","locations":["West
+        Central US","South Central US","East US","West Europe"],"apiVersions":["2017-05-15"]},{"resourceType":"operationResults","locations":["West
+        Central US","South Central US","East US","West Europe"],"apiVersions":["2017-05-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"addsservices","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"configuration","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"operations","locations":["West
@@ -1456,51 +1687,45 @@ http_interactions:
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"servicehealthmetrics","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"logs","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"anonymousapiusers","locations":["West
-        US"],"apiVersions":["2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AnalysisServices","namespace":"Microsoft.AnalysisServices","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"servers","locations":["West
+        US"],"apiVersions":["2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AlertsManagement","namespace":"Microsoft.AlertsManagement","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-11-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AnalysisServices","namespace":"Microsoft.AnalysisServices","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"servers","locations":["West
         US","North Europe","South Central US","West Europe","West Central US","Southeast
         Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
-        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/checkNameAvailability","locations":["West
+        Southeast","Japan East","UK South","West India","West US 2","East US"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"locations/checkNameAvailability","locations":["West
         US","North Europe","South Central US","West Europe","West Central US","Southeast
         Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
-        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationresults","locations":["West
+        Southeast","Japan East","UK South","West India","West US 2","East US"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationresults","locations":["West
         US","North Europe","South Central US","West Europe","West Central US","Southeast
         Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
-        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationstatuses","locations":["West
+        Southeast","Japan East","UK South","West India","West US 2","East US"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationstatuses","locations":["West
         US","North Europe","South Central US","West Europe","West Central US","Southeast
         Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
-        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"operations","locations":["East
-        US 2","West Central US"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AppService","namespace":"Microsoft.AppService","authorization":{"applicationId":"dee7ba80-6a55-4f3b-a86c-746a9231ae49","roleDefinitionId":"6715d172-49c4-46f6-bb21-60512a8689dc"},"resourceTypes":[{"resourceType":"apiapps","locations":["East
-        US","West US","South Central US","North Europe","East Asia","Japan East","West
-        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
-        South","East US 2","Australia Southeast","Australia East","West India","South
-        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"appIdentities","locations":["East
-        US","West US","South Central US","North Europe","East Asia","Japan East","West
-        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
-        South","East US 2","Australia Southeast","Australia East","West India","South
-        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"gateways","locations":["East
-        US","West US","South Central US","North Europe","East Asia","Japan East","West
-        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
-        South","East US 2","Australia Southeast","Australia East","West India","South
-        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"deploymenttemplates","locations":[],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Authorization","namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"roleDefinitions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"classicAdministrators","locations":[],"apiVersions":["2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"permissions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"locks","locations":[],"apiVersions":["2017-04-01","2016-09-01","2015-06-01","2015-05-01-preview","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-01-01","2014-10-01-preview","2014-06-01"]},{"resourceType":"policyDefinitions","locations":[],"apiVersions":["2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"policySetDefinitions","locations":[],"apiVersions":["2017-06-01-preview"]},{"resourceType":"policyAssignments","locations":[],"apiVersions":["2017-06-01-preview","2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"providerOperations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01-preview","2015-07-01"]},{"resourceType":"elevateAccess","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureActiveDirectory","namespace":"Microsoft.AzureActiveDirectory","resourceTypes":[{"resourceType":"b2cDirectories","locations":["Global","United
-        States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureStack","namespace":"Microsoft.AzureStack","resourceTypes":[{"resourceType":"operations","locations":["Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations","locations":["West
+        Southeast","Japan East","UK South","West India","West US 2","East US"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"operations","locations":["East
+        US 2","West Central US","West US 2"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Authorization","namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[],"apiVersions":["2017-10-01-preview","2017-09-01","2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"roleDefinitions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"classicAdministrators","locations":[],"apiVersions":["2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"permissions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"locks","locations":[],"apiVersions":["2017-04-01","2016-09-01","2015-06-01","2015-05-01-preview","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-01-01","2014-10-01-preview","2014-06-01"]},{"resourceType":"policyDefinitions","locations":[],"apiVersions":["2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"policySetDefinitions","locations":[],"apiVersions":["2017-06-01-preview"]},{"resourceType":"policyAssignments","locations":[],"apiVersions":["2017-06-01-preview","2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"providerOperations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01-preview","2015-07-01"]},{"resourceType":"elevateAccess","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"checkAccess","locations":[],"apiVersions":["2017-10-01-preview","2017-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureStack","namespace":"Microsoft.AzureStack","resourceTypes":[{"resourceType":"operations","locations":["Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations","locations":["West
         Central US","Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations/products","locations":["West
-        Central US","Global"],"apiVersions":["2017-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Billing","namespace":"Microsoft.Billing","resourceTypes":[{"resourceType":"BillingPeriods","locations":["Central
+        Central US","Global"],"apiVersions":["2017-06-01","2016-01-01"]},{"resourceType":"registrations/customerSubscriptions","locations":["West
+        Central US","Global"],"apiVersions":["2017-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BatchAI","namespace":"Microsoft.BatchAI","authorization":{"applicationId":"9fcb3732-5f52-4135-8c08-9d4bbaf203ea","roleDefinitionId":"703B89C7-CE2C-431B-BDD8-FA34E39AF696","managedByRoleDefinitionId":"90B8E153-EBFF-4073-A95F-4DAD56B14C78"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"jobs","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"fileservers","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"operations","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01-preview"]},{"resourceType":"locations/operationresults","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Billing","namespace":"Microsoft.Billing","resourceTypes":[{"resourceType":"BillingPeriods","locations":["Central
         US"],"apiVersions":["2017-04-24-preview"]},{"resourceType":"Invoices","locations":["Central
         US"],"apiVersions":["2017-04-24-preview","2017-02-27-preview"]},{"resourceType":"operations","locations":["Central
         US"],"apiVersions":["2017-04-24-preview","2017-02-27-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BingMaps","namespace":"Microsoft.BingMaps","resourceTypes":[{"resourceType":"mapApis","locations":["West
         US"],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-18","2015-07-02"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BizTalkServices","namespace":"Microsoft.BizTalkServices","resourceTypes":[{"resourceType":"BizTalk","locations":["East
         US","West US","North Europe","West Europe","Southeast Asia","East Asia","North
-        Central US","Japan West","Japan East","South Central US"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Cache","namespace":"Microsoft.Cache","authorization":{"applicationId":"96231a05-34ce-4eb4-aa6a-70759cbb5e83","roleDefinitionId":"4f731528-ba85-45c7-acfb-cd0a9b3cf31b"},"resourceTypes":[{"resourceType":"Redis","locations":["North
+        Central US","Japan West","Japan East","South Central US"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BotService","namespace":"Microsoft.BotService","resourceTypes":[{"resourceType":"botServices","locations":["Global"],"apiVersions":["2017-12-01"]},{"resourceType":"checkNameAvailability","locations":["Global"],"apiVersions":["2017-12-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Cache","namespace":"Microsoft.Cache","authorization":{"applicationId":"96231a05-34ce-4eb4-aa6a-70759cbb5e83","roleDefinitionId":"4f731528-ba85-45c7-acfb-cd0a9b3cf31b"},"resourceTypes":[{"resourceType":"Redis","locations":["North
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","Canada Central","Canada East","UK South","UK West","West US 2","West
-        Central US","South India","Korea Central","Korea South"],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","South India","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","South India","Canada Central","Canada East","UK South","UK West","West
-        US 2","West Central US","Korea Central","Korea South"],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01"]},{"resourceType":"Redis/metricDefinitions","locations":["North
+        US 2","West Central US","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01"]},{"resourceType":"Redis/metricDefinitions","locations":["North
         Central US","South Central US","East US","East US 2","West US","Central US","East
         Asia","Southeast Asia","North Europe","West Europe","Japan East","Japan West","Brazil
         South","Australia Southeast","Australia East","Central India","West India","South
@@ -1514,59 +1739,59 @@ http_interactions:
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/origins","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/origins","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/customdomains","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/customdomains","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/originresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/originresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/customdomainresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/customdomainresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkResourceUsage","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkResourceUsage","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02"]},{"resourceType":"validateProbe","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02"]},{"resourceType":"validateProbe","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02"]},{"resourceType":"operations","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02"]},{"resourceType":"operations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"edgenodes","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"edgenodes","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CertificateRegistration","namespace":"Microsoft.CertificateRegistration","authorization":{"applicationId":"f3c21649-0979-4721-ac85-b0216b2cf413","roleDefinitionId":"933fba7e-2ed3-4da8-973d-8bd8298a9b40"},"resourceTypes":[{"resourceType":"certificateOrders","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"certificateOrders/certificates","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"validateCertificateRegistrationInformation","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicSubscription","namespace":"Microsoft.ClassicSubscription","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicInfrastructureMigrate","namespace":"Microsoft.ClassicInfrastructureMigrate","authorization":{"applicationId":"5e5abe2b-83cd-4786-826a-a05653ebb103","roleDefinitionId":"766c4d9b-ef83-4f73-8352-1450a506a69b"},"resourceTypes":[{"resourceType":"classicInfrastructureResources","locations":["East
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CertificateRegistration","namespace":"Microsoft.CertificateRegistration","authorization":{"applicationId":"f3c21649-0979-4721-ac85-b0216b2cf413","roleDefinitionId":"933fba7e-2ed3-4da8-973d-8bd8298a9b40"},"resourceTypes":[{"resourceType":"certificateOrders","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"certificateOrders/certificates","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"validateCertificateRegistrationInformation","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicSubscription","namespace":"Microsoft.ClassicSubscription","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-09-01","2017-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicInfrastructureMigrate","namespace":"Microsoft.ClassicInfrastructureMigrate","authorization":{"applicationId":"5e5abe2b-83cd-4786-826a-a05653ebb103","roleDefinitionId":"766c4d9b-ef83-4f73-8352-1450a506a69b"},"resourceTypes":[{"resourceType":"classicInfrastructureResources","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
         Central US","Central US","North Europe","West Europe","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","West
@@ -1584,8 +1809,9 @@ http_interactions:
         Asia","East Asia","West Central US","South Central US","East US","East US
         2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/updateAccountsCreationSettings","locations":["West
         US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/accountsCreationSettings","locations":["West
-        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2016-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Commerce","namespace":"Microsoft.Commerce","resourceTypes":[{"resourceType":"UsageAggregates","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]},{"resourceType":"RateCard","locations":[],"apiVersions":["2016-08-31-preview","2015-06-01-preview","2015-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Consumption","namespace":"Microsoft.Consumption","resourceTypes":[{"resourceType":"reservationsummaries","locations":[],"apiVersions":["2017-01-30"]},{"resourceType":"reservationdetails","locations":[],"apiVersions":["2017-01-30"]},{"resourceType":"UsageDetails","locations":[],"apiVersions":["2017-06-30-preview","2017-04-24-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-30-preview","2017-04-24-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","resourceTypes":[{"resourceType":"containerGroups","locations":["West
-        US","East US","West Europe"],"apiVersions":["2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
+        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2016-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Commerce","namespace":"Microsoft.Commerce","resourceTypes":[{"resourceType":"UsageAggregates","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]},{"resourceType":"RateCard","locations":[],"apiVersions":["2016-08-31-preview","2015-06-01-preview","2015-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Consumption","namespace":"Microsoft.Consumption","resourceTypes":[{"resourceType":"ReservationSummaries","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationTransactions","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"Balances","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"Pricesheets","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationDetails","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"Budgets","locations":[],"apiVersions":["2017-12-30-preview"]},{"resourceType":"Terms","locations":[],"apiVersions":["2017-12-30-preview"]},{"resourceType":"UsageDetails","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview","2017-04-24-preview"]},{"resourceType":"Operations","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview","2017-04-24-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","resourceTypes":[{"resourceType":"containerGroups","locations":["West
+        US","East US","West Europe","Southeast Asia"],"apiVersions":["2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US","East US","West Europe","Southeast Asia"],"apiVersions":["2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
         US"],"apiVersions":["2016-04-08"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CustomerInsights","namespace":"Microsoft.CustomerInsights","authorization":{"applicationId":"38c77d00-5fcb-4cce-9d93-af4738258e3c","roleDefinitionId":"E006F9C7-F333-477C-8AD6-1F3A9FE87F55"},"resourceTypes":[{"resourceType":"hubs","locations":["East
         US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/profiles","locations":["East
         US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/interactions","locations":["East
@@ -1608,8 +1834,8 @@ http_interactions:
         US","West US","Australia East","West Europe","North Europe","Southeast Asia","West
         Central US"],"apiVersions":["2016-03-30","2015-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataFactory","namespace":"Microsoft.DataFactory","resourceTypes":[{"resourceType":"dataFactories","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview","2014-04-01"]},{"resourceType":"factories","locations":["East
-        US","East US 2"],"apiVersions":["2017-09-01-preview","2017-03-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
-        US","East US 2"],"apiVersions":["2017-09-01-preview","2017-03-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
+        US","East US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
+        US","East US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
         Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"dataFactories/metricDefinitions","locations":["North
         Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"checkDataFactoryNameAvailability","locations":[],"apiVersions":["2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"checkAzureDataFactoryNameAvailability","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"dataFactorySchema","locations":["West
@@ -1621,69 +1847,71 @@ http_interactions:
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers/listSasTokens","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeStore","namespace":"Microsoft.DataLakeStore","authorization":{"applicationId":"e9f49c6b-5ce5-44c8-925d-015017e9f7ad","roleDefinitionId":"17eb9cca-f08a-4499-b2d3-852d175f614f"},"resourceTypes":[{"resourceType":"accounts","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/firewallRules","locations":["East
-        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","resourceTypes":[{"resourceType":"operations","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforPostgreSQL","namespace":"Microsoft.DBforPostgreSQL","resourceTypes":[{"resourceType":"operations","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"checkProvisioningServiceNameAvailability","locations":[],"apiVersions":["2017-08-21-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataMigration","namespace":"Microsoft.DataMigration","authorization":{"applicationId":"a4bad4aa-bf02-4631-9f78-a64ffdba8150","roleDefinitionId":"b831a21d-db98-4760-89cb-bef871952df1","managedByRoleDefinitionId":"6256fb55-9e59-4018-a9e1-76b11c0a4c89"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services/projects","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationStatuses","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforPostgreSQL","namespace":"Microsoft.DBforPostgreSQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"checkProvisioningServiceNameAvailability","locations":[],"apiVersions":["2017-11-15","2017-08-21-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
         US","North Europe","East Asia","East US","West Europe","Southeast Asia","Japan
         East","Japan West","Australia East","Australia Southeast","West US 2","West
         Central US","East US 2","Central US","UK South","UK West","South India","Central
-        India","Canada Central","Canada East"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"ProvisioningServices","locations":["East
-        US","West Europe","Southeast Asia"],"apiVersions":["2017-08-21-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
-        East","Australia Southeast","Canada Central","Canada East","Central India","Central
-        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
-        US","North Europe","South Central US","South India","Southeast Asia","West
-        Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"databaseAccountNames","locations":["Australia
-        East","Australia Southeast","Canada Central","Canada East","Central India","Central
-        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
-        US","North Europe","South Central US","South India","Southeast Asia","West
-        Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"operations","locations":["Australia
-        East","Australia Southeast","Canada Central","Canada East","Central India","Central
-        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
-        US","North Europe","South Central US","South India","Southeast Asia","West
-        Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DomainRegistration","namespace":"Microsoft.DomainRegistration","authorization":{"applicationId":"ea2f600a-4980-45b7-89bf-d34da487bda1","roleDefinitionId":"54d7f2e3-5040-48a7-ae90-eebf629cfa0b"},"resourceTypes":[{"resourceType":"domains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"domains/domainOwnershipIdentifiers","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"topLevelDomains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"checkDomainAvailability","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"listDomainRecommendations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"validateDomainRegistrationInformation","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"generateSsoRequest","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DynamicsLcs","namespace":"Microsoft.DynamicsLcs","resourceTypes":[{"resourceType":"lcsprojects","locations":["Brazil
+        India","Canada Central","Canada East","Brazil South","South Central US"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs/eventGridFilters","locations":["West
+        US","East US","West US 2","West Central US","East US 2","Central US"],"apiVersions":["2018-01-15-preview"]},{"resourceType":"ProvisioningServices","locations":["East
+        US","West US","West Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2017-11-15","2017-08-21-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DomainRegistration","namespace":"Microsoft.DomainRegistration","authorization":{"applicationId":"ea2f600a-4980-45b7-89bf-d34da487bda1","roleDefinitionId":"54d7f2e3-5040-48a7-ae90-eebf629cfa0b"},"resourceTypes":[{"resourceType":"domains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"domains/domainOwnershipIdentifiers","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"topLevelDomains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"checkDomainAvailability","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"listDomainRecommendations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"validateDomainRegistrationInformation","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"generateSsoRequest","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DynamicsLcs","namespace":"Microsoft.DynamicsLcs","resourceTypes":[{"resourceType":"lcsprojects","locations":["Brazil
         South","East Asia","East US","Japan East","Japan West","North Central US","North
         Europe","South Central US","West Europe","West US","Southeast Asia","Central
         US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"lcsprojects/connectors","locations":["Brazil
@@ -1695,21 +1923,21 @@ http_interactions:
         US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"operations","locations":["Brazil
         South","East Asia","East US","Japan East","Japan West","North Central US","North
         Europe","South Central US","West Europe","West US","Southeast Asia","Central
-        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topics","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operations","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topics","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operations","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","West
         US 2","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
         India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/consumergroups","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
         US","East US 2","West US","South Central US","Central US","Australia East","Australia
         Southeast","Central India","West Central US","West US 2","Canada East","Canada
         Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
@@ -1754,23 +1982,23 @@ http_interactions:
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations","locations":["Australia
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations/operationResults","locations":["Australia
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations/operationResults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"operations","locations":["Australia
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"operations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Logic","namespace":"Microsoft.Logic","authorization":{"applicationId":"7cd684f4-8a78-49b0-91ec-6a35d38739ba","roleDefinitionId":"cb3ef1fb-6e31-49e2-9d87-ed821053fe58"},"resourceTypes":[{"resourceType":"workflows","locations":["North
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.LocationBasedServices","namespace":"Microsoft.LocationBasedServices","resourceTypes":[{"resourceType":"accounts","locations":["Global"],"apiVersions":["2017-01-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Logic","namespace":"Microsoft.Logic","authorization":{"applicationId":"7cd684f4-8a78-49b0-91ec-6a35d38739ba","roleDefinitionId":"cb3ef1fb-6e31-49e2-9d87-ed821053fe58"},"resourceTypes":[{"resourceType":"workflows","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
@@ -1791,60 +2019,78 @@ http_interactions:
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada Central","Canada East","West US 2","West Central
-        US","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","West Central US"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"operations","locations":["South
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations","locations":["South
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operations","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"commitmentPlans","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningExperimentation","namespace":"Microsoft.MachineLearningExperimentation","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"accounts","locations":["Australia
-        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces","locations":["Australia
-        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces/projects","locations":["Australia
-        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningCompute","namespace":"Microsoft.MachineLearningCompute","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"376aa7d7-51a9-463d-bd4d-7e1691345612","managedByRoleDefinitionId":"91d00862-cf55-46a5-9dce-260bbd92ce25"},"resourceTypes":[{"resourceType":"operationalizationClusters","locations":["East
-        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"operations","locations":["East
+        US","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningExperimentation","namespace":"Microsoft.MachineLearningExperimentation","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"accounts","locations":["Australia
+        East","East US 2","West Central US","Southeast Asia","West Europe"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces","locations":["Australia
+        East","East US 2","West Central US","Southeast Asia","West Europe"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces/projects","locations":["Australia
+        East","East US 2","West Central US","Southeast Asia","West Europe"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"teamAccounts","locations":["Australia
+        East","West Central US","East US 2"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"teamAccounts/workspaces","locations":["Australia
+        East","West Central US","East US 2"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"teamAccounts/workspaces/projects","locations":["Australia
+        East","West Central US","East US 2"],"apiVersions":["2017-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningCompute","namespace":"Microsoft.MachineLearningCompute","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"376aa7d7-51a9-463d-bd4d-7e1691345612","managedByRoleDefinitionId":"91d00862-cf55-46a5-9dce-260bbd92ce25"},"resourceTypes":[{"resourceType":"operationalizationClusters","locations":["East
+        US 2","West Central US","Australia East","West Europe","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"operations","locations":["East
         US 2"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations","locations":["East
         US 2"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operations","locations":["East
-        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["East
-        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningModelManagement","namespace":"Microsoft.MachineLearningModelManagement","resourceTypes":[{"resourceType":"accounts","locations":["East
-        US 2","West Central US","Australia East"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"operations","locations":["West
-        Central US"],"apiVersions":["2017-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
+        US 2","West Central US","Australia East","West Europe","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["East
+        US 2","West Central US","Australia East","West Europe","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningModelManagement","namespace":"Microsoft.MachineLearningModelManagement","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US 2","West Central US","Australia East","West Europe","Southeast Asia"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"operations","locations":["West
+        Central US"],"apiVersions":["2017-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ManagedIdentity","namespace":"Microsoft.ManagedIdentity","resourceTypes":[{"resourceType":"Identities","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Brazil South","Central
+        India","West India","South India","Japan West","Japan East","East Asia","Southeast
+        Asia","Korea Central","Korea South","North Europe","West Europe","UK West","UK
+        South","Central US","North Central US","East US","East US 2","South Central
+        US","West US","West US 2","West Central US"],"apiVersions":["2015-08-31-PREVIEW"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Brazil South","Central
+        India","West India","South India","Japan West","Japan East","East Asia","Southeast
+        Asia","Korea Central","Korea South","North Europe","West Europe","UK West","UK
+        South","Central US","North Central US","East US","East US 2","South Central
+        US","West US","West US 2","West Central US"],"apiVersions":["2015-08-31-PREVIEW"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Management","namespace":"Microsoft.Management","authorization":{"applicationId":"f2c304cf-8e7e-4c3f-8164-16299ad9d272","roleDefinitionId":"c1cf3708-588a-4647-be7f-f400bbe214cf"},"resourceTypes":[{"resourceType":"resources","locations":[],"apiVersions":["2017-11-01-preview","2017-08-31-preview","2017-06-30-preview","2017-05-31-preview"]},{"resourceType":"managementGroups","locations":[],"apiVersions":["2017-11-01-preview","2017-08-31-preview","2017-06-30-preview","2017-05-31-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01-preview","2017-08-31-preview","2017-06-30-preview","2017-05-31-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceApps","namespace":"Microsoft.MarketplaceApps","resourceTypes":[{"resourceType":"classicDevServices","locations":["Northwest
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","Central US","North
+        Europe","West Europe","Japan East","Japan West","Brazil South","Australia
+        East","Australia Southeast","South India","Central India","Canada Central","Canada
+        East"],"apiVersions":["2017-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
         Central US","West US"],"apiVersions":["2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01"]},{"resourceType":"offertypes","locations":["South
         Central US","West US"],"apiVersions":["2015-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Media","namespace":"Microsoft.Media","authorization":{"applicationId":"374b2a64-3b6b-436b-934c-b820eacca870","roleDefinitionId":"aab70789-0cec-44b5-95d7-84b64c9487af"},"resourceTypes":[{"resourceType":"mediaservices","locations":["Japan
         West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
         US","West US","Australia East","Australia Southeast","Central US","Brazil
         South","Central India","West India","South India","South Central US","Canada
-        Central","Canada East","West Central US"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
+        Central","Canada East","West Central US","West US 2"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
+        Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"operations","locations":["West
+        Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
+        Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PolicyInsights","namespace":"Microsoft.PolicyInsights","authorization":{"applicationId":"1d78a85d-813d-46f0-b496-dd72f50a3ec0","roleDefinitionId":"63d2b225-4c34-4641-8768-21a1f7c68ce8"},"resourceTypes":[{"resourceType":"policyEvents","locations":[],"apiVersions":["2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"policyStates","locations":[],"apiVersions":["2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-17-preview","2017-08-09-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
         Central US","North Central US","East US 2","West US","West Europe","North
         Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
         East","UK South","West India"],"apiVersions":["2016-01-29"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-01-29"]},{"resourceType":"locations/checkNameAvailability","locations":["South
         Central US","North Central US","East US 2","West US","West Europe","North
         Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
-        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"capacities","locations":["West
-        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
-        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationresults","locations":["West
-        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
-        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"operations","locations":["East
-        US 2"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Relay","namespace":"Microsoft.Relay","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"capacities","locations":["Australia
+        Southeast","Brazil South","Canada Central","East Asia","East US","East US
+        2","West India","Japan East","West Central US","North Central US","North Europe","South
+        Central US","Southeast Asia","UK South","West Europe","West US","West US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":["Australia
+        Southeast","Brazil South","Canada Central","East Asia","East US","East US
+        2","West India","Japan East","West Central US","North Central US","North Europe","South
+        Central US","Southeast Asia","UK South","West Europe","West US","West US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationresults","locations":["Australia
+        Southeast","Brazil South","Canada Central","East Asia","East US","East US
+        2","West India","Japan East","West Central US","North Central US","North Europe","South
+        Central US","Southeast Asia","UK South","West Europe","West US","West US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["Australia
+        Southeast","Brazil South","Canada Central","East Asia","East US","East US
+        2","West India","Japan East","West Central US","North Central US","North Europe","South
+        Central US","Southeast Asia","UK South","West Europe","West US","West US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"operations","locations":["East
+        US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Relay","namespace":"Microsoft.Relay","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US 2","West
         US","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
         India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2017-08-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkPolicyCompliance","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/hybridconnections","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/hybridconnections/authorizationrules","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/wcfrelays","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/wcfrelays/authorizationrules","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkPolicyCompliance","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
         Central US","South Central US","North Europe","West Europe","East Asia","Southeast
         Asia","West US","East US","Japan West","Japan East","Brazil South","Central
         US","East US 2","Australia East","Australia Southeast","South India","Central
@@ -1868,12 +2114,12 @@ http_interactions:
         India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19","2015-02-28"]},{"resourceType":"checkServiceNameAvailability","locations":[],"apiVersions":["2015-02-28","2014-07-31-Preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2015-08-19"]},{"resourceType":"resourceHealthMetadata","locations":["West
         US","East US","North Europe","West Europe","Southeast Asia","East Asia","North
         Central US","South Central US","Japan West","Australia East","Brazil South","Central
-        India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","authorization":{"applicationId":"80a10ef9-8168-493d-abf9-3297c4ef6e3c","roleDefinitionId":"2b7763f7-bbe2-4e19-befe-28c79f1cf7f7"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US 2","West
         US","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
         India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"premiumMessagingRegions","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceFabric","namespace":"Microsoft.ServiceFabric","authorization":{"applicationId":"74cb6831-0dbb-4be1-8206-fd4df301cdc2","roleDefinitionId":"e55cc65f-6903-4917-b4ef-f8d4640b57f5"},"resourceTypes":[{"resourceType":"clusters","locations":["West
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/queues","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/queues/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/topics","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/topics/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/topics/subscriptions","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/topics/subscriptions/rules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"premiumMessagingRegions","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceFabric","namespace":"Microsoft.ServiceFabric","authorization":{"applicationId":"74cb6831-0dbb-4be1-8206-fd4df301cdc2","roleDefinitionId":"e55cc65f-6903-4917-b4ef-f8d4640b57f5"},"resourceTypes":[{"resourceType":"clusters","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
@@ -1887,17 +2133,43 @@ http_interactions:
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
-        India","West India","Central India","Brazil South","South Central US","Canada
-        Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
         Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
         Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applianceDefinitions","locations":["West
-        Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"locations","locations":["West
-        Central US"],"apiVersions":["2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
-        Central US"],"apiVersions":["2017-09-01","2016-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
+        Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applications","locations":["South
+        Central US","North Central US","West Central US","West US","West US 2","East
+        US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
+        Asia","Brazil South","Japan West","Japan East","Australia East","Australia
+        Southeast","South India","West India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
+        Central US","North Central US","West Central US","West US","West US 2","East
+        US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
+        Asia","Brazil South","Japan West","Japan East","Australia East","Australia
+        Southeast","South India","West India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
+        Central US"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
+        Central US","North Central US","West Central US","West US","West US 2","East
+        US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
+        Asia","Brazil South","Japan West","Japan East","Australia East","Australia
+        Southeast","South India","West India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/cloudEndpoints","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/serverEndpoints","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/registeredServers","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/workflows","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","West Central US","Japan East","Japan West","Australia East","Australia
         Southeast"],"apiVersions":["2017-06-01","2017-05-15","2017-01-01","2016-10-01","2016-06-01","2015-03-15","2014-09-01"]},{"resourceType":"operations","locations":["West
@@ -1928,23 +2200,11 @@ http_interactions:
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast"],"apiVersions":["2015-07-01-Preview","2015-03-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.TimeSeriesInsights","namespace":"Microsoft.TimeSeriesInsights","authorizations":[{"applicationId":"120d688d-1518-4cf7-bd38-182f158850b6","roleDefinitionId":"5a43abdf-bb87-42c4-9e56-1c24bf364150"}],"resourceTypes":[{"resourceType":"environments","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/eventsources","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/referenceDataSets","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/accessPolicies","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"operations","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
-        Central US","South Central US","East US","West US","Central US","North Europe","West
-        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
-        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/project","locations":["North
-        Central US","South Central US","East US","West US","Central US","North Europe","West
-        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
-        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/extension","locations":["North
-        Central US","South Central US","East US","West US","Central US","North Europe","West
-        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
-        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"checkNameAvailability","locations":["North
-        Central US","South Central US","East US","West US","Central US","North Europe","West
-        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
-        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Myget.PackageManagement","namespace":"Myget.PackageManagement","resourceTypes":[{"resourceType":"services","locations":["West
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]},{"resourceType":"environments/eventsources","locations":["East
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]},{"resourceType":"environments/referenceDataSets","locations":["East
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]},{"resourceType":"environments/accessPolicies","locations":["East
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]},{"resourceType":"operations","locations":["East
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Myget.PackageManagement","namespace":"Myget.PackageManagement","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/NewRelic.APM","namespace":"NewRelic.APM","authorization":{"allowedThirdPartyExtensions":[{"name":"NewRelic_AzurePortal_APM"}]},"resourceTypes":[{"resourceType":"accounts","locations":["North
         Central US","South Central US","West US","East US","North Europe","West Europe","Southeast
         Asia","East Asia","Japan East","Japan West"],"apiVersions":["2014-10-01","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/nuubit.nextgencdn","namespace":"nuubit.nextgencdn","resourceTypes":[{"resourceType":"accounts","locations":["East
@@ -1984,7 +2244,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:41 GMT
+  recorded_at: Tue, 23 Jan 2018 20:06:59 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
@@ -2001,9 +2261,11 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNjAsIm5iZiI6MTUwNjExNjI2MCwiZXhwIjoxNTA2MTIwMTYwLCJhaW8iOiJZMlZnWU5paE9LMDd2L1MyZGlDWHpkSkRPaXdUQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQTlUNDNsbFBWRWV1VDBOajg5OEtBQSIsInZlciI6IjEuMCJ9.m2q1UV9vV03MzAANTYje3G1TeuvrUD7j9xF9RFAZ5K8Zpn8tCFh_-CIuO8uYfW2iT7Dlf1wuo4SO_wd3QIEwibwUzO6Kvx8QfsYAguRT1SJ9c5wjNpPMn5fUsF9ekp2w8naEvHBnxZAaX_6in8ZrOt5lXh2Dye14W65OFYNHV6kHvbVIl70LTnkqkgQsPeKjuVfhFjBvYX6otE_QHiM7PH8IXaadkD4Hk7EIityoza6HM32SHGs2_TNlUKC3vNm_O1ovfa-3NxjyMH94QUIzn0pfoYTskhE3yyLLinP2mDW5sqNEBKrJMlJ7JAZNNMmAO9lIZxOfhOrN-WJuyVSuqg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3MTcsIm5iZiI6MTUxNjczNzcxNywiZXhwIjoxNTE2NzQxNjE3LCJhaW8iOiJZMk5nWUdCbFZFM242NXFhdkh0eDN4U2J5ZkVMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiaDdnZnU2SjNIRW1FSWF4MWlaSUJBQSIsInZlciI6IjEuMCJ9.PAWw9_8VQ4OiYbLMONchobMsu05eUq6JVzocHGf1zWEx8Yjp20nLBB_SS_rOq7r2aoZKYXAEeK2zfQqgo4RT2PijWZSJVwlFNAEJnVT2yvD0CXeWw4DdjjO2gvzovg76NN62OvN74xYYJL7BEVZlEiLpaAOssqydcZPxLxxJ-SfYAjxDw3ObwWE1j9iB7DC7DcNvsQhoIgkT1UuHjPxWyIUIQuYc5F_WQwZbdPu5qI722ZctZ9sBdYRCxZm0vdb1hAWpJ-Z3H8edOwBcLc5vvX0rngE6RaQQhbKiLN_yYDvwucdnfCpcQ-Flhh5DEutk-X-SxGY3E-TGpjv4fOPk9A
       Content-Length:
       - '42'
+      Host:
+      - management.azure.com
   response:
     status:
       code: 202
@@ -2013,39 +2275,41 @@ http_interactions:
       - no-cache
       Pragma:
       - no-cache
-      Content-Length:
-      - '0'
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/0986cdcd-5eef-4095-bb43-6a02f9e20e6a?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/6aee6de5-d2d5-4f94-8568-22c70024c6af?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/0986cdcd-5eef-4095-bb43-6a02f9e20e6a?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/6aee6de5-d2d5-4f94-8568-22c70024c6af?api-version=2017-03-30
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/HighCostHydrate3Min;235,Microsoft.Compute/HighCostHydrate30Min;1162
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131599701143261070
       X-Ms-Request-Id:
-      - 0986cdcd-5eef-4095-bb43-6a02f9e20e6a
+      - 6aee6de5-d2d5-4f94-8568-22c70024c6af
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1182'
+      - '1156'
       X-Ms-Correlation-Request-Id:
-      - 03442526-fc5c-40c7-9a9e-772fa23e7505
+      - 358210ad-2191-4a5c-94a6-8182380c6d49
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214243Z:03442526-fc5c-40c7-9a9e-772fa23e7505
+      - WESTUS:20180123T200659Z:358210ad-2191-4a5c-94a6-8182380c6d49
       Date:
-      - Fri, 22 Sep 2017 21:42:42 GMT
+      - Tue, 23 Jan 2018 20:06:59 GMT
+      Content-Length:
+      - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:42 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:00 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/0986cdcd-5eef-4095-bb43-6a02f9e20e6a?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/6aee6de5-d2d5-4f94-8568-22c70024c6af?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -2059,7 +2323,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNjAsIm5iZiI6MTUwNjExNjI2MCwiZXhwIjoxNTA2MTIwMTYwLCJhaW8iOiJZMlZnWU5paE9LMDd2L1MyZGlDWHpkSkRPaXdUQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQTlUNDNsbFBWRWV1VDBOajg5OEtBQSIsInZlciI6IjEuMCJ9.m2q1UV9vV03MzAANTYje3G1TeuvrUD7j9xF9RFAZ5K8Zpn8tCFh_-CIuO8uYfW2iT7Dlf1wuo4SO_wd3QIEwibwUzO6Kvx8QfsYAguRT1SJ9c5wjNpPMn5fUsF9ekp2w8naEvHBnxZAaX_6in8ZrOt5lXh2Dye14W65OFYNHV6kHvbVIl70LTnkqkgQsPeKjuVfhFjBvYX6otE_QHiM7PH8IXaadkD4Hk7EIityoza6HM32SHGs2_TNlUKC3vNm_O1ovfa-3NxjyMH94QUIzn0pfoYTskhE3yyLLinP2mDW5sqNEBKrJMlJ7JAZNNMmAO9lIZxOfhOrN-WJuyVSuqg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3MTcsIm5iZiI6MTUxNjczNzcxNywiZXhwIjoxNTE2NzQxNjE3LCJhaW8iOiJZMk5nWUdCbFZFM242NXFhdkh0eDN4U2J5ZkVMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiaDdnZnU2SjNIRW1FSWF4MWlaSUJBQSIsInZlciI6IjEuMCJ9.PAWw9_8VQ4OiYbLMONchobMsu05eUq6JVzocHGf1zWEx8Yjp20nLBB_SS_rOq7r2aoZKYXAEeK2zfQqgo4RT2PijWZSJVwlFNAEJnVT2yvD0CXeWw4DdjjO2gvzovg76NN62OvN74xYYJL7BEVZlEiLpaAOssqydcZPxLxxJ-SfYAjxDw3ObwWE1j9iB7DC7DcNvsQhoIgkT1UuHjPxWyIUIQuYc5F_WQwZbdPu5qI722ZctZ9sBdYRCxZm0vdb1hAWpJ-Z3H8edOwBcLc5vvX0rngE6RaQQhbKiLN_yYDvwucdnfCpcQ-Flhh5DEutk-X-SxGY3E-TGpjv4fOPk9A
+      Host:
+      - management.azure.com
   response:
     status:
       code: 200
@@ -2077,34 +2343,36 @@ http_interactions:
       - "-1"
       Vary:
       - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/GetOperation3Min;49989,Microsoft.Compute/GetOperation30Min;249989
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131599701143261070
       X-Ms-Request-Id:
-      - 468eb1fc-e6ea-45e1-bf61-fbf5e452bb41
+      - 310a583a-1968-40ad-acf1-d73d30b068be
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14926'
+      - '14854'
       X-Ms-Correlation-Request-Id:
-      - 0133504e-717f-4345-977e-367b087adae7
+      - '08fd6831-dd25-49e2-b526-ca893ab1b773'
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214244Z:0133504e-717f-4345-977e-367b087adae7
+      - WESTUS:20180123T200701Z:08fd6831-dd25-49e2-b526-ca893ab1b773
       Date:
-      - Fri, 22 Sep 2017 21:42:44 GMT
+      - Tue, 23 Jan 2018 20:07:01 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-22T21:42:44.89792+00:00\",\r\n  \"endTime\":
-        \"2017-09-22T21:42:45.1792464+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=83a4d5f7-2772-4029-b547-3a574d4dc490&sig=er68jdNDqqqTnvcREHFmi%2FkrydxsFoYWdMVjU6A6DaM%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"0986cdcd-5eef-4095-bb43-6a02f9e20e6a\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2018-01-23T20:07:00.1078239+00:00\",\r\n  \"endTime\":
+        \"2018-01-23T20:07:00.326574+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=b8679940-93ae-4a2a-bb67-26f33045be8e&sig=x8jSLlssAfzgU4Zk0na0EQF7fgQarepxuiwA3RJT30w%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"6aee6de5-d2d5-4f94-8568-22c70024c6af\"\r\n}"
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:43 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:01 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/0986cdcd-5eef-4095-bb43-6a02f9e20e6a?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/6aee6de5-d2d5-4f94-8568-22c70024c6af?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -2118,7 +2386,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNjAsIm5iZiI6MTUwNjExNjI2MCwiZXhwIjoxNTA2MTIwMTYwLCJhaW8iOiJZMlZnWU5paE9LMDd2L1MyZGlDWHpkSkRPaXdUQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQTlUNDNsbFBWRWV1VDBOajg5OEtBQSIsInZlciI6IjEuMCJ9.m2q1UV9vV03MzAANTYje3G1TeuvrUD7j9xF9RFAZ5K8Zpn8tCFh_-CIuO8uYfW2iT7Dlf1wuo4SO_wd3QIEwibwUzO6Kvx8QfsYAguRT1SJ9c5wjNpPMn5fUsF9ekp2w8naEvHBnxZAaX_6in8ZrOt5lXh2Dye14W65OFYNHV6kHvbVIl70LTnkqkgQsPeKjuVfhFjBvYX6otE_QHiM7PH8IXaadkD4Hk7EIityoza6HM32SHGs2_TNlUKC3vNm_O1ovfa-3NxjyMH94QUIzn0pfoYTskhE3yyLLinP2mDW5sqNEBKrJMlJ7JAZNNMmAO9lIZxOfhOrN-WJuyVSuqg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3MTcsIm5iZiI6MTUxNjczNzcxNywiZXhwIjoxNTE2NzQxNjE3LCJhaW8iOiJZMk5nWUdCbFZFM242NXFhdkh0eDN4U2J5ZkVMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiaDdnZnU2SjNIRW1FSWF4MWlaSUJBQSIsInZlciI6IjEuMCJ9.PAWw9_8VQ4OiYbLMONchobMsu05eUq6JVzocHGf1zWEx8Yjp20nLBB_SS_rOq7r2aoZKYXAEeK2zfQqgo4RT2PijWZSJVwlFNAEJnVT2yvD0CXeWw4DdjjO2gvzovg76NN62OvN74xYYJL7BEVZlEiLpaAOssqydcZPxLxxJ-SfYAjxDw3ObwWE1j9iB7DC7DcNvsQhoIgkT1UuHjPxWyIUIQuYc5F_WQwZbdPu5qI722ZctZ9sBdYRCxZm0vdb1hAWpJ-Z3H8edOwBcLc5vvX0rngE6RaQQhbKiLN_yYDvwucdnfCpcQ-Flhh5DEutk-X-SxGY3E-TGpjv4fOPk9A
+      Host:
+      - management.azure.com
   response:
     status:
       code: 200
@@ -2136,34 +2406,36 @@ http_interactions:
       - "-1"
       Vary:
       - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/GetOperation3Min;49988,Microsoft.Compute/GetOperation30Min;249988
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131599701143261070
       X-Ms-Request-Id:
-      - 9f7a6fcf-030a-4934-a879-531411e897a9
+      - 720ebdd5-fd0d-4c3a-87f5-a8174f81babf
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14913'
+      - '14867'
       X-Ms-Correlation-Request-Id:
-      - 03d42cd9-6458-4c88-8472-3f8a422dd590
+      - 2bb1c36c-fa28-4e34-b883-749ff4d0c3ea
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214245Z:03d42cd9-6458-4c88-8472-3f8a422dd590
+      - WESTUS:20180123T200702Z:2bb1c36c-fa28-4e34-b883-749ff4d0c3ea
       Date:
-      - Fri, 22 Sep 2017 21:42:44 GMT
+      - Tue, 23 Jan 2018 20:07:01 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-22T21:42:44.89792+00:00\",\r\n  \"endTime\":
-        \"2017-09-22T21:42:45.1792464+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=83a4d5f7-2772-4029-b547-3a574d4dc490&sig=er68jdNDqqqTnvcREHFmi%2FkrydxsFoYWdMVjU6A6DaM%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"0986cdcd-5eef-4095-bb43-6a02f9e20e6a\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2018-01-23T20:07:00.1078239+00:00\",\r\n  \"endTime\":
+        \"2018-01-23T20:07:00.326574+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=b8679940-93ae-4a2a-bb67-26f33045be8e&sig=x8jSLlssAfzgU4Zk0na0EQF7fgQarepxuiwA3RJT30w%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"6aee6de5-d2d5-4f94-8568-22c70024c6af\"\r\n}"
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:44 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:02 GMT
 - request:
     method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=83a4d5f7-2772-4029-b547-3a574d4dc490&sig=er68jdNDqqqTnvcREHFmi/krydxsFoYWdMVjU6A6DaM=&sr=b&sv=2016-05-31
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=b8679940-93ae-4a2a-bb67-26f33045be8e&sig=x8jSLlssAfzgU4Zk0na0EQF7fgQarepxuiwA3RJT30w=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2176,6 +2448,8 @@ http_interactions:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
       X-Ms-Range:
       - bytes=0-0
+      Host:
+      - md-t4jdgqqlgszp.blob.core.windows.net
   response:
     status:
       code: 206
@@ -2188,15 +2462,15 @@ http_interactions:
       Content-Range:
       - bytes 0-0/34359738880
       Last-Modified:
-      - Sat, 15 Jul 2017 14:23:07 GMT
+      - Tue, 23 Jan 2018 20:04:26 GMT
       Accept-Ranges:
       - bytes
       Etag:
-      - '"0x8D4CB8D039FC699"'
+      - '"0x8D5629C811B65EB"'
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 9322e1bf-001e-00b7-6deb-33ae28000000
+      - 0667e468-001e-0047-2685-947e46000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2208,7 +2482,7 @@ http_interactions:
       X-Ms-Blob-Type:
       - PageBlob
       X-Ms-Blob-Sequence-Number:
-      - '20'
+      - '30'
       X-Ms-Copy-Id:
       - 30cedd78-548a-4fd8-967e-f8344f587e3c
       X-Ms-Copy-Source:
@@ -2222,250 +2496,16 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Fri, 22 Sep 2017 21:42:45 GMT
+      - Tue, 23 Jan 2018 20:07:01 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         6w==
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:44 GMT
-- request:
-    method: post
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/EndGetAccess?api-version=2017-03-30
-    body:
-      encoding: ASCII-8BIT
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNjAsIm5iZiI6MTUwNjExNjI2MCwiZXhwIjoxNTA2MTIwMTYwLCJhaW8iOiJZMlZnWU5paE9LMDd2L1MyZGlDWHpkSkRPaXdUQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQTlUNDNsbFBWRWV1VDBOajg5OEtBQSIsInZlciI6IjEuMCJ9.m2q1UV9vV03MzAANTYje3G1TeuvrUD7j9xF9RFAZ5K8Zpn8tCFh_-CIuO8uYfW2iT7Dlf1wuo4SO_wd3QIEwibwUzO6Kvx8QfsYAguRT1SJ9c5wjNpPMn5fUsF9ekp2w8naEvHBnxZAaX_6in8ZrOt5lXh2Dye14W65OFYNHV6kHvbVIl70LTnkqkgQsPeKjuVfhFjBvYX6otE_QHiM7PH8IXaadkD4Hk7EIityoza6HM32SHGs2_TNlUKC3vNm_O1ovfa-3NxjyMH94QUIzn0pfoYTskhE3yyLLinP2mDW5sqNEBKrJMlJ7JAZNNMmAO9lIZxOfhOrN-WJuyVSuqg
-      Content-Length:
-      - '0'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '0'
-      Expires:
-      - "-1"
-      Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/b3433cf7-06eb-4249-931e-878afc3f6f29?monitor=true&api-version=2017-03-30
-      Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/b3433cf7-06eb-4249-931e-878afc3f6f29?api-version=2017-03-30
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - b3433cf7-06eb-4249-931e-878afc3f6f29
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1186'
-      X-Ms-Correlation-Request-Id:
-      - d5f3551f-fdd2-4dd4-9e3c-716b47f166c5
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214246Z:d5f3551f-fdd2-4dd4-9e3c-716b47f166c5
-      Date:
-      - Fri, 22 Sep 2017 21:42:45 GMT
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:45 GMT
-- request:
-    method: post
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
-    body:
-      encoding: UTF-8
-      string: '{"access":"read","durationInSeconds":3600}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNjAsIm5iZiI6MTUwNjExNjI2MCwiZXhwIjoxNTA2MTIwMTYwLCJhaW8iOiJZMlZnWU5paE9LMDd2L1MyZGlDWHpkSkRPaXdUQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQTlUNDNsbFBWRWV1VDBOajg5OEtBQSIsInZlciI6IjEuMCJ9.m2q1UV9vV03MzAANTYje3G1TeuvrUD7j9xF9RFAZ5K8Zpn8tCFh_-CIuO8uYfW2iT7Dlf1wuo4SO_wd3QIEwibwUzO6Kvx8QfsYAguRT1SJ9c5wjNpPMn5fUsF9ekp2w8naEvHBnxZAaX_6in8ZrOt5lXh2Dye14W65OFYNHV6kHvbVIl70LTnkqkgQsPeKjuVfhFjBvYX6otE_QHiM7PH8IXaadkD4Hk7EIityoza6HM32SHGs2_TNlUKC3vNm_O1ovfa-3NxjyMH94QUIzn0pfoYTskhE3yyLLinP2mDW5sqNEBKrJMlJ7JAZNNMmAO9lIZxOfhOrN-WJuyVSuqg
-      Content-Length:
-      - '42'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '0'
-      Expires:
-      - "-1"
-      Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/c914d124-bb8b-418a-9bf9-362923fe7e22?monitor=true&api-version=2017-03-30
-      Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/c914d124-bb8b-418a-9bf9-362923fe7e22?api-version=2017-03-30
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - c914d124-bb8b-418a-9bf9-362923fe7e22
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1176'
-      X-Ms-Correlation-Request-Id:
-      - 3a311246-e451-44fe-a941-f7d51ea655b1
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214247Z:3a311246-e451-44fe-a941-f7d51ea655b1
-      Date:
-      - Fri, 22 Sep 2017 21:42:47 GMT
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:46 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:02 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/c914d124-bb8b-418a-9bf9-362923fe7e22?api-version=2017-03-30
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNjAsIm5iZiI6MTUwNjExNjI2MCwiZXhwIjoxNTA2MTIwMTYwLCJhaW8iOiJZMlZnWU5paE9LMDd2L1MyZGlDWHpkSkRPaXdUQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQTlUNDNsbFBWRWV1VDBOajg5OEtBQSIsInZlciI6IjEuMCJ9.m2q1UV9vV03MzAANTYje3G1TeuvrUD7j9xF9RFAZ5K8Zpn8tCFh_-CIuO8uYfW2iT7Dlf1wuo4SO_wd3QIEwibwUzO6Kvx8QfsYAguRT1SJ9c5wjNpPMn5fUsF9ekp2w8naEvHBnxZAaX_6in8ZrOt5lXh2Dye14W65OFYNHV6kHvbVIl70LTnkqkgQsPeKjuVfhFjBvYX6otE_QHiM7PH8IXaadkD4Hk7EIityoza6HM32SHGs2_TNlUKC3vNm_O1ovfa-3NxjyMH94QUIzn0pfoYTskhE3yyLLinP2mDW5sqNEBKrJMlJ7JAZNNMmAO9lIZxOfhOrN-WJuyVSuqg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - 585238b8-e5d3-402e-951f-ad8ee05ba47b
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14920'
-      X-Ms-Correlation-Request-Id:
-      - e468966c-9130-4888-8af9-db3f72642d31
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214248Z:e468966c-9130-4888-8af9-db3f72642d31
-      Date:
-      - Fri, 22 Sep 2017 21:42:48 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-22T21:42:48.8051957+00:00\",\r\n  \"endTime\":
-        \"2017-09-22T21:42:49.0396021+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=ab501310-d397-4adf-b778-d27a19582557&sig=dqsfJkC8TUHkcbZ14QtUHFpL0fzH3%2BnBN8dg6EcX9bM%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"c914d124-bb8b-418a-9bf9-362923fe7e22\"\r\n}"
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:47 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/c914d124-bb8b-418a-9bf9-362923fe7e22?api-version=2017-03-30
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNjAsIm5iZiI6MTUwNjExNjI2MCwiZXhwIjoxNTA2MTIwMTYwLCJhaW8iOiJZMlZnWU5paE9LMDd2L1MyZGlDWHpkSkRPaXdUQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQTlUNDNsbFBWRWV1VDBOajg5OEtBQSIsInZlciI6IjEuMCJ9.m2q1UV9vV03MzAANTYje3G1TeuvrUD7j9xF9RFAZ5K8Zpn8tCFh_-CIuO8uYfW2iT7Dlf1wuo4SO_wd3QIEwibwUzO6Kvx8QfsYAguRT1SJ9c5wjNpPMn5fUsF9ekp2w8naEvHBnxZAaX_6in8ZrOt5lXh2Dye14W65OFYNHV6kHvbVIl70LTnkqkgQsPeKjuVfhFjBvYX6otE_QHiM7PH8IXaadkD4Hk7EIityoza6HM32SHGs2_TNlUKC3vNm_O1ovfa-3NxjyMH94QUIzn0pfoYTskhE3yyLLinP2mDW5sqNEBKrJMlJ7JAZNNMmAO9lIZxOfhOrN-WJuyVSuqg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - cac2ca4f-dcb0-48b4-9bb9-0d2792a718a1
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14928'
-      X-Ms-Correlation-Request-Id:
-      - 254d62dd-60bd-4242-906f-ba77b868f5a8
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214248Z:254d62dd-60bd-4242-906f-ba77b868f5a8
-      Date:
-      - Fri, 22 Sep 2017 21:42:48 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-22T21:42:48.8051957+00:00\",\r\n  \"endTime\":
-        \"2017-09-22T21:42:49.0396021+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=ab501310-d397-4adf-b778-d27a19582557&sig=dqsfJkC8TUHkcbZ14QtUHFpL0fzH3%2BnBN8dg6EcX9bM%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"c914d124-bb8b-418a-9bf9-362923fe7e22\"\r\n}"
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:47 GMT
-- request:
-    method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=ab501310-d397-4adf-b778-d27a19582557&sig=dqsfJkC8TUHkcbZ14QtUHFpL0fzH3%2BnBN8dg6EcX9bM=&sr=b&sv=2016-05-31
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=b8679940-93ae-4a2a-bb67-26f33045be8e&sig=x8jSLlssAfzgU4Zk0na0EQF7fgQarepxuiwA3RJT30w=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2478,6 +2518,8 @@ http_interactions:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
       X-Ms-Range:
       - bytes=440-443
+      Host:
+      - md-t4jdgqqlgszp.blob.core.windows.net
   response:
     status:
       code: 206
@@ -2490,15 +2532,15 @@ http_interactions:
       Content-Range:
       - bytes 440-443/34359738880
       Last-Modified:
-      - Sat, 15 Jul 2017 14:23:07 GMT
+      - Tue, 23 Jan 2018 20:04:26 GMT
       Accept-Ranges:
       - bytes
       Etag:
-      - '"0x8D4CB8D039FC699"'
+      - '"0x8D5629C811B65EB"'
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 98f1a379-001e-0033-79eb-33f800000000
+      - 1f9d29e2-001e-00a5-3685-949a34000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2510,7 +2552,7 @@ http_interactions:
       X-Ms-Blob-Type:
       - PageBlob
       X-Ms-Blob-Sequence-Number:
-      - '20'
+      - '30'
       X-Ms-Copy-Id:
       - 30cedd78-548a-4fd8-967e-f8344f587e3c
       X-Ms-Copy-Source:
@@ -2524,69 +2566,11 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Fri, 22 Sep 2017 21:42:48 GMT
+      - Tue, 23 Jan 2018 20:07:02 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         U5MJAA==
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:48 GMT
-- request:
-    method: post
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/EndGetAccess?api-version=2017-03-30
-    body:
-      encoding: ASCII-8BIT
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNjAsIm5iZiI6MTUwNjExNjI2MCwiZXhwIjoxNTA2MTIwMTYwLCJhaW8iOiJZMlZnWU5paE9LMDd2L1MyZGlDWHpkSkRPaXdUQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQTlUNDNsbFBWRWV1VDBOajg5OEtBQSIsInZlciI6IjEuMCJ9.m2q1UV9vV03MzAANTYje3G1TeuvrUD7j9xF9RFAZ5K8Zpn8tCFh_-CIuO8uYfW2iT7Dlf1wuo4SO_wd3QIEwibwUzO6Kvx8QfsYAguRT1SJ9c5wjNpPMn5fUsF9ekp2w8naEvHBnxZAaX_6in8ZrOt5lXh2Dye14W65OFYNHV6kHvbVIl70LTnkqkgQsPeKjuVfhFjBvYX6otE_QHiM7PH8IXaadkD4Hk7EIityoza6HM32SHGs2_TNlUKC3vNm_O1ovfa-3NxjyMH94QUIzn0pfoYTskhE3yyLLinP2mDW5sqNEBKrJMlJ7JAZNNMmAO9lIZxOfhOrN-WJuyVSuqg
-      Content-Length:
-      - '0'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '0'
-      Expires:
-      - "-1"
-      Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/3d4d29af-3d3a-4ff7-9d77-e634eee5771d?monitor=true&api-version=2017-03-30
-      Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/3d4d29af-3d3a-4ff7-9d77-e634eee5771d?api-version=2017-03-30
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - 3d4d29af-3d3a-4ff7-9d77-e634eee5771d
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1199'
-      X-Ms-Correlation-Request-Id:
-      - 83214645-3636-4804-bc40-65172941c47b
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214250Z:83214645-3636-4804-bc40-65172941c47b
-      Date:
-      - Fri, 22 Sep 2017 21:42:49 GMT
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:49 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:02 GMT
 recorded_with: VCR 3.0.3

--- a/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_size-1.yml
+++ b/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_size-1.yml
@@ -17,6 +17,8 @@ http_interactions:
       - '186'
       Content-Type:
       - application/x-www-form-urlencoded
+      Host:
+      - login.microsoftonline.com
   response:
     status:
       code: 200
@@ -37,25 +39,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - e6faef01-1a89-4a57-a0a9-33b348810c00
+      - 5bae385d-ce86-40db-814a-fe33f6531200
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAAABlDrqfEFlSaui6xnRjX5EgoZSs1Hrzd4Foo49Rqc2sZC_0GRF_4s5c-lRCHhS6MjRGuVUaTkA9VmS8xN1_2GxfkQKeP-p3WiZ7isFdO0gXjW2nUNJ3Md3cZ38wk9M8EyquQfdy-wLn1cR5ucxuIJ2GwVBwCTDc34yQ7MLw9Hw7V9djv6QqSbHkU78_mpU6UUgAA;
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHz1UzY9ta6D3TZv6amBg51aOTSlR9eAil-GW29Nhpl5u6Q_bOHQ3d7KjXi3FXrfb8n4E7wnYbisTMtCZkMjKSw6RzjvsJb0dgep0LY1ya59O2ILZNqRP14Q4pz-2Y8ic4-RqfQ-HlQFG8ys2YFqX4bux1SLPVylHEUF-_XvPTZwXIgAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=007; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=003; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Fri, 22 Sep 2017 21:42:31 GMT
+      - Tue, 23 Jan 2018 20:07:28 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3600","ext_expires_in":"0","expires_on":"1506120151","not_before":"1506116251","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNTEsIm5iZiI6MTUwNjExNjI1MSwiZXhwIjoxNTA2MTIwMTUxLCJhaW8iOiJZMlZnWUxnV3ZNR2haN3JqaENYWDZqZFBmcVp3RlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQWVfNjVva2FWMHFncVRPelNJRU1BQSIsInZlciI6IjEuMCJ9.yzoeDCrqx6h9nl-b6GtfmDyJbotu_2GBJu-ip3XG01YchUdtta9kywHCIj3lJYb4R5vXZEQPNg9M0bpMuy_rjlMLEWMcFxFU8iocbWvIm1JHj67MsPUQn-01Rl6sIvWrHA_qiKjv4RzfIECHmA6lY9zxpjLywyLjvlC8_zyME4-3AHUoy0felmuv7nWwCUXS4UhWtQkwNzNv5jIoBUb3hWFa5S-GNkgsrUwPgu0S-Y6AfGM58eXZgmPLCJwHrkXQiDcbc7qpncDb06snvYrQVwNHYXKe0QIlAmDEB4kaqJmrPyTRky_GCV63g5lfionsieQSEaKMl4xqchA0MGu36w"}'
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1516741650","not_before":"1516737750","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3NTAsIm5iZiI6MTUxNjczNzc1MCwiZXhwIjoxNTE2NzQxNjUwLCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWFRpdVc0Yk8yMENCU3Y0ejlsTVNBQSIsInZlciI6IjEuMCJ9.JvlnLotIgeGfqHeVtf8RveMNGourqxZKxnVupLwgCwghgdbAGxgPwllZ6c6q-I0eawKs9N3rfx20neFUfyOTZlOsKHa1ARe2_VfBQCAtzx65URN1V4KQiSwvSkPtFA1COuKZip5KL-rc0piB7bUvrmY07T2DAu0Iy5BrZ31iYgbTDJ2LV12xC-jVl4GCuEcpcB5b2B51oQw82fzu6v8UhNnhiaT-Gee8O-PcggNzNEoot7C6gweJ8i9UCccg9JVU2h9K0lk53K7Q2C2iiMBkWVI9g07VNqtwKpBbi2He1hGvkTCd3gsYtBRO3GHRRF511SbHJfYRkeU-p3_3z3Wxbw"}'
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:30 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:30 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -72,7 +74,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNTEsIm5iZiI6MTUwNjExNjI1MSwiZXhwIjoxNTA2MTIwMTUxLCJhaW8iOiJZMlZnWUxnV3ZNR2haN3JqaENYWDZqZFBmcVp3RlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQWVfNjVva2FWMHFncVRPelNJRU1BQSIsInZlciI6IjEuMCJ9.yzoeDCrqx6h9nl-b6GtfmDyJbotu_2GBJu-ip3XG01YchUdtta9kywHCIj3lJYb4R5vXZEQPNg9M0bpMuy_rjlMLEWMcFxFU8iocbWvIm1JHj67MsPUQn-01Rl6sIvWrHA_qiKjv4RzfIECHmA6lY9zxpjLywyLjvlC8_zyME4-3AHUoy0felmuv7nWwCUXS4UhWtQkwNzNv5jIoBUb3hWFa5S-GNkgsrUwPgu0S-Y6AfGM58eXZgmPLCJwHrkXQiDcbc7qpncDb06snvYrQVwNHYXKe0QIlAmDEB4kaqJmrPyTRky_GCV63g5lfionsieQSEaKMl4xqchA0MGu36w
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3NTAsIm5iZiI6MTUxNjczNzc1MCwiZXhwIjoxNTE2NzQxNjUwLCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWFRpdVc0Yk8yMENCU3Y0ejlsTVNBQSIsInZlciI6IjEuMCJ9.JvlnLotIgeGfqHeVtf8RveMNGourqxZKxnVupLwgCwghgdbAGxgPwllZ6c6q-I0eawKs9N3rfx20neFUfyOTZlOsKHa1ARe2_VfBQCAtzx65URN1V4KQiSwvSkPtFA1COuKZip5KL-rc0piB7bUvrmY07T2DAu0Iy5BrZ31iYgbTDJ2LV12xC-jVl4GCuEcpcB5b2B51oQw82fzu6v8UhNnhiaT-Gee8O-PcggNzNEoot7C6gweJ8i9UCccg9JVU2h9K0lk53K7Q2C2iiMBkWVI9g07VNqtwKpBbi2He1hGvkTCd3gsYtBRO3GHRRF511SbHJfYRkeU-p3_3z3Wxbw
+      Host:
+      - management.azure.com
   response:
     status:
       code: 200
@@ -93,21 +97,22 @@ http_interactions:
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
       - '14999'
       X-Ms-Request-Id:
-      - 73523c6c-9895-4aaf-9a88-8d0a559a3a11
+      - 7b92e25a-0084-488c-92e7-8d2a7ac311fd
       X-Ms-Correlation-Request-Id:
-      - 73523c6c-9895-4aaf-9a88-8d0a559a3a11
+      - 7b92e25a-0084-488c-92e7-8d2a7ac311fd
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214232Z:73523c6c-9895-4aaf-9a88-8d0a559a3a11
+      - WESTUS:20180123T200730Z:7b92e25a-0084-488c-92e7-8d2a7ac311fd
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 22 Sep 2017 21:42:31 GMT
+      - Tue, 23 Jan 2018 20:07:29 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
-        Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
+      string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
+        Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
+        Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:31 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:30 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/azure_subscription_id/providers?api-version=2015-01-01
@@ -124,7 +129,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNTEsIm5iZiI6MTUwNjExNjI1MSwiZXhwIjoxNTA2MTIwMTUxLCJhaW8iOiJZMlZnWUxnV3ZNR2haN3JqaENYWDZqZFBmcVp3RlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQWVfNjVva2FWMHFncVRPelNJRU1BQSIsInZlciI6IjEuMCJ9.yzoeDCrqx6h9nl-b6GtfmDyJbotu_2GBJu-ip3XG01YchUdtta9kywHCIj3lJYb4R5vXZEQPNg9M0bpMuy_rjlMLEWMcFxFU8iocbWvIm1JHj67MsPUQn-01Rl6sIvWrHA_qiKjv4RzfIECHmA6lY9zxpjLywyLjvlC8_zyME4-3AHUoy0felmuv7nWwCUXS4UhWtQkwNzNv5jIoBUb3hWFa5S-GNkgsrUwPgu0S-Y6AfGM58eXZgmPLCJwHrkXQiDcbc7qpncDb06snvYrQVwNHYXKe0QIlAmDEB4kaqJmrPyTRky_GCV63g5lfionsieQSEaKMl4xqchA0MGu36w
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3NTAsIm5iZiI6MTUxNjczNzc1MCwiZXhwIjoxNTE2NzQxNjUwLCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWFRpdVc0Yk8yMENCU3Y0ejlsTVNBQSIsInZlciI6IjEuMCJ9.JvlnLotIgeGfqHeVtf8RveMNGourqxZKxnVupLwgCwghgdbAGxgPwllZ6c6q-I0eawKs9N3rfx20neFUfyOTZlOsKHa1ARe2_VfBQCAtzx65URN1V4KQiSwvSkPtFA1COuKZip5KL-rc0piB7bUvrmY07T2DAu0Iy5BrZ31iYgbTDJ2LV12xC-jVl4GCuEcpcB5b2B51oQw82fzu6v8UhNnhiaT-Gee8O-PcggNzNEoot7C6gweJ8i9UCccg9JVU2h9K0lk53K7Q2C2iiMBkWVI9g07VNqtwKpBbi2He1hGvkTCd3gsYtBRO3GHRRF511SbHJfYRkeU-p3_3z3Wxbw
+      Host:
+      - management.azure.com
   response:
     status:
       code: 200
@@ -141,19 +148,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14920'
+      - '14864'
       X-Ms-Request-Id:
-      - f04f34eb-8319-4006-9c04-5733b2147987
+      - 5e0c2a7a-10bf-4d08-8659-d5f104192449
       X-Ms-Correlation-Request-Id:
-      - f04f34eb-8319-4006-9c04-5733b2147987
+      - 5e0c2a7a-10bf-4d08-8659-d5f104192449
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214233Z:f04f34eb-8319-4006-9c04-5733b2147987
+      - WESTUS:20180123T200731Z:5e0c2a7a-10bf-4d08-8659-d5f104192449
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 22 Sep 2017 21:42:33 GMT
+      - Tue, 23 Jan 2018 20:07:31 GMT
       Content-Length:
-      - '254785'
+      - '293551'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
@@ -176,7 +183,7 @@ http_interactions:
         Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
         Central US","North Central US","Japan East","Japan West","Brazil South","Central
         India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
+        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-04-19","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-04-19","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-04-19","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-04-19","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","North Central
         US","South Central US","West Central US","West US","West US 2","Canada Central","Canada
         East","North Europe","West Europe","UK South","UK West","East Asia","Southeast
@@ -184,20 +191,26 @@ http_interactions:
         India","South India","West India"],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"validateServiceName","locations":[],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"checkServiceNameAvailability","locations":[],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"reportFeedback","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"checkFeedbackRequired","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Automation","namespace":"Microsoft.Automation","authorizations":[{"applicationId":"fc75330b-179d-49af-87dd-3b1acf6827fa","roleDefinitionId":"95fd5de3-d071-4362-92bf-cf341c1de832"}],"resourceTypes":[{"resourceType":"automationAccounts","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
         South","UK South","West Central US","North Europe","Canada Central","Australia
-        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/runbooks","locations":["Japan
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/runbooks","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
         South","UK South","West Central US","North Europe","Canada Central","Australia
-        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/configurations","locations":["Japan
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/configurations","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","North
-        Central US","Brazil South","UK South","West Central US","Central India","Australia
-        Southeast","Canada Central","North Europe"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/webhooks","locations":["Japan
+        Central US","Korea Central","East US","West US 2","Brazil South","UK South","West
+        Central US","Central India","Australia Southeast","Canada Central","North
+        Europe"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/webhooks","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
         South","UK South","West Central US","North Europe","Canada Central","Australia
-        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"operations","locations":["South
-        Central US"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/softwareUpdateConfigurations","locations":["Japan
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"operations","locations":["South
+        Central US"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/softwareUpdateConfigurations","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
         South","UK South","West Central US","North Europe","Canada Central","Australia
-        Southeast","Central India"],"apiVersions":["2017-05-15-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Backup","namespace":"Microsoft.Backup","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"BackupVault","locations":["West
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview"]},{"resourceType":"automationAccounts/jobs","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
+        South","UK South","West Central US","North Europe","Canada Central","Australia
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureActiveDirectory","namespace":"Microsoft.AzureActiveDirectory","resourceTypes":[{"resourceType":"b2cDirectories","locations":["Global","United
+        States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]},{"resourceType":"operations","locations":["Global","United
+        States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]}],"registrationState":"Unregistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Backup","namespace":"Microsoft.Backup","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"BackupVault","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
@@ -206,22 +219,22 @@ http_interactions:
         Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
         West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
         East","South India","Central India","Canada Central","Canada East","UK South","UK
-        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01","2015-07-01","2014-05-01-privatepreview"]},{"resourceType":"operations","locations":["West
+        West","West Central US","West US 2"],"apiVersions":["2017-09-01","2017-05-01","2017-01-01","2015-12-01","2015-09-01","2015-07-01","2014-05-01-privatepreview"]},{"resourceType":"operations","locations":["West
         Europe","East US","East US 2","West US","North Central US","Brazil South","North
         Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
         West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
         East","South India","Central India","Canada Central","Canada East","UK South","UK
-        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations/quotas","locations":["West
+        West","West Central US","West US 2"],"apiVersions":["2017-09-01","2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01","2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations/quotas","locations":["West
         Europe","East US","East US 2","West US","North Central US","Brazil South","North
         Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
         West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
         East","South India","Central India","Canada Central","Canada East","UK South","UK
-        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]}],"registrationState":"Unregistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicCompute","namespace":"Microsoft.ClassicCompute","resourceTypes":[{"resourceType":"domainNames","locations":["East
+        West","West Central US","West US 2"],"apiVersions":["2017-09-01","2017-05-01","2017-01-01","2015-12-01","2015-09-01"]}],"registrationState":"Unregistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicCompute","namespace":"Microsoft.ClassicCompute","resourceTypes":[{"resourceType":"domainNames","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
@@ -256,7 +269,7 @@ http_interactions:
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -296,92 +309,92 @@ http_interactions:
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30"]},{"resourceType":"locations/usages","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations/usages","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
+        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
@@ -411,76 +424,138 @@ http_interactions:
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
+        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
         US","East US","South Central US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
         Central","Central US","East US 2","North Central US","West Central US","West
-        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/webhooks","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/ping","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/getCallbackConfig","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/listEvents","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"locations","locations":["South
-        Central US","East US","West US","Central US","East US 2","North Central US","West
-        Central US","West US 2","Brazil South","Canada East","Canada Central","West
-        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
-        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"locations/operationResults","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/GetCredentials","locations":["West
+        US 2"],"apiVersions":["2017-10-01","2017-03-01"]},{"resourceType":"registries/replications","locations":["South
+        Central US","West Central US","East US","West Europe","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/webhooks","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/webhooks/ping","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/webhooks/getCallbackConfig","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/webhooks/listEvents","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"locations/operationResults","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/GetCredentials","locations":["West
         US","East US","South Central US","West Europe"],"apiVersions":["2016-06-27-preview"]},{"resourceType":"registries/listCredentials","locations":["South
         Central US","East US","West US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
         Central","Central US","East US 2","North Central US","West Central US","West
-        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/regenerateCredential","locations":["South
+        US 2"],"apiVersions":["2017-10-01","2017-03-01"]},{"resourceType":"registries/regenerateCredential","locations":["South
         Central US","West US","East US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
         Central","Central US","East US 2","North Central US","West Central US","West
-        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/listUsages","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/regenerateCredentials","locations":["West
+        US 2"],"apiVersions":["2017-10-01","2017-03-01"]},{"resourceType":"registries/listUsages","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/regenerateCredentials","locations":["West
         US","East US","South Central US","West Europe"],"apiVersions":["2016-06-27-preview"]},{"resourceType":"checkNameAvailability","locations":["South
         Central US","East US","West US","Central US","East US 2","North Central US","West
         Central US","West US 2","Brazil South","Canada East","Canada Central","West
         Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
-        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview","2017-03-01","2016-06-27-preview"]},{"resourceType":"operations","locations":["South
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-10-01","2017-06-01-preview","2017-03-01","2016-06-27-preview"]},{"resourceType":"operations","locations":["South
         Central US","East US","West US","Central US","East US 2","North Central US","West
         Central US","West US 2","Brazil South","Canada East","Canada Central","West
         Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
-        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview","2017-03-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerService","namespace":"Microsoft.ContainerService","authorization":{"applicationId":"7319c514-987d-4e9b-ac3d-d38c4f427f4c","roleDefinitionId":"1b4a0c7f-2217-416f-acfa-cf73452fdc1c"},"resourceTypes":[{"resourceType":"containerServices","locations":["Japan
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-10-01","2017-06-01-preview","2017-03-01"]},{"resourceType":"locations","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-10-01","2017-06-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerService","namespace":"Microsoft.ContainerService","authorization":{"applicationId":"7319c514-987d-4e9b-ac3d-d38c4f427f4c","roleDefinitionId":"1b4a0c7f-2217-416f-acfa-cf73452fdc1c","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"containerServices","locations":["Japan
         East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
         Central US","West US 2","South India","Central India","West India","Canada
-        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
+        East","Canada Central","Korea South","Korea Central"],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"managedClusters","locations":["East
+        US","West Europe","Central US","Canada Central","Canada East"],"apiVersions":["2017-08-31"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
         East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
         Central US","West US 2","South India","Central India","West India","Canada
-        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DevTestLab","namespace":"Microsoft.DevTestLab","authorization":{"applicationId":"1a14be2a-e903-4cec-99cf-b2e209259a0f","roleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525"},"resourceTypes":[{"resourceType":"labs","locations":["West
+        East","Canada Central","Korea South","Korea Central"],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/orchestrators","locations":["UK
+        West","West US 2","East US","West Europe","Central US"],"apiVersions":["2017-09-30"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DevTestLab","namespace":"Microsoft.DevTestLab","authorization":{"applicationId":"1a14be2a-e903-4cec-99cf-b2e209259a0f","roleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525","managedByRoleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525"},"resourceTypes":[{"resourceType":"labs","locations":["West
         Central US","Japan East","West US","Australia Southeast","Canada Central","Central
         India","Central US","East Asia","Korea Central","North Europe","South Central
-        US","UK West","Australia East","Brazil South","Canada East","East US","East
-        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        US","UK West","West India","Australia East","Brazil South","Canada East","East
+        US","East US 2","Japan West","Korea South","North Central US","South India","Southeast
         Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"schedules","locations":["West
         Central US","Japan East","West US","Australia Southeast","Canada Central","Central
         India","Central US","East Asia","Korea Central","North Europe","South Central
-        US","UK West","Australia East","Brazil South","Canada East","East US","East
-        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        US","UK West","West India","Australia East","Brazil South","Canada East","East
+        US","East US 2","Japan West","Korea South","North Central US","South India","Southeast
         Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"labs/virtualMachines","locations":["West
         Central US","Japan East","West US","Australia Southeast","Canada Central","Central
         India","Central US","East Asia","Korea Central","North Europe","South Central
-        US","UK West","Australia East","Brazil South","Canada East","East US","East
-        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        US","UK West","West India","Australia East","Brazil South","Canada East","East
+        US","East US 2","Japan West","Korea South","North Central US","South India","Southeast
         Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"labs/serviceRunners","locations":["Central
         US","East US 2","South Central US"],"apiVersions":["2017-04-26-preview","2016-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"locations/operations","locations":["West
         Central US","Japan East","West US","Australia Southeast","Canada Central","Central
         India","Central US","East Asia","Korea Central","North Europe","South Central
-        US","UK West","Australia East","Brazil South","Canada East","East US","East
-        US 2","Japan West","Korea South","North Central US","South India","Southeast
-        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"}],"resourceTypes":[{"resourceType":"components","locations":["East
-        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
-        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01","2014-04-01"]},{"resourceType":"queries","locations":["East
-        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
+        US","UK West","West India","Australia East","Brazil South","Canada East","East
+        US","East US 2","Japan West","Korea South","North Central US","South India","Southeast
+        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","authorizations":[{"applicationId":"57c0fc58-a83a-41d0-8ae9-08952659bdfd","roleDefinitionId":"FFFD5CF5-FFD3-4B24-B0E2-0715ADD4C282"}],"resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"databaseAccountNames","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"operationResults","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"},{"applicationId":"f5c26e74-f226-4ae8-85f0-b4af0080ac9e","roleDefinitionId":"529d7ae6-e892-4d43-809d-8547aeb90643"}],"resourceTypes":[{"resourceType":"components","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2015-05-01","2014-08-01","2014-04-01"]},{"resourceType":"queries","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"components/pricingPlans","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"migrateToNewPricingModel","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"rollbackToLegacyPricingModel","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"listMigrationdate","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
@@ -516,7 +591,7 @@ http_interactions:
         West","North Central US","South Central US","East US 2","Canada East","Canada
         Central","Central US","Australia East","Australia Southeast","Brazil South","South
         India","Central India","West India","North Europe","West US 2","West Central
-        US","Korea South","Korea Central","UK South","UK West","Global"],"apiVersions":["2017-05-01-preview","2016-03-01","2015-07-01"]},{"resourceType":"logDefinitions","locations":["West
+        US","Korea South","Korea Central","UK South","UK West","Global"],"apiVersions":["2017-09-01-preview","2017-05-01-preview","2016-03-01","2015-07-01"]},{"resourceType":"logDefinitions","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
@@ -526,7 +601,7 @@ http_interactions:
         West","North Central US","South Central US","East US 2","Canada East","Canada
         Central","Central US","Australia East","Australia Southeast","Brazil South","South
         India","Central India","West India","North Europe","West US 2","West Central
-        US","Korea South","Korea Central","UK South","UK West"],"apiVersions":["2017-05-01-preview","2016-09-01","2016-06-01"]},{"resourceType":"actiongroups","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]},{"resourceType":"activityLogAlerts","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.KeyVault","namespace":"Microsoft.KeyVault","resourceTypes":[{"resourceType":"vaults","locations":["North
+        US","Korea South","Korea Central","UK South","UK West"],"apiVersions":["2017-09-01-preview","2017-05-01-preview","2016-09-01","2016-06-01"]},{"resourceType":"actiongroups","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]},{"resourceType":"activityLogAlerts","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.KeyVault","namespace":"Microsoft.KeyVault","resourceTypes":[{"resourceType":"vaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
@@ -556,126 +631,153 @@ http_interactions:
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorizations":[{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},{"applicationId":"7c33bfcb-8d33-48d6-8e60-dc6404003489","roleDefinitionId":"ad6261e4-fa9a-4642-aa5f-104f1b67e9e3"},{"applicationId":"1e3e4475-288f-4018-a376-df66fd7fac5f","roleDefinitionId":"1d538b69-3d87-4e56-8ff8-25786fd48261"},{"applicationId":"a0be0c72-870e-46f0-9c49-c98333a996f7","roleDefinitionId":"7ce22727-ffce-45a9-930c-ddb2e56fa131"}],"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","West Central US"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"operations","locations":["South
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations","locations":["South
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operations","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"commitmentPlans","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"Registering"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorizations":[{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},{"applicationId":"7c33bfcb-8d33-48d6-8e60-dc6404003489","roleDefinitionId":"ad6261e4-fa9a-4642-aa5f-104f1b67e9e3"},{"applicationId":"1e3e4475-288f-4018-a376-df66fd7fac5f","roleDefinitionId":"1d538b69-3d87-4e56-8ff8-25786fd48261"},{"applicationId":"a0be0c72-870e-46f0-9c49-c98333a996f7","roleDefinitionId":"7ce22727-ffce-45a9-930c-ddb2e56fa131"}],"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
-        Central US"],"apiVersions":["2017-09-01"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
-        East","UK South","Central India","Canada Central"],"apiVersions":["2017-04-26-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"]},{"resourceType":"workspaces/dataSources","locations":["East
+        East","UK South","Central India","Canada Central"],"apiVersions":["2017-04-26-preview","2017-03-15-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"]},{"resourceType":"workspaces/query","locations":["West
+        Central US","Australia Southeast","West Europe","East US","Southeast Asia","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2017-10-01"]},{"resourceType":"workspaces/dataSources","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
         East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"storageInsightConfigs","locations":[],"apiVersions":["2014-10-10"]},{"resourceType":"workspaces/linkedServices","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
         East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"linkTargets","locations":["East
         US"],"apiVersions":["2015-03-20"]},{"resourceType":"operations","locations":[],"apiVersions":["2014-11-10"]},{"resourceType":"devices","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationsManagement","namespace":"Microsoft.OperationsManagement","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"aa249101-6816-4966-aafa-08175d795f14"},"resourceTypes":[{"resourceType":"solutions","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
-        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Portal","namespace":"Microsoft.Portal","resourceTypes":[{"resourceType":"dashboards","locations":["Central
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"managementconfigurations","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"managementassociations","locations":[],"apiVersions":["2015-11-01-preview"]},{"resourceType":"views","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2017-08-21-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Portal","namespace":"Microsoft.Portal","resourceTypes":[{"resourceType":"dashboards","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
@@ -687,9 +789,9 @@ http_interactions:
         East","West India","South India","Central India","Canada Central","Canada
         East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"consoles","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/consoles","locations":["West
         US","East US","Central India","North Europe","West Europe","South Central
-        US","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
+        US","Southeast Asia","East US 2","Central US"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
         US","East US","Central India","North Europe","West Europe","South Central
-        US","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
+        US","Southeast Asia","East US 2","Central US"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
@@ -710,7 +812,17 @@ http_interactions:
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ResourceHealth","namespace":"Microsoft.ResourceHealth","authorization":{"applicationId":"8bdebf23-c0fe-4187-a378-717ad86f6a53","roleDefinitionId":"cc026344-c8b1-4561-83ba-59eba84b27cc"},"resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2017-07-01","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"notifications","locations":["Australia
+        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]},{"resourceType":"locations/backupValidateFeatures","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-07-01"]},{"resourceType":"locations/backupPreValidateProtection","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-07-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ResourceHealth","namespace":"Microsoft.ResourceHealth","authorization":{"applicationId":"8bdebf23-c0fe-4187-a378-717ad86f6a53","roleDefinitionId":"cc026344-c8b1-4561-83ba-59eba84b27cc"},"resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2017-07-01","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"notifications","locations":["Australia
         Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Security","namespace":"Microsoft.Security","authorization":{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatuses","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/virtualMachines","locations":["Central
@@ -743,10 +855,14 @@ http_interactions:
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securitySolutionsReferenceData","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/securitySolutionsReferenceData","locations":["Central
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"jitNetworkAccessPolicies","locations":["Central
-        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/jitNetworkAccessPolicies","locations":["Central
-        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations","locations":["Central
+        US","East US","North Europe","West Europe","UK South","UK West","West Central
+        US","West US 2"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/jitNetworkAccessPolicies","locations":["Central
+        US","East US","North Europe","West Europe","UK South","UK West","West Central
+        US","West US 2"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatusesSummaries","locations":["Central
-        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/alerts","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"applicationWhitelistings","locations":["Central
+        US","East US","West Central US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/applicationWhitelistings","locations":["Central
+        US","West Central US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/alerts","locations":["Central
         US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/tasks","locations":["Central
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"externalSecuritySolutions","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/externalSecuritySolutions","locations":["Central
@@ -769,7 +885,17 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/databaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/databaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -814,7 +940,7 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01","2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -829,7 +955,7 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -859,12 +985,17 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/geoBackupPolicies","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -879,12 +1010,12 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/firewallrules","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/backupLongTermRetentionPolicies","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -999,6 +1130,16 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
         US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
@@ -1034,7 +1175,22 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -1144,7 +1300,47 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -1159,7 +1355,17 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/administratorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -1179,52 +1385,52 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorization":{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorizations":[{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},{"applicationId":"e406a681-f3d4-42a8-90b6-c2b029497af1"}],"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
         US","West US","West Europe","North Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","South India","Central
@@ -1234,7 +1440,19 @@ http_interactions:
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Web","namespace":"Microsoft.Web","authorization":{"applicationId":"abfa0a7c-a6b6-4736-8310-5855508787cd","roleDefinitionId":"f47ed98b-b063-4a5b-9e10-4b9b44fa7735"},"resourceTypes":[{"resourceType":"sites/extensions","locations":["South
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/project","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/extension","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"checkNameAvailability","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Web","namespace":"Microsoft.Web","authorization":{"applicationId":"abfa0a7c-a6b6-4736-8310-5855508787cd","roleDefinitionId":"f47ed98b-b063-4a5b-9e10-4b9b44fa7735"},"resourceTypes":[{"resourceType":"sites/extensions","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
         South","West US","East US","Japan West","Japan East","East Asia","East US
         2","North Central US","Central US","Brazil South","Australia East","Australia
@@ -1339,7 +1557,7 @@ http_interactions:
         South","West US","East US","Japan West","Japan East","East Asia","East US
         2","North Central US","Central US","Brazil South","Australia East","Australia
         Southeast","West India","Central India","South India","Canada Central","Canada
-        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms/workers","locations":["South
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms/workers","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
         South","West US","East US","Japan West","Japan East","East Asia","East US
         2","North Central US","Central US","Brazil South","Australia East","Australia
@@ -1394,7 +1612,17 @@ http_interactions:
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","West US 2","West Central US","Canada Central","Canada
-        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/managedApis","locations":["North
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/listWsdlInterfaces","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/extractApiDefinitionFromWsdl","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/managedApis","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
@@ -1445,8 +1673,11 @@ http_interactions:
         US","North Europe","Japan West","Japan East","East Asia","West Europe","East
         US","Southeast Asia","Central US"],"apiVersions":["2016-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Lombiq.DotNest","namespace":"Lombiq.DotNest","resourceTypes":[{"resourceType":"sites","locations":["East
         US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Mailjet.Email","namespace":"Mailjet.Email","resourceTypes":[{"resourceType":"services","locations":["West
-        US"],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
-        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
+        US","West Europe"],"apiVersions":["2017-10-01","2017-02-03"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-10-01","2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-10-01","2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]},{"resourceType":"diagnosticSettings","locations":[],"apiVersions":["2017-04-01"]},{"resourceType":"diagnosticSettingsCategories","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Addons","namespace":"Microsoft.Addons","authorization":{"applicationId":"24d3987b-be4a-48e0-a3e7-11c186f39e41","roleDefinitionId":"8004BAAB-A4CB-4981-8571-F7E44D039D93"},"resourceTypes":[{"resourceType":"supportProviders","locations":["West
+        Central US","South Central US","East US","West Europe"],"apiVersions":["2017-05-15"]},{"resourceType":"operations","locations":["West
+        Central US","South Central US","East US","West Europe"],"apiVersions":["2017-05-15"]},{"resourceType":"operationResults","locations":["West
+        Central US","South Central US","East US","West Europe"],"apiVersions":["2017-05-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"addsservices","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"configuration","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"operations","locations":["West
@@ -1456,51 +1687,45 @@ http_interactions:
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"servicehealthmetrics","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"logs","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"anonymousapiusers","locations":["West
-        US"],"apiVersions":["2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AnalysisServices","namespace":"Microsoft.AnalysisServices","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"servers","locations":["West
+        US"],"apiVersions":["2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AlertsManagement","namespace":"Microsoft.AlertsManagement","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-11-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AnalysisServices","namespace":"Microsoft.AnalysisServices","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"servers","locations":["West
         US","North Europe","South Central US","West Europe","West Central US","Southeast
         Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
-        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/checkNameAvailability","locations":["West
+        Southeast","Japan East","UK South","West India","West US 2","East US"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"locations/checkNameAvailability","locations":["West
         US","North Europe","South Central US","West Europe","West Central US","Southeast
         Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
-        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationresults","locations":["West
+        Southeast","Japan East","UK South","West India","West US 2","East US"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationresults","locations":["West
         US","North Europe","South Central US","West Europe","West Central US","Southeast
         Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
-        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationstatuses","locations":["West
+        Southeast","Japan East","UK South","West India","West US 2","East US"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationstatuses","locations":["West
         US","North Europe","South Central US","West Europe","West Central US","Southeast
         Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
-        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"operations","locations":["East
-        US 2","West Central US"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AppService","namespace":"Microsoft.AppService","authorization":{"applicationId":"dee7ba80-6a55-4f3b-a86c-746a9231ae49","roleDefinitionId":"6715d172-49c4-46f6-bb21-60512a8689dc"},"resourceTypes":[{"resourceType":"apiapps","locations":["East
-        US","West US","South Central US","North Europe","East Asia","Japan East","West
-        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
-        South","East US 2","Australia Southeast","Australia East","West India","South
-        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"appIdentities","locations":["East
-        US","West US","South Central US","North Europe","East Asia","Japan East","West
-        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
-        South","East US 2","Australia Southeast","Australia East","West India","South
-        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"gateways","locations":["East
-        US","West US","South Central US","North Europe","East Asia","Japan East","West
-        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
-        South","East US 2","Australia Southeast","Australia East","West India","South
-        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"deploymenttemplates","locations":[],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Authorization","namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"roleDefinitions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"classicAdministrators","locations":[],"apiVersions":["2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"permissions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"locks","locations":[],"apiVersions":["2017-04-01","2016-09-01","2015-06-01","2015-05-01-preview","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-01-01","2014-10-01-preview","2014-06-01"]},{"resourceType":"policyDefinitions","locations":[],"apiVersions":["2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"policySetDefinitions","locations":[],"apiVersions":["2017-06-01-preview"]},{"resourceType":"policyAssignments","locations":[],"apiVersions":["2017-06-01-preview","2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"providerOperations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01-preview","2015-07-01"]},{"resourceType":"elevateAccess","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureActiveDirectory","namespace":"Microsoft.AzureActiveDirectory","resourceTypes":[{"resourceType":"b2cDirectories","locations":["Global","United
-        States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureStack","namespace":"Microsoft.AzureStack","resourceTypes":[{"resourceType":"operations","locations":["Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations","locations":["West
+        Southeast","Japan East","UK South","West India","West US 2","East US"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"operations","locations":["East
+        US 2","West Central US","West US 2"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Authorization","namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[],"apiVersions":["2017-10-01-preview","2017-09-01","2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"roleDefinitions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"classicAdministrators","locations":[],"apiVersions":["2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"permissions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"locks","locations":[],"apiVersions":["2017-04-01","2016-09-01","2015-06-01","2015-05-01-preview","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-01-01","2014-10-01-preview","2014-06-01"]},{"resourceType":"policyDefinitions","locations":[],"apiVersions":["2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"policySetDefinitions","locations":[],"apiVersions":["2017-06-01-preview"]},{"resourceType":"policyAssignments","locations":[],"apiVersions":["2017-06-01-preview","2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"providerOperations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01-preview","2015-07-01"]},{"resourceType":"elevateAccess","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"checkAccess","locations":[],"apiVersions":["2017-10-01-preview","2017-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureStack","namespace":"Microsoft.AzureStack","resourceTypes":[{"resourceType":"operations","locations":["Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations","locations":["West
         Central US","Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations/products","locations":["West
-        Central US","Global"],"apiVersions":["2017-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Billing","namespace":"Microsoft.Billing","resourceTypes":[{"resourceType":"BillingPeriods","locations":["Central
+        Central US","Global"],"apiVersions":["2017-06-01","2016-01-01"]},{"resourceType":"registrations/customerSubscriptions","locations":["West
+        Central US","Global"],"apiVersions":["2017-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BatchAI","namespace":"Microsoft.BatchAI","authorization":{"applicationId":"9fcb3732-5f52-4135-8c08-9d4bbaf203ea","roleDefinitionId":"703B89C7-CE2C-431B-BDD8-FA34E39AF696","managedByRoleDefinitionId":"90B8E153-EBFF-4073-A95F-4DAD56B14C78"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"jobs","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"fileservers","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"operations","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01-preview"]},{"resourceType":"locations/operationresults","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Billing","namespace":"Microsoft.Billing","resourceTypes":[{"resourceType":"BillingPeriods","locations":["Central
         US"],"apiVersions":["2017-04-24-preview"]},{"resourceType":"Invoices","locations":["Central
         US"],"apiVersions":["2017-04-24-preview","2017-02-27-preview"]},{"resourceType":"operations","locations":["Central
         US"],"apiVersions":["2017-04-24-preview","2017-02-27-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BingMaps","namespace":"Microsoft.BingMaps","resourceTypes":[{"resourceType":"mapApis","locations":["West
         US"],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-18","2015-07-02"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BizTalkServices","namespace":"Microsoft.BizTalkServices","resourceTypes":[{"resourceType":"BizTalk","locations":["East
         US","West US","North Europe","West Europe","Southeast Asia","East Asia","North
-        Central US","Japan West","Japan East","South Central US"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Cache","namespace":"Microsoft.Cache","authorization":{"applicationId":"96231a05-34ce-4eb4-aa6a-70759cbb5e83","roleDefinitionId":"4f731528-ba85-45c7-acfb-cd0a9b3cf31b"},"resourceTypes":[{"resourceType":"Redis","locations":["North
+        Central US","Japan West","Japan East","South Central US"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BotService","namespace":"Microsoft.BotService","resourceTypes":[{"resourceType":"botServices","locations":["Global"],"apiVersions":["2017-12-01"]},{"resourceType":"checkNameAvailability","locations":["Global"],"apiVersions":["2017-12-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Cache","namespace":"Microsoft.Cache","authorization":{"applicationId":"96231a05-34ce-4eb4-aa6a-70759cbb5e83","roleDefinitionId":"4f731528-ba85-45c7-acfb-cd0a9b3cf31b"},"resourceTypes":[{"resourceType":"Redis","locations":["North
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","Canada Central","Canada East","UK South","UK West","West US 2","West
-        Central US","South India","Korea Central","Korea South"],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","South India","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","South India","Canada Central","Canada East","UK South","UK West","West
-        US 2","West Central US","Korea Central","Korea South"],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01"]},{"resourceType":"Redis/metricDefinitions","locations":["North
+        US 2","West Central US","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01"]},{"resourceType":"Redis/metricDefinitions","locations":["North
         Central US","South Central US","East US","East US 2","West US","Central US","East
         Asia","Southeast Asia","North Europe","West Europe","Japan East","Japan West","Brazil
         South","Australia Southeast","Australia East","Central India","West India","South
@@ -1514,59 +1739,59 @@ http_interactions:
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/origins","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/origins","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/customdomains","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/customdomains","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/originresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/originresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/customdomainresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/customdomainresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkResourceUsage","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkResourceUsage","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02"]},{"resourceType":"validateProbe","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02"]},{"resourceType":"validateProbe","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02"]},{"resourceType":"operations","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02"]},{"resourceType":"operations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"edgenodes","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"edgenodes","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CertificateRegistration","namespace":"Microsoft.CertificateRegistration","authorization":{"applicationId":"f3c21649-0979-4721-ac85-b0216b2cf413","roleDefinitionId":"933fba7e-2ed3-4da8-973d-8bd8298a9b40"},"resourceTypes":[{"resourceType":"certificateOrders","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"certificateOrders/certificates","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"validateCertificateRegistrationInformation","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicSubscription","namespace":"Microsoft.ClassicSubscription","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicInfrastructureMigrate","namespace":"Microsoft.ClassicInfrastructureMigrate","authorization":{"applicationId":"5e5abe2b-83cd-4786-826a-a05653ebb103","roleDefinitionId":"766c4d9b-ef83-4f73-8352-1450a506a69b"},"resourceTypes":[{"resourceType":"classicInfrastructureResources","locations":["East
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CertificateRegistration","namespace":"Microsoft.CertificateRegistration","authorization":{"applicationId":"f3c21649-0979-4721-ac85-b0216b2cf413","roleDefinitionId":"933fba7e-2ed3-4da8-973d-8bd8298a9b40"},"resourceTypes":[{"resourceType":"certificateOrders","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"certificateOrders/certificates","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"validateCertificateRegistrationInformation","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicSubscription","namespace":"Microsoft.ClassicSubscription","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-09-01","2017-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicInfrastructureMigrate","namespace":"Microsoft.ClassicInfrastructureMigrate","authorization":{"applicationId":"5e5abe2b-83cd-4786-826a-a05653ebb103","roleDefinitionId":"766c4d9b-ef83-4f73-8352-1450a506a69b"},"resourceTypes":[{"resourceType":"classicInfrastructureResources","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
         Central US","Central US","North Europe","West Europe","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","West
@@ -1584,8 +1809,9 @@ http_interactions:
         Asia","East Asia","West Central US","South Central US","East US","East US
         2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/updateAccountsCreationSettings","locations":["West
         US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/accountsCreationSettings","locations":["West
-        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2016-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Commerce","namespace":"Microsoft.Commerce","resourceTypes":[{"resourceType":"UsageAggregates","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]},{"resourceType":"RateCard","locations":[],"apiVersions":["2016-08-31-preview","2015-06-01-preview","2015-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Consumption","namespace":"Microsoft.Consumption","resourceTypes":[{"resourceType":"reservationsummaries","locations":[],"apiVersions":["2017-01-30"]},{"resourceType":"reservationdetails","locations":[],"apiVersions":["2017-01-30"]},{"resourceType":"UsageDetails","locations":[],"apiVersions":["2017-06-30-preview","2017-04-24-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-30-preview","2017-04-24-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","resourceTypes":[{"resourceType":"containerGroups","locations":["West
-        US","East US","West Europe"],"apiVersions":["2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
+        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2016-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Commerce","namespace":"Microsoft.Commerce","resourceTypes":[{"resourceType":"UsageAggregates","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]},{"resourceType":"RateCard","locations":[],"apiVersions":["2016-08-31-preview","2015-06-01-preview","2015-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Consumption","namespace":"Microsoft.Consumption","resourceTypes":[{"resourceType":"ReservationSummaries","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationTransactions","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"Balances","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"Pricesheets","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationDetails","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"Budgets","locations":[],"apiVersions":["2017-12-30-preview"]},{"resourceType":"Terms","locations":[],"apiVersions":["2017-12-30-preview"]},{"resourceType":"UsageDetails","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview","2017-04-24-preview"]},{"resourceType":"Operations","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview","2017-04-24-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","resourceTypes":[{"resourceType":"containerGroups","locations":["West
+        US","East US","West Europe","Southeast Asia"],"apiVersions":["2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US","East US","West Europe","Southeast Asia"],"apiVersions":["2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
         US"],"apiVersions":["2016-04-08"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CustomerInsights","namespace":"Microsoft.CustomerInsights","authorization":{"applicationId":"38c77d00-5fcb-4cce-9d93-af4738258e3c","roleDefinitionId":"E006F9C7-F333-477C-8AD6-1F3A9FE87F55"},"resourceTypes":[{"resourceType":"hubs","locations":["East
         US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/profiles","locations":["East
         US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/interactions","locations":["East
@@ -1608,8 +1834,8 @@ http_interactions:
         US","West US","Australia East","West Europe","North Europe","Southeast Asia","West
         Central US"],"apiVersions":["2016-03-30","2015-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataFactory","namespace":"Microsoft.DataFactory","resourceTypes":[{"resourceType":"dataFactories","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview","2014-04-01"]},{"resourceType":"factories","locations":["East
-        US","East US 2"],"apiVersions":["2017-09-01-preview","2017-03-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
-        US","East US 2"],"apiVersions":["2017-09-01-preview","2017-03-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
+        US","East US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
+        US","East US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
         Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"dataFactories/metricDefinitions","locations":["North
         Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"checkDataFactoryNameAvailability","locations":[],"apiVersions":["2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"checkAzureDataFactoryNameAvailability","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"dataFactorySchema","locations":["West
@@ -1621,69 +1847,71 @@ http_interactions:
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers/listSasTokens","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeStore","namespace":"Microsoft.DataLakeStore","authorization":{"applicationId":"e9f49c6b-5ce5-44c8-925d-015017e9f7ad","roleDefinitionId":"17eb9cca-f08a-4499-b2d3-852d175f614f"},"resourceTypes":[{"resourceType":"accounts","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/firewallRules","locations":["East
-        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","resourceTypes":[{"resourceType":"operations","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforPostgreSQL","namespace":"Microsoft.DBforPostgreSQL","resourceTypes":[{"resourceType":"operations","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"checkProvisioningServiceNameAvailability","locations":[],"apiVersions":["2017-08-21-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataMigration","namespace":"Microsoft.DataMigration","authorization":{"applicationId":"a4bad4aa-bf02-4631-9f78-a64ffdba8150","roleDefinitionId":"b831a21d-db98-4760-89cb-bef871952df1","managedByRoleDefinitionId":"6256fb55-9e59-4018-a9e1-76b11c0a4c89"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services/projects","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationStatuses","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforPostgreSQL","namespace":"Microsoft.DBforPostgreSQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"checkProvisioningServiceNameAvailability","locations":[],"apiVersions":["2017-11-15","2017-08-21-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
         US","North Europe","East Asia","East US","West Europe","Southeast Asia","Japan
         East","Japan West","Australia East","Australia Southeast","West US 2","West
         Central US","East US 2","Central US","UK South","UK West","South India","Central
-        India","Canada Central","Canada East"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"ProvisioningServices","locations":["East
-        US","West Europe","Southeast Asia"],"apiVersions":["2017-08-21-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
-        East","Australia Southeast","Canada Central","Canada East","Central India","Central
-        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
-        US","North Europe","South Central US","South India","Southeast Asia","West
-        Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"databaseAccountNames","locations":["Australia
-        East","Australia Southeast","Canada Central","Canada East","Central India","Central
-        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
-        US","North Europe","South Central US","South India","Southeast Asia","West
-        Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"operations","locations":["Australia
-        East","Australia Southeast","Canada Central","Canada East","Central India","Central
-        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
-        US","North Europe","South Central US","South India","Southeast Asia","West
-        Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DomainRegistration","namespace":"Microsoft.DomainRegistration","authorization":{"applicationId":"ea2f600a-4980-45b7-89bf-d34da487bda1","roleDefinitionId":"54d7f2e3-5040-48a7-ae90-eebf629cfa0b"},"resourceTypes":[{"resourceType":"domains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"domains/domainOwnershipIdentifiers","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"topLevelDomains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"checkDomainAvailability","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"listDomainRecommendations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"validateDomainRegistrationInformation","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"generateSsoRequest","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DynamicsLcs","namespace":"Microsoft.DynamicsLcs","resourceTypes":[{"resourceType":"lcsprojects","locations":["Brazil
+        India","Canada Central","Canada East","Brazil South","South Central US"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs/eventGridFilters","locations":["West
+        US","East US","West US 2","West Central US","East US 2","Central US"],"apiVersions":["2018-01-15-preview"]},{"resourceType":"ProvisioningServices","locations":["East
+        US","West US","West Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2017-11-15","2017-08-21-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DomainRegistration","namespace":"Microsoft.DomainRegistration","authorization":{"applicationId":"ea2f600a-4980-45b7-89bf-d34da487bda1","roleDefinitionId":"54d7f2e3-5040-48a7-ae90-eebf629cfa0b"},"resourceTypes":[{"resourceType":"domains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"domains/domainOwnershipIdentifiers","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"topLevelDomains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"checkDomainAvailability","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"listDomainRecommendations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"validateDomainRegistrationInformation","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"generateSsoRequest","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DynamicsLcs","namespace":"Microsoft.DynamicsLcs","resourceTypes":[{"resourceType":"lcsprojects","locations":["Brazil
         South","East Asia","East US","Japan East","Japan West","North Central US","North
         Europe","South Central US","West Europe","West US","Southeast Asia","Central
         US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"lcsprojects/connectors","locations":["Brazil
@@ -1695,21 +1923,21 @@ http_interactions:
         US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"operations","locations":["Brazil
         South","East Asia","East US","Japan East","Japan West","North Central US","North
         Europe","South Central US","West Europe","West US","Southeast Asia","Central
-        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topics","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operations","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topics","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operations","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","West
         US 2","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
         India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/consumergroups","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
         US","East US 2","West US","South Central US","Central US","Australia East","Australia
         Southeast","Central India","West Central US","West US 2","Canada East","Canada
         Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
@@ -1754,23 +1982,23 @@ http_interactions:
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations","locations":["Australia
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations/operationResults","locations":["Australia
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations/operationResults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"operations","locations":["Australia
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"operations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Logic","namespace":"Microsoft.Logic","authorization":{"applicationId":"7cd684f4-8a78-49b0-91ec-6a35d38739ba","roleDefinitionId":"cb3ef1fb-6e31-49e2-9d87-ed821053fe58"},"resourceTypes":[{"resourceType":"workflows","locations":["North
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.LocationBasedServices","namespace":"Microsoft.LocationBasedServices","resourceTypes":[{"resourceType":"accounts","locations":["Global"],"apiVersions":["2017-01-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Logic","namespace":"Microsoft.Logic","authorization":{"applicationId":"7cd684f4-8a78-49b0-91ec-6a35d38739ba","roleDefinitionId":"cb3ef1fb-6e31-49e2-9d87-ed821053fe58"},"resourceTypes":[{"resourceType":"workflows","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
@@ -1791,60 +2019,78 @@ http_interactions:
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada Central","Canada East","West US 2","West Central
-        US","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","West Central US"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"operations","locations":["South
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations","locations":["South
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operations","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"commitmentPlans","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningExperimentation","namespace":"Microsoft.MachineLearningExperimentation","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"accounts","locations":["Australia
-        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces","locations":["Australia
-        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces/projects","locations":["Australia
-        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningCompute","namespace":"Microsoft.MachineLearningCompute","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"376aa7d7-51a9-463d-bd4d-7e1691345612","managedByRoleDefinitionId":"91d00862-cf55-46a5-9dce-260bbd92ce25"},"resourceTypes":[{"resourceType":"operationalizationClusters","locations":["East
-        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"operations","locations":["East
+        US","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningExperimentation","namespace":"Microsoft.MachineLearningExperimentation","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"accounts","locations":["Australia
+        East","East US 2","West Central US","Southeast Asia","West Europe"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces","locations":["Australia
+        East","East US 2","West Central US","Southeast Asia","West Europe"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces/projects","locations":["Australia
+        East","East US 2","West Central US","Southeast Asia","West Europe"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"teamAccounts","locations":["Australia
+        East","West Central US","East US 2"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"teamAccounts/workspaces","locations":["Australia
+        East","West Central US","East US 2"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"teamAccounts/workspaces/projects","locations":["Australia
+        East","West Central US","East US 2"],"apiVersions":["2017-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningCompute","namespace":"Microsoft.MachineLearningCompute","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"376aa7d7-51a9-463d-bd4d-7e1691345612","managedByRoleDefinitionId":"91d00862-cf55-46a5-9dce-260bbd92ce25"},"resourceTypes":[{"resourceType":"operationalizationClusters","locations":["East
+        US 2","West Central US","Australia East","West Europe","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"operations","locations":["East
         US 2"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations","locations":["East
         US 2"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operations","locations":["East
-        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["East
-        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningModelManagement","namespace":"Microsoft.MachineLearningModelManagement","resourceTypes":[{"resourceType":"accounts","locations":["East
-        US 2","West Central US","Australia East"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"operations","locations":["West
-        Central US"],"apiVersions":["2017-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
+        US 2","West Central US","Australia East","West Europe","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["East
+        US 2","West Central US","Australia East","West Europe","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningModelManagement","namespace":"Microsoft.MachineLearningModelManagement","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US 2","West Central US","Australia East","West Europe","Southeast Asia"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"operations","locations":["West
+        Central US"],"apiVersions":["2017-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ManagedIdentity","namespace":"Microsoft.ManagedIdentity","resourceTypes":[{"resourceType":"Identities","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Brazil South","Central
+        India","West India","South India","Japan West","Japan East","East Asia","Southeast
+        Asia","Korea Central","Korea South","North Europe","West Europe","UK West","UK
+        South","Central US","North Central US","East US","East US 2","South Central
+        US","West US","West US 2","West Central US"],"apiVersions":["2015-08-31-PREVIEW"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Brazil South","Central
+        India","West India","South India","Japan West","Japan East","East Asia","Southeast
+        Asia","Korea Central","Korea South","North Europe","West Europe","UK West","UK
+        South","Central US","North Central US","East US","East US 2","South Central
+        US","West US","West US 2","West Central US"],"apiVersions":["2015-08-31-PREVIEW"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Management","namespace":"Microsoft.Management","authorization":{"applicationId":"f2c304cf-8e7e-4c3f-8164-16299ad9d272","roleDefinitionId":"c1cf3708-588a-4647-be7f-f400bbe214cf"},"resourceTypes":[{"resourceType":"resources","locations":[],"apiVersions":["2017-11-01-preview","2017-08-31-preview","2017-06-30-preview","2017-05-31-preview"]},{"resourceType":"managementGroups","locations":[],"apiVersions":["2017-11-01-preview","2017-08-31-preview","2017-06-30-preview","2017-05-31-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01-preview","2017-08-31-preview","2017-06-30-preview","2017-05-31-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceApps","namespace":"Microsoft.MarketplaceApps","resourceTypes":[{"resourceType":"classicDevServices","locations":["Northwest
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","Central US","North
+        Europe","West Europe","Japan East","Japan West","Brazil South","Australia
+        East","Australia Southeast","South India","Central India","Canada Central","Canada
+        East"],"apiVersions":["2017-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
         Central US","West US"],"apiVersions":["2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01"]},{"resourceType":"offertypes","locations":["South
         Central US","West US"],"apiVersions":["2015-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Media","namespace":"Microsoft.Media","authorization":{"applicationId":"374b2a64-3b6b-436b-934c-b820eacca870","roleDefinitionId":"aab70789-0cec-44b5-95d7-84b64c9487af"},"resourceTypes":[{"resourceType":"mediaservices","locations":["Japan
         West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
         US","West US","Australia East","Australia Southeast","Central US","Brazil
         South","Central India","West India","South India","South Central US","Canada
-        Central","Canada East","West Central US"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
+        Central","Canada East","West Central US","West US 2"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
+        Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"operations","locations":["West
+        Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
+        Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PolicyInsights","namespace":"Microsoft.PolicyInsights","authorization":{"applicationId":"1d78a85d-813d-46f0-b496-dd72f50a3ec0","roleDefinitionId":"63d2b225-4c34-4641-8768-21a1f7c68ce8"},"resourceTypes":[{"resourceType":"policyEvents","locations":[],"apiVersions":["2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"policyStates","locations":[],"apiVersions":["2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-17-preview","2017-08-09-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
         Central US","North Central US","East US 2","West US","West Europe","North
         Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
         East","UK South","West India"],"apiVersions":["2016-01-29"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-01-29"]},{"resourceType":"locations/checkNameAvailability","locations":["South
         Central US","North Central US","East US 2","West US","West Europe","North
         Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
-        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"capacities","locations":["West
-        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
-        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationresults","locations":["West
-        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
-        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"operations","locations":["East
-        US 2"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Relay","namespace":"Microsoft.Relay","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"capacities","locations":["Australia
+        Southeast","Brazil South","Canada Central","East Asia","East US","East US
+        2","West India","Japan East","West Central US","North Central US","North Europe","South
+        Central US","Southeast Asia","UK South","West Europe","West US","West US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":["Australia
+        Southeast","Brazil South","Canada Central","East Asia","East US","East US
+        2","West India","Japan East","West Central US","North Central US","North Europe","South
+        Central US","Southeast Asia","UK South","West Europe","West US","West US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationresults","locations":["Australia
+        Southeast","Brazil South","Canada Central","East Asia","East US","East US
+        2","West India","Japan East","West Central US","North Central US","North Europe","South
+        Central US","Southeast Asia","UK South","West Europe","West US","West US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["Australia
+        Southeast","Brazil South","Canada Central","East Asia","East US","East US
+        2","West India","Japan East","West Central US","North Central US","North Europe","South
+        Central US","Southeast Asia","UK South","West Europe","West US","West US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"operations","locations":["East
+        US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Relay","namespace":"Microsoft.Relay","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US 2","West
         US","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
         India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2017-08-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkPolicyCompliance","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/hybridconnections","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/hybridconnections/authorizationrules","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/wcfrelays","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/wcfrelays/authorizationrules","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkPolicyCompliance","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
         Central US","South Central US","North Europe","West Europe","East Asia","Southeast
         Asia","West US","East US","Japan West","Japan East","Brazil South","Central
         US","East US 2","Australia East","Australia Southeast","South India","Central
@@ -1868,12 +2114,12 @@ http_interactions:
         India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19","2015-02-28"]},{"resourceType":"checkServiceNameAvailability","locations":[],"apiVersions":["2015-02-28","2014-07-31-Preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2015-08-19"]},{"resourceType":"resourceHealthMetadata","locations":["West
         US","East US","North Europe","West Europe","Southeast Asia","East Asia","North
         Central US","South Central US","Japan West","Australia East","Brazil South","Central
-        India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","authorization":{"applicationId":"80a10ef9-8168-493d-abf9-3297c4ef6e3c","roleDefinitionId":"2b7763f7-bbe2-4e19-befe-28c79f1cf7f7"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US 2","West
         US","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
         India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"premiumMessagingRegions","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceFabric","namespace":"Microsoft.ServiceFabric","authorization":{"applicationId":"74cb6831-0dbb-4be1-8206-fd4df301cdc2","roleDefinitionId":"e55cc65f-6903-4917-b4ef-f8d4640b57f5"},"resourceTypes":[{"resourceType":"clusters","locations":["West
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/queues","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/queues/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/topics","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/topics/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/topics/subscriptions","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/topics/subscriptions/rules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"premiumMessagingRegions","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceFabric","namespace":"Microsoft.ServiceFabric","authorization":{"applicationId":"74cb6831-0dbb-4be1-8206-fd4df301cdc2","roleDefinitionId":"e55cc65f-6903-4917-b4ef-f8d4640b57f5"},"resourceTypes":[{"resourceType":"clusters","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
@@ -1887,17 +2133,43 @@ http_interactions:
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
-        India","West India","Central India","Brazil South","South Central US","Canada
-        Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
         Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
         Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applianceDefinitions","locations":["West
-        Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"locations","locations":["West
-        Central US"],"apiVersions":["2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
-        Central US"],"apiVersions":["2017-09-01","2016-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
+        Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applications","locations":["South
+        Central US","North Central US","West Central US","West US","West US 2","East
+        US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
+        Asia","Brazil South","Japan West","Japan East","Australia East","Australia
+        Southeast","South India","West India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
+        Central US","North Central US","West Central US","West US","West US 2","East
+        US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
+        Asia","Brazil South","Japan West","Japan East","Australia East","Australia
+        Southeast","South India","West India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
+        Central US"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
+        Central US","North Central US","West Central US","West US","West US 2","East
+        US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
+        Asia","Brazil South","Japan West","Japan East","Australia East","Australia
+        Southeast","South India","West India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/cloudEndpoints","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/serverEndpoints","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/registeredServers","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/workflows","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","West Central US","Japan East","Japan West","Australia East","Australia
         Southeast"],"apiVersions":["2017-06-01","2017-05-15","2017-01-01","2016-10-01","2016-06-01","2015-03-15","2014-09-01"]},{"resourceType":"operations","locations":["West
@@ -1928,23 +2200,11 @@ http_interactions:
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast"],"apiVersions":["2015-07-01-Preview","2015-03-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.TimeSeriesInsights","namespace":"Microsoft.TimeSeriesInsights","authorizations":[{"applicationId":"120d688d-1518-4cf7-bd38-182f158850b6","roleDefinitionId":"5a43abdf-bb87-42c4-9e56-1c24bf364150"}],"resourceTypes":[{"resourceType":"environments","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/eventsources","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/referenceDataSets","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/accessPolicies","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"operations","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
-        Central US","South Central US","East US","West US","Central US","North Europe","West
-        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
-        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/project","locations":["North
-        Central US","South Central US","East US","West US","Central US","North Europe","West
-        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
-        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/extension","locations":["North
-        Central US","South Central US","East US","West US","Central US","North Europe","West
-        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
-        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"checkNameAvailability","locations":["North
-        Central US","South Central US","East US","West US","Central US","North Europe","West
-        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
-        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Myget.PackageManagement","namespace":"Myget.PackageManagement","resourceTypes":[{"resourceType":"services","locations":["West
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]},{"resourceType":"environments/eventsources","locations":["East
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]},{"resourceType":"environments/referenceDataSets","locations":["East
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]},{"resourceType":"environments/accessPolicies","locations":["East
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]},{"resourceType":"operations","locations":["East
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Myget.PackageManagement","namespace":"Myget.PackageManagement","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/NewRelic.APM","namespace":"NewRelic.APM","authorization":{"allowedThirdPartyExtensions":[{"name":"NewRelic_AzurePortal_APM"}]},"resourceTypes":[{"resourceType":"accounts","locations":["North
         Central US","South Central US","West US","East US","North Europe","West Europe","Southeast
         Asia","East Asia","Japan East","Japan West"],"apiVersions":["2014-10-01","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/nuubit.nextgencdn","namespace":"nuubit.nextgencdn","resourceTypes":[{"resourceType":"accounts","locations":["East
@@ -1984,7 +2244,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:32 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:31 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
@@ -2001,9 +2261,11 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNTEsIm5iZiI6MTUwNjExNjI1MSwiZXhwIjoxNTA2MTIwMTUxLCJhaW8iOiJZMlZnWUxnV3ZNR2haN3JqaENYWDZqZFBmcVp3RlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQWVfNjVva2FWMHFncVRPelNJRU1BQSIsInZlciI6IjEuMCJ9.yzoeDCrqx6h9nl-b6GtfmDyJbotu_2GBJu-ip3XG01YchUdtta9kywHCIj3lJYb4R5vXZEQPNg9M0bpMuy_rjlMLEWMcFxFU8iocbWvIm1JHj67MsPUQn-01Rl6sIvWrHA_qiKjv4RzfIECHmA6lY9zxpjLywyLjvlC8_zyME4-3AHUoy0felmuv7nWwCUXS4UhWtQkwNzNv5jIoBUb3hWFa5S-GNkgsrUwPgu0S-Y6AfGM58eXZgmPLCJwHrkXQiDcbc7qpncDb06snvYrQVwNHYXKe0QIlAmDEB4kaqJmrPyTRky_GCV63g5lfionsieQSEaKMl4xqchA0MGu36w
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3NTAsIm5iZiI6MTUxNjczNzc1MCwiZXhwIjoxNTE2NzQxNjUwLCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWFRpdVc0Yk8yMENCU3Y0ejlsTVNBQSIsInZlciI6IjEuMCJ9.JvlnLotIgeGfqHeVtf8RveMNGourqxZKxnVupLwgCwghgdbAGxgPwllZ6c6q-I0eawKs9N3rfx20neFUfyOTZlOsKHa1ARe2_VfBQCAtzx65URN1V4KQiSwvSkPtFA1COuKZip5KL-rc0piB7bUvrmY07T2DAu0Iy5BrZ31iYgbTDJ2LV12xC-jVl4GCuEcpcB5b2B51oQw82fzu6v8UhNnhiaT-Gee8O-PcggNzNEoot7C6gweJ8i9UCccg9JVU2h9K0lk53K7Q2C2iiMBkWVI9g07VNqtwKpBbi2He1hGvkTCd3gsYtBRO3GHRRF511SbHJfYRkeU-p3_3z3Wxbw
       Content-Length:
       - '42'
+      Host:
+      - management.azure.com
   response:
     status:
       code: 202
@@ -2013,39 +2275,41 @@ http_interactions:
       - no-cache
       Pragma:
       - no-cache
-      Content-Length:
-      - '0'
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/4a0c2863-3b65-416f-b65a-3a178db4140c?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/36610ef8-5aa0-4ae9-a15d-f7e6a7af1ef3?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/4a0c2863-3b65-416f-b65a-3a178db4140c?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/36610ef8-5aa0-4ae9-a15d-f7e6a7af1ef3?api-version=2017-03-30
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/HighCostHydrate3Min;230,Microsoft.Compute/HighCostHydrate30Min;1157
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131599701143261070
       X-Ms-Request-Id:
-      - 4a0c2863-3b65-416f-b65a-3a178db4140c
+      - 36610ef8-5aa0-4ae9-a15d-f7e6a7af1ef3
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1185'
+      - '1160'
       X-Ms-Correlation-Request-Id:
-      - 31a56b3f-6742-44a1-948e-8022efc8eadd
+      - 2147fb76-45c3-4262-9a96-8ae33e704b46
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214234Z:31a56b3f-6742-44a1-948e-8022efc8eadd
+      - WESTUS:20180123T200733Z:2147fb76-45c3-4262-9a96-8ae33e704b46
       Date:
-      - Fri, 22 Sep 2017 21:42:34 GMT
+      - Tue, 23 Jan 2018 20:07:32 GMT
+      Content-Length:
+      - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:33 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:33 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/4a0c2863-3b65-416f-b65a-3a178db4140c?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/36610ef8-5aa0-4ae9-a15d-f7e6a7af1ef3?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -2059,7 +2323,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNTEsIm5iZiI6MTUwNjExNjI1MSwiZXhwIjoxNTA2MTIwMTUxLCJhaW8iOiJZMlZnWUxnV3ZNR2haN3JqaENYWDZqZFBmcVp3RlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQWVfNjVva2FWMHFncVRPelNJRU1BQSIsInZlciI6IjEuMCJ9.yzoeDCrqx6h9nl-b6GtfmDyJbotu_2GBJu-ip3XG01YchUdtta9kywHCIj3lJYb4R5vXZEQPNg9M0bpMuy_rjlMLEWMcFxFU8iocbWvIm1JHj67MsPUQn-01Rl6sIvWrHA_qiKjv4RzfIECHmA6lY9zxpjLywyLjvlC8_zyME4-3AHUoy0felmuv7nWwCUXS4UhWtQkwNzNv5jIoBUb3hWFa5S-GNkgsrUwPgu0S-Y6AfGM58eXZgmPLCJwHrkXQiDcbc7qpncDb06snvYrQVwNHYXKe0QIlAmDEB4kaqJmrPyTRky_GCV63g5lfionsieQSEaKMl4xqchA0MGu36w
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3NTAsIm5iZiI6MTUxNjczNzc1MCwiZXhwIjoxNTE2NzQxNjUwLCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWFRpdVc0Yk8yMENCU3Y0ejlsTVNBQSIsInZlciI6IjEuMCJ9.JvlnLotIgeGfqHeVtf8RveMNGourqxZKxnVupLwgCwghgdbAGxgPwllZ6c6q-I0eawKs9N3rfx20neFUfyOTZlOsKHa1ARe2_VfBQCAtzx65URN1V4KQiSwvSkPtFA1COuKZip5KL-rc0piB7bUvrmY07T2DAu0Iy5BrZ31iYgbTDJ2LV12xC-jVl4GCuEcpcB5b2B51oQw82fzu6v8UhNnhiaT-Gee8O-PcggNzNEoot7C6gweJ8i9UCccg9JVU2h9K0lk53K7Q2C2iiMBkWVI9g07VNqtwKpBbi2He1hGvkTCd3gsYtBRO3GHRRF511SbHJfYRkeU-p3_3z3Wxbw
+      Host:
+      - management.azure.com
   response:
     status:
       code: 200
@@ -2077,34 +2343,36 @@ http_interactions:
       - "-1"
       Vary:
       - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/GetOperation3Min;49974,Microsoft.Compute/GetOperation30Min;249974
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131599701143261070
       X-Ms-Request-Id:
-      - eef11316-2ad5-4ff7-a8cb-cc9a836a6a69
+      - 4e7da9bc-02ad-44a9-bd1e-cb3fe215b109
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14913'
+      - '14855'
       X-Ms-Correlation-Request-Id:
-      - 4cbeb191-cdc4-4114-974f-fd25a5718bb6
+      - 84a13989-4f01-4973-a838-e588eedd7214
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214235Z:4cbeb191-cdc4-4114-974f-fd25a5718bb6
+      - WESTUS:20180123T200733Z:84a13989-4f01-4973-a838-e588eedd7214
       Date:
-      - Fri, 22 Sep 2017 21:42:34 GMT
+      - Tue, 23 Jan 2018 20:07:33 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-22T21:42:35.8383046+00:00\",\r\n  \"endTime\":
-        \"2017-09-22T21:42:36.0570674+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=ea7f51ca-94cc-4b22-a944-7d1201dce37e&sig=XABfazFRzmWVlCzOZJVLNDF%2BCgQtDUE1J9y9YqJaZAg%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"4a0c2863-3b65-416f-b65a-3a178db4140c\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2018-01-23T20:07:32.5070876+00:00\",\r\n  \"endTime\":
+        \"2018-01-23T20:07:32.7414631+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=c9861f23-aa7b-48cd-81c9-c6594d6b55aa&sig=J%2FulH%2Fx3DkWTp6lFyHJ6ZCkILJwKsZrj5zTTplIg5tI%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"36610ef8-5aa0-4ae9-a15d-f7e6a7af1ef3\"\r\n}"
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:34 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:33 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/4a0c2863-3b65-416f-b65a-3a178db4140c?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/36610ef8-5aa0-4ae9-a15d-f7e6a7af1ef3?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -2118,7 +2386,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNTEsIm5iZiI6MTUwNjExNjI1MSwiZXhwIjoxNTA2MTIwMTUxLCJhaW8iOiJZMlZnWUxnV3ZNR2haN3JqaENYWDZqZFBmcVp3RlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQWVfNjVva2FWMHFncVRPelNJRU1BQSIsInZlciI6IjEuMCJ9.yzoeDCrqx6h9nl-b6GtfmDyJbotu_2GBJu-ip3XG01YchUdtta9kywHCIj3lJYb4R5vXZEQPNg9M0bpMuy_rjlMLEWMcFxFU8iocbWvIm1JHj67MsPUQn-01Rl6sIvWrHA_qiKjv4RzfIECHmA6lY9zxpjLywyLjvlC8_zyME4-3AHUoy0felmuv7nWwCUXS4UhWtQkwNzNv5jIoBUb3hWFa5S-GNkgsrUwPgu0S-Y6AfGM58eXZgmPLCJwHrkXQiDcbc7qpncDb06snvYrQVwNHYXKe0QIlAmDEB4kaqJmrPyTRky_GCV63g5lfionsieQSEaKMl4xqchA0MGu36w
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3NTAsIm5iZiI6MTUxNjczNzc1MCwiZXhwIjoxNTE2NzQxNjUwLCJhaW8iOiJZMk5nWVBEWWRZck5ONUw1d3JXK2c4KzZybS85Q2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWFRpdVc0Yk8yMENCU3Y0ejlsTVNBQSIsInZlciI6IjEuMCJ9.JvlnLotIgeGfqHeVtf8RveMNGourqxZKxnVupLwgCwghgdbAGxgPwllZ6c6q-I0eawKs9N3rfx20neFUfyOTZlOsKHa1ARe2_VfBQCAtzx65URN1V4KQiSwvSkPtFA1COuKZip5KL-rc0piB7bUvrmY07T2DAu0Iy5BrZ31iYgbTDJ2LV12xC-jVl4GCuEcpcB5b2B51oQw82fzu6v8UhNnhiaT-Gee8O-PcggNzNEoot7C6gweJ8i9UCccg9JVU2h9K0lk53K7Q2C2iiMBkWVI9g07VNqtwKpBbi2He1hGvkTCd3gsYtBRO3GHRRF511SbHJfYRkeU-p3_3z3Wxbw
+      Host:
+      - management.azure.com
   response:
     status:
       code: 200
@@ -2136,34 +2406,36 @@ http_interactions:
       - "-1"
       Vary:
       - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/GetOperation3Min;49973,Microsoft.Compute/GetOperation30Min;249973
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131599701143261070
       X-Ms-Request-Id:
-      - f18c5793-071a-46fc-94ca-382fc78d61fa
+      - 3246b887-e847-4901-ac37-40165f4a182b
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14923'
+      - '14887'
       X-Ms-Correlation-Request-Id:
-      - aac6c222-5dbc-48a7-864e-93e84d18a1cf
+      - 195b1889-38ed-47d5-b86b-03950a923dbe
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214235Z:aac6c222-5dbc-48a7-864e-93e84d18a1cf
+      - WESTUS:20180123T200734Z:195b1889-38ed-47d5-b86b-03950a923dbe
       Date:
-      - Fri, 22 Sep 2017 21:42:35 GMT
+      - Tue, 23 Jan 2018 20:07:33 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-22T21:42:35.8383046+00:00\",\r\n  \"endTime\":
-        \"2017-09-22T21:42:36.0570674+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=ea7f51ca-94cc-4b22-a944-7d1201dce37e&sig=XABfazFRzmWVlCzOZJVLNDF%2BCgQtDUE1J9y9YqJaZAg%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"4a0c2863-3b65-416f-b65a-3a178db4140c\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2018-01-23T20:07:32.5070876+00:00\",\r\n  \"endTime\":
+        \"2018-01-23T20:07:32.7414631+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=c9861f23-aa7b-48cd-81c9-c6594d6b55aa&sig=J%2FulH%2Fx3DkWTp6lFyHJ6ZCkILJwKsZrj5zTTplIg5tI%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"36610ef8-5aa0-4ae9-a15d-f7e6a7af1ef3\"\r\n}"
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:34 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:34 GMT
 - request:
     method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=ea7f51ca-94cc-4b22-a944-7d1201dce37e&sig=XABfazFRzmWVlCzOZJVLNDF%2BCgQtDUE1J9y9YqJaZAg=&sr=b&sv=2016-05-31
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=c9861f23-aa7b-48cd-81c9-c6594d6b55aa&sig=J/ulH/x3DkWTp6lFyHJ6ZCkILJwKsZrj5zTTplIg5tI=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2176,6 +2448,8 @@ http_interactions:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
       X-Ms-Range:
       - bytes=0-0
+      Host:
+      - md-t4jdgqqlgszp.blob.core.windows.net
   response:
     status:
       code: 206
@@ -2188,15 +2462,15 @@ http_interactions:
       Content-Range:
       - bytes 0-0/34359738880
       Last-Modified:
-      - Sat, 15 Jul 2017 14:23:07 GMT
+      - Tue, 23 Jan 2018 20:04:26 GMT
       Accept-Ranges:
       - bytes
       Etag:
-      - '"0x8D4CB8D039FC699"'
+      - '"0x8D5629C811B65EB"'
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - b1326ac1-001e-00bf-55eb-33b55b000000
+      - 86e4ef5e-001e-00eb-1f85-945fd1000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2208,7 +2482,7 @@ http_interactions:
       X-Ms-Blob-Type:
       - PageBlob
       X-Ms-Blob-Sequence-Number:
-      - '20'
+      - '30'
       X-Ms-Copy-Id:
       - 30cedd78-548a-4fd8-967e-f8344f587e3c
       X-Ms-Copy-Source:
@@ -2222,250 +2496,16 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Fri, 22 Sep 2017 21:42:35 GMT
+      - Tue, 23 Jan 2018 20:07:34 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         6w==
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:35 GMT
-- request:
-    method: post
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/EndGetAccess?api-version=2017-03-30
-    body:
-      encoding: ASCII-8BIT
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNTEsIm5iZiI6MTUwNjExNjI1MSwiZXhwIjoxNTA2MTIwMTUxLCJhaW8iOiJZMlZnWUxnV3ZNR2haN3JqaENYWDZqZFBmcVp3RlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQWVfNjVva2FWMHFncVRPelNJRU1BQSIsInZlciI6IjEuMCJ9.yzoeDCrqx6h9nl-b6GtfmDyJbotu_2GBJu-ip3XG01YchUdtta9kywHCIj3lJYb4R5vXZEQPNg9M0bpMuy_rjlMLEWMcFxFU8iocbWvIm1JHj67MsPUQn-01Rl6sIvWrHA_qiKjv4RzfIECHmA6lY9zxpjLywyLjvlC8_zyME4-3AHUoy0felmuv7nWwCUXS4UhWtQkwNzNv5jIoBUb3hWFa5S-GNkgsrUwPgu0S-Y6AfGM58eXZgmPLCJwHrkXQiDcbc7qpncDb06snvYrQVwNHYXKe0QIlAmDEB4kaqJmrPyTRky_GCV63g5lfionsieQSEaKMl4xqchA0MGu36w
-      Content-Length:
-      - '0'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '0'
-      Expires:
-      - "-1"
-      Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/1410599e-84ce-4711-b867-3cbf4e36754f?monitor=true&api-version=2017-03-30
-      Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/1410599e-84ce-4711-b867-3cbf4e36754f?api-version=2017-03-30
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - 1410599e-84ce-4711-b867-3cbf4e36754f
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1183'
-      X-Ms-Correlation-Request-Id:
-      - 5188bf09-9e1d-495b-95d9-9c6ef7eedca4
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214236Z:5188bf09-9e1d-495b-95d9-9c6ef7eedca4
-      Date:
-      - Fri, 22 Sep 2017 21:42:36 GMT
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:35 GMT
-- request:
-    method: post
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
-    body:
-      encoding: UTF-8
-      string: '{"access":"read","durationInSeconds":3600}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNTEsIm5iZiI6MTUwNjExNjI1MSwiZXhwIjoxNTA2MTIwMTUxLCJhaW8iOiJZMlZnWUxnV3ZNR2haN3JqaENYWDZqZFBmcVp3RlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQWVfNjVva2FWMHFncVRPelNJRU1BQSIsInZlciI6IjEuMCJ9.yzoeDCrqx6h9nl-b6GtfmDyJbotu_2GBJu-ip3XG01YchUdtta9kywHCIj3lJYb4R5vXZEQPNg9M0bpMuy_rjlMLEWMcFxFU8iocbWvIm1JHj67MsPUQn-01Rl6sIvWrHA_qiKjv4RzfIECHmA6lY9zxpjLywyLjvlC8_zyME4-3AHUoy0felmuv7nWwCUXS4UhWtQkwNzNv5jIoBUb3hWFa5S-GNkgsrUwPgu0S-Y6AfGM58eXZgmPLCJwHrkXQiDcbc7qpncDb06snvYrQVwNHYXKe0QIlAmDEB4kaqJmrPyTRky_GCV63g5lfionsieQSEaKMl4xqchA0MGu36w
-      Content-Length:
-      - '42'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '0'
-      Expires:
-      - "-1"
-      Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/16e4e359-1754-41ab-bd6e-b62ac7bf805e?monitor=true&api-version=2017-03-30
-      Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/16e4e359-1754-41ab-bd6e-b62ac7bf805e?api-version=2017-03-30
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - 16e4e359-1754-41ab-bd6e-b62ac7bf805e
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1183'
-      X-Ms-Correlation-Request-Id:
-      - 10063a85-2416-4699-8112-8e354f43726f
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214237Z:10063a85-2416-4699-8112-8e354f43726f
-      Date:
-      - Fri, 22 Sep 2017 21:42:36 GMT
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:36 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:34 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/16e4e359-1754-41ab-bd6e-b62ac7bf805e?api-version=2017-03-30
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNTEsIm5iZiI6MTUwNjExNjI1MSwiZXhwIjoxNTA2MTIwMTUxLCJhaW8iOiJZMlZnWUxnV3ZNR2haN3JqaENYWDZqZFBmcVp3RlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQWVfNjVva2FWMHFncVRPelNJRU1BQSIsInZlciI6IjEuMCJ9.yzoeDCrqx6h9nl-b6GtfmDyJbotu_2GBJu-ip3XG01YchUdtta9kywHCIj3lJYb4R5vXZEQPNg9M0bpMuy_rjlMLEWMcFxFU8iocbWvIm1JHj67MsPUQn-01Rl6sIvWrHA_qiKjv4RzfIECHmA6lY9zxpjLywyLjvlC8_zyME4-3AHUoy0felmuv7nWwCUXS4UhWtQkwNzNv5jIoBUb3hWFa5S-GNkgsrUwPgu0S-Y6AfGM58eXZgmPLCJwHrkXQiDcbc7qpncDb06snvYrQVwNHYXKe0QIlAmDEB4kaqJmrPyTRky_GCV63g5lfionsieQSEaKMl4xqchA0MGu36w
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - a1a64b8e-0a5e-4d4f-b42c-c313b69fd055
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14928'
-      X-Ms-Correlation-Request-Id:
-      - d3ff3779-7b7a-42dc-84f3-59899702e675
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214238Z:d3ff3779-7b7a-42dc-84f3-59899702e675
-      Date:
-      - Fri, 22 Sep 2017 21:42:37 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-22T21:42:38.7452672+00:00\",\r\n  \"endTime\":
-        \"2017-09-22T21:42:38.9640627+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=ecd23b31-3157-4872-9b2d-bed4826624f0&sig=iulVige61e9ofaQPJbKxWQQJIrQIp7787w1Q25UfWyw%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"16e4e359-1754-41ab-bd6e-b62ac7bf805e\"\r\n}"
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:37 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/16e4e359-1754-41ab-bd6e-b62ac7bf805e?api-version=2017-03-30
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNTEsIm5iZiI6MTUwNjExNjI1MSwiZXhwIjoxNTA2MTIwMTUxLCJhaW8iOiJZMlZnWUxnV3ZNR2haN3JqaENYWDZqZFBmcVp3RlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQWVfNjVva2FWMHFncVRPelNJRU1BQSIsInZlciI6IjEuMCJ9.yzoeDCrqx6h9nl-b6GtfmDyJbotu_2GBJu-ip3XG01YchUdtta9kywHCIj3lJYb4R5vXZEQPNg9M0bpMuy_rjlMLEWMcFxFU8iocbWvIm1JHj67MsPUQn-01Rl6sIvWrHA_qiKjv4RzfIECHmA6lY9zxpjLywyLjvlC8_zyME4-3AHUoy0felmuv7nWwCUXS4UhWtQkwNzNv5jIoBUb3hWFa5S-GNkgsrUwPgu0S-Y6AfGM58eXZgmPLCJwHrkXQiDcbc7qpncDb06snvYrQVwNHYXKe0QIlAmDEB4kaqJmrPyTRky_GCV63g5lfionsieQSEaKMl4xqchA0MGu36w
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - 38d8ea10-b71e-44c8-a354-96228b7a1e82
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14939'
-      X-Ms-Correlation-Request-Id:
-      - 072fad29-5aab-4597-9bc2-d84ac7cbdbee
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214238Z:072fad29-5aab-4597-9bc2-d84ac7cbdbee
-      Date:
-      - Fri, 22 Sep 2017 21:42:38 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-22T21:42:38.7452672+00:00\",\r\n  \"endTime\":
-        \"2017-09-22T21:42:38.9640627+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=ecd23b31-3157-4872-9b2d-bed4826624f0&sig=iulVige61e9ofaQPJbKxWQQJIrQIp7787w1Q25UfWyw%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"16e4e359-1754-41ab-bd6e-b62ac7bf805e\"\r\n}"
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:38 GMT
-- request:
-    method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=ecd23b31-3157-4872-9b2d-bed4826624f0&sig=iulVige61e9ofaQPJbKxWQQJIrQIp7787w1Q25UfWyw=&sr=b&sv=2016-05-31
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=c9861f23-aa7b-48cd-81c9-c6594d6b55aa&sig=J/ulH/x3DkWTp6lFyHJ6ZCkILJwKsZrj5zTTplIg5tI=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2478,6 +2518,8 @@ http_interactions:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
       X-Ms-Range:
       - bytes=440-443
+      Host:
+      - md-t4jdgqqlgszp.blob.core.windows.net
   response:
     status:
       code: 206
@@ -2490,15 +2532,15 @@ http_interactions:
       Content-Range:
       - bytes 440-443/34359738880
       Last-Modified:
-      - Sat, 15 Jul 2017 14:23:07 GMT
+      - Tue, 23 Jan 2018 20:04:26 GMT
       Accept-Ranges:
       - bytes
       Etag:
-      - '"0x8D4CB8D039FC699"'
+      - '"0x8D5629C811B65EB"'
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 1ffd947e-001e-010a-25eb-33fef1000000
+      - c238562b-001e-011b-2185-94c9ea000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2510,7 +2552,7 @@ http_interactions:
       X-Ms-Blob-Type:
       - PageBlob
       X-Ms-Blob-Sequence-Number:
-      - '20'
+      - '30'
       X-Ms-Copy-Id:
       - 30cedd78-548a-4fd8-967e-f8344f587e3c
       X-Ms-Copy-Source:
@@ -2524,69 +2566,11 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Fri, 22 Sep 2017 21:42:38 GMT
+      - Tue, 23 Jan 2018 20:07:35 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         U5MJAA==
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:38 GMT
-- request:
-    method: post
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/EndGetAccess?api-version=2017-03-30
-    body:
-      encoding: ASCII-8BIT
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyNTEsIm5iZiI6MTUwNjExNjI1MSwiZXhwIjoxNTA2MTIwMTUxLCJhaW8iOiJZMlZnWUxnV3ZNR2haN3JqaENYWDZqZFBmcVp3RlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQWVfNjVva2FWMHFncVRPelNJRU1BQSIsInZlciI6IjEuMCJ9.yzoeDCrqx6h9nl-b6GtfmDyJbotu_2GBJu-ip3XG01YchUdtta9kywHCIj3lJYb4R5vXZEQPNg9M0bpMuy_rjlMLEWMcFxFU8iocbWvIm1JHj67MsPUQn-01Rl6sIvWrHA_qiKjv4RzfIECHmA6lY9zxpjLywyLjvlC8_zyME4-3AHUoy0felmuv7nWwCUXS4UhWtQkwNzNv5jIoBUb3hWFa5S-GNkgsrUwPgu0S-Y6AfGM58eXZgmPLCJwHrkXQiDcbc7qpncDb06snvYrQVwNHYXKe0QIlAmDEB4kaqJmrPyTRky_GCV63g5lfionsieQSEaKMl4xqchA0MGu36w
-      Content-Length:
-      - '0'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '0'
-      Expires:
-      - "-1"
-      Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/239777ed-b55a-4216-ae05-deae75ec3404?monitor=true&api-version=2017-03-30
-      Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/239777ed-b55a-4216-ae05-deae75ec3404?api-version=2017-03-30
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - 239777ed-b55a-4216-ae05-deae75ec3404
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1185'
-      X-Ms-Correlation-Request-Id:
-      - 7c80fd65-86f4-48b4-978d-e3f1800557a5
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214239Z:7c80fd65-86f4-48b4-978d-e3f1800557a5
-      Date:
-      - Fri, 22 Sep 2017 21:42:39 GMT
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:39 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:35 GMT
 recorded_with: VCR 3.0.3

--- a/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_startByteAddr-1.yml
+++ b/spec/recordings/disk/modules/azure_managed_disk_spec/azure_managed_disk_spec_startByteAddr-1.yml
@@ -17,6 +17,8 @@ http_interactions:
       - '186'
       Content-Type:
       - application/x-www-form-urlencoded
+      Host:
+      - login.microsoftonline.com
   response:
     status:
       code: 200
@@ -37,25 +39,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 48f95e2d-d869-4fe7-8c36-f13c0f0a0d00
+      - ff1bdf47-e965-4dc7-991a-9a01974a4300
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAAABlDrqfEFlSaui6xnRjX5EwYQxHm0G_qE03nz-XmxlFNDp4oqMZOIr4gb2JPCJ3egC57SGsnb2kVyx18N444Aup3nF3av7UvGhiu6ZU0U2jZtNiT6ib96uHGDpgbMfVK_UDksNX--DLS2S3JatRfzBc_k0ANMv_ctMuzZ9H8DBFTqbyONlYgREUlHm_Nwjx6kgAA;
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzRYH-5Ttylkfr1C-Q7Y3MBYPUkNwMI8h6rgaZE97Zv1Ur_57w1gQtvotVwIUYWspVgDSspgUsFucDuoQlei7bIrm4vn2GMb1xRAw6sIZkpbYNmf7XF_DORFe-9SOfLZTrLk3djuvkOfdy5-xG-Bdct70zYG0jwfBXHsp1THMG5YsgAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=008; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=007; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Fri, 22 Sep 2017 21:42:07 GMT
+      - Tue, 23 Jan 2018 20:07:14 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1506120127","not_before":"1506116227","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMjcsIm5iZiI6MTUwNjExNjIyNywiZXhwIjoxNTA2MTIwMTI3LCJhaW8iOiJZMlZnWU5pV0pXUHdMc2ZWM2ZoSVFWajJIT3N5QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTFY3NVNHblk1MC1NTnZFOER3b05BQSIsInZlciI6IjEuMCJ9.qvqsibTj97Wje7DCzUZsV0avjdDT3jRuYQaaD4f6Zx9Nw6quJKnQDC-ifyJGTzLH38kpVmfLEZhClnR-HC2Y7nFMt_MEgpSrE1kOx9ZC3tbRPCp053tqyehRMpwIDaSQaulpJEL2SW-a3uR_4twj7Tck7yGwaA0jT9rV1kEARjo3g-A5P4fVwmf7vhMI-3u4QcBSrxN0JsYO5OufKAiXaECbT1aBUKACVMQzQjhu5w2RJLpS45vFL9y-H8VboQC3XB92D4wGvsYEh1APnSXBPvOpvGt72M-ob_uFHh4q7opWMyKUpDccB7mWtALp3MNCWeTfxyx9misbaWEzPnEhoQ"}'
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1516741633","not_before":"1516737733","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3MzMsIm5iZiI6MTUxNjczNzczMywiZXhwIjoxNTE2NzQxNjMzLCJhaW8iOiJZMk5nWU5qWTM4RStWU2lPKzlxT2duY0JKOWN0QlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUjk4Yl8yWHB4MDJaR3BvQmwwcERBQSIsInZlciI6IjEuMCJ9.NM3ejSPT249gsaL8A4EMGuEfHCRthnrVDy2bes8VW3sb1OsRTrgRz7uH_qPMinDTdqHpjbK2qNWeT2vmM5HVJr2mwRFK-OwoabJIeGSn1vtXvx6XIfL_M28g1jxu7qjVGtrzeI5G8A7z8RdsfRzcCHNKz1xzC9kZI8WO-aKKJRXY0E8qEFtv49rjUMItXtQieMdNyCXrP-ezuJ0cR2hk-f5JSQpIOylRYjUL3qrHD5ocM08L-eMMg1R79FoStNOBkwMDNWB6o9m9K1LDpgUcZZlkBwNiJU7IZHXt59RwAzExDo1ddMV3w924Aw1to1rbcINWYiBpU37ZdtR9T-72vQ"}'
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:06 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:13 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -72,7 +74,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMjcsIm5iZiI6MTUwNjExNjIyNywiZXhwIjoxNTA2MTIwMTI3LCJhaW8iOiJZMlZnWU5pV0pXUHdMc2ZWM2ZoSVFWajJIT3N5QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTFY3NVNHblk1MC1NTnZFOER3b05BQSIsInZlciI6IjEuMCJ9.qvqsibTj97Wje7DCzUZsV0avjdDT3jRuYQaaD4f6Zx9Nw6quJKnQDC-ifyJGTzLH38kpVmfLEZhClnR-HC2Y7nFMt_MEgpSrE1kOx9ZC3tbRPCp053tqyehRMpwIDaSQaulpJEL2SW-a3uR_4twj7Tck7yGwaA0jT9rV1kEARjo3g-A5P4fVwmf7vhMI-3u4QcBSrxN0JsYO5OufKAiXaECbT1aBUKACVMQzQjhu5w2RJLpS45vFL9y-H8VboQC3XB92D4wGvsYEh1APnSXBPvOpvGt72M-ob_uFHh4q7opWMyKUpDccB7mWtALp3MNCWeTfxyx9misbaWEzPnEhoQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3MzMsIm5iZiI6MTUxNjczNzczMywiZXhwIjoxNTE2NzQxNjMzLCJhaW8iOiJZMk5nWU5qWTM4RStWU2lPKzlxT2duY0JKOWN0QlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUjk4Yl8yWHB4MDJaR3BvQmwwcERBQSIsInZlciI6IjEuMCJ9.NM3ejSPT249gsaL8A4EMGuEfHCRthnrVDy2bes8VW3sb1OsRTrgRz7uH_qPMinDTdqHpjbK2qNWeT2vmM5HVJr2mwRFK-OwoabJIeGSn1vtXvx6XIfL_M28g1jxu7qjVGtrzeI5G8A7z8RdsfRzcCHNKz1xzC9kZI8WO-aKKJRXY0E8qEFtv49rjUMItXtQieMdNyCXrP-ezuJ0cR2hk-f5JSQpIOylRYjUL3qrHD5ocM08L-eMMg1R79FoStNOBkwMDNWB6o9m9K1LDpgUcZZlkBwNiJU7IZHXt59RwAzExDo1ddMV3w924Aw1to1rbcINWYiBpU37ZdtR9T-72vQ
+      Host:
+      - management.azure.com
   response:
     status:
       code: 200
@@ -93,21 +97,22 @@ http_interactions:
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
       - '14999'
       X-Ms-Request-Id:
-      - 5205dab7-0047-42cc-a95f-84bf16dfc828
+      - 38d0b8c7-e835-41a0-be97-f33d8098f32e
       X-Ms-Correlation-Request-Id:
-      - 5205dab7-0047-42cc-a95f-84bf16dfc828
+      - 38d0b8c7-e835-41a0-be97-f33d8098f32e
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214207Z:5205dab7-0047-42cc-a95f-84bf16dfc828
+      - WESTUS:20180123T200713Z:38d0b8c7-e835-41a0-be97-f33d8098f32e
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 22 Sep 2017 21:42:07 GMT
+      - Tue, 23 Jan 2018 20:07:12 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
-        Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Default_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
+      string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
+        Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/azure_subscription_id","subscriptionId":"azure_subscription_id","displayName":"Microsoft
+        Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:06 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:13 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/azure_subscription_id/providers?api-version=2015-01-01
@@ -124,7 +129,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMjcsIm5iZiI6MTUwNjExNjIyNywiZXhwIjoxNTA2MTIwMTI3LCJhaW8iOiJZMlZnWU5pV0pXUHdMc2ZWM2ZoSVFWajJIT3N5QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTFY3NVNHblk1MC1NTnZFOER3b05BQSIsInZlciI6IjEuMCJ9.qvqsibTj97Wje7DCzUZsV0avjdDT3jRuYQaaD4f6Zx9Nw6quJKnQDC-ifyJGTzLH38kpVmfLEZhClnR-HC2Y7nFMt_MEgpSrE1kOx9ZC3tbRPCp053tqyehRMpwIDaSQaulpJEL2SW-a3uR_4twj7Tck7yGwaA0jT9rV1kEARjo3g-A5P4fVwmf7vhMI-3u4QcBSrxN0JsYO5OufKAiXaECbT1aBUKACVMQzQjhu5w2RJLpS45vFL9y-H8VboQC3XB92D4wGvsYEh1APnSXBPvOpvGt72M-ob_uFHh4q7opWMyKUpDccB7mWtALp3MNCWeTfxyx9misbaWEzPnEhoQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3MzMsIm5iZiI6MTUxNjczNzczMywiZXhwIjoxNTE2NzQxNjMzLCJhaW8iOiJZMk5nWU5qWTM4RStWU2lPKzlxT2duY0JKOWN0QlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUjk4Yl8yWHB4MDJaR3BvQmwwcERBQSIsInZlciI6IjEuMCJ9.NM3ejSPT249gsaL8A4EMGuEfHCRthnrVDy2bes8VW3sb1OsRTrgRz7uH_qPMinDTdqHpjbK2qNWeT2vmM5HVJr2mwRFK-OwoabJIeGSn1vtXvx6XIfL_M28g1jxu7qjVGtrzeI5G8A7z8RdsfRzcCHNKz1xzC9kZI8WO-aKKJRXY0E8qEFtv49rjUMItXtQieMdNyCXrP-ezuJ0cR2hk-f5JSQpIOylRYjUL3qrHD5ocM08L-eMMg1R79FoStNOBkwMDNWB6o9m9K1LDpgUcZZlkBwNiJU7IZHXt59RwAzExDo1ddMV3w924Aw1to1rbcINWYiBpU37ZdtR9T-72vQ
+      Host:
+      - management.azure.com
   response:
     status:
       code: 200
@@ -141,19 +148,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14930'
+      - '14838'
       X-Ms-Request-Id:
-      - df750db1-3f19-4aea-9baf-094e814f1664
+      - ec57a969-bd70-446b-8f07-70dde4e345a9
       X-Ms-Correlation-Request-Id:
-      - df750db1-3f19-4aea-9baf-094e814f1664
+      - ec57a969-bd70-446b-8f07-70dde4e345a9
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214209Z:df750db1-3f19-4aea-9baf-094e814f1664
+      - WESTUS:20180123T200714Z:ec57a969-bd70-446b-8f07-70dde4e345a9
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 22 Sep 2017 21:42:08 GMT
+      - Tue, 23 Jan 2018 20:07:14 GMT
       Content-Length:
-      - '254785'
+      - '293551'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
@@ -176,7 +183,7 @@ http_interactions:
         Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
         Central US","North Central US","Japan East","Japan West","Brazil South","Central
         India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
+        2"],"apiVersions":["2017-06-01","2017-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Advisor","namespace":"Microsoft.Advisor","authorization":{"applicationId":"c39c9bac-9d1f-4dfb-aa29-27f6365e5cb7","roleDefinitionId":"8a63b04c-3731-409b-9765-f1175c047872"},"resourceTypes":[{"resourceType":"suppressions","locations":[],"apiVersions":["2017-04-19-alpha","2017-04-19","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"recommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-04-19","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"generateRecommendations","locations":[],"apiVersions":["2017-04-19-alpha","2017-04-19","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-19-alpha","2017-04-19","2017-03-31-alpha","2017-03-31","2016-07-12-rc","2016-07-12-preview","2016-07-12-alpha","2016-05-09-preview","2016-05-09-alpha"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ApiManagement","namespace":"Microsoft.ApiManagement","authorization":{"applicationId":"8602e328-9b72-4f2d-a4ae-1387d013a2b3","roleDefinitionId":"e263b525-2e60-4418-b655-420bae0b172e"},"resourceTypes":[{"resourceType":"service","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","North Central
         US","South Central US","West Central US","West US","West US 2","Canada Central","Canada
         East","North Europe","West Europe","UK South","UK West","East Asia","Southeast
@@ -184,20 +191,26 @@ http_interactions:
         India","South India","West India"],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"validateServiceName","locations":[],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"checkServiceNameAvailability","locations":[],"apiVersions":["2015-09-15","2014-02-14"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"reportFeedback","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"checkFeedbackRequired","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-03-01","2016-10-10","2016-07-07","2015-09-15","2014-02-14"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Automation","namespace":"Microsoft.Automation","authorizations":[{"applicationId":"fc75330b-179d-49af-87dd-3b1acf6827fa","roleDefinitionId":"95fd5de3-d071-4362-92bf-cf341c1de832"}],"resourceTypes":[{"resourceType":"automationAccounts","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
         South","UK South","West Central US","North Europe","Canada Central","Australia
-        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/runbooks","locations":["Japan
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/runbooks","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
         South","UK South","West Central US","North Europe","Canada Central","Australia
-        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/configurations","locations":["Japan
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/configurations","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","North
-        Central US","Brazil South","UK South","West Central US","Central India","Australia
-        Southeast","Canada Central","North Europe"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/webhooks","locations":["Japan
+        Central US","Korea Central","East US","West US 2","Brazil South","UK South","West
+        Central US","Central India","Australia Southeast","Canada Central","North
+        Europe"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/webhooks","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
         South","UK South","West Central US","North Europe","Canada Central","Australia
-        Southeast","Central India"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"operations","locations":["South
-        Central US"],"apiVersions":["2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/softwareUpdateConfigurations","locations":["Japan
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"operations","locations":["South
+        Central US"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]},{"resourceType":"automationAccounts/softwareUpdateConfigurations","locations":["Japan
         East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
         South","UK South","West Central US","North Europe","Canada Central","Australia
-        Southeast","Central India"],"apiVersions":["2017-05-15-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Backup","namespace":"Microsoft.Backup","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"BackupVault","locations":["West
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview"]},{"resourceType":"automationAccounts/jobs","locations":["Japan
+        East","East US 2","West Europe","Southeast Asia","South Central US","Brazil
+        South","UK South","West Central US","North Europe","Canada Central","Australia
+        Southeast","Central India"],"apiVersions":["2018-01-15","2017-05-15-preview","2015-10-31","2015-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureActiveDirectory","namespace":"Microsoft.AzureActiveDirectory","resourceTypes":[{"resourceType":"b2cDirectories","locations":["Global","United
+        States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]},{"resourceType":"operations","locations":["Global","United
+        States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]}],"registrationState":"Unregistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Backup","namespace":"Microsoft.Backup","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"BackupVault","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
@@ -206,22 +219,22 @@ http_interactions:
         Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
         West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
         East","South India","Central India","Canada Central","Canada East","UK South","UK
-        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01","2015-07-01","2014-05-01-privatepreview"]},{"resourceType":"operations","locations":["West
+        West","West Central US","West US 2"],"apiVersions":["2017-09-01","2017-05-01","2017-01-01","2015-12-01","2015-09-01","2015-07-01","2014-05-01-privatepreview"]},{"resourceType":"operations","locations":["West
         Europe","East US","East US 2","West US","North Central US","Brazil South","North
         Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
         West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
         East","South India","Central India","Canada Central","Canada East","UK South","UK
-        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations/quotas","locations":["West
+        West","West Central US","West US 2"],"apiVersions":["2017-09-01","2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01","2017-05-01","2017-01-01","2015-12-01","2015-09-01"]},{"resourceType":"locations/quotas","locations":["West
         Europe","East US","East US 2","West US","North Central US","Brazil South","North
         Europe","Central US","East Asia","Japan East","Australia Southeast","Japan
         West","Korea South","Korea Central","Southeast Asia","South Central US","Australia
         East","South India","Central India","Canada Central","Canada East","UK South","UK
-        West","West Central US","West US 2"],"apiVersions":["2017-05-01","2017-01-01","2015-12-01","2015-09-01"]}],"registrationState":"Unregistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicCompute","namespace":"Microsoft.ClassicCompute","resourceTypes":[{"resourceType":"domainNames","locations":["East
+        West","West Central US","West US 2"],"apiVersions":["2017-09-01","2017-05-01","2017-01-01","2015-12-01","2015-09-01"]}],"registrationState":"Unregistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicCompute","namespace":"Microsoft.ClassicCompute","resourceTypes":[{"resourceType":"domainNames","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
@@ -256,7 +269,7 @@ http_interactions:
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -296,92 +309,92 @@ http_interactions:
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30"]},{"resourceType":"locations/usages","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations/usages","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
+        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
+        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
@@ -411,76 +424,138 @@ http_interactions:
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
+        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
         US","East US","South Central US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
         Central","Central US","East US 2","North Central US","West Central US","West
-        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/webhooks","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/ping","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/getCallbackConfig","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/webhooks/listEvents","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"locations","locations":["South
-        Central US","East US","West US","Central US","East US 2","North Central US","West
-        Central US","West US 2","Brazil South","Canada East","Canada Central","West
-        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
-        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"locations/operationResults","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/GetCredentials","locations":["West
+        US 2"],"apiVersions":["2017-10-01","2017-03-01"]},{"resourceType":"registries/replications","locations":["South
+        Central US","West Central US","East US","West Europe","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/webhooks","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/webhooks/ping","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/webhooks/getCallbackConfig","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/webhooks/listEvents","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"locations/operationResults","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/GetCredentials","locations":["West
         US","East US","South Central US","West Europe"],"apiVersions":["2016-06-27-preview"]},{"resourceType":"registries/listCredentials","locations":["South
         Central US","East US","West US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
         Central","Central US","East US 2","North Central US","West Central US","West
-        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/regenerateCredential","locations":["South
+        US 2"],"apiVersions":["2017-10-01","2017-03-01"]},{"resourceType":"registries/regenerateCredential","locations":["South
         Central US","West US","East US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
         Central","Central US","East US 2","North Central US","West Central US","West
-        US 2"],"apiVersions":["2017-03-01"]},{"resourceType":"registries/listUsages","locations":["West
-        Central US","East US","West Europe"],"apiVersions":["2017-06-01-preview"]},{"resourceType":"registries/regenerateCredentials","locations":["West
+        US 2"],"apiVersions":["2017-10-01","2017-03-01"]},{"resourceType":"registries/listUsages","locations":["West
+        Central US","East US","West Europe","South Central US","West US","Japan East","North
+        Europe","Southeast Asia","North Central US","East US 2","West US 2","Brazil
+        South","Australia East","Central India","Central US","Canada East","Canada
+        Central","UK South","UK West","Australia Southeast","East Asia","Japan West","South
+        India"],"apiVersions":["2017-10-01"]},{"resourceType":"registries/regenerateCredentials","locations":["West
         US","East US","South Central US","West Europe"],"apiVersions":["2016-06-27-preview"]},{"resourceType":"checkNameAvailability","locations":["South
         Central US","East US","West US","Central US","East US 2","North Central US","West
         Central US","West US 2","Brazil South","Canada East","Canada Central","West
         Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
-        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview","2017-03-01","2016-06-27-preview"]},{"resourceType":"operations","locations":["South
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-10-01","2017-06-01-preview","2017-03-01","2016-06-27-preview"]},{"resourceType":"operations","locations":["South
         Central US","East US","West US","Central US","East US 2","North Central US","West
         Central US","West US 2","Brazil South","Canada East","Canada Central","West
         Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
-        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-06-01-preview","2017-03-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerService","namespace":"Microsoft.ContainerService","authorization":{"applicationId":"7319c514-987d-4e9b-ac3d-d38c4f427f4c","roleDefinitionId":"1b4a0c7f-2217-416f-acfa-cf73452fdc1c"},"resourceTypes":[{"resourceType":"containerServices","locations":["Japan
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-10-01","2017-06-01-preview","2017-03-01"]},{"resourceType":"locations","locations":["South
+        Central US","East US","West US","Central US","East US 2","North Central US","West
+        Central US","West US 2","Brazil South","Canada East","Canada Central","West
+        Europe","North Europe","UK South","UK West","Australia East","Australia Southeast","Central
+        India","East Asia","Japan East","Japan West","Southeast Asia","South India"],"apiVersions":["2017-10-01","2017-06-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerService","namespace":"Microsoft.ContainerService","authorization":{"applicationId":"7319c514-987d-4e9b-ac3d-d38c4f427f4c","roleDefinitionId":"1b4a0c7f-2217-416f-acfa-cf73452fdc1c","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"containerServices","locations":["Japan
         East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
         Central US","West US 2","South India","Central India","West India","Canada
-        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
+        East","Canada Central","Korea South","Korea Central"],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"managedClusters","locations":["East
+        US","West Europe","Central US","Canada Central","Canada East"],"apiVersions":["2017-08-31"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
         East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
         Central US","West US 2","South India","Central India","West India","Canada
-        East","Canada Central"],"apiVersions":["2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DevTestLab","namespace":"Microsoft.DevTestLab","authorization":{"applicationId":"1a14be2a-e903-4cec-99cf-b2e209259a0f","roleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525"},"resourceTypes":[{"resourceType":"labs","locations":["West
+        East","Canada Central","Korea South","Korea Central"],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/orchestrators","locations":["UK
+        West","West US 2","East US","West Europe","Central US"],"apiVersions":["2017-09-30"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DevTestLab","namespace":"Microsoft.DevTestLab","authorization":{"applicationId":"1a14be2a-e903-4cec-99cf-b2e209259a0f","roleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525","managedByRoleDefinitionId":"8f2de81a-b9aa-49d8-b24c-11814d3ab525"},"resourceTypes":[{"resourceType":"labs","locations":["West
         Central US","Japan East","West US","Australia Southeast","Canada Central","Central
         India","Central US","East Asia","Korea Central","North Europe","South Central
-        US","UK West","Australia East","Brazil South","Canada East","East US","East
-        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        US","UK West","West India","Australia East","Brazil South","Canada East","East
+        US","East US 2","Japan West","Korea South","North Central US","South India","Southeast
         Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"schedules","locations":["West
         Central US","Japan East","West US","Australia Southeast","Canada Central","Central
         India","Central US","East Asia","Korea Central","North Europe","South Central
-        US","UK West","Australia East","Brazil South","Canada East","East US","East
-        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        US","UK West","West India","Australia East","Brazil South","Canada East","East
+        US","East US 2","Japan West","Korea South","North Central US","South India","Southeast
         Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"labs/virtualMachines","locations":["West
         Central US","Japan East","West US","Australia Southeast","Canada Central","Central
         India","Central US","East Asia","Korea Central","North Europe","South Central
-        US","UK West","Australia East","Brazil South","Canada East","East US","East
-        US 2","Japan West","Korea South","North Central US","South India","Southeast
+        US","UK West","West India","Australia East","Brazil South","Canada East","East
+        US","East US 2","Japan West","Korea South","North Central US","South India","Southeast
         Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"labs/serviceRunners","locations":["Central
         US","East US 2","South Central US"],"apiVersions":["2017-04-26-preview","2016-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]},{"resourceType":"locations/operations","locations":["West
         Central US","Japan East","West US","Australia Southeast","Canada Central","Central
         India","Central US","East Asia","Korea Central","North Europe","South Central
-        US","UK West","Australia East","Brazil South","Canada East","East US","East
-        US 2","Japan West","Korea South","North Central US","South India","Southeast
-        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"}],"resourceTypes":[{"resourceType":"components","locations":["East
-        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
-        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01","2014-04-01"]},{"resourceType":"queries","locations":["East
-        US","South Central US","North Europe","West Europe"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
+        US","UK West","West India","Australia East","Brazil South","Canada East","East
+        US","East US 2","Japan West","Korea South","North Central US","South India","Southeast
+        Asia","UK South","West Europe","West US 2"],"apiVersions":["2017-04-26-preview","2016-05-15","2015-05-21-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","authorizations":[{"applicationId":"57c0fc58-a83a-41d0-8ae9-08952659bdfd","roleDefinitionId":"FFFD5CF5-FFD3-4B24-B0E2-0715ADD4C282"}],"resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"databaseAccountNames","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"operationResults","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Central India","Central
+        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
+        US","North Europe","South Central US","South India","Southeast Asia","West
+        Central US","West Europe","West India","West US","West US 2","UK West","UK
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"},{"applicationId":"f5c26e74-f226-4ae8-85f0-b4af0080ac9e","roleDefinitionId":"529d7ae6-e892-4d43-809d-8547aeb90643"}],"resourceTypes":[{"resourceType":"components","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2015-05-01","2014-08-01","2014-04-01"]},{"resourceType":"queries","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2015-05-01","2014-08-01"]},{"resourceType":"components/pricingPlans","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"migrateToNewPricingModel","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"rollbackToLegacyPricingModel","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"listMigrationdate","locations":["East
+        US","South Central US","North Europe","West Europe","Southeast Asia","West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
@@ -516,7 +591,7 @@ http_interactions:
         West","North Central US","South Central US","East US 2","Canada East","Canada
         Central","Central US","Australia East","Australia Southeast","Brazil South","South
         India","Central India","West India","North Europe","West US 2","West Central
-        US","Korea South","Korea Central","UK South","UK West","Global"],"apiVersions":["2017-05-01-preview","2016-03-01","2015-07-01"]},{"resourceType":"logDefinitions","locations":["West
+        US","Korea South","Korea Central","UK South","UK West","Global"],"apiVersions":["2017-09-01-preview","2017-05-01-preview","2016-03-01","2015-07-01"]},{"resourceType":"logDefinitions","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
@@ -526,7 +601,7 @@ http_interactions:
         West","North Central US","South Central US","East US 2","Canada East","Canada
         Central","Central US","Australia East","Australia Southeast","Brazil South","South
         India","Central India","West India","North Europe","West US 2","West Central
-        US","Korea South","Korea Central","UK South","UK West"],"apiVersions":["2017-05-01-preview","2016-09-01","2016-06-01"]},{"resourceType":"actiongroups","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]},{"resourceType":"activityLogAlerts","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.KeyVault","namespace":"Microsoft.KeyVault","resourceTypes":[{"resourceType":"vaults","locations":["North
+        US","Korea South","Korea Central","UK South","UK West"],"apiVersions":["2017-09-01-preview","2017-05-01-preview","2016-09-01","2016-06-01"]},{"resourceType":"actiongroups","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]},{"resourceType":"activityLogAlerts","locations":["Global"],"apiVersions":["2017-04-01","2017-03-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.KeyVault","namespace":"Microsoft.KeyVault","resourceTypes":[{"resourceType":"vaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
@@ -556,126 +631,153 @@ http_interactions:
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorizations":[{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},{"applicationId":"7c33bfcb-8d33-48d6-8e60-dc6404003489","roleDefinitionId":"ad6261e4-fa9a-4642-aa5f-104f1b67e9e3"},{"applicationId":"1e3e4475-288f-4018-a376-df66fd7fac5f","roleDefinitionId":"1d538b69-3d87-4e56-8ff8-25786fd48261"},{"applicationId":"a0be0c72-870e-46f0-9c49-c98333a996f7","roleDefinitionId":"7ce22727-ffce-45a9-930c-ddb2e56fa131"}],"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
+        Central US","West US 2","Korea Central","Korea South"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","West Central US"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"operations","locations":["South
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations","locations":["South
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operations","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"commitmentPlans","locations":["South
+        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
+        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"Registering"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Network","namespace":"Microsoft.Network","authorizations":[{"applicationId":"2cf9eb86-36b5-49dc-86ae-9a63135dfa8c","roleDefinitionId":"13ba9ab4-19f0-4804-adc4-14ece36cc7a1"},{"applicationId":"7c33bfcb-8d33-48d6-8e60-dc6404003489","roleDefinitionId":"ad6261e4-fa9a-4642-aa5f-104f1b67e9e3"},{"applicationId":"1e3e4475-288f-4018-a376-df66fd7fac5f","roleDefinitionId":"1d538b69-3d87-4e56-8ff8-25786fd48261"},{"applicationId":"a0be0c72-870e-46f0-9c49-c98333a996f7","roleDefinitionId":"7ce22727-ffce-45a9-930c-ddb2e56fa131"}],"resourceTypes":[{"resourceType":"virtualNetworks","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
-        Central US"],"apiVersions":["2017-09-01"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","North
-        Central US","South Central US","West Central US","East Asia","Southeast Asia","Brazil
-        South","Japan East","Japan West","North Europe","West Europe","Central India","South
-        India","West India","Canada Central","Canada East"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"namespaces/notificationHubs","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]},{"resourceType":"operationResults","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South"],"apiVersions":["2017-04-01","2016-03-01","2014-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationalInsights","namespace":"Microsoft.OperationalInsights","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"86695298-2eb9-48a7-9ec3-2fdb38b6878b"},"resourceTypes":[{"resourceType":"workspaces","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
-        East","UK South","Central India","Canada Central"],"apiVersions":["2017-04-26-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"]},{"resourceType":"workspaces/dataSources","locations":["East
+        East","UK South","Central India","Canada Central"],"apiVersions":["2017-04-26-preview","2017-03-15-preview","2017-03-03-preview","2017-01-01-preview","2015-11-01-preview","2015-03-20"]},{"resourceType":"workspaces/query","locations":["West
+        Central US","Australia Southeast","West Europe","East US","Southeast Asia","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2017-10-01"]},{"resourceType":"workspaces/dataSources","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
         East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"storageInsightConfigs","locations":[],"apiVersions":["2014-10-10"]},{"resourceType":"workspaces/linkedServices","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
         East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"linkTargets","locations":["East
         US"],"apiVersions":["2015-03-20"]},{"resourceType":"operations","locations":[],"apiVersions":["2014-11-10"]},{"resourceType":"devices","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.OperationsManagement","namespace":"Microsoft.OperationsManagement","authorization":{"applicationId":"d2a0a418-0aac-4541-82b2-b3142c89da77","roleDefinitionId":"aa249101-6816-4966-aafa-08175d795f14"},"resourceTypes":[{"resourceType":"solutions","locations":["East
         US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
-        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Portal","namespace":"Microsoft.Portal","resourceTypes":[{"resourceType":"dashboards","locations":["Central
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"managementconfigurations","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2015-11-01-preview"]},{"resourceType":"managementassociations","locations":[],"apiVersions":["2015-11-01-preview"]},{"resourceType":"views","locations":["East
+        US","West Europe","Southeast Asia","Australia Southeast","West Central US","Japan
+        East","UK South","Central India","Canada Central"],"apiVersions":["2017-08-21-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-11-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Portal","namespace":"Microsoft.Portal","resourceTypes":[{"resourceType":"dashboards","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
@@ -687,9 +789,9 @@ http_interactions:
         East","West India","South India","Central India","Canada Central","Canada
         East"],"apiVersions":["2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"consoles","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/consoles","locations":["West
         US","East US","Central India","North Europe","West Europe","South Central
-        US","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
+        US","Southeast Asia","East US 2","Central US"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"userSettings","locations":[],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]},{"resourceType":"locations/userSettings","locations":["West
         US","East US","Central India","North Europe","West Europe","South Central
-        US","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
+        US","Southeast Asia","East US 2","Central US"],"apiVersions":["2017-08-01-preview","2017-01-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.RecoveryServices","namespace":"Microsoft.RecoveryServices","authorization":{"applicationId":"262044b1-e2ce-469f-a196-69ab7ada62d3","roleDefinitionId":"21CEC436-F7D0-4ADE-8AD8-FEC5668484CC"},"resourceTypes":[{"resourceType":"vaults","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
@@ -710,7 +812,17 @@ http_interactions:
         Asia","North Central US","South Central US","Japan East","Japan West","Australia
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ResourceHealth","namespace":"Microsoft.ResourceHealth","authorization":{"applicationId":"8bdebf23-c0fe-4187-a378-717ad86f6a53","roleDefinitionId":"cc026344-c8b1-4561-83ba-59eba84b27cc"},"resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2017-07-01","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"notifications","locations":["Australia
+        West","Korea Central","Korea South"],"apiVersions":["2016-06-01"]},{"resourceType":"locations/backupValidateFeatures","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-07-01"]},{"resourceType":"locations/backupPreValidateProtection","locations":["West
+        US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
+        Asia","North Central US","South Central US","Japan East","Japan West","Australia
+        East","Australia Southeast","Central US","East US 2","Central India","South
+        India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
+        West","Korea Central","Korea South"],"apiVersions":["2017-07-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ResourceHealth","namespace":"Microsoft.ResourceHealth","authorization":{"applicationId":"8bdebf23-c0fe-4187-a378-717ad86f6a53","roleDefinitionId":"cc026344-c8b1-4561-83ba-59eba84b27cc"},"resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2017-07-01","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"notifications","locations":["Australia
         Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Security","namespace":"Microsoft.Security","authorization":{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatuses","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/virtualMachines","locations":["Central
@@ -743,10 +855,14 @@ http_interactions:
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securitySolutionsReferenceData","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/securitySolutionsReferenceData","locations":["Central
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"jitNetworkAccessPolicies","locations":["Central
-        US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/jitNetworkAccessPolicies","locations":["Central
-        US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations","locations":["Central
+        US","East US","North Europe","West Europe","UK South","UK West","West Central
+        US","West US 2"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/jitNetworkAccessPolicies","locations":["Central
+        US","East US","North Europe","West Europe","UK South","UK West","West Central
+        US","West US 2"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatusesSummaries","locations":["Central
-        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/alerts","locations":["Central
+        US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"applicationWhitelistings","locations":["Central
+        US","East US","West Central US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/applicationWhitelistings","locations":["Central
+        US","West Central US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/alerts","locations":["Central
         US","West Europe"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/tasks","locations":["Central
         US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"externalSecuritySolutions","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"locations/externalSecuritySolutions","locations":["Central
@@ -769,7 +885,17 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/databaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/databaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -814,7 +940,7 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01","2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -829,7 +955,7 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -859,12 +985,17 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/geoBackupPolicies","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -879,12 +1010,12 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/firewallrules","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/backupLongTermRetentionPolicies","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -999,6 +1130,16 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
         US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
@@ -1034,7 +1175,22 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -1144,7 +1300,47 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -1159,7 +1355,17 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/administratorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","Japan East","Japan
+        West","Korea Central","Korea South","North Central US","North Europe","South
+        Central US","South India","Southeast Asia","UK South","UK West","West Central
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
@@ -1179,52 +1385,52 @@ http_interactions:
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","Korea South","North Central US","North Europe","South
         Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorization":{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorizations":[{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},{"applicationId":"e406a681-f3d4-42a8-90b6-c2b029497af1"}],"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
         US","West US","West Europe","North Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","South India","Central
@@ -1234,7 +1440,19 @@ http_interactions:
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Web","namespace":"Microsoft.Web","authorization":{"applicationId":"abfa0a7c-a6b6-4736-8310-5855508787cd","roleDefinitionId":"f47ed98b-b063-4a5b-9e10-4b9b44fa7735"},"resourceTypes":[{"resourceType":"sites/extensions","locations":["South
+        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/project","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/extension","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"checkNameAvailability","locations":["North
+        Central US","South Central US","East US","West US","Central US","North Europe","West
+        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
+        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Web","namespace":"Microsoft.Web","authorization":{"applicationId":"abfa0a7c-a6b6-4736-8310-5855508787cd","roleDefinitionId":"f47ed98b-b063-4a5b-9e10-4b9b44fa7735"},"resourceTypes":[{"resourceType":"sites/extensions","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
         South","West US","East US","Japan West","Japan East","East Asia","East US
         2","North Central US","Central US","Brazil South","Australia East","Australia
@@ -1339,7 +1557,7 @@ http_interactions:
         South","West US","East US","Japan West","Japan East","East Asia","East US
         2","North Central US","Central US","Brazil South","Australia East","Australia
         Southeast","West India","Central India","South India","Canada Central","Canada
-        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms/workers","locations":["South
+        East","West Central US","UK West","UK South","West US 2"],"apiVersions":["2017-08-01","2016-09-01","2016-03-01","2015-08-01","2015-07-01","2015-06-01","2015-05-01","2015-04-01","2015-02-01","2014-11-01","2014-06-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"serverFarms/workers","locations":["South
         Central US","North Europe","West Europe","Southeast Asia","Korea Central","Korea
         South","West US","East US","Japan West","Japan East","East Asia","East US
         2","North Central US","Central US","Brazil South","Australia East","Australia
@@ -1394,7 +1612,17 @@ http_interactions:
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","West US 2","West Central US","Canada Central","Canada
-        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/managedApis","locations":["North
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/listWsdlInterfaces","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/extractApiDefinitionFromWsdl","locations":["North
+        Central US","Central US","South Central US","North Europe","West Europe","East
+        Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
+        East","Brazil South","Australia East","Australia Southeast","South India","Central
+        India","West India","West US 2","West Central US","Canada Central","Canada
+        East","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]},{"resourceType":"locations/managedApis","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
@@ -1445,8 +1673,11 @@ http_interactions:
         US","North Europe","Japan West","Japan East","East Asia","West Europe","East
         US","Southeast Asia","Central US"],"apiVersions":["2016-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Lombiq.DotNest","namespace":"Lombiq.DotNest","resourceTypes":[{"resourceType":"sites","locations":["East
         US"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Mailjet.Email","namespace":"Mailjet.Email","resourceTypes":[{"resourceType":"services","locations":["West
-        US"],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
-        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
+        US","West Europe"],"apiVersions":["2017-10-01","2017-02-03"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-05-29","2017-02-03","2016-11-01","2016-07-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-10-01","2017-02-03","2016-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-10-01","2017-02-03","2016-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.aadiam","namespace":"microsoft.aadiam","resourceTypes":[{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2017-04-01","2017-03-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-01","2016-02-01","2015-11-01","2015-01-01"]},{"resourceType":"diagnosticSettings","locations":[],"apiVersions":["2017-04-01"]},{"resourceType":"diagnosticSettingsCategories","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Addons","namespace":"Microsoft.Addons","authorization":{"applicationId":"24d3987b-be4a-48e0-a3e7-11c186f39e41","roleDefinitionId":"8004BAAB-A4CB-4981-8571-F7E44D039D93"},"resourceTypes":[{"resourceType":"supportProviders","locations":["West
+        Central US","South Central US","East US","West Europe"],"apiVersions":["2017-05-15"]},{"resourceType":"operations","locations":["West
+        Central US","South Central US","East US","West Europe"],"apiVersions":["2017-05-15"]},{"resourceType":"operationResults","locations":["West
+        Central US","South Central US","East US","West Europe"],"apiVersions":["2017-05-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ADHybridHealthService","namespace":"Microsoft.ADHybridHealthService","resourceTypes":[{"resourceType":"services","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"addsservices","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"configuration","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"operations","locations":["West
@@ -1456,51 +1687,45 @@ http_interactions:
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"servicehealthmetrics","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"logs","locations":["West
         US"],"apiVersions":["2014-01-01"]},{"resourceType":"anonymousapiusers","locations":["West
-        US"],"apiVersions":["2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AnalysisServices","namespace":"Microsoft.AnalysisServices","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"servers","locations":["West
+        US"],"apiVersions":["2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AlertsManagement","namespace":"Microsoft.AlertsManagement","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-11-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AnalysisServices","namespace":"Microsoft.AnalysisServices","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"servers","locations":["West
         US","North Europe","South Central US","West Europe","West Central US","Southeast
         Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
-        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/checkNameAvailability","locations":["West
+        Southeast","Japan East","UK South","West India","West US 2","East US"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"locations/checkNameAvailability","locations":["West
         US","North Europe","South Central US","West Europe","West Central US","Southeast
         Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
-        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationresults","locations":["West
+        Southeast","Japan East","UK South","West India","West US 2","East US"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationresults","locations":["West
         US","North Europe","South Central US","West Europe","West Central US","Southeast
         Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
-        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationstatuses","locations":["West
+        Southeast","Japan East","UK South","West India","West US 2","East US"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"locations/operationstatuses","locations":["West
         US","North Europe","South Central US","West Europe","West Central US","Southeast
         Asia","East US 2","North Central US","Brazil South","Canada Central","Australia
-        Southeast","Japan East","UK South","West India"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]},{"resourceType":"operations","locations":["East
-        US 2","West Central US"],"apiVersions":["2017-08-01-beta","2017-07-14","2016-05-16"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AppService","namespace":"Microsoft.AppService","authorization":{"applicationId":"dee7ba80-6a55-4f3b-a86c-746a9231ae49","roleDefinitionId":"6715d172-49c4-46f6-bb21-60512a8689dc"},"resourceTypes":[{"resourceType":"apiapps","locations":["East
-        US","West US","South Central US","North Europe","East Asia","Japan East","West
-        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
-        South","East US 2","Australia Southeast","Australia East","West India","South
-        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"appIdentities","locations":["East
-        US","West US","South Central US","North Europe","East Asia","Japan East","West
-        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
-        South","East US 2","Australia Southeast","Australia East","West India","South
-        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"gateways","locations":["East
-        US","West US","South Central US","North Europe","East Asia","Japan East","West
-        Europe","Southeast Asia","Japan West","North Central US","Central US","Brazil
-        South","East US 2","Australia Southeast","Australia East","West India","South
-        India","Central India"],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"deploymenttemplates","locations":[],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-03-01-preview","2015-03-01-alpha"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Authorization","namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"roleDefinitions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"classicAdministrators","locations":[],"apiVersions":["2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"permissions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"locks","locations":[],"apiVersions":["2017-04-01","2016-09-01","2015-06-01","2015-05-01-preview","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-01-01","2014-10-01-preview","2014-06-01"]},{"resourceType":"policyDefinitions","locations":[],"apiVersions":["2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"policySetDefinitions","locations":[],"apiVersions":["2017-06-01-preview"]},{"resourceType":"policyAssignments","locations":[],"apiVersions":["2017-06-01-preview","2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"providerOperations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01-preview","2015-07-01"]},{"resourceType":"elevateAccess","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureActiveDirectory","namespace":"Microsoft.AzureActiveDirectory","resourceTypes":[{"resourceType":"b2cDirectories","locations":["Global","United
-        States","Europe"],"apiVersions":["2017-01-30","2016-12-13-preview","2016-02-10-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureStack","namespace":"Microsoft.AzureStack","resourceTypes":[{"resourceType":"operations","locations":["Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations","locations":["West
+        Southeast","Japan East","UK South","West India","West US 2","East US"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]},{"resourceType":"operations","locations":["East
+        US 2","West Central US","West US 2"],"apiVersions":["2017-08-01-beta","2017-08-01","2017-07-14","2016-05-16"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Authorization","namespace":"Microsoft.Authorization","resourceTypes":[{"resourceType":"roleAssignments","locations":[],"apiVersions":["2017-10-01-preview","2017-09-01","2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"roleDefinitions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"classicAdministrators","locations":[],"apiVersions":["2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"permissions","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"locks","locations":[],"apiVersions":["2017-04-01","2016-09-01","2015-06-01","2015-05-01-preview","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-01-01","2014-10-01-preview","2014-06-01"]},{"resourceType":"policyDefinitions","locations":[],"apiVersions":["2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"policySetDefinitions","locations":[],"apiVersions":["2017-06-01-preview"]},{"resourceType":"policyAssignments","locations":[],"apiVersions":["2017-06-01-preview","2016-12-01","2016-04-01","2015-10-01-preview"]},{"resourceType":"providerOperations","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01-preview","2015-07-01"]},{"resourceType":"elevateAccess","locations":[],"apiVersions":["2017-05-01","2016-07-01","2015-07-01","2015-06-01","2015-05-01-preview","2014-10-01-preview","2014-07-01-preview","2014-04-01-preview"]},{"resourceType":"checkAccess","locations":[],"apiVersions":["2017-10-01-preview","2017-09-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.AzureStack","namespace":"Microsoft.AzureStack","resourceTypes":[{"resourceType":"operations","locations":["Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations","locations":["West
         Central US","Global"],"apiVersions":["2017-06-01"]},{"resourceType":"registrations/products","locations":["West
-        Central US","Global"],"apiVersions":["2017-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Billing","namespace":"Microsoft.Billing","resourceTypes":[{"resourceType":"BillingPeriods","locations":["Central
+        Central US","Global"],"apiVersions":["2017-06-01","2016-01-01"]},{"resourceType":"registrations/customerSubscriptions","locations":["West
+        Central US","Global"],"apiVersions":["2017-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BatchAI","namespace":"Microsoft.BatchAI","authorization":{"applicationId":"9fcb3732-5f52-4135-8c08-9d4bbaf203ea","roleDefinitionId":"703B89C7-CE2C-431B-BDD8-FA34E39AF696","managedByRoleDefinitionId":"90B8E153-EBFF-4073-A95F-4DAD56B14C78"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"jobs","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"fileservers","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"operations","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-09-01-preview"]},{"resourceType":"locations/operationresults","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["East
+        US","West US 2","West Europe"],"apiVersions":["2017-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Billing","namespace":"Microsoft.Billing","resourceTypes":[{"resourceType":"BillingPeriods","locations":["Central
         US"],"apiVersions":["2017-04-24-preview"]},{"resourceType":"Invoices","locations":["Central
         US"],"apiVersions":["2017-04-24-preview","2017-02-27-preview"]},{"resourceType":"operations","locations":["Central
         US"],"apiVersions":["2017-04-24-preview","2017-02-27-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BingMaps","namespace":"Microsoft.BingMaps","resourceTypes":[{"resourceType":"mapApis","locations":["West
         US"],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-08-18","2015-07-02"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-08-18","2015-07-02"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BizTalkServices","namespace":"Microsoft.BizTalkServices","resourceTypes":[{"resourceType":"BizTalk","locations":["East
         US","West US","North Europe","West Europe","Southeast Asia","East Asia","North
-        Central US","Japan West","Japan East","South Central US"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Cache","namespace":"Microsoft.Cache","authorization":{"applicationId":"96231a05-34ce-4eb4-aa6a-70759cbb5e83","roleDefinitionId":"4f731528-ba85-45c7-acfb-cd0a9b3cf31b"},"resourceTypes":[{"resourceType":"Redis","locations":["North
+        Central US","Japan West","Japan East","South Central US"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.BotService","namespace":"Microsoft.BotService","resourceTypes":[{"resourceType":"botServices","locations":["Global"],"apiVersions":["2017-12-01"]},{"resourceType":"checkNameAvailability","locations":["Global"],"apiVersions":["2017-12-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Cache","namespace":"Microsoft.Cache","authorization":{"applicationId":"96231a05-34ce-4eb4-aa6a-70759cbb5e83","roleDefinitionId":"4f731528-ba85-45c7-acfb-cd0a9b3cf31b"},"resourceTypes":[{"resourceType":"Redis","locations":["North
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","Canada Central","Canada East","UK South","UK West","West US 2","West
-        Central US","South India","Korea Central","Korea South"],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","South India","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","South India","Canada Central","Canada East","UK South","UK West","West
-        US 2","West Central US","Korea Central","Korea South"],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-02-01","2016-04-01","2015-08-01","2015-03-01"]},{"resourceType":"Redis/metricDefinitions","locations":["North
+        US 2","West Central US","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01"]},{"resourceType":"Redis/metricDefinitions","locations":["North
         Central US","South Central US","East US","East US 2","West US","Central US","East
         Asia","Southeast Asia","North Europe","West Europe","Japan East","Japan West","Brazil
         South","Australia Southeast","Australia East","Central India","West India","South
@@ -1514,59 +1739,59 @@ http_interactions:
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/origins","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/origins","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/customdomains","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"profiles/endpoints/customdomains","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/originresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/originresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/customdomainresults","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"operationresults/profileresults/endpointresults/customdomainresults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkNameAvailability","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkResourceUsage","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"checkResourceUsage","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02"]},{"resourceType":"validateProbe","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02"]},{"resourceType":"validateProbe","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02"]},{"resourceType":"operations","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02"]},{"resourceType":"operations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"edgenodes","locations":["Australia
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]},{"resourceType":"edgenodes","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","North Central US","North Europe","South Central US","South India","Southeast
-        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-04-02","2016-10-02","2016-04-02","2015-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CertificateRegistration","namespace":"Microsoft.CertificateRegistration","authorization":{"applicationId":"f3c21649-0979-4721-ac85-b0216b2cf413","roleDefinitionId":"933fba7e-2ed3-4da8-973d-8bd8298a9b40"},"resourceTypes":[{"resourceType":"certificateOrders","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"certificateOrders/certificates","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"validateCertificateRegistrationInformation","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicSubscription","namespace":"Microsoft.ClassicSubscription","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicInfrastructureMigrate","namespace":"Microsoft.ClassicInfrastructureMigrate","authorization":{"applicationId":"5e5abe2b-83cd-4786-826a-a05653ebb103","roleDefinitionId":"766c4d9b-ef83-4f73-8352-1450a506a69b"},"resourceTypes":[{"resourceType":"classicInfrastructureResources","locations":["East
+        Asia","West Europe","West India","West US","West Central US"],"apiVersions":["2017-10-12","2017-04-02","2016-10-02","2016-04-02","2015-06-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CertificateRegistration","namespace":"Microsoft.CertificateRegistration","authorization":{"applicationId":"f3c21649-0979-4721-ac85-b0216b2cf413","roleDefinitionId":"933fba7e-2ed3-4da8-973d-8bd8298a9b40"},"resourceTypes":[{"resourceType":"certificateOrders","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"certificateOrders/certificates","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"validateCertificateRegistrationInformation","locations":["global"],"apiVersions":["2015-08-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-08-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicSubscription","namespace":"Microsoft.ClassicSubscription","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-09-01","2017-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ClassicInfrastructureMigrate","namespace":"Microsoft.ClassicInfrastructureMigrate","authorization":{"applicationId":"5e5abe2b-83cd-4786-826a-a05653ebb103","roleDefinitionId":"766c4d9b-ef83-4f73-8352-1450a506a69b"},"resourceTypes":[{"resourceType":"classicInfrastructureResources","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","North Central US","South
         Central US","Central US","North Europe","West Europe","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","West
@@ -1584,8 +1809,9 @@ http_interactions:
         Asia","East Asia","West Central US","South Central US","East US","East US
         2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/updateAccountsCreationSettings","locations":["West
         US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/accountsCreationSettings","locations":["West
-        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2016-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Commerce","namespace":"Microsoft.Commerce","resourceTypes":[{"resourceType":"UsageAggregates","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]},{"resourceType":"RateCard","locations":[],"apiVersions":["2016-08-31-preview","2015-06-01-preview","2015-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Consumption","namespace":"Microsoft.Consumption","resourceTypes":[{"resourceType":"reservationsummaries","locations":[],"apiVersions":["2017-01-30"]},{"resourceType":"reservationdetails","locations":[],"apiVersions":["2017-01-30"]},{"resourceType":"UsageDetails","locations":[],"apiVersions":["2017-06-30-preview","2017-04-24-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-30-preview","2017-04-24-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","resourceTypes":[{"resourceType":"containerGroups","locations":["West
-        US","East US","West Europe"],"apiVersions":["2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
+        US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2016-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Commerce","namespace":"Microsoft.Commerce","resourceTypes":[{"resourceType":"UsageAggregates","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]},{"resourceType":"RateCard","locations":[],"apiVersions":["2016-08-31-preview","2015-06-01-preview","2015-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Consumption","namespace":"Microsoft.Consumption","resourceTypes":[{"resourceType":"ReservationSummaries","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationTransactions","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"Balances","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"Pricesheets","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationDetails","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview"]},{"resourceType":"Budgets","locations":[],"apiVersions":["2017-12-30-preview"]},{"resourceType":"Terms","locations":[],"apiVersions":["2017-12-30-preview"]},{"resourceType":"UsageDetails","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview","2017-04-24-preview"]},{"resourceType":"Operations","locations":[],"apiVersions":["2017-11-30","2017-06-30-preview","2017-04-24-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","resourceTypes":[{"resourceType":"containerGroups","locations":["West
+        US","East US","West Europe","Southeast Asia"],"apiVersions":["2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US","East US","West Europe","Southeast Asia"],"apiVersions":["2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
         US"],"apiVersions":["2016-04-08"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.CustomerInsights","namespace":"Microsoft.CustomerInsights","authorization":{"applicationId":"38c77d00-5fcb-4cce-9d93-af4738258e3c","roleDefinitionId":"E006F9C7-F333-477C-8AD6-1F3A9FE87F55"},"resourceTypes":[{"resourceType":"hubs","locations":["East
         US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/profiles","locations":["East
         US 2","North Europe"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/interactions","locations":["East
@@ -1608,8 +1834,8 @@ http_interactions:
         US","West US","Australia East","West Europe","North Europe","Southeast Asia","West
         Central US"],"apiVersions":["2016-03-30","2015-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataFactory","namespace":"Microsoft.DataFactory","resourceTypes":[{"resourceType":"dataFactories","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview","2014-04-01"]},{"resourceType":"factories","locations":["East
-        US","East US 2"],"apiVersions":["2017-09-01-preview","2017-03-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
-        US","East US 2"],"apiVersions":["2017-09-01-preview","2017-03-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
+        US","East US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"factories/integrationRuntimes","locations":["East
+        US","East US 2","West Europe"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"dataFactories/diagnosticSettings","locations":["North
         Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"dataFactories/metricDefinitions","locations":["North
         Europe","East US","West US","West Central US"],"apiVersions":["2014-04-01"]},{"resourceType":"checkDataFactoryNameAvailability","locations":[],"apiVersions":["2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"checkAzureDataFactoryNameAvailability","locations":["West
         US","North Europe","East US","West Central US"],"apiVersions":["2015-10-01","2015-09-01","2015-08-01","2015-07-01-preview","2015-05-01-preview","2015-01-01-preview"]},{"resourceType":"dataFactorySchema","locations":["West
@@ -1621,69 +1847,71 @@ http_interactions:
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers/listSasTokens","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataLakeStore","namespace":"Microsoft.DataLakeStore","authorization":{"applicationId":"e9f49c6b-5ce5-44c8-925d-015017e9f7ad","roleDefinitionId":"17eb9cca-f08a-4499-b2d3-852d175f614f"},"resourceTypes":[{"resourceType":"accounts","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/firewallRules","locations":["East
-        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","resourceTypes":[{"resourceType":"operations","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforPostgreSQL","namespace":"Microsoft.DBforPostgreSQL","resourceTypes":[{"resourceType":"operations","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Central
-        India","East Asia","East US 2","East US","Japan East","Japan West","North
-        Central US","North Europe","South Central US","Southeast Asia","West Europe","West
-        India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"checkProvisioningServiceNameAvailability","locations":[],"apiVersions":["2017-08-21-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
+        US 2","North Europe","Central US"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DataMigration","namespace":"Microsoft.DataMigration","authorization":{"applicationId":"a4bad4aa-bf02-4631-9f78-a64ffdba8150","roleDefinitionId":"b831a21d-db98-4760-89cb-bef871952df1","managedByRoleDefinitionId":"6256fb55-9e59-4018-a9e1-76b11c0a4c89"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services/projects","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationStatuses","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["Brazil
+        South","North Europe","South Central US","West Europe","West US","East US","Canada
+        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DBforPostgreSQL","namespace":"Microsoft.DBforPostgreSQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/azureAsyncOperation","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"locations/performanceTiers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-04-30-preview","2016-02-01-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Devices","namespace":"Microsoft.Devices","resourceTypes":[{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"checkProvisioningServiceNameAvailability","locations":[],"apiVersions":["2017-11-15","2017-08-21-preview"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs","locations":["West
         US","North Europe","East Asia","East US","West Europe","Southeast Asia","Japan
         East","Japan West","Australia East","Australia Southeast","West US 2","West
         Central US","East US 2","Central US","UK South","UK West","South India","Central
-        India","Canada Central","Canada East"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"ProvisioningServices","locations":["East
-        US","West Europe","Southeast Asia"],"apiVersions":["2017-08-21-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DocumentDB","namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["Australia
-        East","Australia Southeast","Canada Central","Canada East","Central India","Central
-        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
-        US","North Europe","South Central US","South India","Southeast Asia","West
-        Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"databaseAccountNames","locations":["Australia
-        East","Australia Southeast","Canada Central","Canada East","Central India","Central
-        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
-        US","North Europe","South Central US","South India","Southeast Asia","West
-        Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]},{"resourceType":"operations","locations":["Australia
-        East","Australia Southeast","Canada Central","Canada East","Central India","Central
-        US","East Asia","East US","East US 2","Japan East","Japan West","North Central
-        US","North Europe","South Central US","South India","Southeast Asia","West
-        Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DomainRegistration","namespace":"Microsoft.DomainRegistration","authorization":{"applicationId":"ea2f600a-4980-45b7-89bf-d34da487bda1","roleDefinitionId":"54d7f2e3-5040-48a7-ae90-eebf629cfa0b"},"resourceTypes":[{"resourceType":"domains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"domains/domainOwnershipIdentifiers","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"topLevelDomains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"checkDomainAvailability","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"listDomainRecommendations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"validateDomainRegistrationInformation","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"generateSsoRequest","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DynamicsLcs","namespace":"Microsoft.DynamicsLcs","resourceTypes":[{"resourceType":"lcsprojects","locations":["Brazil
+        India","Canada Central","Canada East","Brazil South","South Central US"],"apiVersions":["2017-07-01","2017-01-19","2016-02-03","2015-08-15-preview"]},{"resourceType":"IotHubs/eventGridFilters","locations":["West
+        US","East US","West US 2","West Central US","East US 2","Central US"],"apiVersions":["2018-01-15-preview"]},{"resourceType":"ProvisioningServices","locations":["East
+        US","West US","West Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2017-11-15","2017-08-21-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DomainRegistration","namespace":"Microsoft.DomainRegistration","authorization":{"applicationId":"ea2f600a-4980-45b7-89bf-d34da487bda1","roleDefinitionId":"54d7f2e3-5040-48a7-ae90-eebf629cfa0b"},"resourceTypes":[{"resourceType":"domains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"domains/domainOwnershipIdentifiers","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"topLevelDomains","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"checkDomainAvailability","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"listDomainRecommendations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"validateDomainRegistrationInformation","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"generateSsoRequest","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]},{"resourceType":"operations","locations":["global"],"apiVersions":["2015-04-01","2015-02-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.DynamicsLcs","namespace":"Microsoft.DynamicsLcs","resourceTypes":[{"resourceType":"lcsprojects","locations":["Brazil
         South","East Asia","East US","Japan East","Japan West","North Central US","North
         Europe","South Central US","West Europe","West US","Southeast Asia","Central
         US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"lcsprojects/connectors","locations":["Brazil
@@ -1695,21 +1923,21 @@ http_interactions:
         US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-05-01-alpha","2015-04-01-alpha","2015-03-01-alpha","2015-02-01-privatepreview","2015-02-01-preview","2015-02-01-beta","2015-02-01-alpha"]},{"resourceType":"operations","locations":["Brazil
         South","East Asia","East US","Japan East","Japan West","North Central US","North
         Europe","South Central US","West Europe","West US","Southeast Asia","Central
-        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topics","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operations","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
-        US 2","West Central US"],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US","East US 2","Australia East","Australia Southeast"],"apiVersions":["2015-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventGrid","namespace":"Microsoft.EventGrid","authorizations":[{"applicationId":"4962773b-9cdb-44cf-a8bf-237846a00ab7","roleDefinitionId":"7FE036D8-246F-48BF-A78F-AB3EE699C8F3"}],"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/eventSubscriptions","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"eventSubscriptions","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topics","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"topicTypes","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operations","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationsStatus","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/operationResults","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"locations/topicTypes","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
+        US 2","East US","West US","Central US","East US 2","West Central US"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","West
         US 2","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
         India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/consumergroups","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
         US","East US 2","West US","South Central US","Central US","Australia East","Australia
         Southeast","Central India","West Central US","West US 2","Canada East","Canada
         Central","Brazil South","UK South","UK West","East Asia","Japan East","Japan
@@ -1754,23 +1982,23 @@ http_interactions:
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations","locations":["Australia
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations/operationResults","locations":["Australia
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"locations/operationResults","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"operations","locations":["Australia
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]},{"resourceType":"operations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
         West","Korea Central","North Central US","North Europe","South Central US","Southeast
-        Asia","South India","UK South","West Central US","West Europe","West India","West
-        US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Logic","namespace":"Microsoft.Logic","authorization":{"applicationId":"7cd684f4-8a78-49b0-91ec-6a35d38739ba","roleDefinitionId":"cb3ef1fb-6e31-49e2-9d87-ed821053fe58"},"resourceTypes":[{"resourceType":"workflows","locations":["North
+        Asia","South India","UK South","UK West","West Central US","West Europe","West
+        India","West US","West US 2"],"apiVersions":["2016-11-01","2016-07-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.LocationBasedServices","namespace":"Microsoft.LocationBasedServices","resourceTypes":[{"resourceType":"accounts","locations":["Global"],"apiVersions":["2017-01-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Logic","namespace":"Microsoft.Logic","authorization":{"applicationId":"7cd684f4-8a78-49b0-91ec-6a35d38739ba","roleDefinitionId":"cb3ef1fb-6e31-49e2-9d87-ed821053fe58"},"resourceTypes":[{"resourceType":"workflows","locations":["North
         Central US","Central US","South Central US","North Europe","West Europe","East
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
@@ -1791,60 +2019,78 @@ http_interactions:
         Asia","Southeast Asia","West US","East US","East US 2","Japan West","Japan
         East","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada Central","Canada East","West US 2","West Central
-        US","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","West Central US"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"operations","locations":["South
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations","locations":["South
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operations","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"commitmentPlans","locations":["South
-        Central US","West Europe","Southeast Asia","Japan East","East US 2","West
-        Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningExperimentation","namespace":"Microsoft.MachineLearningExperimentation","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"accounts","locations":["Australia
-        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces","locations":["Australia
-        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces/projects","locations":["Australia
-        East","East US 2","West Central US"],"apiVersions":["2017-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningCompute","namespace":"Microsoft.MachineLearningCompute","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"376aa7d7-51a9-463d-bd4d-7e1691345612","managedByRoleDefinitionId":"91d00862-cf55-46a5-9dce-260bbd92ce25"},"resourceTypes":[{"resourceType":"operationalizationClusters","locations":["East
-        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"operations","locations":["East
+        US","UK South","UK West"],"apiVersions":["2016-06-01","2015-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningExperimentation","namespace":"Microsoft.MachineLearningExperimentation","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"accounts","locations":["Australia
+        East","East US 2","West Central US","Southeast Asia","West Europe"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces","locations":["Australia
+        East","East US 2","West Central US","Southeast Asia","West Europe"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"accounts/workspaces/projects","locations":["Australia
+        East","East US 2","West Central US","Southeast Asia","West Europe"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"teamAccounts","locations":["Australia
+        East","West Central US","East US 2"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"teamAccounts/workspaces","locations":["Australia
+        East","West Central US","East US 2"],"apiVersions":["2017-05-01-preview"]},{"resourceType":"teamAccounts/workspaces/projects","locations":["Australia
+        East","West Central US","East US 2"],"apiVersions":["2017-05-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningCompute","namespace":"Microsoft.MachineLearningCompute","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"376aa7d7-51a9-463d-bd4d-7e1691345612","managedByRoleDefinitionId":"91d00862-cf55-46a5-9dce-260bbd92ce25"},"resourceTypes":[{"resourceType":"operationalizationClusters","locations":["East
+        US 2","West Central US","Australia East","West Europe","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"operations","locations":["East
         US 2"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations","locations":["East
         US 2"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operations","locations":["East
-        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["East
-        US 2","West Central US","Australia East"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningModelManagement","namespace":"Microsoft.MachineLearningModelManagement","resourceTypes":[{"resourceType":"accounts","locations":["East
-        US 2","West Central US","Australia East"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"operations","locations":["West
-        Central US"],"apiVersions":["2017-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
+        US 2","West Central US","Australia East","West Europe","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]},{"resourceType":"locations/operationsStatus","locations":["East
+        US 2","West Central US","Australia East","West Europe","Southeast Asia"],"apiVersions":["2017-08-01-preview","2017-06-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MachineLearningModelManagement","namespace":"Microsoft.MachineLearningModelManagement","resourceTypes":[{"resourceType":"accounts","locations":["East
+        US 2","West Central US","Australia East","West Europe","Southeast Asia"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"operations","locations":["West
+        Central US"],"apiVersions":["2017-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ManagedIdentity","namespace":"Microsoft.ManagedIdentity","resourceTypes":[{"resourceType":"Identities","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Brazil South","Central
+        India","West India","South India","Japan West","Japan East","East Asia","Southeast
+        Asia","Korea Central","Korea South","North Europe","West Europe","UK West","UK
+        South","Central US","North Central US","East US","East US 2","South Central
+        US","West US","West US 2","West Central US"],"apiVersions":["2015-08-31-PREVIEW"]},{"resourceType":"operations","locations":["Australia
+        East","Australia Southeast","Canada Central","Canada East","Brazil South","Central
+        India","West India","South India","Japan West","Japan East","East Asia","Southeast
+        Asia","Korea Central","Korea South","North Europe","West Europe","UK West","UK
+        South","Central US","North Central US","East US","East US 2","South Central
+        US","West US","West US 2","West Central US"],"apiVersions":["2015-08-31-PREVIEW"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Management","namespace":"Microsoft.Management","authorization":{"applicationId":"f2c304cf-8e7e-4c3f-8164-16299ad9d272","roleDefinitionId":"c1cf3708-588a-4647-be7f-f400bbe214cf"},"resourceTypes":[{"resourceType":"resources","locations":[],"apiVersions":["2017-11-01-preview","2017-08-31-preview","2017-06-30-preview","2017-05-31-preview"]},{"resourceType":"managementGroups","locations":[],"apiVersions":["2017-11-01-preview","2017-08-31-preview","2017-06-30-preview","2017-05-31-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01-preview","2017-08-31-preview","2017-06-30-preview","2017-05-31-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceApps","namespace":"Microsoft.MarketplaceApps","resourceTypes":[{"resourceType":"classicDevServices","locations":["Northwest
+        US","East Asia","Southeast Asia","East US","East US 2","West US","West US
+        2","North Central US","South Central US","West Central US","Central US","North
+        Europe","West Europe","Japan East","Japan West","Brazil South","Australia
+        East","Australia Southeast","South India","Central India","Canada Central","Canada
+        East"],"apiVersions":["2017-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2017-11-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2017-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.MarketplaceOrdering","namespace":"Microsoft.MarketplaceOrdering","resourceTypes":[{"resourceType":"agreements","locations":["South
         Central US","West US"],"apiVersions":["2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01"]},{"resourceType":"offertypes","locations":["South
         Central US","West US"],"apiVersions":["2015-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Media","namespace":"Microsoft.Media","authorization":{"applicationId":"374b2a64-3b6b-436b-934c-b820eacca870","roleDefinitionId":"aab70789-0cec-44b5-95d7-84b64c9487af"},"resourceTypes":[{"resourceType":"mediaservices","locations":["Japan
         West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
         US","West US","Australia East","Australia Southeast","Central US","Brazil
         South","Central India","West India","South India","South Central US","Canada
-        Central","Canada East","West Central US"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
+        Central","Canada East","West Central US","West US 2"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
+        Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"operations","locations":["West
+        Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
+        Central US"],"apiVersions":["2017-11-11-preview","2017-09-25-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PolicyInsights","namespace":"Microsoft.PolicyInsights","authorization":{"applicationId":"1d78a85d-813d-46f0-b496-dd72f50a3ec0","roleDefinitionId":"63d2b225-4c34-4641-8768-21a1f7c68ce8"},"resourceTypes":[{"resourceType":"policyEvents","locations":[],"apiVersions":["2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"policyStates","locations":[],"apiVersions":["2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-17-preview","2017-08-09-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
         Central US","North Central US","East US 2","West US","West Europe","North
         Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
         East","UK South","West India"],"apiVersions":["2016-01-29"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-01-29"]},{"resourceType":"locations/checkNameAvailability","locations":["South
         Central US","North Central US","East US 2","West US","West Europe","North
         Europe","Brazil South","Southeast Asia","Australia Southeast","Canada Central","Japan
-        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"capacities","locations":["West
-        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
-        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationresults","locations":["West
-        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
-        Europe"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"operations","locations":["East
-        US 2"],"apiVersions":["2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Relay","namespace":"Microsoft.Relay","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","UK South","West India"],"apiVersions":["2016-01-29"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.PowerBIDedicated","namespace":"Microsoft.PowerBIDedicated","authorization":{"applicationId":"4ac7d521-0382-477b-b0f8-7e1d95f85ca2","roleDefinitionId":"490d5987-bcf6-4be6-b6b2-056a78cb693a"},"resourceTypes":[{"resourceType":"capacities","locations":["Australia
+        Southeast","Brazil South","Canada Central","East Asia","East US","East US
+        2","West India","Japan East","West Central US","North Central US","North Europe","South
+        Central US","Southeast Asia","UK South","West Europe","West US","West US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-01-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":["Australia
+        Southeast","Brazil South","Canada Central","East Asia","East US","East US
+        2","West India","Japan East","West Central US","North Central US","North Europe","South
+        Central US","Southeast Asia","UK South","West Europe","West US","West US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationresults","locations":["Australia
+        Southeast","Brazil South","Canada Central","East Asia","East US","East US
+        2","West India","Japan East","West Central US","North Central US","North Europe","South
+        Central US","Southeast Asia","UK South","West Europe","West US","West US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["Australia
+        Southeast","Brazil South","Canada Central","East Asia","East US","East US
+        2","West India","Japan East","West Central US","North Central US","North Europe","South
+        Central US","Southeast Asia","UK South","West Europe","West US","West US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]},{"resourceType":"operations","locations":["East
+        US 2"],"apiVersions":["2017-10-01","2017-01-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Relay","namespace":"Microsoft.Relay","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US 2","West
         US","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
         India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2017-08-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkPolicyCompliance","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/hybridconnections","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/hybridconnections/authorizationrules","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/wcfrelays","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/wcfrelays/authorizationrules","locations":[],"apiVersions":["2017-04-01","2016-07-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2016-07-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-07-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Resources","namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"tenants","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkPolicyCompliance","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"checkresourcename","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/providers","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/operationresults","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
         Central US","South Central US","North Europe","West Europe","East Asia","Southeast
         Asia","West US","East US","Japan West","Japan East","Brazil South","Central
         US","East US 2","Australia East","Australia Southeast","South India","Central
@@ -1868,12 +2114,12 @@ http_interactions:
         India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19","2015-02-28"]},{"resourceType":"checkServiceNameAvailability","locations":[],"apiVersions":["2015-02-28","2014-07-31-Preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2015-08-19"]},{"resourceType":"resourceHealthMetadata","locations":["West
         US","East US","North Europe","West Europe","Southeast Asia","East Asia","North
         Central US","South Central US","Japan West","Australia East","Brazil South","Central
-        India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        India","West Central US","Canada Central","UK South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","authorization":{"applicationId":"80a10ef9-8168-493d-abf9-3297c4ef6e3c","roleDefinitionId":"2b7763f7-bbe2-4e19-befe-28c79f1cf7f7"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US 2","West
         US","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
         India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"premiumMessagingRegions","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceFabric","namespace":"Microsoft.ServiceFabric","authorization":{"applicationId":"74cb6831-0dbb-4be1-8206-fd4df301cdc2","roleDefinitionId":"e55cc65f-6903-4917-b4ef-f8d4640b57f5"},"resourceTypes":[{"resourceType":"clusters","locations":["West
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/queues","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/queues/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/topics","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/topics/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/topics/subscriptions","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/topics/subscriptions/rules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"premiumMessagingRegions","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.ServiceFabric","namespace":"Microsoft.ServiceFabric","authorization":{"applicationId":"74cb6831-0dbb-4be1-8206-fd4df301cdc2","roleDefinitionId":"e55cc65f-6903-4917-b4ef-f8d4640b57f5"},"resourceTypes":[{"resourceType":"clusters","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
@@ -1887,17 +2133,43 @@ http_interactions:
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
-        India","West India","Central India","Brazil South","South Central US","Canada
-        Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
         Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
         Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applianceDefinitions","locations":["West
-        Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"locations","locations":["West
-        Central US"],"apiVersions":["2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
-        Central US"],"apiVersions":["2017-09-01","2016-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
+        Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applications","locations":["South
+        Central US","North Central US","West Central US","West US","West US 2","East
+        US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
+        Asia","Brazil South","Japan West","Japan East","Australia East","Australia
+        Southeast","South India","West India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
+        Central US","North Central US","West Central US","West US","West US 2","East
+        US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
+        Asia","Brazil South","Japan West","Japan East","Australia East","Australia
+        Southeast","South India","West India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
+        Central US"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
+        Central US","North Central US","West Central US","West US","West US 2","East
+        US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
+        Asia","Brazil South","Japan West","Japan East","Australia East","Australia
+        Southeast","South India","West India","Central India","Canada Central","Canada
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/cloudEndpoints","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/serverEndpoints","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/registeredServers","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/workflows","locations":["West
+        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
+        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","West Central US","Japan East","Japan West","Australia East","Australia
         Southeast"],"apiVersions":["2017-06-01","2017-05-15","2017-01-01","2016-10-01","2016-06-01","2015-03-15","2014-09-01"]},{"resourceType":"operations","locations":["West
@@ -1928,23 +2200,11 @@ http_interactions:
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast"],"apiVersions":["2015-07-01-Preview","2015-03-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/azure_subscription_id/providers/Microsoft.TimeSeriesInsights","namespace":"Microsoft.TimeSeriesInsights","authorizations":[{"applicationId":"120d688d-1518-4cf7-bd38-182f158850b6","roleDefinitionId":"5a43abdf-bb87-42c4-9e56-1c24bf364150"}],"resourceTypes":[{"resourceType":"environments","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/eventsources","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/referenceDataSets","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"environments/accessPolicies","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]},{"resourceType":"operations","locations":["East
-        US 2","North Europe","West Europe","West US"],"apiVersions":["2017-02-28-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
-        Central US","South Central US","East US","West US","Central US","North Europe","West
-        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
-        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/project","locations":["North
-        Central US","South Central US","East US","West US","Central US","North Europe","West
-        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
-        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/extension","locations":["North
-        Central US","South Central US","East US","West US","Central US","North Europe","West
-        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
-        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"checkNameAvailability","locations":["North
-        Central US","South Central US","East US","West US","Central US","North Europe","West
-        Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
-        East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Myget.PackageManagement","namespace":"Myget.PackageManagement","resourceTypes":[{"resourceType":"services","locations":["West
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]},{"resourceType":"environments/eventsources","locations":["East
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]},{"resourceType":"environments/referenceDataSets","locations":["East
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]},{"resourceType":"environments/accessPolicies","locations":["East
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]},{"resourceType":"operations","locations":["East
+        US","East US 2","North Europe","West Europe","West US"],"apiVersions":["2017-11-15","2017-02-28-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/Myget.PackageManagement","namespace":"Myget.PackageManagement","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/NewRelic.APM","namespace":"NewRelic.APM","authorization":{"allowedThirdPartyExtensions":[{"name":"NewRelic_AzurePortal_APM"}]},"resourceTypes":[{"resourceType":"accounts","locations":["North
         Central US","South Central US","West US","East US","North Europe","West Europe","Southeast
         Asia","East Asia","Japan East","Japan West"],"apiVersions":["2014-10-01","2014-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/nuubit.nextgencdn","namespace":"nuubit.nextgencdn","resourceTypes":[{"resourceType":"accounts","locations":["East
@@ -1984,7 +2244,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/azure_subscription_id/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:08 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:15 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
@@ -2001,9 +2261,11 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMjcsIm5iZiI6MTUwNjExNjIyNywiZXhwIjoxNTA2MTIwMTI3LCJhaW8iOiJZMlZnWU5pV0pXUHdMc2ZWM2ZoSVFWajJIT3N5QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTFY3NVNHblk1MC1NTnZFOER3b05BQSIsInZlciI6IjEuMCJ9.qvqsibTj97Wje7DCzUZsV0avjdDT3jRuYQaaD4f6Zx9Nw6quJKnQDC-ifyJGTzLH38kpVmfLEZhClnR-HC2Y7nFMt_MEgpSrE1kOx9ZC3tbRPCp053tqyehRMpwIDaSQaulpJEL2SW-a3uR_4twj7Tck7yGwaA0jT9rV1kEARjo3g-A5P4fVwmf7vhMI-3u4QcBSrxN0JsYO5OufKAiXaECbT1aBUKACVMQzQjhu5w2RJLpS45vFL9y-H8VboQC3XB92D4wGvsYEh1APnSXBPvOpvGt72M-ob_uFHh4q7opWMyKUpDccB7mWtALp3MNCWeTfxyx9misbaWEzPnEhoQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3MzMsIm5iZiI6MTUxNjczNzczMywiZXhwIjoxNTE2NzQxNjMzLCJhaW8iOiJZMk5nWU5qWTM4RStWU2lPKzlxT2duY0JKOWN0QlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUjk4Yl8yWHB4MDJaR3BvQmwwcERBQSIsInZlciI6IjEuMCJ9.NM3ejSPT249gsaL8A4EMGuEfHCRthnrVDy2bes8VW3sb1OsRTrgRz7uH_qPMinDTdqHpjbK2qNWeT2vmM5HVJr2mwRFK-OwoabJIeGSn1vtXvx6XIfL_M28g1jxu7qjVGtrzeI5G8A7z8RdsfRzcCHNKz1xzC9kZI8WO-aKKJRXY0E8qEFtv49rjUMItXtQieMdNyCXrP-ezuJ0cR2hk-f5JSQpIOylRYjUL3qrHD5ocM08L-eMMg1R79FoStNOBkwMDNWB6o9m9K1LDpgUcZZlkBwNiJU7IZHXt59RwAzExDo1ddMV3w924Aw1to1rbcINWYiBpU37ZdtR9T-72vQ
       Content-Length:
       - '42'
+      Host:
+      - management.azure.com
   response:
     status:
       code: 202
@@ -2013,39 +2275,41 @@ http_interactions:
       - no-cache
       Pragma:
       - no-cache
-      Content-Length:
-      - '0'
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/41bcee67-68a7-4667-8f73-fd109c9041c5?monitor=true&api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/b290853d-fa49-4f2d-89c3-0ccbfe99daae?monitor=true&api-version=2017-03-30
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/41bcee67-68a7-4667-8f73-fd109c9041c5?api-version=2017-03-30
+      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/b290853d-fa49-4f2d-89c3-0ccbfe99daae?api-version=2017-03-30
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/HighCostHydrate3Min;233,Microsoft.Compute/HighCostHydrate30Min;1160
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131599701143261070
       X-Ms-Request-Id:
-      - 41bcee67-68a7-4667-8f73-fd109c9041c5
+      - b290853d-fa49-4f2d-89c3-0ccbfe99daae
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1178'
+      - '1152'
       X-Ms-Correlation-Request-Id:
-      - 93553c50-6cc9-4a9c-8d08-fb453d07384e
+      - 026b5fe9-b7fc-4556-ae4a-163e31baf41e
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214210Z:93553c50-6cc9-4a9c-8d08-fb453d07384e
+      - WESTUS:20180123T200716Z:026b5fe9-b7fc-4556-ae4a-163e31baf41e
       Date:
-      - Fri, 22 Sep 2017 21:42:09 GMT
+      - Tue, 23 Jan 2018 20:07:15 GMT
+      Content-Length:
+      - '0'
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:09 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:16 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/41bcee67-68a7-4667-8f73-fd109c9041c5?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/b290853d-fa49-4f2d-89c3-0ccbfe99daae?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -2059,7 +2323,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMjcsIm5iZiI6MTUwNjExNjIyNywiZXhwIjoxNTA2MTIwMTI3LCJhaW8iOiJZMlZnWU5pV0pXUHdMc2ZWM2ZoSVFWajJIT3N5QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTFY3NVNHblk1MC1NTnZFOER3b05BQSIsInZlciI6IjEuMCJ9.qvqsibTj97Wje7DCzUZsV0avjdDT3jRuYQaaD4f6Zx9Nw6quJKnQDC-ifyJGTzLH38kpVmfLEZhClnR-HC2Y7nFMt_MEgpSrE1kOx9ZC3tbRPCp053tqyehRMpwIDaSQaulpJEL2SW-a3uR_4twj7Tck7yGwaA0jT9rV1kEARjo3g-A5P4fVwmf7vhMI-3u4QcBSrxN0JsYO5OufKAiXaECbT1aBUKACVMQzQjhu5w2RJLpS45vFL9y-H8VboQC3XB92D4wGvsYEh1APnSXBPvOpvGt72M-ob_uFHh4q7opWMyKUpDccB7mWtALp3MNCWeTfxyx9misbaWEzPnEhoQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3MzMsIm5iZiI6MTUxNjczNzczMywiZXhwIjoxNTE2NzQxNjMzLCJhaW8iOiJZMk5nWU5qWTM4RStWU2lPKzlxT2duY0JKOWN0QlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUjk4Yl8yWHB4MDJaR3BvQmwwcERBQSIsInZlciI6IjEuMCJ9.NM3ejSPT249gsaL8A4EMGuEfHCRthnrVDy2bes8VW3sb1OsRTrgRz7uH_qPMinDTdqHpjbK2qNWeT2vmM5HVJr2mwRFK-OwoabJIeGSn1vtXvx6XIfL_M28g1jxu7qjVGtrzeI5G8A7z8RdsfRzcCHNKz1xzC9kZI8WO-aKKJRXY0E8qEFtv49rjUMItXtQieMdNyCXrP-ezuJ0cR2hk-f5JSQpIOylRYjUL3qrHD5ocM08L-eMMg1R79FoStNOBkwMDNWB6o9m9K1LDpgUcZZlkBwNiJU7IZHXt59RwAzExDo1ddMV3w924Aw1to1rbcINWYiBpU37ZdtR9T-72vQ
+      Host:
+      - management.azure.com
   response:
     status:
       code: 200
@@ -2077,34 +2343,36 @@ http_interactions:
       - "-1"
       Vary:
       - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/GetOperation3Min;49982,Microsoft.Compute/GetOperation30Min;249982
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131599701143261070
       X-Ms-Request-Id:
-      - a415e4a1-d042-464d-8517-220046eb0bd5
+      - afed6fb1-a9d2-4982-b3d5-c48e05ebe4d0
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14929'
+      - '14862'
       X-Ms-Correlation-Request-Id:
-      - b6d2b3dd-d323-4f0f-ade0-5b527ee3e2bb
+      - 41c67ca8-e4d2-4c6e-be19-275273a6463f
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214211Z:b6d2b3dd-d323-4f0f-ade0-5b527ee3e2bb
+      - WESTUS:20180123T200717Z:41c67ca8-e4d2-4c6e-be19-275273a6463f
       Date:
-      - Fri, 22 Sep 2017 21:42:11 GMT
+      - Tue, 23 Jan 2018 20:07:16 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-22T21:42:12.1094742+00:00\",\r\n  \"endTime\":
-        \"2017-09-22T21:42:12.2501206+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=c33ab88c-087e-436b-a3d6-433b3af6e71f&sig=unMkh%2Buv5JQPB7i4OLpcRekonXIKQ6kSH2%2FZU084k4c%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"41bcee67-68a7-4667-8f73-fd109c9041c5\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2018-01-23T20:07:15.691746+00:00\",\r\n  \"endTime\":
+        \"2018-01-23T20:07:15.9417691+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=de6fdde2-a845-47ce-a31c-204eb9ac2a98&sig=LQ8zmEluBsypHs5mEXmRAGRfLmeGalQxQrxMo0eyBks%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"b290853d-fa49-4f2d-89c3-0ccbfe99daae\"\r\n}"
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:10 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:17 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/41bcee67-68a7-4667-8f73-fd109c9041c5?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/b290853d-fa49-4f2d-89c3-0ccbfe99daae?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -2118,7 +2386,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMjcsIm5iZiI6MTUwNjExNjIyNywiZXhwIjoxNTA2MTIwMTI3LCJhaW8iOiJZMlZnWU5pV0pXUHdMc2ZWM2ZoSVFWajJIT3N5QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTFY3NVNHblk1MC1NTnZFOER3b05BQSIsInZlciI6IjEuMCJ9.qvqsibTj97Wje7DCzUZsV0avjdDT3jRuYQaaD4f6Zx9Nw6quJKnQDC-ifyJGTzLH38kpVmfLEZhClnR-HC2Y7nFMt_MEgpSrE1kOx9ZC3tbRPCp053tqyehRMpwIDaSQaulpJEL2SW-a3uR_4twj7Tck7yGwaA0jT9rV1kEARjo3g-A5P4fVwmf7vhMI-3u4QcBSrxN0JsYO5OufKAiXaECbT1aBUKACVMQzQjhu5w2RJLpS45vFL9y-H8VboQC3XB92D4wGvsYEh1APnSXBPvOpvGt72M-ob_uFHh4q7opWMyKUpDccB7mWtALp3MNCWeTfxyx9misbaWEzPnEhoQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSIsImtpZCI6Ino0NHdNZEh1OHdLc3VtcmJmYUs5OHF4czVZSSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MTY3Mzc3MzMsIm5iZiI6MTUxNjczNzczMywiZXhwIjoxNTE2NzQxNjMzLCJhaW8iOiJZMk5nWU5qWTM4RStWU2lPKzlxT2duY0JKOWN0QlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUjk4Yl8yWHB4MDJaR3BvQmwwcERBQSIsInZlciI6IjEuMCJ9.NM3ejSPT249gsaL8A4EMGuEfHCRthnrVDy2bes8VW3sb1OsRTrgRz7uH_qPMinDTdqHpjbK2qNWeT2vmM5HVJr2mwRFK-OwoabJIeGSn1vtXvx6XIfL_M28g1jxu7qjVGtrzeI5G8A7z8RdsfRzcCHNKz1xzC9kZI8WO-aKKJRXY0E8qEFtv49rjUMItXtQieMdNyCXrP-ezuJ0cR2hk-f5JSQpIOylRYjUL3qrHD5ocM08L-eMMg1R79FoStNOBkwMDNWB6o9m9K1LDpgUcZZlkBwNiJU7IZHXt59RwAzExDo1ddMV3w924Aw1to1rbcINWYiBpU37ZdtR9T-72vQ
+      Host:
+      - management.azure.com
   response:
     status:
       code: 200
@@ -2136,34 +2406,36 @@ http_interactions:
       - "-1"
       Vary:
       - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/GetOperation3Min;49981,Microsoft.Compute/GetOperation30Min;249981
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131599701143261070
       X-Ms-Request-Id:
-      - 990ffa35-f0b9-4789-a1db-2681493779e5
+      - 7a0e6aad-58d2-48bf-a21e-75e7ab121ac6
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14921'
+      - '14864'
       X-Ms-Correlation-Request-Id:
-      - 230e63cc-5381-421a-9c25-ddc7f327d898
+      - 8c975843-0d3f-4fa5-93df-db3fcdaed286
       X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214212Z:230e63cc-5381-421a-9c25-ddc7f327d898
+      - WESTUS:20180123T200717Z:8c975843-0d3f-4fa5-93df-db3fcdaed286
       Date:
-      - Fri, 22 Sep 2017 21:42:11 GMT
+      - Tue, 23 Jan 2018 20:07:17 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-22T21:42:12.1094742+00:00\",\r\n  \"endTime\":
-        \"2017-09-22T21:42:12.2501206+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=c33ab88c-087e-436b-a3d6-433b3af6e71f&sig=unMkh%2Buv5JQPB7i4OLpcRekonXIKQ6kSH2%2FZU084k4c%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"41bcee67-68a7-4667-8f73-fd109c9041c5\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2018-01-23T20:07:15.691746+00:00\",\r\n  \"endTime\":
+        \"2018-01-23T20:07:15.9417691+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=de6fdde2-a845-47ce-a31c-204eb9ac2a98&sig=LQ8zmEluBsypHs5mEXmRAGRfLmeGalQxQrxMo0eyBks%3D\"\r\n}\r\n
+        \ },\r\n  \"name\": \"b290853d-fa49-4f2d-89c3-0ccbfe99daae\"\r\n}"
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:11 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:17 GMT
 - request:
     method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=c33ab88c-087e-436b-a3d6-433b3af6e71f&sig=unMkh%2Buv5JQPB7i4OLpcRekonXIKQ6kSH2/ZU084k4c=&sr=b&sv=2016-05-31
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=de6fdde2-a845-47ce-a31c-204eb9ac2a98&sig=LQ8zmEluBsypHs5mEXmRAGRfLmeGalQxQrxMo0eyBks=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2176,6 +2448,8 @@ http_interactions:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
       X-Ms-Range:
       - bytes=0-0
+      Host:
+      - md-t4jdgqqlgszp.blob.core.windows.net
   response:
     status:
       code: 206
@@ -2188,15 +2462,15 @@ http_interactions:
       Content-Range:
       - bytes 0-0/34359738880
       Last-Modified:
-      - Sat, 15 Jul 2017 14:23:07 GMT
+      - Tue, 23 Jan 2018 20:04:26 GMT
       Accept-Ranges:
       - bytes
       Etag:
-      - '"0x8D4CB8D039FC699"'
+      - '"0x8D5629C811B65EB"'
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - f4c3fe69-001e-00a1-2beb-336fb6000000
+      - 8ac15aac-001e-008f-6a85-94ef71000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2208,7 +2482,7 @@ http_interactions:
       X-Ms-Blob-Type:
       - PageBlob
       X-Ms-Blob-Sequence-Number:
-      - '20'
+      - '30'
       X-Ms-Copy-Id:
       - 30cedd78-548a-4fd8-967e-f8344f587e3c
       X-Ms-Copy-Source:
@@ -2222,250 +2496,16 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Fri, 22 Sep 2017 21:42:11 GMT
+      - Tue, 23 Jan 2018 20:07:17 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         6w==
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:11 GMT
-- request:
-    method: post
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/EndGetAccess?api-version=2017-03-30
-    body:
-      encoding: ASCII-8BIT
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMjcsIm5iZiI6MTUwNjExNjIyNywiZXhwIjoxNTA2MTIwMTI3LCJhaW8iOiJZMlZnWU5pV0pXUHdMc2ZWM2ZoSVFWajJIT3N5QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTFY3NVNHblk1MC1NTnZFOER3b05BQSIsInZlciI6IjEuMCJ9.qvqsibTj97Wje7DCzUZsV0avjdDT3jRuYQaaD4f6Zx9Nw6quJKnQDC-ifyJGTzLH38kpVmfLEZhClnR-HC2Y7nFMt_MEgpSrE1kOx9ZC3tbRPCp053tqyehRMpwIDaSQaulpJEL2SW-a3uR_4twj7Tck7yGwaA0jT9rV1kEARjo3g-A5P4fVwmf7vhMI-3u4QcBSrxN0JsYO5OufKAiXaECbT1aBUKACVMQzQjhu5w2RJLpS45vFL9y-H8VboQC3XB92D4wGvsYEh1APnSXBPvOpvGt72M-ob_uFHh4q7opWMyKUpDccB7mWtALp3MNCWeTfxyx9misbaWEzPnEhoQ
-      Content-Length:
-      - '0'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '0'
-      Expires:
-      - "-1"
-      Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/ef0e785e-1355-457e-a735-bb73e38aa4cb?monitor=true&api-version=2017-03-30
-      Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/ef0e785e-1355-457e-a735-bb73e38aa4cb?api-version=2017-03-30
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - ef0e785e-1355-457e-a735-bb73e38aa4cb
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1183'
-      X-Ms-Correlation-Request-Id:
-      - d9cd58c8-6a1a-4ea1-ba4b-207b7788bd60
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214213Z:d9cd58c8-6a1a-4ea1-ba4b-207b7788bd60
-      Date:
-      - Fri, 22 Sep 2017 21:42:13 GMT
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:12 GMT
-- request:
-    method: post
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/BeginGetAccess?api-version=2017-03-30
-    body:
-      encoding: UTF-8
-      string: '{"access":"read","durationInSeconds":3600}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMjcsIm5iZiI6MTUwNjExNjIyNywiZXhwIjoxNTA2MTIwMTI3LCJhaW8iOiJZMlZnWU5pV0pXUHdMc2ZWM2ZoSVFWajJIT3N5QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTFY3NVNHblk1MC1NTnZFOER3b05BQSIsInZlciI6IjEuMCJ9.qvqsibTj97Wje7DCzUZsV0avjdDT3jRuYQaaD4f6Zx9Nw6quJKnQDC-ifyJGTzLH38kpVmfLEZhClnR-HC2Y7nFMt_MEgpSrE1kOx9ZC3tbRPCp053tqyehRMpwIDaSQaulpJEL2SW-a3uR_4twj7Tck7yGwaA0jT9rV1kEARjo3g-A5P4fVwmf7vhMI-3u4QcBSrxN0JsYO5OufKAiXaECbT1aBUKACVMQzQjhu5w2RJLpS45vFL9y-H8VboQC3XB92D4wGvsYEh1APnSXBPvOpvGt72M-ob_uFHh4q7opWMyKUpDccB7mWtALp3MNCWeTfxyx9misbaWEzPnEhoQ
-      Content-Length:
-      - '42'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '0'
-      Expires:
-      - "-1"
-      Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/e7e667ba-efe5-4973-bfe6-79ad0dfc239e?monitor=true&api-version=2017-03-30
-      Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/e7e667ba-efe5-4973-bfe6-79ad0dfc239e?api-version=2017-03-30
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - e7e667ba-efe5-4973-bfe6-79ad0dfc239e
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1186'
-      X-Ms-Correlation-Request-Id:
-      - c28c8945-dfeb-4174-9b33-3222a422ff86
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214214Z:c28c8945-dfeb-4174-9b33-3222a422ff86
-      Date:
-      - Fri, 22 Sep 2017 21:42:13 GMT
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:13 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:18 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/e7e667ba-efe5-4973-bfe6-79ad0dfc239e?api-version=2017-03-30
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMjcsIm5iZiI6MTUwNjExNjIyNywiZXhwIjoxNTA2MTIwMTI3LCJhaW8iOiJZMlZnWU5pV0pXUHdMc2ZWM2ZoSVFWajJIT3N5QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTFY3NVNHblk1MC1NTnZFOER3b05BQSIsInZlciI6IjEuMCJ9.qvqsibTj97Wje7DCzUZsV0avjdDT3jRuYQaaD4f6Zx9Nw6quJKnQDC-ifyJGTzLH38kpVmfLEZhClnR-HC2Y7nFMt_MEgpSrE1kOx9ZC3tbRPCp053tqyehRMpwIDaSQaulpJEL2SW-a3uR_4twj7Tck7yGwaA0jT9rV1kEARjo3g-A5P4fVwmf7vhMI-3u4QcBSrxN0JsYO5OufKAiXaECbT1aBUKACVMQzQjhu5w2RJLpS45vFL9y-H8VboQC3XB92D4wGvsYEh1APnSXBPvOpvGt72M-ob_uFHh4q7opWMyKUpDccB7mWtALp3MNCWeTfxyx9misbaWEzPnEhoQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - ab554cb7-1d31-44c1-b392-24f9b729105f
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14914'
-      X-Ms-Correlation-Request-Id:
-      - 8842d634-0ccf-4c5a-bd4d-03dc6fe203c4
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214214Z:8842d634-0ccf-4c5a-bd4d-03dc6fe203c4
-      Date:
-      - Fri, 22 Sep 2017 21:42:14 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-22T21:42:15.5009669+00:00\",\r\n  \"endTime\":
-        \"2017-09-22T21:42:15.7041218+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=ced7963c-2fba-4a05-84e2-fba42eed5327&sig=uzaOefZdnSRaa3jJHLmnqb2LFx8GZ0aqBzQw9z6cLoI%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"e7e667ba-efe5-4973-bfe6-79ad0dfc239e\"\r\n}"
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:14 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/e7e667ba-efe5-4973-bfe6-79ad0dfc239e?api-version=2017-03-30
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMjcsIm5iZiI6MTUwNjExNjIyNywiZXhwIjoxNTA2MTIwMTI3LCJhaW8iOiJZMlZnWU5pV0pXUHdMc2ZWM2ZoSVFWajJIT3N5QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTFY3NVNHblk1MC1NTnZFOER3b05BQSIsInZlciI6IjEuMCJ9.qvqsibTj97Wje7DCzUZsV0avjdDT3jRuYQaaD4f6Zx9Nw6quJKnQDC-ifyJGTzLH38kpVmfLEZhClnR-HC2Y7nFMt_MEgpSrE1kOx9ZC3tbRPCp053tqyehRMpwIDaSQaulpJEL2SW-a3uR_4twj7Tck7yGwaA0jT9rV1kEARjo3g-A5P4fVwmf7vhMI-3u4QcBSrxN0JsYO5OufKAiXaECbT1aBUKACVMQzQjhu5w2RJLpS45vFL9y-H8VboQC3XB92D4wGvsYEh1APnSXBPvOpvGt72M-ob_uFHh4q7opWMyKUpDccB7mWtALp3MNCWeTfxyx9misbaWEzPnEhoQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - e723ac75-d2af-4493-bdcb-1ac98ed61e0d
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14924'
-      X-Ms-Correlation-Request-Id:
-      - a12079a4-9317-4c4b-9161-d84ea56be7a7
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214215Z:a12079a4-9317-4c4b-9161-d84ea56be7a7
-      Date:
-      - Fri, 22 Sep 2017 21:42:15 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"startTime\": \"2017-09-22T21:42:15.5009669+00:00\",\r\n  \"endTime\":
-        \"2017-09-22T21:42:15.7041218+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"properties\": {\r\n    \"output\": {\r\n  \"accessSAS\": \"https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?sv=2016-05-31&sr=b&si=ced7963c-2fba-4a05-84e2-fba42eed5327&sig=uzaOefZdnSRaa3jJHLmnqb2LFx8GZ0aqBzQw9z6cLoI%3D\"\r\n}\r\n
-        \ },\r\n  \"name\": \"e7e667ba-efe5-4973-bfe6-79ad0dfc239e\"\r\n}"
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:14 GMT
-- request:
-    method: get
-    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=ced7963c-2fba-4a05-84e2-fba42eed5327&sig=uzaOefZdnSRaa3jJHLmnqb2LFx8GZ0aqBzQw9z6cLoI=&sr=b&sv=2016-05-31
+    uri: https://md-t4jdgqqlgszp.blob.core.windows.net/mtzm0hsfz311/abcd?si=de6fdde2-a845-47ce-a31c-204eb9ac2a98&sig=LQ8zmEluBsypHs5mEXmRAGRfLmeGalQxQrxMo0eyBks=&sr=b&sv=2016-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -2478,6 +2518,8 @@ http_interactions:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
       X-Ms-Range:
       - bytes=440-443
+      Host:
+      - md-t4jdgqqlgszp.blob.core.windows.net
   response:
     status:
       code: 206
@@ -2490,15 +2532,15 @@ http_interactions:
       Content-Range:
       - bytes 440-443/34359738880
       Last-Modified:
-      - Sat, 15 Jul 2017 14:23:07 GMT
+      - Tue, 23 Jan 2018 20:04:26 GMT
       Accept-Ranges:
       - bytes
       Etag:
-      - '"0x8D4CB8D039FC699"'
+      - '"0x8D5629C811B65EB"'
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - fe4eebbd-001e-0009-32eb-33bba3000000
+      - 847e4482-001e-00fb-4885-946937000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Pirtag:
@@ -2510,7 +2552,7 @@ http_interactions:
       X-Ms-Blob-Type:
       - PageBlob
       X-Ms-Blob-Sequence-Number:
-      - '20'
+      - '30'
       X-Ms-Copy-Id:
       - 30cedd78-548a-4fd8-967e-f8344f587e3c
       X-Ms-Copy-Source:
@@ -2524,69 +2566,11 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Fri, 22 Sep 2017 21:42:15 GMT
+      - Tue, 23 Jan 2018 20:07:18 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         U5MJAA==
     http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:15 GMT
-- request:
-    method: post
-    uri: https://management.azure.com/subscriptions/azure_subscription_id/resourceGroups/my-azure-resource-group/providers/Microsoft.Compute/disks/my-azure-managed-OsDisk_1_1234567890abcdef1234567890abcdef/EndGetAccess?api-version=2017-03-30
-    body:
-      encoding: ASCII-8BIT
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyIsImtpZCI6IkhIQnlLVS0wRHFBcU1aaDZaRlBkMlZXYU90ZyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MDYxMTYyMjcsIm5iZiI6MTUwNjExNjIyNywiZXhwIjoxNTA2MTIwMTI3LCJhaW8iOiJZMlZnWU5pV0pXUHdMc2ZWM2ZoSVFWajJIT3N5QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTFY3NVNHblk1MC1NTnZFOER3b05BQSIsInZlciI6IjEuMCJ9.qvqsibTj97Wje7DCzUZsV0avjdDT3jRuYQaaD4f6Zx9Nw6quJKnQDC-ifyJGTzLH38kpVmfLEZhClnR-HC2Y7nFMt_MEgpSrE1kOx9ZC3tbRPCp053tqyehRMpwIDaSQaulpJEL2SW-a3uR_4twj7Tck7yGwaA0jT9rV1kEARjo3g-A5P4fVwmf7vhMI-3u4QcBSrxN0JsYO5OufKAiXaECbT1aBUKACVMQzQjhu5w2RJLpS45vFL9y-H8VboQC3XB92D4wGvsYEh1APnSXBPvOpvGt72M-ob_uFHh4q7opWMyKUpDccB7mWtALp3MNCWeTfxyx9misbaWEzPnEhoQ
-      Content-Length:
-      - '0'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '0'
-      Expires:
-      - "-1"
-      Location:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/3dcdfaac-a7a4-49d4-a900-eb161cef6bbf?monitor=true&api-version=2017-03-30
-      Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/azure_subscription_id/providers/Microsoft.Compute/locations/eastus/DiskOperations/3dcdfaac-a7a4-49d4-a900-eb161cef6bbf?api-version=2017-03-30
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131358034511653293
-      X-Ms-Request-Id:
-      - 3dcdfaac-a7a4-49d4-a900-eb161cef6bbf
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1184'
-      X-Ms-Correlation-Request-Id:
-      - 2f902528-a7fc-432d-8926-7da697f119ac
-      X-Ms-Routing-Request-Id:
-      - WESTUS:20170922T214216Z:2f902528-a7fc-432d-8926-7da697f119ac
-      Date:
-      - Fri, 22 Sep 2017 21:42:16 GMT
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Fri, 22 Sep 2017 21:42:16 GMT
+  recorded_at: Tue, 23 Jan 2018 20:07:18 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
Azure Managed Disk Instances have been taking exceptionally long in
some locations. It turns out that the semantic that azure-armrest
uses to perform reads via the get_blob_raw method is the culprit.
The method gets a SAS URL - an access token to the disk - each
time it performs a read operation. The call to get the access token
is asynchronous and if it does not return immediately with success when
poll is called the gem sleeps for 5 seconds. This adds 5 seconds to
every call to get data.

What the disk module will now do:

Call open on the service (disk service or snapshot service).
Open returns a ManagedDisk object.
Call read on the ManagedDisk object as many times as you need, then call
close on the ManagedDisk object when finished.

Under the covers the ManagedDisk will contain the SAS URL to be used.
In the case that a read on the ManagedDisk returns a Forbidden error,
the assumption is that the SAS URL is no longer any good (perhaps it has
timed out) and we will get a new ManagedDisk object and continue.

Depends on PR github.com/ManageIQ/azure-armrest/pull/355

@blomquisg @djberg96 @hsong-rh @roliveri for your reading and reviewing pleasure.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1508154