### PR TITLE
Fix to remove duplicated records in services list after SSA

### DIFF
--- a/lib/metadata/linux/LinuxSystemd.rb
+++ b/lib/metadata/linux/LinuxSystemd.rb
@@ -55,6 +55,11 @@ module MiqLinux
     def parse_service(file)
       debug "Parsing service unit: #{file}"
 
+      if @fs.fileSymLink?(file)
+        debug "#{file} is a soft link, skip to parse."
+        return nil
+      end
+
       unit        = @fs.fileBasename(file)
       name        = unit.gsub(".service", "")
       inif        = ini(file)
@@ -91,6 +96,11 @@ module MiqLinux
 
     def parse_target(file)
       debug "Parsing target unit: #{file}"
+
+      if @fs.fileSymLink?(file)
+        debug "#{file} is a soft link, skip to parse."
+        return nil
+      end
 
       unit = @fs.fileBasename(file)
       name = unit.gsub(".target", "")

--- a/lib/metadata/linux/LinuxSystemd.rb
+++ b/lib/metadata/linux/LinuxSystemd.rb
@@ -130,11 +130,7 @@ module MiqLinux
     end
 
     def duplicated_link?(file)
-      existing_dirs.any? do |dir|
-        link_levels = @fs.getLinkPath(file).split('/')
-        levels = dir.split('/')
-        link_levels.take(levels.length).eql?(levels)
-      end if @fs.fileSymLink?(file)
+      existing_dirs.any? { |dir| @fs.getLinkPath(file).start_with?("#{dir}/") } if @fs.fileSymLink?(file)
     end
 
     def debug(msg)

--- a/lib/metadata/linux/LinuxSystemd.rb
+++ b/lib/metadata/linux/LinuxSystemd.rb
@@ -55,8 +55,8 @@ module MiqLinux
     def parse_service(file)
       debug "Parsing service unit: #{file}"
 
-      if @fs.fileSymLink?(file)
-        debug "#{file} is a soft link, skip to parse."
+      if duplicated_link?(file)
+        debug("#{file} is a soft link, skip to parse.")
         return nil
       end
 
@@ -97,8 +97,8 @@ module MiqLinux
     def parse_target(file)
       debug "Parsing target unit: #{file}"
 
-      if @fs.fileSymLink?(file)
-        debug "#{file} is a soft link, skip to parse."
+      if duplicated_link?(file)
+        debug("#{file} is a soft link, skip to parse.")
         return nil
       end
 
@@ -127,6 +127,10 @@ module MiqLinux
       (service[:required_by] + service[:wanted_by]).collect do |tgt|
         {"value" => tgt.gsub(".target", "")}
       end
+    end
+
+    def duplicated_link?(file)
+      existing_dirs.any? { |dir| @fs.getLinkPath(file).start_with?(dir) } if @fs.fileSymLink?(file)
     end
 
     def debug(msg)

--- a/lib/metadata/linux/LinuxSystemd.rb
+++ b/lib/metadata/linux/LinuxSystemd.rb
@@ -130,7 +130,11 @@ module MiqLinux
     end
 
     def duplicated_link?(file)
-      existing_dirs.any? { |dir| @fs.getLinkPath(file).start_with?(dir) } if @fs.fileSymLink?(file)
+      existing_dirs.any? do |dir|
+        link_levels = @fs.getLinkPath(file).split('/')
+        levels = dir.split('/')
+        link_levels.take(levels.length).eql?(levels)
+      end if @fs.fileSymLink?(file)
     end
 
     def debug(msg)


### PR DESCRIPTION
The existing soft links in service config file cause the service report list has duplicate records. Skip these links when parsing them.

https://bugzilla.redhat.com/show_bug.cgi?id=1578792