### PR TITLE
Reduce Complexity of Win32Software.rb

### DIFF
--- a/lib/metadata/util/win32/Win32Software.rb
+++ b/lib/metadata/util/win32/Win32Software.rb
@@ -189,20 +189,20 @@ module MiqWin32
         next if e.attributes.nil? || e.attributes[:keyname].nil?
         if e.attributes[:keyname][0, 8] == 'Package_'
           # don't add this package if the ID is nil
-          next if (hotfix_id = hotfix_id(package, e)).nil?
+          next if (hotfix_id = hotfix_id(e)).nil?
 
           hotfix[hotfix_id] ||=
-          begin
-            attrs = XmlFind.decode(e, HOTFIX_MAPPING_VISTA)
-            install_time = wtime2time(attrs[:install_time_high], attrs[:install_time_low])
-            @patches << {:name => hotfix_id, :vendor => "Microsoft Corporation", :installed_on => install_time, :installed => 1}
-            true
-          end
+            begin
+              attrs = XmlFind.decode(e, HOTFIX_MAPPING_VISTA)
+              install_time = wtime2time(attrs[:install_time_high], attrs[:install_time_low])
+              @patches << {:name => hotfix_id, :vendor => "Microsoft Corporation", :installed_on => install_time, :installed => 1}
+              true
+            end
         end
       end
     end
 
-    def hotfix_id(package, element)
+    def hotfix_id(element)
       # Expected pattern: Package_for_KBxxx_RTM~xxxx
       # Get the hotfix id (KB #) out of the keyname
       package = element.attributes[:keyname].split("_")
@@ -219,7 +219,7 @@ module MiqWin32
         element.write(str)
         $log.warn("Win32Software::initialize - Can't determine patch element's hotfix id: #{str}")
       end
-      hotfix_id = hotfix_id&.split('~')[0]
+      hotfix_id.split('~')[0] unless hotfix_id.nil?
     end
 
     def to_xml(doc = nil)

--- a/lib/metadata/util/win32/Win32Software.rb
+++ b/lib/metadata/util/win32/Win32Software.rb
@@ -118,7 +118,7 @@ module MiqWin32
         users.each_element_with_attribute(:keyname) do |components|
           next unless components.attributes[:keyname].downcase == "products"
           components.each_element_with_attribute(:keyname) do |products|
-            add_applications(PRODUCTS_MAPPING, "win32_product")
+            add_applications(PRODUCTS_MAPPING, "win32_product", products)
           end
         end
       end
@@ -128,12 +128,12 @@ module MiqWin32
       return unless (reg_node = MIQRexml.findRegElement(registry_path, registry_doc.root))
       postProcessApps(reg_node, fs)
       reg_node.each_element_with_attribute(:keyname) do |e|
-        add_applications(APP_PATHS_MAPPING, "app_path")
+        add_applications(APP_PATHS_MAPPING, "app_path", e)
       end
     end
 
-    def add_applications(mapping, type_name)
-      return if (attrs = XmlFind.decode(e, mapping))[:name].nil?
+    def add_applications(mapping, type_name, element)
+      return if (attrs = XmlFind.decode(element, mapping))[:name].nil?
       attrs[:typename] = type_name; attrs[:product_key] = @product_keys[attrs[:name]]
       clean_up_path(attrs)
       @applications << attrs unless isDupApp?(attrs)

--- a/lib/metadata/util/win32/Win32Software.rb
+++ b/lib/metadata/util/win32/Win32Software.rb
@@ -212,24 +212,16 @@ module MiqWin32
 
     def to_xml(doc = nil)
       doc ||= MiqXml.createDoc(nil)
-      applicationsToXml(doc)
-      patchesToXml(doc)
+      element_to_xml(doc, @applications, "applications", "application")
+      element_to_xml(doc, @patches, "patches", "patch")
       doc
     end
 
-    def applicationsToXml(doc = nil)
+    def element_to_xml(doc = nil, software_type, doc_element, node_element)
       doc ||= MiqXml.createDoc(nil)
-      return doc if @applications.empty?
-      node = doc.add_element("applications")
-      @applications.each { |a| node.add_element("application", XmlHelpers.stringify_keys(a)) }
-      doc
-    end
-
-    def patchesToXml(doc = nil)
-      doc ||= MiqXml.createDoc(nil)
-      return doc if @patches.empty?
-      node = doc.add_element("patches")
-      @patches.each { |p| node.add_element("patch", XmlHelpers.stringify_keys(p)) }
+      return doc if software_type.empty?
+      node = doc.add_element(doc_element)
+      software_type.each { |a| node.add_element(node_element, XmlHelpers.stringify_keys(a)) }
       doc
     end
 


### PR DESCRIPTION
Reduce the complexity and size of the initialize and postProcessApps
methods by splitting them into component sections and other refactoring.
This along with other issues addressed by https://github.com/ManageIQ/manageiq-smartstate/pull/61 should reduce
the CodeClimate Maintainability score from D to A.

@roliveri @hsong-rh please review.  Continuing saga of addressing CodeClimate
complexity issues in this repo.