### PR TITLE
Replace miq-uuid with uuidtools

### DIFF
--- a/lib/VolumeManager/MiqLdm.rb
+++ b/lib/VolumeManager/MiqLdm.rb
@@ -5,7 +5,7 @@
 
 require 'ostruct'
 require 'binary_struct'
-require 'util/miq-uuid'
+require 'uuidtools'
 
 class BinaryStruct
   def self.stepDecode(data, format)

--- a/lib/fs/ext3/superblock.rb
+++ b/lib/fs/ext3/superblock.rb
@@ -4,7 +4,7 @@ require 'fs/ext3/group_descriptor_table'
 require 'fs/ext3/inode'
 
 require 'binary_struct'
-require 'util/miq-uuid'
+require 'uuidtools'
 require 'stringio'
 require 'memory_buffer'
 

--- a/lib/fs/ext4/superblock.rb
+++ b/lib/fs/ext4/superblock.rb
@@ -4,7 +4,7 @@ require 'fs/ext4/group_descriptor_table'
 require 'fs/ext4/inode'
 
 require 'binary_struct'
-require 'util/miq-uuid'
+require 'uuidtools'
 require 'stringio'
 require 'memory_buffer'
 
@@ -225,7 +225,7 @@ module Ext4
     end
 
     def groupDescriptorSize
-      @groupDescriptorSize ||= is_enabled_64_bit? ? @sb['group_desc_size'] : GDE_SIZE 
+      @groupDescriptorSize ||= is_enabled_64_bit? ? @sb['group_desc_size'] : GDE_SIZE
     end
 
     def freeBytes

--- a/lib/fs/ntfs/attrib_object_id.rb
+++ b/lib/fs/ntfs/attrib_object_id.rb
@@ -1,4 +1,4 @@
-require 'util/miq-uuid'
+require 'uuidtools'
 
 module NTFS
   # There is no real data definition for this class - it consists entirely of GUIDs.

--- a/lib/fs/xfs/allocation_group.rb
+++ b/lib/fs/xfs/allocation_group.rb
@@ -1,5 +1,5 @@
 require 'binary_struct'
-require 'util/miq-uuid'
+require 'uuidtools'
 require 'stringio'
 require 'memory_buffer'
 require 'fs/xfs/superblock'

--- a/lib/fs/xfs/bmap_btree_block.rb
+++ b/lib/fs/xfs/bmap_btree_block.rb
@@ -1,5 +1,5 @@
 require 'binary_struct'
-require 'util/miq-uuid'
+require 'uuidtools'
 require 'stringio'
 
 require 'rufus/lru'

--- a/lib/fs/xfs/superblock.rb
+++ b/lib/fs/xfs/superblock.rb
@@ -1,7 +1,7 @@
 # encoding: US-ASCII
 
 require 'binary_struct'
-require 'util/miq-uuid'
+require 'uuidtools'
 require 'stringio'
 require 'memory_buffer'
 require 'fs/xfs/allocation_group'

--- a/manageiq-smartstate.gemspec
+++ b/manageiq-smartstate.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "memory_buffer",      ">=0.1.0"
   spec.add_dependency "rufus-lru",          "~>1.0.3"
   spec.add_dependency "sys-uname",          "~>1.2.1"
+  spec.add_dependency "uuidtools",          "~>2.1"
   spec.add_dependency "vmware_web_service", "~>1.0"
 
   spec.add_development_dependency "bundler"


### PR DESCRIPTION
As far as I can tell, the only reason to `require miq-uuid` within this repo is to load the `uuidtools` library (which is require'd within the miq-uuid.rb file). The `MiqUUID` module doesn't appear to be used anywhere in this code (it only defines one method - `clean_guid`), but `UUIDTools::UUID.parse_raw` is used directly in several places.

So, as part of the https://github.com/ManageIQ/manageiq-gems-pending/issues/231 effort, this PR declares the uuidtools library as a dependency, and updates the various `require` statements to use `uuidtools` instead of `miq-uuid`.

