### PR TITLE
Add Expanded Glob Processing for SSA

### DIFF
--- a/lib/metadata/util/find_class_methods.rb
+++ b/lib/metadata/util/find_class_methods.rb
@@ -105,14 +105,14 @@ module FindClassMethods
     @fs.fileExists?(@search_path) ? File.join(components) : nil
   end
 
-  def self.path_components(glob_path)
+  def self.path_components(glob_path, search_path = @search_path)
     components = glob_path.each_filename.to_a
     while (comp = components.shift)
       if glob_str?(comp)
         components.unshift(comp)
         break
       end
-      @search_path = File.join(@search_path, comp)
+      @search_path = File.join(search_path, comp)
       @specified_path = @specified_path ? File.join(@specified_path, comp) : comp
     end
     components

--- a/lib/metadata/util/find_class_methods.rb
+++ b/lib/metadata/util/find_class_methods.rb
@@ -1,0 +1,151 @@
+module FindClassMethods
+  # Return directory entries matching specified glob pattern
+  #
+  # @param glob_pattern [String] pattern to match
+  # @param flags [Integer] file match flags
+  # @yield block invoked with each match if specified
+  #
+  # @see VfsRealFile.fnmatch
+  # @see FindClassMethods#dir_and_glob which does most of the work regarding globbing
+  # @see FindClassMethods#find which retrieves stats information & dir entries for found files
+  #
+  def self.glob(glob_pattern, fs, flags = 0)
+    @fs = fs
+    begin
+    search_path, specified_path, glob = dir_and_glob(glob_pattern)
+    $log.debug "dir_and_glob(#{glob_pattern}) returned \"#{search_path}\", \"#{specified_path}\", and \"#{glob}\""
+
+    unless @fs.fileExists?(search_path)
+      return [] unless block_given?
+      return false
+    end
+
+    ra = [] unless block_given?
+    find(search_path, glob_depth(glob)) do |p|
+      $log.debug "find(#{search_path}, #{glob_depth(glob)}) returned #{p}"
+      next if p == search_path
+
+      if search_path == File::SEPARATOR
+        p.sub!(File::SEPARATOR, "")
+      else
+        p.sub!("#{search_path}#{File::SEPARATOR}", "")
+      end
+
+      next if p == ""
+      next unless File.fnmatch(glob, p, flags)
+
+      p = File.join(specified_path, p) if specified_path
+      block_given? ? yield(p) : ra << p
+    end
+    rescue Exception => err
+      $log.info "Exception #{err}"
+      $log.debug err.backtrace.join("\n")
+    end
+    block_given? ? false : ra.sort_by(&:downcase)
+  end
+  #
+  # Modified version of Find.find:
+  # - Accepts only a single path.
+  # - Can be restricted by depth - optimization for glob searches.
+  #
+  # @param path [String] starting directory of the find
+  # @param max_depth [Integer] max number of levels to decend befroelookup
+  # @yield files found
+  #
+  def self.find(path, max_depth = nil)
+    raise SystemCallError.new(path, Errno::ENOENT::Errno) unless @fs.fileExists?(path)
+    if @fs.fileExists?(path)
+      $log.debug "Path #{path} exists."
+    else
+      $log.debug "Path #{path} does NOT exist."
+    end
+    $log.debug  "max_depth is #{max_depth}"
+
+    block_given? || (return enum_for(__method__, path, max_depth))
+
+    depths = [0]
+    paths  = [path.dup]
+
+    while (file = paths.shift)
+      depth = depths.shift
+      catch(:prune) do
+        yield file.dup.taint
+        if @fs.fileExists?(file) && @fs.fileDirectory?(file)
+          $log.debug "find: while-loop file #{file} is a directory, depth is #{depth}, max_depth is #{max_depth}"
+          next if depth + 1 > max_depth if max_depth
+          begin
+            files = @fs.dirEntries(file)
+            $log.debug "find: while-loop files are #{files}"
+          rescue Errno::ENOENT, Errno::EACCES, Errno::ENOTDIR, Errno::ELOOP, Errno::ENAMETOOLONG
+            $log.info "find: while-loop @fs.dirEntries #{file} returned an error"
+            next
+          rescue Exception => err
+            $log.info "find: unexpected Exception #{err} processing #{file}"
+            $log.debug err.backtrace.join("\n")
+          end
+          files.sort!
+          files.reverse_each do |f|
+            next if f == "." || f == ".."
+            f = File.join(file, f)
+            paths.unshift f.untaint
+            depths.unshift depth + 1
+          end
+        end
+      end
+    end
+  end
+
+  GLOB_CHARS = '*?[{'
+  def self.glob_str?(str)
+    str.gsub(/\\./, "X").count(GLOB_CHARS) != 0
+  end
+
+  # Returns files matching glob pattern
+  #
+  # @api private
+  # @param glob_pattern [String,Regex] pattern to search for
+  # @return [String] paths to files found
+  #
+  def self.dir_and_glob(glob_pattern)
+    stripped_path  = glob_pattern.sub(/^[a-zA-Z]:/, "")
+    glob_path      = Pathname.new(stripped_path)
+    $log.debug "dir_and_glob: glob_pattern is #{glob_pattern}, stripped pattern is #{stripped_path}"
+
+    if glob_path.absolute?
+      $log.debug "dir_and_glob: glob_path #{glob_path} is absolute"
+      search_path    = File::SEPARATOR
+      specified_path = File::SEPARATOR
+    else
+      $log.debug "dir_and_glob: glob_path #{glob_path} is relative"
+      search_path    = Dir.getwd
+      specified_path = nil
+    end
+    $log.debug "dir_and_glob: search_path is #{search_path}, specified_path is #{specified_path}"
+
+    components = glob_path.each_filename.to_a
+    while (comp = components.shift)
+      if glob_str?(comp)
+        components.unshift(comp)
+        break
+      end
+      search_path = File.join(search_path, comp)
+      if specified_path
+        specified_path = File.join(specified_path, comp)
+      else
+        specified_path = comp
+      end
+    end
+    return File.expand_path(search_path, "/"), specified_path, File.join(components)
+  end
+
+  # Return max levels which glob pattern may resolve to
+  #
+  # @api private
+  # @param glob_pattern [String,Regex] pattern to search for
+  # @return [Integer] max levels which pattern may match
+  def self.glob_depth(glob_pattern)
+    path_components = Pathname(glob_pattern).each_filename.to_a
+    return nil if path_components.include?('**')
+    path_components.length
+  end
+end

