### PR TITLE
Replace Ruby 2.6 Array#difference

### DIFF
--- a/lib/metadata/util/find_class_methods.rb
+++ b/lib/metadata/util/find_class_methods.rb
@@ -71,7 +71,7 @@ module FindClassMethods
     return [] unless @fs.fileExists?(directory) && @fs.fileDirectory?(directory)
 
     files = @fs.dirEntries(directory)
-    files.difference([".", ".."])
+    files -= [".", ".."]
     files.sort!
     files.reverse_each
   rescue Errno::ENOENT, Errno::EACCES, Errno::ENOTDIR, Errno::ELOOP, Errno::ENAMETOOLONG


### PR DESCRIPTION
Ruby 2.6 Array#difference() method was used without realizing
it was added in 2.6 and not available in 2.5.
Replacing with Array#-().

@roliveri please review.

Will be required in Ivanchuk as well.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1824259