### PR TITLE
Rubocop tiny empty line fix OpenStack

### DIFF
--- a/lib/OpenStackExtract/MiqOpenStackVm/MiqOpenStackInstance.rb
+++ b/lib/OpenStackExtract/MiqOpenStackVm/MiqOpenStackInstance.rb
@@ -141,6 +141,7 @@ class MiqOpenStackInstance
         image = compute_service.images.get(image_id)
         image.metadata.each do |m|
           next unless m.key == "block_device_mapping"
+
           m.value.each do |volume_snapshot|
             volume_snapshot_id = volume_snapshot["snapshot_id"]
             delete_volume_snapshot(volume_snapshot_id) if volume_snapshot_id


### PR DESCRIPTION
OpenStack snapshot removal method update PR introduced a rubocop issue,
which is fixed by this PR.

Follow up on https://github.com/ManageIQ/manageiq-smartstate/pull/94