### PR TITLE
Rescue TypeError During PEheader Processing

### DIFF
--- a/lib/metadata/util/md5deep.rb
+++ b/lib/metadata/util/md5deep.rb
@@ -140,10 +140,15 @@ class MD5deep
           ext = File.extname(currFile).downcase
           if @opts.winVerList.include?(ext)
             if @opts.versioninfo || @opts.imports
-              peHdr = PEheader.new(fh) rescue nil
-              unless peHdr.nil?
-                xmlFileNode.add_element("versioninfo", peHdr.versioninfo) if @opts.versioninfo && !peHdr.versioninfo.blank?
-                xmlFileNode.add_element("libraries", "imports" => peHdr.getImportList) if @opts.imports && !peHdr.imports.blank?
+              begin
+                peHdr = PEheader.new(fh) rescue nil
+                unless peHdr.nil?
+                  xmlFileNode.add_element("versioninfo", peHdr.versioninfo) if @opts.versioninfo && !peHdr.versioninfo.blank?
+                  xmlFileNode.add_element("libraries", "imports" => peHdr.getImportList) if @opts.imports && !peHdr.imports.blank?
+                end
+              rescue TypeError => err
+                $log.debug "processFile: TypeError handling PEheader; skipping PEheader info"
+                $log.debug err.backtrace.join("\n")
               end
             end
           end


### PR DESCRIPTION
Currently TypeError is ignored during processing of the .ico files in the PEheader processing code.
This results in all the information collected about all files in the VM being discarded and no new
info being available about said files.

Rescue the TypeError so that processing of the files can continue successfully.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1805467

This can be backported as far back as we'd like.

@roliveri please review and merge when appropriate.