### PR TITLE
Scan for directory names as if they were files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@
 
 # rspec failure tracking
 .rspec_status
+
+# Komodo project file
+manageiq-smartstate.komodoproject

--- a/lib/fs/xfs/inode.rb
+++ b/lib/fs/xfs/inode.rb
@@ -301,7 +301,7 @@ module XFS
     def access_time
       @access_time ||= Time.at(@in['atime_secs'])
     end
-    
+
     # For compatibility with other filesystem methods
     def aTime
       access_time
@@ -310,7 +310,7 @@ module XFS
     def create_time
       @create_time ||= Time.at(@in['ctime_secs'])
     end
-    
+
     # For compatibility with other filesystem methods
     def cTime
       create_time
@@ -319,7 +319,7 @@ module XFS
     def modification_time
       @modification_time ||= Time.at(@in['mtime_secs'])
     end
-    
+
     # For compatibility with other filesystem methods
     def mTime
       modification_time

--- a/lib/fs/xfs/inode.rb
+++ b/lib/fs/xfs/inode.rb
@@ -304,7 +304,7 @@ module XFS
     
     # For compatibility with other filesystem methods
     def aTime
-      self.access_time
+      access_time
     end
 
     def create_time
@@ -313,7 +313,7 @@ module XFS
     
     # For compatibility with other filesystem methods
     def cTime
-      self.create_time
+      create_time
     end
 
     def modification_time
@@ -322,7 +322,7 @@ module XFS
     
     # For compatibility with other filesystem methods
     def mTime
-      self.modification_time
+      modification_time
     end
 
     def permissions

--- a/lib/fs/xfs/inode.rb
+++ b/lib/fs/xfs/inode.rb
@@ -301,13 +301,28 @@ module XFS
     def access_time
       @access_time ||= Time.at(@in['atime_secs'])
     end
+    
+    # For compatibility with other filesystem methods
+    def aTime
+      self.access_time
+    end
 
     def create_time
       @create_time ||= Time.at(@in['ctime_secs'])
     end
+    
+    # For compatibility with other filesystem methods
+    def cTime
+      self.create_time
+    end
 
     def modification_time
       @modification_time ||= Time.at(@in['mtime_secs'])
+    end
+    
+    # For compatibility with other filesystem methods
+    def mTime
+      self.modification_time
     end
 
     def permissions

--- a/lib/metadata/util/md5deep.rb
+++ b/lib/metadata/util/md5deep.rb
@@ -60,7 +60,7 @@ class MD5deep
 
     # First check if we are passed a fully qualifed file name
     if @fs.fileExists?(filename)
-      isDir?(filename) ? processDirAsFile(startDir, globPattern, @xml.root) : processFile(startDir, globPattern, @xml.root)
+      isDir?(filename) ? process_dir_as_file(startDir, globPattern, @xml.root) : processFile(startDir, globPattern, @xml.root)
     else
       # If the file is not found then process the data as a glob pattern.
       @fs.dirGlob(globPattern) do |f|
@@ -108,17 +108,14 @@ class MD5deep
     end
   end
   
-  def processDirAsFile(path, x, xmlNode)
+  def process_dir_as_file(path, x, xmlNode)
     if x != "." && x != ".."
-      currDir = File.join(path, x)
-      begin
-        if isDir?(currDir)
-          xmlFileNode = xmlNode.add_element("file", "name" => x, "fqname" => currDir)
-          statHash = {}
-          statHash.merge!(getDirStats(currDir))
-          xmlFileNode.add_attributes(statHash)
-        end
-      rescue Errno::EACCES, RuntimeError, SystemCallError
+      curr_dir = File.join(path, x)
+      if isDir?(curr_dir)
+        xmlFileNode = xmlNode.add_element("file", "name" => x, "fqname" => curr_dir)
+        stat_hash = {}
+        stat_hash.merge!(get_dir_stats(curr_dir))
+        xmlFileNode.add_attributes(stat_hash)
       end
     end
   end
@@ -182,7 +179,7 @@ class MD5deep
     {"size" => fh.size, "atime" => fh.atime.getutc.iso8601, "ctime" => fh.ctime.getutc.iso8601, "mtime" => fh.mtime.getutc.iso8601}
   end
   
-  def getDirStats(dir)
+  def get_dir_stats(dir)
     if @fs
       {"size" => @fs.fileSize(dir), "atime" => @fs.fileAtime(dir).getutc.iso8601, "ctime" => @fs.fileCtime(dir).getutc.iso8601, "mtime" => @fs.fileMtime(dir).getutc.iso8601}
     else

--- a/lib/metadata/util/md5deep.rb
+++ b/lib/metadata/util/md5deep.rb
@@ -108,14 +108,14 @@ class MD5deep
     end
   end
   
-  def process_dir_as_file(path, x, xmlNode)
+  def process_dir_as_file(path, x, xml_node)
     if x != "." && x != ".."
       curr_dir = File.join(path, x)
       if isDir?(curr_dir)
-        xmlFileNode = xmlNode.add_element("file", "name" => x, "fqname" => curr_dir)
+        xml_file_node = xml_node.add_element("file", "name" => x, "fqname" => curr_dir)
         stat_hash = {}
         stat_hash.merge!(get_dir_stats(curr_dir))
-        xmlFileNode.add_attributes(stat_hash)
+        xml_file_node.add_attributes(stat_hash)
       end
     end
   end

--- a/lib/metadata/util/md5deep.rb
+++ b/lib/metadata/util/md5deep.rb
@@ -107,7 +107,7 @@ class MD5deep
       @fullDirCount += 1
     end
   end
-  
+
   def process_dir_as_file(path, x, xml_node)
     if x != "." && x != ".."
       curr_dir = File.join(path, x)
@@ -178,7 +178,7 @@ class MD5deep
     fh = fh.stat if fh.class == File
     {"size" => fh.size, "atime" => fh.atime.getutc.iso8601, "ctime" => fh.ctime.getutc.iso8601, "mtime" => fh.mtime.getutc.iso8601}
   end
-  
+
   def get_dir_stats(dir)
     if @fs
       {"size" => @fs.fileSize(dir), "atime" => @fs.fileAtime(dir).getutc.iso8601, "ctime" => @fs.fileCtime(dir).getutc.iso8601, "mtime" => @fs.fileMtime(dir).getutc.iso8601}


### PR DESCRIPTION
This PR implements this RFE: https://bugzilla.redhat.com/show_bug.cgi?id=1684592. It allows for a user to add a directory name to search for in the SSA profile as if it were a file. The presence of the directory is reported in the list of discovered files from a VM.