### PR TITLE
Don't include 'test' subdirectories in gem

### DIFF
--- a/manageiq-smartstate.gemspec
+++ b/manageiq-smartstate.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.license       = "Apache-2.0"
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
-    f.match(%r{^(test|spec|features)/})
+    f.match(%r{^(spec|features)/|test/})
   end
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }


### PR DESCRIPTION
Brought up during appliance build cleanup. I assumed all "test" subdirectories can be excluded from gem.

gem contents diff before/after change:

Only in before/lib/MiqVm: test
Only in before/lib/Scvmm: test
Only in before/lib: VmLocalDiskAccess  <-- this directory contains "test" subdirectory only
Only in before/lib/VolumeManager: test
Only in before/lib/fs/MetakitFS: test
Only in before/lib/fs/ext3: test
Only in before/lib/fs: test
Only in before/lib/metadata/MIQExtract: test
Only in before/lib/metadata/VmConfig: test
Only in before/lib/metadata/linux: test  <-- this directory contains 30MB `Packages` file
Files before/manageiq-smartstate.gemspec and after/manageiq-smartstate.gemspec differ

cc @bdunne @Fryguy @roliveri 