### PR TITLE
File collection exceptions

### DIFF
--- a/lib/fs/ntfs/data_run.rb
+++ b/lib/fs/ntfs/data_run.rb
@@ -282,7 +282,7 @@ module NTFS
 
       @runSpec.each_slice(2) do |lcn, len|
         total_clusters += len
-        next unless total_clusters > start_vcn
+        next unless lcn && len && total_clusters > start_vcn
 
         start = lcn + (vcn - (total_clusters - len))
         count = len - (start - lcn)

--- a/lib/metadata/util/md5deep.rb
+++ b/lib/metadata/util/md5deep.rb
@@ -232,9 +232,6 @@ class MD5deep
         while (buf = fileName.read(10_240_000))
           digest.each_pair { |_k, v| v << buf }
         end
-      rescue NoMethodError => method_err
-        $log.error "Exception NoMethodError #{method_err} reading file to calculate digest"
-        $log.debug method_err.backtrace.join("\n")
       rescue => err
         $log.error "Error #{err} reading file to calculate digest"
         $log.debug err.backtrace.join("\n")

--- a/lib/metadata/util/md5deep.rb
+++ b/lib/metadata/util/md5deep.rb
@@ -78,7 +78,7 @@ class MD5deep
       processFile(File.dirname(f), File.basename(f), @xml.root)
     end
   rescue => err
-    $log.info "scan_glob: Exception #{err} rescued"
+    $log.error "process_each_glob_file: Exception #{err} rescued"
     $log.debug err.backtrace.join("\n")
   end
 
@@ -226,10 +226,18 @@ class MD5deep
       # Create hash for requested digests
       digest = create_digest_hash
 
-      fileName.seek(0, IO::SEEK_SET)
-      # Loop over each digest and add the file contents
-      while buf = fileName.read(10240000)
-        digest.each_pair { |_k, v| v << buf }
+      begin
+        fileName.seek(0, IO::SEEK_SET)
+        # Loop over each digest and add the file contents
+        while buf = fileName.read(10240000)
+          digest.each_pair { |_k, v| v << buf }
+        end
+      rescue NoMethodError => method_err
+        $log.error "Exception NoMethodError #{method_err} reading file to calculate digest"
+        $log.debug method_err.backtrace.join("\n")
+      rescue => err
+        $log.error "Error #{err} reading file to calculate digest"
+        $log.debug err.backtrace.join("\n")
       end
     end
 

--- a/lib/metadata/util/md5deep.rb
+++ b/lib/metadata/util/md5deep.rb
@@ -229,7 +229,7 @@ class MD5deep
       begin
         fileName.seek(0, IO::SEEK_SET)
         # Loop over each digest and add the file contents
-        while buf = fileName.read(10240000)
+        while (buf = fileName.read(10_240_000))
           digest.each_pair { |_k, v| v << buf }
         end
       rescue NoMethodError => method_err


### PR DESCRIPTION
If errors reading the disk to calculate the file digest are received,
information such as the file access time will be lost, and not written to
the xml file.  Make sure that calculate_digest handles the error to avoid this.
The upshot of an error like this is that an exception occurs parsing the
time data in the xml when it is supposed to be written to the database.
That exception would cause all scan_profile data to be lost.

One such disk/filesystem error that occurs is the following - 
The NTFS run spec LCN and length values need to be checked for nil values
prior to using them in the computation to determine which blocks to read.
If invalid data is read from the virtual disk, an exception will occur.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1821933

@roliveri please review.  I'd like to get this in next week's build if possible.