### PR TITLE
Fix Symlink Processing so Packages dont Get Missed Sometimes

### DIFF
--- a/lib/fs/modules/LinuxMount.rb
+++ b/lib/fs/modules/LinuxMount.rb
@@ -321,9 +321,9 @@ module LinuxMount
     #
     no_more_links = false
     until no_more_links
-      filesys, link_ptr = getFsPathBase(link_ptr)
-      if filesys.fileSymLink?(link_ptr)
-        symlink = getSymLink(filesys, link_ptr)
+      filesys, tmp_link_ptr = getFsPathBase(link_ptr)
+      if filesys.fileSymLink?(tmp_link_ptr)
+        symlink = getSymLink(filesys, tmp_link_ptr)
         link_ptr = symlink[0, 1] == '/' ? symlink : File.join(File.dirname(link_ptr), symlink)
       else
         no_more_links = true


### PR DESCRIPTION
Symlink processing added by a previous change to follow all symlinks in a file sometimes caused Packages to be missed mistakenly.  This fixes that issue.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1825961

Original PR was #117 

@roliveri @djberg96 please review for merge.