### PR TITLE
Clean up all volume snapshots when removing OSP evm snapshot

### DIFF
--- a/lib/OpenStackExtract/MiqOpenStackVm/MiqOpenStackInstance.rb
+++ b/lib/OpenStackExtract/MiqOpenStackVm/MiqOpenStackInstance.rb
@@ -137,8 +137,14 @@ class MiqOpenStackInstance
           $log.warn "#{log_prefix}: pointer from instance doesn't match #{snapshot_image_id}"
         end
         $log.info "#{log_prefix}: deleting snapshot image"
-        if (volume_snapshot_id = get_image_metadata_snapshot_id(compute_service.images.get(image_id)))
-          delete_volume_snapshot(volume_snapshot_id)
+
+        image = compute_service.images.get(image_id)
+        image.metadata.each do |m|
+          next unless m.key == "block_device_mapping"
+          m.value.each do |volume_snapshot|
+            volume_snapshot_id = volume_snapshot["snapshot_id"]
+            delete_volume_snapshot(volume_snapshot_id) if volume_snapshot_id
+          end
         end
         snapshot.destroy
         snapshot_metadata.destroy


### PR DESCRIPTION
`delete_evm_snapshot` only deletes the first volume snapshot, of which there could be more than one depending on the number of volumes the snapshotted VM had. This PR causes `delete_evm_snapshot` to delete all of the volume snapshots associated with the image being deleted.

https://bugzilla.redhat.com/show_bug.cgi?id=1696846