--- a/lib/metadata/util/find_class_methods.rb
+++ b/lib/metadata/util/find_class_methods.rb
@@ -44,8 +44,6 @@ module FindClassMethods
   # @yield files found
   #
   def self.find(path, max_depth = nil)
-    raise SystemCallError.new(path, Errno::ENOENT::Errno) unless @fs.fileExists?(path)
-
     block_given? || (return enum_for(__method__, path, max_depth))
 
     depths = [0]

--- a/lib/metadata/util/md5deep.rb
+++ b/lib/metadata/util/md5deep.rb
@@ -60,12 +60,12 @@ class MD5deep
   def scan_glob(filename)
     filename.tr!("\\", "/")
     startDir = File.dirname(filename)
-    globPattern = File.basename(filename)
     @xml.root.add_attribute("base_path", startDir)
 
     # First check if we are passed a fully qualifed file name
     if @fs.fileExists?(filename)
-      isDir?(filename) ? process_dir_as_file(startDir, globPattern, @xml.root) : processFile(startDir, globPattern, @xml.root)
+      base_file = File.basename(filename)
+      isDir?(filename) ? process_dir_as_file(startDir, base_file, @xml.root) : processFile(startDir, base_file, @xml.root)
     else
       # If the file is not found then process the data as a glob pattern.
       begin

--- a/lib/metadata/util/md5deep.rb
+++ b/lib/metadata/util/md5deep.rb
@@ -48,13 +48,8 @@ class MD5deep
   end
 
   def self.scan_glob(fs, filename, options = {})
