### PR TITLE
Check Drivetype for Each Differencing VhdxDisk

### DIFF
--- a/lib/MiqVm/miq_scvmm_vm.rb
+++ b/lib/MiqVm/miq_scvmm_vm.rb
@@ -26,6 +26,7 @@ class MiqScvmmVm < MiqVm
     disk_info.hyperv_connection        = {}
     disk_info.fileName                 = disk_file
     disk_info.driveType                = @scvmm.get_drivetype(disk_file)
+    disk_info.scvmm                    = @scvmm
     disk_info.hyperv_connection[:host] = @ost.miq_hyperv[:host]
     disk_info.hyperv_connection[:port] = @ost.miq_hyperv[:port]
     if @ost.miq_hyperv[:domain].nil?

--- a/lib/disk/modules/VhdxDisk.rb
+++ b/lib/disk/modules/VhdxDisk.rb
@@ -182,6 +182,7 @@ module VhdxDisk
     @has_parent           = nil
     @parent_locator       = nil
     @file_name            = dInfo.fileName
+    @scvmm                = dInfo.scvmm
     @hyperv_connection    = nil
     @vhdx_file            = connection_to_file(dInfo)
     @converter            = Encoding::Converter.new("UTF-16LE", "UTF-8")
@@ -518,7 +519,7 @@ module VhdxDisk
   def parent_disk(path)
     @parent_ostruct                   = OpenStruct.new
     @parent_ostruct.fileName          = path
-    @parent_ostruct.driveType         = dInfo.driveType
+    @parent_ostruct.driveType         = @scvmm.get_drivetype(path)
     @parent_ostruct.hyperv_connection = @hyperv_connection if @hyperv_connection
     parent                            = MiqDisk.getDisk(@parent_ostruct)
     raise "Unable to access parent disk #{path}" if parent.nil?


### PR DESCRIPTION
When running Smartstate Analysis on SCVMM VhdxDisks first we need to
determine if the virtual disk file lives on a local disk or on a network disk.
Accessing the network disk must be through an elevated WinRM call, while that is
not necessary for local disks.

Previously once the determination is made on the initial disk opened the same type
is assumed for each differencing (parent) disk in the chain of snapshots for a VhdxDisk.

This, of course, may be incorrect since not each disk in the chain is necessarily on either
a local or network disk.  If the initial disk is local, and the parent is remote, this would
cause an access error trying to read the parent disk.

We are changing this to check the type of disk for each new one opened.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1547766

@roliveri @hsong-rh please review and merge.