### PR TITLE
RHEV SSA Fails on VMs with Direct LUNs

### DIFF
--- a/lib/MiqVm/MiqRhevmVm.rb
+++ b/lib/MiqVm/MiqRhevmVm.rb
@@ -42,7 +42,7 @@ class MiqRhevmVm < MiqVm
     disks = @rhevm.collect_vm_disks(@rhevmVm)
     disks.each_with_index do |disk, idx|
       $log.debug "MiqRhevmVm#getCfg: disk = #{disk.inspect}"
-      storage_domain = disk.storage_domains.first
+      storage_domain = disk.storage_domains&.first
       if storage_domain.nil?
         $log.info("Disk <#{disk.name}> is skipped due to unassigned storage domain")
         next

--- a/lib/metadata/VmConfig/VmConfig.rb
+++ b/lib/metadata/VmConfig/VmConfig.rb
@@ -498,7 +498,7 @@ class VmConfig
   end
 
   def rhevm_disk_file_entry(disk)
-    storage_id = disk.storage_domains.first&.id
+    storage_id = disk.storage_domains&.first&.id
     disk_id = disk.image_id || disk.id
     full_path = storage_id && File.join('/dev', storage_id, disk_id)
     {:path => full_path, :name => disk_id, :size => disk.actual_size.to_i}
@@ -550,7 +550,7 @@ class VmConfig
         elsif miqvm.rhevmVm
           disks = miqvm.rhevm.collect_vm_disks(miqvm.rhevmVm)
           disks.each do |disk|
-            storage_id = disk.storage_domains.first&.id
+            storage_id = disk.storage_domains&.first&.id
             disk_id = disk.image_id || disk.id
             full_path = storage_id && File.join('/dev', storage_id, disk_id)
             d = {:path => full_path, :name => disk.name.to_s, :size => disk.actual_size.to_i}


### PR DESCRIPTION
There were assumptions in the code in three places that a RHEV VM's disk
storage_domains should exist when they do not for Direct Luns on a VM.
It looks like at attempt to rectify this was made previously by checking
if the ".first"  entry in the storage_domains array exists - but no attempt
was ever made to check if the array itself was nil.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1872954

@roliveri @djberg96 @Fryguy please review and merge as appropriate.  Thanks.