-    begin
     md5 = MD5deep.new(fs, options)
     md5.scan_glob(filename)
-    rescue Exception => err
-      $log.info "MD5.scan_glob: Exception #{err} rescued"
-      $log.debug err.backtrace.join("\n")
-    end
   end
 
   def scan_glob(filename)
@@ -69,26 +64,15 @@ class MD5deep
     else
       # If the file is not found then process the data as a glob pattern.
       begin
-      FindClassMethods.glob(filename, @fs) do |f|
-        $log.debug "scan_glob: FindClassMethods.glob returned \"#{f}\""
-        # Passing "startDir" as the first parameter is a work-around for issues
-        # when scanning Win VMs from Linux where the path returned from dirGlob
-        # do not include the drive letter.
-        # Below is the original line
-        begin
-          startDir = File.dirname(f)
-          $log.debug "scan_glob: startDir after File.dirname for #{f} is #{startDir}"
-          processFile(startDir, File.basename(f), @xml.root)
-          $log.debug "scan_glob: xml after processFile for #{f} is #{@xml.to_s}"
-        rescue Exception => err
-          $log.info "scan_glob: Exception #{err} rescued"
-          $log.debug err.backtrace.join("\n")
+        FindClassMethods.glob(filename, @fs) do |f|
+          # Passing "startDir" as the first parameter is a work-around for issues
+          # when scanning Win VMs from Linux where the path returned from dirGlob
+          # do not include the drive letter.
+          processFile(File.dirname(f), File.basename(f), @xml.root)
+          $log.debug "scan_glob: xml after processFile for #{f} is #{@xml}"
         end
-
-      end
       rescue Exception => err
         $log.info "scan_glob: Exception #{err} rescued"
-        $log.debug "scan_glob: xml in rescue after processFile for #{f} is #{@xml.to_s}"
         $log.debug err.backtrace.join("\n")
       end
     end
@@ -169,7 +153,7 @@ class MD5deep
         fh.close if fh.kind_of?(File) && !fh.closed?
       end
     end
-    $log.debug "processFile: finished @xml is #{@xml.to_s}"
+    $log.debug "processFile: finished @xml is #{@xml}"
   end
 
   def process_pe_header(pe_hdr, xml_file_node)
@@ -315,7 +299,7 @@ if __FILE__ == $0
       $log.warn err
       $log.fatal err.backtrace.join("\n")
     end
-  rescue Exception => err
+  rescue => err
     $log.fatal err
     $log.fatal err.backtrace.join("\n")
   end

--- a/lib/metadata/util/md5deep.rb
+++ b/lib/metadata/util/md5deep.rb
@@ -1,6 +1,7 @@
 require 'time'
 require 'metadata/util/win32/peheader'
 require 'metadata/util/win32/versioninfo'
+require 'metadata/util/find_class_methods'
 require 'util/miq-xml'
 require 'ostruct'
 require 'util/miq-encode'
@@ -47,8 +48,13 @@ class MD5deep
   end
 
   def self.scan_glob(fs, filename, options = {})
+    begin
     md5 = MD5deep.new(fs, options)
     md5.scan_glob(filename)
+    rescue Exception => err
+      $log.info "MD5.scan_glob: Exception #{err} rescued"
+      $log.debug err.backtrace.join("\n")
+    end
   end
 
   def scan_glob(filename)
@@ -56,21 +62,34 @@ class MD5deep
     startDir = File.dirname(filename)
     globPattern = File.basename(filename)
     @xml.root.add_attribute("base_path", startDir)
-    @fs.chdir(startDir)
 
     # First check if we are passed a fully qualifed file name
     if @fs.fileExists?(filename)
       isDir?(filename) ? process_dir_as_file(startDir, globPattern, @xml.root) : processFile(startDir, globPattern, @xml.root)
     else
       # If the file is not found then process the data as a glob pattern.
