### PR TITLE
Typo linkptr should be link_ptr

### DIFF
--- a/lib/fs/modules/LinuxMount.rb
+++ b/lib/fs/modules/LinuxMount.rb
@@ -323,7 +323,7 @@ module LinuxMount
     until no_more_links
       filesys, link_ptr = getFsPathBase(link_ptr)
       if filesys.fileSymLink?(link_ptr)
-        symlink = getSymLink(filesys, linkptr)
+        symlink = getSymLink(filesys, link_ptr)
         link_ptr = symlink[0, 1] == '/' ? symlink : File.join(File.dirname(link_ptr), symlink)
       else
         no_more_links = true


### PR DESCRIPTION
The variable linkptr in follow_all_symlinks() should be link_ptr as
in the rest of the method.  This causes an exception when executed
prior to the fix.

Fixed by https://bugzilla.redhat.com/show_bug.cgi?id=1824920

@roliveri please review.

Will be required in IvanChuk as well.