### PR TITLE
Update to Azure-Armrest Gem Version 0.9.6

### DIFF
--- a/manageiq-smartstate.gemspec
+++ b/manageiq-smartstate.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "azure-armrest",      "~> 0.9.5"
+  spec.add_dependency "azure-armrest",      "~> 0.9.6"
   spec.add_dependency "binary_struct",      "~> 2.1"
   spec.add_dependency "iniparse"
   spec.add_dependency "linux_block_device", "~>0.2.1"


### PR DESCRIPTION
Upgrade manageiq-smartstate to the latest version of the azure-armrest gem.

@roliveri @hsong-rh @djberg96 please review.