### PR TITLE
Use manageiq-gems-pending ivanchuk branch for 0.3.x gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in manageiq-smartstate.gemspec
 gemspec
 
-gem "manageiq-gems-pending", :git => "https://github.com/ManageIQ/manageiq-gems-pending.git", :branch => "master"
+gem "manageiq-gems-pending", :git => "https://github.com/ManageIQ/manageiq-gems-pending.git", :branch => "ivanchuk"
 
 # Modified gems for vmware_web_service.  Setting sources here since they are git references
 gem "handsoap", "~>0.2.5", :require => false, :git => "https://github.com/ManageIQ/handsoap.git", :tag => "v0.2.5-5"


### PR DESCRIPTION
0.3.x version of manageiq-smartstate gem is used with manageiq ivanchuk branch.

Fix Travis error: https://travis-ci.org/github/ManageIQ/manageiq-smartstate/jobs/668820136

```
Bundler could not find compatible versions for gem "handsoap":
  In Gemfile:
    handsoap (~> 0.2.5)
    manageiq-gems-pending was resolved to 0.1.0, which depends on
      handsoap (= 0.2.5.5)
Could not find gem 'handsoap (= 0.2.5.5)', which is required by gem
'manageiq-gems-pending', in any of the relevant sources:
  https://github.com/ManageIQ/handsoap.git (at v0.2.5-5@b1247a7)
```