### PR TITLE
Update sys-uname to 1.2.1

### DIFF
--- a/manageiq-smartstate.gemspec
+++ b/manageiq-smartstate.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "manageiq-password",  "~>0.3"
   spec.add_dependency "memory_buffer",      ">=0.1.0"
   spec.add_dependency "rufus-lru",          "~>1.0.3"
-  spec.add_dependency "sys-uname",          "~>1.0.1"
+  spec.add_dependency "sys-uname",          "~>1.2.1"
   spec.add_dependency "vmware_web_service", "~>1.0"
 
   spec.add_development_dependency "bundler"


### PR DESCRIPTION
This updates the sys-uname gem to 1.2.1.

The latest version uses Apache-2.0 (previously it was Artistic-2.0), which is what we want. There were some code updates, but they only applied to MS Windows. The rest of the changes were test suite updates and other minor documentation changes.

https://github.com/djberg96/sys-uname/blob/ffi/CHANGES.rdoc

It also keeps us in sync with gems-pending.