### PR TITLE
Duplicate fileMode Code in Disk Modules

### DIFF
--- a/lib/disk/modules/MSVSDiffDisk.rb
+++ b/lib/disk/modules/MSVSDiffDisk.rb
@@ -1,19 +1,13 @@
 # encoding: US-ASCII
 
 require 'disk/modules/MSCommon'
+require 'disk/modules/miq_disk_common'
 
 module MSVSDiffDisk
   def d_init
     self.diskType = "MSVS Differencing"
     self.blockSize = MSCommon::SECTOR_LENGTH
-    if dInfo.mountMode.nil? || dInfo.mountMode == "r"
-      dInfo.mountMode = "r"
-      fileMode = "r"
-    elsif dInfo.mountMode == "rw"
-      fileMode = "r+"
-    else
-      raise "Unrecognized mountMode: #{dInfo.mountMode}"
-    end
+    fileMode = MiqDiskCommon.file_mode(dInfo)
     if dInfo.hyperv_connection
       @hyperv_connection = dInfo.hyperv_connection
       @ms_disk_file      = MSCommon.connect_to_hyperv(dInfo)

--- a/lib/disk/modules/MSVSDynamicDisk.rb
+++ b/lib/disk/modules/MSVSDynamicDisk.rb
@@ -1,17 +1,11 @@
 require 'disk/modules/MSCommon'
+require 'disk/modules/miq_disk_common'
 
 module MSVSDynamicDisk
   def d_init
     self.diskType = "MSVS Dynamic"
     self.blockSize = MSCommon::SECTOR_LENGTH
-    if dInfo.mountMode.nil? || dInfo.mountMode == "r"
-      dInfo.mountMode = "r"
-      fileMode = "r"
-    elsif dInfo.mountMode == "rw"
-      fileMode = "r+"
-    else
-      raise "Unrecognized mountMode: #{dInfo.mountMode}"
-    end
+    fileMode = MiqDiskCommon.file_mode(dInfo)
     @ms_disk_file = if dInfo.hyperv_connection
                       MSCommon.connect_to_hyperv(dInfo)
                     else

--- a/lib/disk/modules/MSVSFixedDisk.rb
+++ b/lib/disk/modules/MSVSFixedDisk.rb
@@ -1,18 +1,12 @@
 require 'disk/modules/MiqLargeFile'
+require 'disk/modules/miq_disk_common'
 
 module MSVSFixedDisk
   def d_init
     @diskType = "MSVSFixed"
     @blockSize = 512
 
-    if dInfo.mountMode.nil? || dInfo.mountMode == "r"
-      dInfo.mountMode = "r"
-      fileMode = "r"
-    elsif dInfo.mountMode == "rw"
-      fileMode = "r+"
-    else
-      raise "Unrecognized mountMode: #{dInfo.mountMode}"
-    end
+    fileMode = MiqDiskCommon.file_mode
 
     if dInfo.hyperv_connection
       @ms_flat_disk_file = MSCommon.connect_to_hyperv(dInfo)

--- a/lib/disk/modules/RawDisk.rb
+++ b/lib/disk/modules/RawDisk.rb
@@ -1,18 +1,12 @@
 require 'disk/modules/MiqLargeFile'
+require 'disk/modules/miq_disk_common'
 
 module RawDisk
   def d_init
     self.diskType = "Raw"
     self.blockSize = 512
 
-    if dInfo.mountMode.nil? || dInfo.mountMode == "r"
-      dInfo.mountMode = "r"
-      fileMode = "r"
-    elsif dInfo.mountMode == "rw"
-      fileMode = "r+"
-    else
-      raise "Unrecognized mountMode: #{dInfo.mountMode}"
-    end
+    fileMode = MiqDiskCommon.file_mode(dInfo)
 
     @dOffset = dInfo.offset
     @rawDisk_file = MiqLargeFile.open(dInfo.fileName, fileMode)

--- a/lib/disk/modules/VMWareCowdDisk.rb
+++ b/lib/disk/modules/VMWareCowdDisk.rb
@@ -1,4 +1,5 @@
 require 'disk/modules/MiqLargeFile'
