### PR TITLE
update azure armrest

### DIFF
--- a/manageiq-smartstate.gemspec
+++ b/manageiq-smartstate.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "azure-armrest",      "~> 0.9.6"
+  spec.add_dependency "azure-armrest",      "~> 0.9"
   spec.add_dependency "binary_struct",      "~> 2.1"
   spec.add_dependency "iniparse"
   spec.add_dependency "linux_block_device", "~>0.2.1"


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq-providers-azure/pull/395 needs core rest client updated and the cross repo specs on https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/124 are failing because smartstate also needs to upgrade