### PR TITLE
release 0.6.2

### DIFF
--- a/lib/manageiq/smartstate/version.rb
+++ b/lib/manageiq/smartstate/version.rb
@@ -1,5 +1,5 @@
 module ManageIQ
   module Smartstate
-    VERSION = "0.6.1".freeze
+    VERSION = "0.6.2".freeze
   end
 end


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq-smartstate/compare/v0.6.1...HEAD


updating travis rubies and the presence check required from the previous removal of to_miq_a