### PR TITLE
Reduce MiqVm.rb Complexity

### DIFF
--- a/lib/MiqVm/MiqRhevmVm.rb
+++ b/lib/MiqVm/MiqRhevmVm.rb
@@ -20,18 +20,18 @@ class MiqRhevmVm < MiqVm
 
   def get_vmconfig(vm_config)
     @rhevm = @ost.miqRhevm
-    $log.debug "MiqVm::initialize: accessing VM through RHEVM server" if $log.debug?
-    $log.debug "MiqVm::initialize: vmCfg = #{vmCfg}"
+    $log.debug("MiqVm::initialize: accessing VM through RHEVM server") if $log.debug?
+    $log.debug("MiqVm::initialize: vmCfg = #{vmCfg}")
     @rhevmVm = @rhevm.get_vm(vm_config)
-    $log.debug "MiqVm::initialize: setting @ost.miqRhevmVm = #{@rhevmVm.class}" if $log.debug?
+    $log.debug("MiqVm::initialize: setting @ost.miqRhevmVm = #{@rhevmVm.class}") if $log.debug?
     @ost.miqRhevmVm = @rhevmVm
     #
     # If we're passed a snapshot ID, then obtain the configuration of the
     # VM when the snapshot was taken.
     #
     @vmConfig = VmConfig.new(getCfg(@ost.snapId))
-    $log.debug "MiqVm::initialize: @vmConfig.getHash = #{@vmConfig.getHash.inspect}"
-    $log.debug "MiqVm::initialize: @vmConfig.getDiskFileHash = #{@vmConfig.getDiskFileHash.inspect}"
+    $log.debug("MiqVm::initialize: @vmConfig.getHash = #{@vmConfig.getHash.inspect}")
+    $log.debug("MiqVm::initialize: @vmConfig.getDiskFileHash = #{@vmConfig.getDiskFileHash.inspect}")
   end
 
   def unmount
@@ -42,7 +42,7 @@ class MiqRhevmVm < MiqVm
 
   def init_disk(d_info)
     d = applianceVolumeManager.lvHash[d_info.fileName] if applianceVolumeManager
-    $log.debug "MiqVm::openDisks: using applianceVolumeManager for #{dInfo.fileName}" if $log.debug?
+    $log.debug("MiqVm::openDisks: using applianceVolumeManager for #{dInfo.fileName}") if $log.debug?
     d.dInfo.fileName               = d_info.fileName
     d.dInfo.hardwareId             = d_info.hardwareId
     d.dInfo.baseOnly               = d_info.baseOnly

--- a/lib/MiqVm/MiqVm.rb
+++ b/lib/MiqVm/MiqVm.rb
@@ -99,22 +99,26 @@ class MiqVm
 
   def init_disk_info(d_info, disk_tag, disk_file)
     if @ost.miqVim
-      d_info.vixDiskInfo            = {}
-      d_info.vixDiskInfo[:fileName] = @ost.miqVim.datastorePath(df)
-      @vdlConnection ||=
-        if @ost.miqVimVm
-          @ost.miqVimVm.vdlVcConnection
-        else
-          @ost.miqVim.vdlConnection
-        end
-      $log.debug("init_disk_info: using disk file path: #{d_info.vixDiskInfo[:fileName]}")
-      d_info.vixDiskInfo[:connection] = @vdlConnection
+      vim_disk_info(d_info, disk_file)
     else
       d_info.fileName = disk_file
       disk_format     = @vmConfig.getHash["#{disk_tag}.format"]  # Set by rhevm for iscsi and fcp disks
       d_info.format   = disk_format if disk_format.present?
     end
     common_disk_info(d_info, disk_tag)
+  end
+
+  def vim_disk_info(d_info, disk_file)
+    d_info.vixDiskInfo            = {}
+    d_info.vixDiskInfo[:fileName] = @ost.miqVim.datastorePath(disk_file)
+    @vdlConnection ||=
+      if @ost.miqVimVm
+        @ost.miqVimVm.vdlVcConnection
+      else
+        @ost.miqVim.vdlConnection
+      end
+    $log.debug("init_disk_info: using disk file path: #{d_info.vixDiskInfo[:fileName]}")
+    d_info.vixDiskInfo[:connection] = @vdlConnection
   end
 
   def common_disk_info(d_info, disk_tag)

--- a/lib/MiqVm/MiqVm.rb
+++ b/lib/MiqVm/MiqVm.rb
@@ -26,7 +26,7 @@ class MiqVm
     $log.debug "MiqVm::initialize: @ost.openParent = #{@ost.openParent}" if $log
 
     get_vmconfig(vmCfg)
-  end # def initialize
+  end
 
   def get_vmconfig(vm_config)
     #
@@ -101,17 +101,18 @@ class MiqVm
     if @ost.miqVim
       d_info.vixDiskInfo            = {}
       d_info.vixDiskInfo[:fileName] = @ost.miqVim.datastorePath(df)
