### PR TITLE
Show Improper Credentials Message in Smartstate Failure in UI

### DIFF
--- a/lib/Scvmm/miq_hyperv_disk.rb
+++ b/lib/Scvmm/miq_hyperv_disk.rb
@@ -1,6 +1,7 @@
 # encoding: US-ASCII
 
 require 'util/miq_winrm'
+require 'util/miq-exception'
 require 'Scvmm/miq_scvmm_parse_powershell'
 require 'base64'
 require 'securerandom'
@@ -50,7 +51,7 @@ STAT_EOL
     file_size, stderr = @parser.parse_single_powershell_value(run_correct_powershell(stat_script))
 
     if @network && stderr.include?("RegisterTaskDefinition")
-      raise "Unable to obtain virtual disk size for #{vm_disk}. Check Hyper-V Host Domain Credentials"
+      raise MiqException::MiqInvalidCredentialsError, "Unable to obtain virtual disk size for #{vm_disk}. Check Hyper-V Host Domain Credentials."
     end
     OPEN_ERRORS.each { |error| raise "Unable to obtain virtual disk size for #{vm_disk}" if stderr.include?(error) }
     @file_size           = file_size.to_i

--- a/lib/disk/DiskProbe.rb
+++ b/lib/disk/DiskProbe.rb
@@ -1,4 +1,5 @@
 module DiskProbe
+  require 'util/miq-exception'
   MODDIR = File.expand_path(File.join(File.dirname(__FILE__), "modules"))
 
   PROBE_FILES = Dir.glob(File.join(MODDIR, "*Probe.rb*"))
@@ -30,6 +31,9 @@ module DiskProbe
           require_relative "modules/#{mod}"
           return Object.const_get(mod)
         end
+      rescue MiqException::MiqInvalidCredentialsError => err
+        $log.error "MIQ(DiskProbe-getDiskMod) [#{pmod.chomp("Probe")}-#{mod}] for [#{fname}]: #{err}"
+        raise err
       rescue => err
         $log.warn "MIQ(DiskProbe-getDiskMod) [#{pmod.chomp("Probe")}-#{mod}] for [#{fname}]: #{err}"
       end


### PR DESCRIPTION
When the incorrect domain credentials are provided and a Virtual Machine
disk is located in a network accessible disk share, access to the virtual
disk may be denied.  Previously the error displayed in the UI for a failure
of this type was not meaningful.  This change will show the error as related
to the credentials. 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1534352

In the following screenshot, the error has been received twice since there are two disks to be scanned for the VM in question.  

![screen shot 2018-02-19 at 3 00 27 pm](https://user-images.githubusercontent.com/6118503/36395159-aa9c06e2-1585-11e8-8aca-e569b09993e5.png)

@roliveri @hsong-rh please review and merge when appropriate.
