### PR TITLE
Bump VMwareWebService to v1.0

### DIFF
--- a/manageiq-smartstate.gemspec
+++ b/manageiq-smartstate.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "memory_buffer",      ">=0.1.0"
   spec.add_dependency "rufus-lru",          "~>1.0.3"
   spec.add_dependency "sys-uname",          "~>1.0.1"
-  spec.add_dependency "vmware_web_service", "~>0.4.0"
+  spec.add_dependency "vmware_web_service", "~>1.0"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
Manageiq-providers-vmware needs vmware_web_service version 1.0.0 so that
the update thread can be run without the broker.

Cross Repo Tests: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/56