### PR TITLE
Fix require for miq_tempfile

### DIFF
--- a/lib/OpenStackExtract/MiqOpenStackVm/MiqOpenStackImage.rb
+++ b/lib/OpenStackExtract/MiqOpenStackVm/MiqOpenStackImage.rb
@@ -1,4 +1,4 @@
-require 'util/miq_tempfile'
+require 'miq_tempfile'
 require_relative '../../MiqVm/MiqVm'
 require_relative 'MiqOpenStackCommon'
 


### PR DESCRIPTION
Missed this, not sure how the specs passed without it.

Followup to https://github.com/ManageIQ/manageiq-smartstate/pull/124