### PR TITLE
remove deprecated test reporter gem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,12 @@ language: ruby
 rvm:
 - 2.5.8
 - 2.6.6
-after_script: bundle exec codeclimate-test-reporter
+before_script:
+- curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+- chmod +x ./cc-test-reporter
+- ./cc-test-reporter before-build
+after_script:
+- ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
 notifications:
   webhooks:
     urls:

--- a/manageiq-smartstate.gemspec
+++ b/manageiq-smartstate.gemspec
@@ -34,7 +34,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "camcorder"
-  spec.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
```
Post-install message from codeclimate-test-reporter:

  Code Climate's codeclimate-test-reporter gem has been deprecated in favor of
  our language-agnostic unified test reporter. The new test reporter is faster,
  distributed as a static binary so dependency conflicts never occur, and
  supports parallelized CI builds & multi-language CI configurations.

  Please visit https://docs.codeclimate.com/v1.0/docs/configuring-test-coverage
  for help setting up your CI process with our new test reporter.
```

the token re: https://github.com/ManageIQ/azure-armrest/pull/403#issuecomment-754050779 got added last week

@miq-bot add_label dependencies, test 
@miq-bot assign @Fryguy 
