### PR TITLE
A few warning fixes

### DIFF
--- a/lib/metadata/util/md5deep.rb
+++ b/lib/metadata/util/md5deep.rb
@@ -179,9 +179,9 @@ class MD5deep
 
   def fileOpen(currFile)
     if @fs
-      fh = @fs.fileOpen(currFile)
+      @fs.fileOpen(currFile)
     else
-      fh = File.open(currFile)
+      File.open(currFile)
     end
   end
 

--- a/lib/metadata/util/win32/Win32EventLog.rb
+++ b/lib/metadata/util/win32/Win32EventLog.rb
@@ -684,8 +684,8 @@ class Win32EventLog
       reg.each_key do |subKey, _wtime|
         subpath = "#{src}\\#{subKey}"
         subKey.downcase!
-        Win32::Registry::HKEY_LOCAL_MACHINE.open(subpath) do |reg|
-          reg.each_value do |name, _type, data|
+        Win32::Registry::HKEY_LOCAL_MACHINE.open(subpath) do |subreg|
+          subreg.each_value do |name, _type, data|
             case name
             when 'EventMessageFile', 'ParameterMessageFile', 'CategoryMessageFile' then
               fn = data.to_s

--- a/lib/metadata/util/win32/peheader.rb
+++ b/lib/metadata/util/win32/peheader.rb
@@ -15,8 +15,6 @@ class PEheader
   IMAGE_NT_SIGNATURE = "PE\0\0"
   IMAGE_DOS_SIGNATURE = "MZ"
 
-  attr_reader :imports, :icons, :messagetables, :versioninfo
-
   def initialize(path)
     @fname = path
     @dataDirs = []
@@ -91,19 +89,19 @@ class PEheader
   end
 
   def imports
-    @import_array ||= getImports
+    @imports ||= getImports
   end
 
   def icons
-    @icon_array ||= getIcons(@fBuf)
+    @icons ||= getIcons(@fBuf)
   end
 
   def messagetables
-    @messagetable_hash ||= getMessagetables
+    @messagetables ||= getMessagetables
   end
 
   def versioninfo
-    @versioninfo_array ||= getVersioninfo
+    @versioninfo ||= getVersioninfo
   end
 
   # //////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This PR fixes a few issues that I posted about in https://github.com/ManageIQ/manageiq-smartstate/issues/131. Specifically:

* Unused variable "fh" in md5deep.rb.
* The "reg" block variable shadowing an outer variable.
* attr_reader being used for methods that are explicitly defined.

Regarding the outer variable shadowing, I know we need to be careful with these, but in this case no assignment is happening within the block(s), it's just an iterator.