### PR TITLE
Add waning messages when snapshots missed due to host credentials

### DIFF
--- a/lib/metadata/VmConfig/VmConfig.rb
+++ b/lib/metadata/VmConfig/VmConfig.rb
@@ -390,7 +390,10 @@ class VmConfig
         creds = $miqHostCfg.ems[$miqHostCfg.emsLocal]
       elsif $miqHostCfg.vimHost
         c = $miqHostCfg.vimHost
-        return nil if c[:username].nil?
+        if c[:username].nil?
+          $log.warn "Host credentials are missing: skipping snapshot information."
+          return nil
+        end
         creds = {'host' => (c[:hostname] || c[:ipaddress]), 'user' => c[:username], 'password' => c[:password], 'use_vim_broker' => c[:use_vim_broker]}
       end
     end
@@ -611,7 +614,12 @@ class VmConfig
       hostVim = nil
       if miqvm.vim.isVirtualCenter?
         hostVim = connect_to_host_vim('snapshot_metadata', miqvm.vmConfigFile)
-        return if hostVim.nil?
+
+        if hostVim.nil?
+          $log.warn "Snapshots information will be skipped due to EMS host missing credentials."
+          return
+        end
+
         vimDs = hostVim.getVimDataStore(ds)
       else
         vimDs = miqvm.vim.getVimDataStore(ds)


### PR DESCRIPTION
If no EMS host credentials are input after vmware provider is added and SSA is set `scan_via_host: false` in setting, the `snapshots` in vm detail page will display zero. This PR will add more clear warning message in log file as following:
`
[----] W, [2019-01-26T19:19:06.442414 #24089:3a6f60]  WARN -- : Q-task_id([job_dispatcher]) Host credentials are missing: { ... }
[----] W, [2019-01-26T19:19:06.442461 #24089:3a6f60]  WARN -- : Q-task_id([job_dispatcher]) Snapshots information will be skipped due to EMS host missing credentials.

https://bugzilla.redhat.com/show_bug.cgi?id=1657873
`