### PR TITLE
Use rubygems.manageiq.org for handsoap

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,4 @@ gemspec
 gem "manageiq-gems-pending", :git => "https://github.com/ManageIQ/manageiq-gems-pending.git", :branch => "master"
 
 # Modified gems for vmware_web_service.  Setting sources here since they are git references
-gem "handsoap", "~>0.2.5", :require => false, :git => "https://github.com/ManageIQ/handsoap.git", :tag => "v0.2.5-5"
+gem "handsoap", "=0.2.5.5", :require => false, :source => "http://rubygems.manageiq.org"


### PR DESCRIPTION
Just mimicking what is being used in the `ManageIQ/manageiq` `Gemfile` currently:

https://github.com/ManageIQ/manageiq/blob/22858673dfae6b0018f3dc45aab8d94f7324a0ee/Gemfile#L16

Possibly we could just add an additional source at the top:

```ruby
source "http://rubygems.manageiq.org"
```

but just going to stay consistent for the time being with what we have in core for now.