-      if @ost.miqVimVm
-        @vdlConnection ||= @ost.miqVimVm.vdlVcConnection
-      else
-        @vdlConnection ||= @ost.miqVim.vdlConnection
-      end
-      $log.debug "init_disk_info: using disk file path: #{d_info.vixDiskInfo[:fileName]}"
+      @vdlConnection ||=
+        if @ost.miqVimVm
+          @ost.miqVimVm.vdlVcConnection
+        else
+          @ost.miqVim.vdlConnection
+        end
+      $log.debug("init_disk_info: using disk file path: #{d_info.vixDiskInfo[:fileName]}")
       d_info.vixDiskInfo[:connection] = @vdlConnection
     else
       d_info.fileName = disk_file
       disk_format     = @vmConfig.getHash["#{disk_tag}.format"]  # Set by rhevm for iscsi and fcp disks
-      d_info.format   = disk_format unless disk_format.blank?
+      d_info.format   = disk_format if disk_format.present?
     end
     common_disk_info(d_info, disk_tag)
   end
@@ -121,7 +122,7 @@ class MiqVm
     d_info.hardwareId = disk_tag
     d_info.baseOnly   = @ost.openParent unless mode && mode["independent"]
     d_info.rawDisk    = @ost.rawDisk
-    $log.debug "MiqVm::init_disk_info: d_info.baseOnly = #{d_info.baseOnly}"
+    $log.debug("MiqVm::init_disk_info: d_info.baseOnly = #{d_info.baseOnly}")
   end
 
   def init_disk(d_info)
@@ -131,7 +132,7 @@ class MiqVm
   def rootTrees
     return @rootTrees if @rootTrees
     @rootTrees = MiqMountManager.mountVolumes(volumeManager, @vmConfig, @ost)
-	volumeManager.rootTrees = @rootTrees
+    volumeManager.rootTrees = @rootTrees
     @rootTrees
   end
 

--- a/lib/MiqVm/miq_scvmm_vm.rb
+++ b/lib/MiqVm/miq_scvmm_vm.rb
@@ -20,9 +20,20 @@ class MiqScvmmVm < MiqVm
     cfg_hash
   end
 
+  def get_vmconfig(_vm_config)
+    @scvmm = @ost.miq_scvmm
+    $log.debug "MiqVm::initialize: accessing VM through HyperV server" if $log.debug?
+    #
+    # If we're passed a snapshot ID, then obtain the configuration of the
+    # VM when the snapshot was taken.
+    #
+    @vmConfig = VmConfig.new(getCfg(@ost.snapId))
+    $log.debug "MiqVm::initialize: setting @ost.miq_scvmm_vm = #{@scvmm_vm.class}" if $log.debug?
+  end
+
   private
 
-  def init_disk_info(disk_info, disk_file)
+  def init_disk_info(disk_info, disk_tag, disk_file)
     disk_info.hyperv_connection        = {}
     disk_info.fileName                 = disk_file
     disk_info.driveType                = @scvmm.get_drivetype(disk_file)
@@ -35,5 +46,6 @@ class MiqScvmmVm < MiqVm
       disk_info.hyperv_connection[:user] = @ost.miq_hyperv[:domain] + "\\" + @ost.miq_hyperv[:user]
     end
     disk_info.hyperv_connection[:password] = @ost.miq_hyperv[:password]
+    common_disk_info(disk_info, disk_tag)
   end
 end

--- a/lib/MiqVm/miq_scvmm_vm.rb
+++ b/lib/MiqVm/miq_scvmm_vm.rb
@@ -22,13 +22,13 @@ class MiqScvmmVm < MiqVm
 
   def get_vmconfig(_vm_config)
     @scvmm = @ost.miq_scvmm
-    $log.debug "MiqVm::initialize: accessing VM through HyperV server" if $log.debug?
+    $log.debug("MiqVm::initialize: accessing VM through HyperV server") if $log.debug?
     #
     # If we're passed a snapshot ID, then obtain the configuration of the
     # VM when the snapshot was taken.
     #
     @vmConfig = VmConfig.new(getCfg(@ost.snapId))
-    $log.debug "MiqVm::initialize: setting @ost.miq_scvmm_vm = #{@scvmm_vm.class}" if $log.debug?
+    $log.debug("MiqVm::initialize: setting @ost.miq_scvmm_vm = #{@scvmm_vm.class}") if $log.debug?
   end
 
   private


### PR DESCRIPTION
CodeClimate complains that methods initialize and openDisks
in MiqVm.rb are too complex and too large.
In order to reduce both size and complexity, some of the functionality
was migrated to the relevant subclasses for Rhevm and Scvmm, where
appropriate.

@hsong-rh and @roliveri please review.  This is one that we've been talking about for a while - there was code in MiqVm that should have been moved into subclasses.  Since CodeClimate was complaining about the size and complexity of the methods this was an appropriate way to help.

Please note this moves the Maintainability score for this file from "C" to "A".