### PR TITLE
Fix Invalid Sort in Glob with Nil Array

### DIFF
--- a/lib/metadata/util/find_class_methods.rb
+++ b/lib/metadata/util/find_class_methods.rb
@@ -15,8 +15,9 @@ module FindClassMethods
 
     ra = []
     find(@search_path, glob_depth(glob)) do |p|
-      p = check_file(p, glob, flags)
-      p && block_given? ? yield(p) : ra << p
+      if (p = check_file(p, glob, flags))
+        block_given? ? yield(p) : ra << p
+      end
     end
     ra.sort_by(&:downcase)
   end


### PR DESCRIPTION
Fix check for valid return from check_file prior to
adding result to return array.
Failure to do so can result in an exception that will cause 
collected files not to be returned.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1821750

Related to https://bugzilla.redhat.com/show_bug.cgi?id=1684589

@roliveri please review.  Would like this ready for the upcoming build. Thanks.