-      @fs.dirGlob(globPattern) do |f|
-        # $log.info "Glob file found: [#{f}]"
+      begin
+      FindClassMethods.glob(filename, @fs) do |f|
+        $log.debug "scan_glob: FindClassMethods.glob returned \"#{f}\""
         # Passing "startDir" as the first parameter is a work-around for issues
         # when scanning Win VMs from Linux where the path returned from dirGlob
         # do not include the drive letter.
         # Below is the original line
-        # processFile(File.dirname(f), File.basename(f), @xml.root)
-        processFile(startDir, File.basename(f), @xml.root)
+        begin
+          startDir = File.dirname(f)
+          $log.debug "scan_glob: startDir after File.dirname for #{f} is #{startDir}"
+          processFile(startDir, File.basename(f), @xml.root)
+          $log.debug "scan_glob: xml after processFile for #{f} is #{@xml.to_s}"
+        rescue Exception => err
+          $log.info "scan_glob: Exception #{err} rescued"
+          $log.debug err.backtrace.join("\n")
+        end
+
+      end
+      rescue Exception => err
+        $log.info "scan_glob: Exception #{err} rescued"
+        $log.debug "scan_glob: xml in rescue after processFile for #{f} is #{@xml.to_s}"
+        $log.debug err.backtrace.join("\n")
       end
     end
     @xml
@@ -150,6 +169,7 @@ class MD5deep
         fh.close if fh.kind_of?(File) && !fh.closed?
       end
     end
+    $log.debug "processFile: finished @xml is #{@xml.to_s}"
   end
 
   def process_pe_header(pe_hdr, xml_file_node)
@@ -295,7 +315,7 @@ if __FILE__ == $0
       $log.warn err
       $log.fatal err.backtrace.join("\n")
     end
-  rescue => err
+  rescue Exception => err
     $log.fatal err
     $log.fatal err.backtrace.join("\n")
   end

--- a/spec/metadata/util/find_spec.rb
+++ b/spec/metadata/util/find_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+require 'metadata/util/find_class_methods'
+
+describe FindClassMethods, "find for SSA and support methods)" do
+  describe "::glob_depth" do
+    it "should return the find depth required for the glob pattern" do
+      expect(FindClassMethods.glob_depth("*")).to           eq(1)
+      expect(FindClassMethods.glob_depth("*/*")).to         eq(2)
+      expect(FindClassMethods.glob_depth("*/*/*.rb")).to    eq(3)
+      expect(FindClassMethods.glob_depth("**")).to          eq(nil)
+      expect(FindClassMethods.glob_depth("*.d/**/*.rb")).to eq(nil)
+    end
+  end
+
+  describe "::glob_str?" do
+    it "should return false when string isn't a glob" do
+      expect(FindClassMethods.glob_str?("hello")).to be false
+    end
+
+    it "should return true when string is a glob" do
+      expect(FindClassMethods.glob_str?("*.rb")).to   be true
+      expect(FindClassMethods.glob_str?("foo.r?")).to be true
+    end
+
+    it "should return false when glob characters are escaped" do
+      expect(FindClassMethods.glob_str?("\\*.rb")).to   be false
+      expect(FindClassMethods.glob_str?("foo.r\\?")).to be false
+    end
+  end
+
+  describe "::path_components" do
+    it "should return no components with a glob path with no globs" do
+      expect(FindClassMethods.path_components(Pathname.new("spec/foo.rb"), "/")).to match_array([])
+    end
+
+    it "should return one component with a glob path with one glob" do
+      expect(FindClassMethods.path_components(Pathname.new("spec/*.rb"), "/")).to match_array(["*.rb"])
+    end
+  end
+end


### PR DESCRIPTION
Add find methodology from the virtfs gem.
find_class_methods.rb has some of the code from the same file in virtfs, as well as from v_dir.rb
in that gem.
Modify glob parsing in MD5deep to use this new FindClassMethods glob method instead.

Currently the XML processing aborts sometime after about 950 file entries.  This may be an already existing bug that is exacerbated by the amount of data now available when multiple glob characters can be entered in a scan profile.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1684589  (RFE).

@roliveri now available for initial review.