### PR TITLE
Remove v3 api form SSA

### DIFF
--- a/lib/MiqVm/MiqVm.rb
+++ b/lib/MiqVm/MiqVm.rb
@@ -42,7 +42,7 @@ class MiqVm
     elsif (@rhevm = @ost.miqRhevm)
       $log.debug "MiqVm::initialize: accessing VM through RHEVM server" if $log.debug?
       $log.debug "MiqVm::initialize: vmCfg = #{vmCfg}"
-      @rhevmVm = @rhevm.get_vm(vmCfg)
+      @rhevmVm = @rhevm.vm_or_template_by_path(vmCfg)
       $log.debug "MiqVm::initialize: setting @ost.miqRhevmVm = #{@rhevmVm.class}" if $log.debug?
       @ost.miqRhevmVm = @rhevmVm
       @vmConfig = VmConfig.new(getCfg(@ost.snapId))


### PR DESCRIPTION
Remove the usage of the ovirt gem and version 3 api from the SSA

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1535782

Depends on: https://github.com/ManageIQ/manageiq-providers-ovirt/pull/394