### PR TITLE
Move miq_tempfile here

### DIFF
--- a/lib/OpenStackExtract/MiqOpenStackVm/MiqOpenStackInstance.rb
+++ b/lib/OpenStackExtract/MiqOpenStackVm/MiqOpenStackInstance.rb
@@ -1,4 +1,4 @@
-require 'util/miq_tempfile'
+require 'miq_tempfile'
 require_relative '../../MiqVm/MiqVm'
 require_relative 'MiqOpenStackCommon'
 

--- a/lib/miq_tempfile.rb
+++ b/lib/miq_tempfile.rb
@@ -1,0 +1,15 @@
+require 'delegate'
+require 'tempfile'
+
+class MiqTempfile < DelegateClass(Tempfile)
+  # TODO: share this definition with appliance console code.
+  MIQ_TMP_DIR = '/var/www/miq_tmp'.freeze
+
+  def initialize(basename, *options)
+    if File.directory?(MIQ_TMP_DIR)
+      super(Tempfile.new(basename, MIQ_TMP_DIR, *options))
+    else
+      super(Tempfile.new(basename, *options))
+    end
+  end
+end


### PR DESCRIPTION
Let's move miq_tempfile.rb here, since smartstate is the only repo that uses it.

Part of the checklist for https://github.com/ManageIQ/manageiq-gems-pending/issues/231

I put it under `lib` since the gem configuration should make it available, but I can put it directly in the `OpenStackExtract/MiqOpenStackVm`directory if you prefer.