### PR TITLE
Bump vmware_web_service to 0.4.0

### DIFF
--- a/manageiq-smartstate.gemspec
+++ b/manageiq-smartstate.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "memory_buffer",      ">=0.1.0"
   spec.add_dependency "rufus-lru",          "~>1.0.3"
   spec.add_dependency "sys-uname",          "~>1.0.1"
-  spec.add_dependency "vmware_web_service", "~>0.3.0"
+  spec.add_dependency "vmware_web_service", "~>0.4.0"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
`vmware_web_service` will use `rbvmomi` v2.0.0 in the 0.4.0 branch, which will be needed for dependency reasons post `hammer` releases.


Links
-----

* Related to this snafu that I helped cause... https://github.com/ManageIQ/manageiq/pull/18395