### PR TITLE
Fix to remove extra leading spaces in /etc/fstab during SSA

### DIFF
--- a/lib/fs/modules/LinuxMount.rb
+++ b/lib/fs/modules/LinuxMount.rb
@@ -198,7 +198,7 @@ module LinuxMount
 
   def do_fstab_line(fstab_line, fs_spec_hash)
     return if fstab_line =~ /^#.*$/ || fstab_line =~ /^\s*$/
-    fs_spec, mt_point = fstab_line.split(/\s+/)
+    fs_spec, mt_point = fstab_line.strip.split(/\s+/)
     return if fs_spec == "none" || mt_point == "swap"
     return unless (fs = fs_spec_hash[fs_spec])
     $log.debug("LinuxMount: Adding fs_spec: #{fs_spec}, mt_point: #{mt_point}") if $log.debug


### PR DESCRIPTION
Extra leading spaces in the entry of /etc/fstab will cause mount points missing. In our case, this cause packages information is empty after scanning finishes.

https://bugzilla.redhat.com/show_bug.cgi?id=1551273