+require 'disk/modules/miq_disk_common'
 require 'binary_struct'
 require 'memory_buffer'
 
@@ -24,14 +25,7 @@ module VMWareCowdDisk
   def d_init
     self.diskType = "VMWare CopyOnWrite"
     self.blockSize = 512
-    if dInfo.mountMode.nil? || dInfo.mountMode == "r"
-      dInfo.mountMode = "r"
-      fileMode = "r"
-    elsif dInfo.mountMode == "rw"
-      fileMode = "r+"
-    else
-      raise "Unrecognized mountMode: #{dInfo.mountMode}"
-    end
+    fileMode = MiqDiskCommon.file_mode(dInfo)
     @dParent = @dInfo.parent
 
     @vmwareCowDisk_file = MiqLargeFile.open(dInfo.fileName, fileMode)

--- a/lib/disk/modules/VMWareSparseDisk.rb
+++ b/lib/disk/modules/VMWareSparseDisk.rb
@@ -1,4 +1,5 @@
 require 'disk/modules/MiqLargeFile'
+require 'disk/modules/miq_disk_common'
 require 'binary_struct'
 require 'memory_buffer'
 
@@ -24,14 +25,7 @@ module VMWareSparseDisk
   def d_init
     self.diskType = "VMWare Sparse"
     self.blockSize = 512
-    if dInfo.mountMode.nil? || dInfo.mountMode == "r"
-      dInfo.mountMode = "r"
-      fileMode = "r"
-    elsif dInfo.mountMode == "rw"
-      fileMode = "r+"
-    else
-      raise "Unrecognized mountMode: #{dInfo.mountMode}"
-    end
+    fileMode = MiqDiskCommon.file_mode(dInfo)
     @vmwareSparseDisk_file = MiqLargeFile.open(dInfo.fileName, fileMode)
     buf = @vmwareSparseDisk_file.read(SIZEOF_SPARSE_EXTENT_HEADER)
     @sparseHeader = OpenStruct.new(SPARSE_EXTENT_HEADER.decode(buf))

--- a/lib/disk/modules/miq_disk_common.rb
+++ b/lib/disk/modules/miq_disk_common.rb
@@ -4,7 +4,7 @@ module MiqDiskCommon
     if dInfo.mountMode.nil? || dInfo.mountMode == "r"
       dInfo.mountMode = "r"
       return "r"
-    elsif dInfo.mountMode = "rw"
+    elsif dInfo.mountMode == "rw"
       return "r+"
     end
     raise "Unrecognized mountMode: #{dInfo.mountMode}"

--- a/lib/disk/modules/miq_disk_common.rb
+++ b/lib/disk/modules/miq_disk_common.rb
@@ -1,0 +1,13 @@
+module MiqDiskCommon
+
+  def self.file_mode(dInfo)
+    if dInfo.mountMode.nil? || dInfo.mountMode == "r"
+      dInfo.mountMode = "r"
+      return "r"
+    elsif dInfo.mountMode = "rw"
+      return "r+"
+    end
+    raise "Unrecognized mountMode: #{dInfo.mountMode}"
+  end
+
+end # module

--- a/lib/disk/modules/miq_disk_common.rb
+++ b/lib/disk/modules/miq_disk_common.rb
@@ -1,13 +1,11 @@
 module MiqDiskCommon
-
-  def self.file_mode(dInfo)
-    if dInfo.mountMode.nil? || dInfo.mountMode == "r"
-      dInfo.mountMode = "r"
+  def self.file_mode(d_info)
+    if d_info.mountMode.nil? || d_info.mountMode == "r"
+      d_info.mountMode = "r"
       return "r"
-    elsif dInfo.mountMode == "rw"
+    elsif d_info.mountMode == "rw"
       return "r+"
     end
-    raise "Unrecognized mountMode: #{dInfo.mountMode}"
+    raise "Unrecognized mountMode: #{d_info.mountMode}"
   end
-
-end # module
+end


### PR DESCRIPTION
CodeClimate complains about identical code checking
file modes during initialization of 6 different MiqDisk
disk modules.  Pulling this out into a separate file will
reduce this complaint.

@roliveri @hsong-rh please review.