### PR TITLE
No need for MiqFaultTolerantVim without DRb

### DIFF
--- a/lib/metadata/VmConfig/VmConfig.rb
+++ b/lib/metadata/VmConfig/VmConfig.rb
@@ -409,10 +409,10 @@ class VmConfig
       ems_display_text = "host(#{ems_host['use_vim_broker'] ? 'via broker' : 'directly'}):#{ems_host['host']}"
       $log.info "#{conn_reason}: Connecting to [#{ems_display_text}] for VM:[#{vmCfgFile}]"
 
-      require 'VMwareWebService/miq_fault_tolerant_vim'
+      require 'VMwareWebService/MiqVim'
 
       password_decrypt = ManageIQ::Password.decrypt(ems_host['password'])
-      hostVim = MiqFaultTolerantVim.new(:ip => ems_host['host'], :user => ems_host['user'], :pass => password_decrypt, :use_broker => ems_host['use_vim_broker'], :vim_broker_drb_uri => ems_host['vim_broker_drb_uri'])
+      hostVim = MiqVim.new(ems_host['host'], ems_host['user'], password_decrypt)
       $log.info "#{conn_reason}: Connection to [#{ems_display_text}] completed for VM:[#{vmCfgFile}] in [#{Time.now - st}] seconds"
       return hostVim
     rescue Timeout::Error => err


### PR DESCRIPTION
Now that VMware connections are brokered by the OperationsWorker instead
of going over DRb to the VimBrokerWorker we no longer need
MiqFaultTolerantVim and can just use MiqVim.

https://github.com/ManageIQ/manageiq-providers-vmware/issues/520