### PR TITLE
Follow All Symlinks

### DIFF
--- a/lib/fs/modules/LinuxMount.rb
+++ b/lib/fs/modules/LinuxMount.rb
@@ -315,17 +315,24 @@ module LinuxMount
       #
       fs, lp = getFsPathBase(ncp)
       if fs.fileSymLink?(lp)
-        sl = getSymLink(fs, lp)
-        if sl[0, 1] == '/'
-          cp = sl
-        else
-          cp = File.join(cp, sl)
-        end
+        cp = follow_all_symlinks(fs, lp, cp)
       else
         cp = ncp
       end
     end
     (cp)
+  end
+
+  def follow_all_symlinks(fs, lp, cp)
+    while fs.fileSymLink?(lp)
+      sl = getSymLink(fs, lp)
+      if sl[0, 1] == '/'
+        lp = sl
+      else
+        lp = File.join(cp, sl)
+      end
+    end
+    lp
   end
 
   def getSymLink(fs, p)

--- a/lib/fs/modules/LinuxMount.rb
+++ b/lib/fs/modules/LinuxMount.rb
@@ -309,30 +309,27 @@ module LinuxMount
     #
     components.each do |c|
       ncp = File.join(cp, c)
-      #
-      # Each file system know how to check for,
-      # and read its own links.
-      #
-      fs, lp = getFsPathBase(ncp)
-      if fs.fileSymLink?(lp)
-        cp = follow_all_symlinks(fs, lp, cp)
-      else
-        cp = ncp
-      end
+      cp = follow_all_symlinks(ncp)
     end
     (cp)
   end
 
-  def follow_all_symlinks(fs, lp, cp)
-    while fs.fileSymLink?(lp)
-      sl = getSymLink(fs, lp)
-      if sl[0, 1] == '/'
-        lp = sl
+  def follow_all_symlinks(link_ptr)
+    #
+    # Each filesystem knows how to check for,
+    # and read its own links.
+    #
+    no_more_links = nil
+    until no_more_links
+      filesys, link_ptr = getFsPathBase(link_ptr)
+      if filesys.fileSymLink?(link_ptr)
+        symlink = getSymLink(filesys, linkptr)
+        link_ptr = symlink[0, 1] == '/' ? symlink : File.join(comp, symlink)
       else
-        lp = File.join(cp, sl)
+        no_more_links = true
       end
     end
-    lp
+    link_ptr
   end
 
   def getSymLink(fs, p)

--- a/lib/fs/modules/LinuxMount.rb
+++ b/lib/fs/modules/LinuxMount.rb
@@ -311,7 +311,7 @@ module LinuxMount
       ncp = File.join(cp, c)
       cp = follow_all_symlinks(ncp)
     end
-    (cp)
+    cp
   end
 
   def follow_all_symlinks(link_ptr)
@@ -319,12 +319,12 @@ module LinuxMount
     # Each filesystem knows how to check for,
     # and read its own links.
     #
-    no_more_links = nil
+    no_more_links = false
     until no_more_links
       filesys, link_ptr = getFsPathBase(link_ptr)
       if filesys.fileSymLink?(link_ptr)
         symlink = getSymLink(filesys, linkptr)
-        link_ptr = symlink[0, 1] == '/' ? symlink : File.join(comp, symlink)
+        link_ptr = symlink[0, 1] == '/' ? symlink : File.join(File.dirname(link_ptr), symlink)
       else
         no_more_links = true
       end


### PR DESCRIPTION
Currently SSA will follow symbolic links for every component in a path,
but if one component links to multiple files/directories only the first is followed.
This change will follow all the symbolic links for each component in a path.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1810194

@roliveri @hsong-rh please review.