### PR TITLE
Pre-existing Checkpoint Issue

### DIFF
--- a/lib/disk/modules/VhdxDisk.rb
+++ b/lib/disk/modules/VhdxDisk.rb
@@ -519,6 +519,7 @@ module VhdxDisk
   def parent_disk(path)
     @parent_ostruct                   = OpenStruct.new
     @parent_ostruct.fileName          = path
+    @parent_ostruct.scvmm             = @scvmm
     @parent_ostruct.driveType         = @scvmm.get_drivetype(path)
     @parent_ostruct.hyperv_connection = @hyperv_connection if @hyperv_connection
     parent                            = MiqDisk.getDisk(@parent_ostruct)


### PR DESCRIPTION
Handling SSA on a VM with pre-existing checkpoints
on Hyper-V hosts is causing an issue because there is
an attempt to use an uninitialized "@scvmm" variable
when attempting to open the second disk in the chain.
Not sure why this never happened before but it works now.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1581329

@roliveri @hsong-rh please review this one line change.  Thanks.