### PR TITLE
Integrate miq-unicode.rb into smartstate

### DIFF
--- a/lib/disk/modules/MSCommon.rb
+++ b/lib/disk/modules/MSCommon.rb
@@ -1,10 +1,12 @@
 require 'disk/modules/MiqLargeFile'
-require 'util/miq-unicode'
+require 'miq_unicode'
 require 'binary_struct'
 require 'memory_buffer'
 require 'Scvmm/miq_hyperv_disk'
 
 module MSCommon
+  using ManageIQ
+
   # NOTE: All values are stored in network byte order.
 
   FOOTER = BinaryStruct.new([

--- a/lib/disk/modules/MSCommon.rb
+++ b/lib/disk/modules/MSCommon.rb
@@ -5,7 +5,7 @@ require 'memory_buffer'
 require 'Scvmm/miq_hyperv_disk'
 
 module MSCommon
-  using ManageIQ
+  using ManageIQ::UnicodeString
 
   # NOTE: All values are stored in network byte order.
 

--- a/lib/disk/modules/VhdxDisk.rb
+++ b/lib/disk/modules/VhdxDisk.rb
@@ -8,7 +8,7 @@ require 'disk/modules/MiqLargeFile'
 require 'disk/modules/vhdx_bat_entry'
 
 module VhdxDisk
-  using ManageIQ
+  using ManageIQ::UnicodeString
 
   # NOTE: All values are stored in network byte order.
 

--- a/lib/disk/modules/VhdxDisk.rb
+++ b/lib/disk/modules/VhdxDisk.rb
@@ -1,6 +1,6 @@
 # encoding: US-ASCII
 
-require 'util/miq-unicode'
+require 'miq_unicode'
 require 'binary_struct'
 require 'disk/MiqDisk'
 require 'memory_buffer'
@@ -8,6 +8,8 @@ require 'disk/modules/MiqLargeFile'
 require 'disk/modules/vhdx_bat_entry'
 
 module VhdxDisk
+  using ManageIQ
+
   # NOTE: All values are stored in network byte order.
 
   VHDX_FILE_IDENTIFIER = BinaryStruct.new([

--- a/lib/fs/fat32/directory_entry.rb
+++ b/lib/fs/fat32/directory_entry.rb
@@ -1,9 +1,8 @@
 # encoding: US-ASCII
 
 require 'stringio'
-
 require 'binary_struct'
-require 'util/miq-unicode'
+require 'miq_unicode'
 
 # ////////////////////////////////////////////////////////////////////////////
 # // Data definitions.
@@ -13,6 +12,7 @@ require 'util/miq-unicode'
 # (which yields uppercase names on XP).
 
 module Fat32
+  using ManageIQ
 
   DIR_ENT_SFN = BinaryStruct.new([
     'a11',  'name',         # If name[0] = 0, unallocated; if name[0] = 0xe5, deleted. DOES NOT INCLUDE DOT.
@@ -39,17 +39,17 @@ module Fat32
     'S',  'reserved2',  # Reserved.
     'a4', 'name3'       # UNICODE chars 12-13 of name.
   ])
-  
+
   CHARS_PER_LFN   = 13
   LFN_NAME_MAXLEN = 260
   DIR_ENT_SIZE    = 32
   ATTRIB_OFFSET   = 11
-  
+
   # ////////////////////////////////////////////////////////////////////////////
   # // Class.
 
   class DirectoryEntry
-    
+
     # From the UTF-8 perspective.
     # LFN name components: entry hash name, char offset, length.
     LFN_NAME_COMPONENTS = [
@@ -61,19 +61,19 @@ module Fat32
     LFN_NC_HASHNAME = 0
     LFN_NC_OFFSET   = 1
     LFN_NC_LENGTH   = 2
-    
+
     # SFN failure cases.
     SFN_NAME_LENGTH   = 1
     SFN_EXT_LENGTH    = 2
     SFN_NAME_NULL     = 3
     SFN_NAME_DEVICE   = 4
     SFN_ILLEGAL_CHARS = 5
-    
+
     # LFN failure cases.
     LFN_NAME_LENGTH   = 1
     LFN_NAME_DEVICE   = 2
     LFN_ILLEGAL_CHARS = 3
-    
+
     # FileAttributes
     FA_READONLY   = 0x01
     FA_HIDDEN     = 0x02
@@ -82,7 +82,7 @@ module Fat32
     FA_DIRECTORY  = 0x10
     FA_ARCHIVE    = 0x20
     FA_LFN        = 0x0f
-    
+
     # DOS time masks.
     MSK_DAY   = 0x001f  # Range: 1 - 31
     MSK_MONTH = 0x01e0  # Right shift 5, Range: 1 - 12
@@ -90,18 +90,18 @@ module Fat32
     MSK_SEC   = 0x001f  # Range: 0 - 29 WARNING: 2 second granularity on this.
     MSK_MIN   = 0x07e0  # Right shift 5, Range: 0 - 59
     MSK_HOUR  = 0xf800  # Right shift 11, Range: 0 - 23
-    
+
     # AllocationFlags
     AF_NOT_ALLOCATED  = 0x00
     AF_DELETED        = 0xe5
     AF_LFN_LAST       = 0x40
-    
+
     # Members.
     attr_reader :unused, :name, :dirty
     attr_accessor :parentCluster, :parentOffset
     # NOTE: Directory is responsible for setting parent.
     # These describe the cluster & offset of the START of the directory entry.
-    
+
     # Initialization
     def initialize(buf = nil)
       # Create for write.
@@ -109,7 +109,7 @@ module Fat32
         self.create
         return
       end
-      
+
       # Handle possibly multiple LFN records.
       data = StringIO.new(buf); @lfn_ents = []
       checksum = 0; @name = ""
@@ -119,12 +119,12 @@ module Fat32
           @unused = ""
           return
         end
-        
+
         # If attribute contains 0x0f then LFN entry.
         isLfn = buf[ATTRIB_OFFSET] == FA_LFN
         @dir_ent = isLfn ? DIR_ENT_LFN.decode(buf) : DIR_ENT_SFN.decode(buf)
         break if !isLfn
-        
+
         # Ignore this entry if deleted or not allocated.
         af = @dir_ent['seq_num']
         if af == AF_DELETED || af == AF_NOT_ALLOCATED
@@ -132,19 +132,19 @@ module Fat32
           @unused = data.read()
           return
         end
-        
+
         # Set checksum or make sure it's the same
         checksum = @dir_ent['checksum'] if checksum == 0
         raise "Directory entry LFN checksum mismatch." if @dir_ent['checksum'] != checksum
-        
+
         # Track LFN entry, gather names & prepend to name.
         @lfn_ents << @dir_ent
         @name = getLongNameFromEntry(@dir_ent) + @name
       end #LFN loop
-      
+
       # Push the rest of the data back.
       @unused = data.read()
-      
+
       # If this is the last record of an LFN chain, check the checksum.
       if checksum != 0
         csum = calcChecksum
@@ -156,7 +156,7 @@ module Fat32
           raise "Checksum error"
         end
       end
-      
+
       # Populate name if not LFN.
       if @name == "" && !@dir_ent['name'].empty?
         @name = @dir_ent['name'][0, 8].strip
@@ -167,21 +167,21 @@ module Fat32
 
     # ////////////////////////////////////////////////////////////////////////////
     # // Class helpers & accessors.
-    
+
     # Return this entry as a raw string.
     def raw
       out = ""
       @lfn_ents.each {|ent| out += BinaryStruct.encode(ent, DIR_ENT_LFN)} if @lfn_ents
       out += BinaryStruct.encode(@dir_ent, DIR_ENT_SFN)
     end
-    
+
     # Number of dir ent structures (both sfn and lfn).
     def numEnts
       num = 1
       num += @lfn_ents.size if @lfn_ents
       return num
     end
-    
+
     # Return normalized 8.3 name.
     def shortName
       name = @dir_ent['name'][0, 8].strip
@@ -189,7 +189,7 @@ module Fat32
       name += "." + ext if ext != ""
       return name
     end
-    
+
     # Construct & return long name from lfn entries.
     def longName
       return nil if @lfn_ents == nil
@@ -197,7 +197,7 @@ module Fat32
       @lfn_ents.reverse.each {|ent| name += getLongNameFromEntry(ent)}
       return name
     end
-    
+
     # WRITE: change filename.
     def name=(filename)
       @dirty = true
@@ -215,17 +215,17 @@ module Fat32
         @name = filename
       end
     end
-    
+
     # WRITE: change magic number.
     def magic=(magic)
       @dirty = true
       @dir_ent['reserved1'] = magic
     end
-    
+
     def magic
       return @dir_ent['reserved1']
     end
-    
+
     # WRITE: change attribs.
     def setAttribute(attrib, set = true)
       @dirty = true
@@ -235,27 +235,27 @@ module Fat32
         @dir_ent['attributes'] &= (~attrib)
       end
     end
-    
+
     # WRITE: change length.
     def length=(len)
       @dirty = true
       @dir_ent['file_size'] = len
     end
-    
+
     # WRITE: change first cluster.
     def firstCluster=(first_clus)
       @dirty = true
       @dir_ent['first_clus_hi'] = (first_clus >> 16)
       @dir_ent['first_clus_lo'] = (first_clus & 0xffff)
     end
-    
+
     # WRITE: change access time.
     def aTime=(tim)
       @dirty = true
       time, day = rubyToDosTime(tim)
       @dir_ent['atime_day'] = day
     end
-    
+
     # To support root dir times (all zero).
     def zeroTime
       @dirty = true
@@ -263,13 +263,13 @@ module Fat32
       @dir_ent['ctime_tos'] = 0; @dir_ent['ctime_hms'] = 0; @dir_ent['ctime_day'] = 0
       @dir_ent['mtime_hms'] = 0; @dir_ent['mtime_day'] = 0
     end
-    
+
     # WRITE: change modified (written) time.
     def mTime=(tim)
       @dirty = true
       @dir_ent['mtime_hms'], @dir_ent['mtime_day'] = rubyToDosTime(tim)
     end
-    
+
     # WRITE: write or rewrite directory entry.
     def writeEntry(bs)
       return if not @dirty
@@ -290,7 +290,7 @@ module Fat32
       bs.putCluster(cluster, buf)
       @dirty = false
     end
-    
+
     # WRITE: delete file.
     def delete(bs)
       # Deallocate data chain.
@@ -301,43 +301,43 @@ module Fat32
       @dirty = true
       self.writeEntry(bs)
     end
-    
+
     def close(bs)
       writeEntry(bs) if @dirty
     end
-    
+
     def attributes
       return @dir_ent['attributes']
     end
-    
+
     def length
       return @dir_ent['file_size']
     end
-    
+
     def firstCluster
       return (@dir_ent['first_clus_hi'] << 16) + @dir_ent['first_clus_lo']
     end
-    
+
     def isDir?
       return true if @dir_ent['attributes'] & FA_DIRECTORY == FA_DIRECTORY
       return false
     end
-    
+
     def mTime
       return dosToRubyTime(@dir_ent['mtime_day'], @dir_ent['mtime_hms'])
     end
-    
+
     def aTime
       return dosToRubyTime(@dir_ent['atime_day'], 0)
     end
-    
+
     def cTime
       return dosToRubyTime(@dir_ent['ctime_day'], @dir_ent['ctime_hms'])
     end
-        
+
     # ////////////////////////////////////////////////////////////////////////////
     # // Utility functions.
-    
+
     def getLongNameFromEntry(ent)
       pre_name = ""; hashNames = %w(name name2 name3)
       hashNames.each {|name|
@@ -351,7 +351,7 @@ module Fat32
       }
       return pre_name
     end
-    
+
     def incShortName
       @dirty = true
       num = @dir_ent['name'][7].to_i
@@ -363,7 +363,7 @@ module Fat32
         @lfn_ents.each {|ent| ent['checksum'] = csum}
       end
     end
-    
+
     def create
       @dirty = true
       @dir_ent = Hash.new
@@ -377,7 +377,7 @@ module Fat32
       # Must fill all members or BinaryStruct.encode fails.
       self.magic = 0x00; self.length = 0; self.firstCluster = 0 #magic used to be 0x18
     end
-    
+
     def mkLongName(name)
       @lfn_ents = mkLfn(name)
       @dir_ent['name'] = mkSfn(name)
@@ -387,7 +387,7 @@ module Fat32
       csum = calcChecksum()
       @lfn_ents.each {|ent| ent['checksum'] = csum}
     end
-    
+
     def mkLfn(name)
       name = mkLegalLfn(name)
       lfn_ents = []
@@ -420,11 +420,11 @@ module Fat32
       lfn_ents[0]['seq_num'] |= AF_LFN_LAST
       return lfn_ents
     end
-    
+
     def mkSfn(name)
       return mkLegalSfn(name)
     end
-    
+
     def isIllegalSfn(name)
       # Check: name length, extension length, NULL file name,
       # device names as file names & illegal chars.
@@ -437,14 +437,14 @@ module Fat32
       return SFN_ILLEGAL_CHARS if name.index(/[;+=\[\]',\"*\\<>\/?\:|]/) != nil
       return false
     end
-    
+
     def checkForDeviceName(fn)
       %w[aux com1 com2 com3 com4 lpt lpt1 lpt2 lpt3 lpt4 mailslot nul pipe prn].each {|bad|
         return true if fn == bad
       }
       return false
     end
-    
+
     def mkLegalSfn(name)
       name = name.upcase; name = name.delete(" ")
       name = name + "." if not name.include?(".")
@@ -454,18 +454,18 @@ module Fat32
       fn = fn[0, 6] + "~1" if fn.length > 8
       return (fn.ljust(8) + ext.ljust(3)).gsub(/[;+=\[\]',\"*\\<>\/?\:|]/, "_")
     end
-    
+
     def isIllegalLfn(name)
       return LFN_NAME_LENGTH if name.length > LFN_NAME_MAXLEN
       return LFN_ILLEGAL_CHARS if name.index(/\/\\:><?/) != nil
       return false
     end
-    
+
     def mkLegalLfn(name)
       name = name[0...LFN_NAME_MAXLEN] if name.length > LFN_NAME_MAXLEN
       return name.gsub(/\/\\:><?/, "_")
     end
-    
+
     def calcChecksum
       name = @dir_ent['name']; csum = 0
       0.upto(10) {|i|
@@ -473,7 +473,7 @@ module Fat32
       }
       return csum
     end
-    
+
     def dosToRubyTime(dos_day, dos_time)
       # Extract d,m,y,s,m,h & range check.
       day = dos_day & MSK_DAY; day = 1 if day == 0
@@ -487,7 +487,7 @@ module Fat32
       # Make a Ruby time.
       return Time.mktime(year, month, day, hour, min, sec)
     end
-    
+
     def rubyToDosTime(tim)
       # Time
       sec = tim.sec; sec -= 1 if sec == 60 #correction for possible leap second.
@@ -501,7 +501,7 @@ module Fat32
       dos_day = (year << 9) + (month << 5) + day
       return dos_time, dos_day
     end
-    
+
     # Dump object.
     def dump
       out = "\#<#{self.class}:0x#{'%08x' % self.object_id}>\n"
@@ -535,6 +535,6 @@ module Fat32
       out += "First clus lo: 0x#{'%04x' % @dir_ent['first_clus_lo']}\n"
       out += "File size    : 0x#{'%08x' % @dir_ent['file_size']}\n"
     end
-    
+
   end
 end # module Fat32

--- a/lib/fs/fat32/directory_entry.rb
+++ b/lib/fs/fat32/directory_entry.rb
@@ -12,7 +12,7 @@ require 'miq_unicode'
 # (which yields uppercase names on XP).
 
 module Fat32
-  using ManageIQ
+  using ManageIQ::UnicodeString
 
   DIR_ENT_SFN = BinaryStruct.new([
     'a11',  'name',         # If name[0] = 0, unallocated; if name[0] = 0xe5, deleted. DOES NOT INCLUDE DOT.

--- a/lib/fs/iso9660/boot_sector.rb
+++ b/lib/fs/iso9660/boot_sector.rb
@@ -5,7 +5,7 @@ require 'miq_unicode'
 
 module Iso9660
   class BootSector
-    using ManageIQ
+    using ManageIQ::UnicodeString
 
     # Universal Volume Descriptor ID.
     DESCRIPTOR_ID = "CD001"

--- a/lib/fs/iso9660/boot_sector.rb
+++ b/lib/fs/iso9660/boot_sector.rb
@@ -1,11 +1,12 @@
 require 'fs/iso9660/util'
-
 require 'sys-uname'
 require 'binary_struct'
-require 'util/miq-unicode'
+require 'miq_unicode'
 
 module Iso9660
   class BootSector
+    using ManageIQ
+
     # Universal Volume Descriptor ID.
     DESCRIPTOR_ID = "CD001"
 

--- a/lib/fs/iso9660/directory_entry.rb
+++ b/lib/fs/iso9660/directory_entry.rb
@@ -4,7 +4,7 @@ require 'binary_struct'
 require 'miq_unicode'
 
 module Iso9660
-  using ManageIQ
+  using ManageIQ::UnicodeString
 
   # FlagBits: FB_
   FB_HIDDEN     = 0x01  # 0 if not hidden.

--- a/lib/fs/iso9660/directory_entry.rb
+++ b/lib/fs/iso9660/directory_entry.rb
@@ -1,10 +1,11 @@
 require 'fs/iso9660/util'
 require 'fs/iso9660/rock_ridge'
-
 require 'binary_struct'
-require 'util/miq-unicode'
+require 'miq_unicode'
 
 module Iso9660
+  using ManageIQ
+
   # FlagBits: FB_
   FB_HIDDEN     = 0x01  # 0 if not hidden.
   FB_DIRECTORY  = 0x02  # 0 if file.

--- a/lib/fs/iso9660/rock_ridge.rb
+++ b/lib/fs/iso9660/rock_ridge.rb
@@ -1,7 +1,9 @@
 require 'binary_struct'
-require 'util/miq-unicode'
+require 'miq_unicode'
 
 module Iso9660
+  using ManageIQ
+
   # SUSP extensions are present if the first two characters of the SUA of
   # the first directory entry are "SP". After SUSP is identified, if the
   # first two characters of any directory entry's SUA are "RR" a Rock Ridge

--- a/lib/fs/iso9660/rock_ridge.rb
+++ b/lib/fs/iso9660/rock_ridge.rb
@@ -2,7 +2,7 @@ require 'binary_struct'
 require 'miq_unicode'
 
 module Iso9660
-  using ManageIQ
+  using ManageIQ::UnicodeString
 
   # SUSP extensions are present if the first two characters of the SUA of
   # the first directory entry are "SP". After SUSP is identified, if the

--- a/lib/fs/ntfs/attrib_attribute_list.rb
+++ b/lib/fs/ntfs/attrib_attribute_list.rb
@@ -3,7 +3,7 @@ require 'binary_struct'
 require 'miq_unicode'
 
 module NTFS
-  using ManageIQ
+  using ManageIQ::UnicodeString
 
   #
   # ATTR_LIST_ENTRY - Attribute: Attribute list (0x20).

--- a/lib/fs/ntfs/attrib_attribute_list.rb
+++ b/lib/fs/ntfs/attrib_attribute_list.rb
@@ -1,8 +1,10 @@
 require 'fs/ntfs/utils'
 require 'binary_struct'
-require 'util/miq-unicode'
+require 'miq_unicode'
 
 module NTFS
+  using ManageIQ
+
   #
   # ATTR_LIST_ENTRY - Attribute: Attribute list (0x20).
   #

--- a/lib/fs/ntfs/attrib_file_name.rb
+++ b/lib/fs/ntfs/attrib_file_name.rb
@@ -1,10 +1,12 @@
 require 'fs/ntfs/utils'
 require 'util/win32/nt_util'
 require 'binary_struct'
-require 'util/miq-unicode'
+require 'miq_unicode'
 require 'fs/ntfs/attrib_standard_information'
 
 module NTFS
+  using ManageIQ
+
   #
   # FILE_NAME_ATTR - Attribute: Filename (0x30)
   #

--- a/lib/fs/ntfs/attrib_file_name.rb
+++ b/lib/fs/ntfs/attrib_file_name.rb
@@ -5,7 +5,7 @@ require 'miq_unicode'
 require 'fs/ntfs/attrib_standard_information'
 
 module NTFS
-  using ManageIQ
+  using ManageIQ::UnicodeString
 
   #
   # FILE_NAME_ATTR - Attribute: Filename (0x30)

--- a/lib/fs/ntfs/attrib_header.rb
+++ b/lib/fs/ntfs/attrib_header.rb
@@ -4,7 +4,7 @@ require 'fs/ntfs/utils'
 require 'fs/ntfs/attrib_type'
 
 module NTFS
-  using ManageIQ
+  using ManageIQ::UnicodeString
 
   # Standard attribute header.
   # Each attribute begins with one of these.

--- a/lib/fs/ntfs/attrib_header.rb
+++ b/lib/fs/ntfs/attrib_header.rb
@@ -1,9 +1,11 @@
 require 'binary_struct'
-require 'util/miq-unicode'
+require 'miq_unicode'
 require 'fs/ntfs/utils'
 require 'fs/ntfs/attrib_type'
 
 module NTFS
+  using ManageIQ
+
   # Standard attribute header.
   # Each attribute begins with one of these.
   STANDARD_ATTRIBUTE_HEADER = BinaryStruct.new([

--- a/lib/fs/ntfs/attrib_index_root.rb
+++ b/lib/fs/ntfs/attrib_index_root.rb
@@ -1,10 +1,12 @@
 require 'binary_struct'
-require 'util/miq-unicode'
+require 'miq_unicode'
 require 'fs/ntfs/index_node_header'
 require 'fs/ntfs/directory_index_node'
 require 'fs/ntfs/index_record_header'
 
 module NTFS
+  using ManageIQ
+
   #
   # INDEX_ROOT - Attribute: Index root (0x90).
   #

--- a/lib/fs/ntfs/attrib_index_root.rb
+++ b/lib/fs/ntfs/attrib_index_root.rb
@@ -5,7 +5,7 @@ require 'fs/ntfs/directory_index_node'
 require 'fs/ntfs/index_record_header'
 
 module NTFS
-  using ManageIQ
+  using ManageIQ::UnicodeString
 
   #
   # INDEX_ROOT - Attribute: Index root (0x90).

--- a/lib/fs/ntfs/attrib_volume_name.rb
+++ b/lib/fs/ntfs/attrib_volume_name.rb
@@ -1,7 +1,7 @@
 require 'miq_unicode'
 
 module NTFS
-  using ManageIQ
+  using ManageIQ::UnicodeString
 
   #
   # VOLUME_NAME - Attribute: Volume name (0x60).

--- a/lib/fs/ntfs/attrib_volume_name.rb
+++ b/lib/fs/ntfs/attrib_volume_name.rb
@@ -1,6 +1,8 @@
-require 'util/miq-unicode'
+require 'miq_unicode'
 
 module NTFS
+  using ManageIQ
+
   #
   # VOLUME_NAME - Attribute: Volume name (0x60).
   #

--- a/lib/metadata/VmConfig/VmConfig.rb
+++ b/lib/metadata/VmConfig/VmConfig.rb
@@ -8,7 +8,7 @@ require 'util/miq-extensions'
 require 'VMwareWebService/MiqVimBroker'
 
 class VmConfig
-  using ManageIQ
+  using ManageIQ::UnicodeString
 
   attr_reader :configFile
 

--- a/lib/metadata/VmConfig/VmConfig.rb
+++ b/lib/metadata/VmConfig/VmConfig.rb
@@ -1,6 +1,6 @@
 require 'pathname'
 require 'metadata/VMMount/VMMount'
-require 'util/miq-unicode'
+require 'miq_unicode'
 require 'util/miq-xml'
 require 'VMwareWebService/MiqVimInventory'
 require 'timeout'
@@ -8,6 +8,8 @@ require 'util/miq-extensions'
 require 'VMwareWebService/MiqVimBroker'
 
 class VmConfig
+  using ManageIQ
+
   attr_reader :configFile
 
   def initialize(filename)

--- a/lib/metadata/linux/MiqRpmPackages.rb
+++ b/lib/metadata/linux/MiqRpmPackages.rb
@@ -6,7 +6,7 @@ require 'miq_unicode'
 # RPM Specification located at: http://jrpm.sourceforge.net/rpmspec/index.html
 
 class MiqRpmPackages
-  using ManageIQ
+  using ManageIQ::UnicodeString
 
   #
   # The data types we support.

--- a/lib/metadata/linux/MiqRpmPackages.rb
+++ b/lib/metadata/linux/MiqRpmPackages.rb
@@ -1,11 +1,13 @@
 require 'binary_struct'
 require 'util/miq-hash_struct'
 require 'db/MiqBdb/MiqBdb'
-require 'util/miq-unicode'
+require 'miq_unicode'
 
 # RPM Specification located at: http://jrpm.sourceforge.net/rpmspec/index.html
 
 class MiqRpmPackages
+  using ManageIQ
+
   #
   # The data types we support.
   #

--- a/lib/metadata/util/win32/Win32EventLog.rb
+++ b/lib/metadata/util/win32/Win32EventLog.rb
@@ -26,7 +26,7 @@ require 'util/miq-exception'
 require 'metadata/util/event_log_filter'
 
 class Win32EventLog
-  using ManageIQ
+  using ManageIQ::UnicodeString
 
   # Standard file log names
   SYSTEM_LOGS = %w(Application System Security)

--- a/lib/metadata/util/win32/Win32EventLog.rb
+++ b/lib/metadata/util/win32/Win32EventLog.rb
@@ -19,13 +19,15 @@ require 'digest/md5'
 
 # Common utilities.
 require 'binary_struct'
-require 'util/miq-unicode'
+require 'miq_unicode'
 require 'util/miq-xml'
 require 'util/miq-exception'
 
 require 'metadata/util/event_log_filter'
 
 class Win32EventLog
+  using ManageIQ
+
   # Standard file log names
   SYSTEM_LOGS = %w(Application System Security)
   BUFFER_READ_SIZE = 10485760  # 10 MB buffer

--- a/lib/metadata/util/win32/ms-registry.rb
+++ b/lib/metadata/util/win32/ms-registry.rb
@@ -13,7 +13,7 @@ DEBUG_LOG_PERFORMANCE = false
 DEBUG_FILE_READS = false
 
 class MSRegHive
-  using ManageIQ
+  using ManageIQ::UnicodeString
 
   attr_reader :fileLoadTime, :fileParseTime, :digitalProductKeys, :xmlNode
 

--- a/lib/metadata/util/win32/ms-registry.rb
+++ b/lib/metadata/util/win32/ms-registry.rb
@@ -1,7 +1,7 @@
 # encoding: US-ASCII
 
 require 'binary_struct'
-require 'util/miq-unicode'
+require 'miq_unicode'
 require 'enumerator'
 require 'util/miq-xml'
 require 'util/xml/xml_hash'
@@ -13,6 +13,8 @@ DEBUG_LOG_PERFORMANCE = false
 DEBUG_FILE_READS = false
 
 class MSRegHive
+  using ManageIQ
+
   attr_reader :fileLoadTime, :fileParseTime, :digitalProductKeys, :xmlNode
 
   # Size of the HBIN data (as well as initiale REGF) segments

--- a/lib/metadata/util/win32/peheader.rb
+++ b/lib/metadata/util/win32/peheader.rb
@@ -11,7 +11,7 @@ require 'miq_unicode'
 #       to open them and display each resolution contained in the icon (if more than one).
 
 class PEheader
-  using ManageIQ
+  using ManageIQ::UnicodeString
 
   IMAGE_NT_SIGNATURE = "PE\0\0"
   IMAGE_DOS_SIGNATURE = "MZ"

--- a/lib/metadata/util/win32/peheader.rb
+++ b/lib/metadata/util/win32/peheader.rb
@@ -1,9 +1,8 @@
 # encoding: US-ASCII
 
 require 'stringio'
-
 require 'binary_struct'
-require 'util/miq-unicode'
+require 'miq_unicode'
 
 # Notes:
 #       The peheader object member 'icons' is an array of icons in the file. Sub 0 is the application
@@ -12,6 +11,8 @@ require 'util/miq-unicode'
 #       to open them and display each resolution contained in the icon (if more than one).
 
 class PEheader
+  using ManageIQ
+
   IMAGE_NT_SIGNATURE = "PE\0\0"
   IMAGE_DOS_SIGNATURE = "MZ"
 

--- a/lib/miq_unicode.rb
+++ b/lib/miq_unicode.rb
@@ -1,43 +1,45 @@
 module ManageIQ
-  refine String do
-    def UnicodeToUtf8
-      dup.force_encoding("UTF-16LE").encode("UTF-8")
-    end
+  module UnicodeString
+    refine String do
+      def UnicodeToUtf8
+        dup.force_encoding("UTF-16LE").encode("UTF-8")
+      end
 
-    def UnicodeToUtf8!
-      force_encoding("UTF-16LE").encode!("UTF-8")
-    end
+      def UnicodeToUtf8!
+        force_encoding("UTF-16LE").encode!("UTF-8")
+      end
 
-    def Utf8ToUnicode
-      dup.force_encoding("UTF-8").encode("UTF-16LE")
-    end
+      def Utf8ToUnicode
+        dup.force_encoding("UTF-8").encode("UTF-16LE")
+      end
 
-    def Utf8ToUnicode!
-      force_encoding("UTF-8").encode!("UTF-16LE")
-    end
+      def Utf8ToUnicode!
+        force_encoding("UTF-8").encode!("UTF-16LE")
+      end
 
-    def AsciiToUtf8
-      dup.force_encoding("ISO-8859-1").encode("UTF-8")
-    end
+      def AsciiToUtf8
+        dup.force_encoding("ISO-8859-1").encode("UTF-8")
+      end
 
-    def AsciiToUtf8!
-      force_encoding("ISO-8859-1").encode!("UTF-8")
-    end
+      def AsciiToUtf8!
+        force_encoding("ISO-8859-1").encode!("UTF-8")
+      end
 
-    def Utf8ToAscii
-      dup.force_encoding("UTF-8").encode("ISO-8859-1")
-    end
+      def Utf8ToAscii
+        dup.force_encoding("UTF-8").encode("ISO-8859-1")
+      end
 
-    def Utf8ToAscii!
-      force_encoding("UTF-8").encode!("ISO-8859-1")
-    end
+      def Utf8ToAscii!
+        force_encoding("UTF-8").encode!("ISO-8859-1")
+      end
 
-    def Ucs2ToAscii
-      dup.force_encoding("UTF-16LE").encode("ISO-8859-1")
-    end
+      def Ucs2ToAscii
+        dup.force_encoding("UTF-16LE").encode("ISO-8859-1")
+      end
 
-    def Ucs2ToAscii!
-      force_encoding("UTF-16LE").encode!("ISO-8859-1")
+      def Ucs2ToAscii!
+        force_encoding("UTF-16LE").encode!("ISO-8859-1")
+      end
     end
   end
 end

--- a/lib/miq_unicode.rb
+++ b/lib/miq_unicode.rb
@@ -2,7 +2,7 @@ module ManageIQ
   module UnicodeString
     refine String do
       def UnicodeToUtf8
-        dup.force_encoding("UTF-16LE").encode("UTF-8")
+        dup.UnicodeToUtf8!
       end
 
       def UnicodeToUtf8!
@@ -10,7 +10,7 @@ module ManageIQ
       end
 
       def Utf8ToUnicode
-        dup.force_encoding("UTF-8").encode("UTF-16LE")
+        dup.Utf8ToUnicode!
       end
 
       def Utf8ToUnicode!
@@ -18,7 +18,7 @@ module ManageIQ
       end
 
       def AsciiToUtf8
-        dup.force_encoding("ISO-8859-1").encode("UTF-8")
+        dup.AsciiToUtf8!
       end
 
       def AsciiToUtf8!
@@ -26,7 +26,7 @@ module ManageIQ
       end
 
       def Utf8ToAscii
-        dup.force_encoding("UTF-8").encode("ISO-8859-1")
+        dup.Utf8ToAscii!
       end
 
       def Utf8ToAscii!
@@ -34,7 +34,7 @@ module ManageIQ
       end
 
       def Ucs2ToAscii
-        dup.force_encoding("UTF-16LE").encode("ISO-8859-1")
+        dup.Ucs2ToAscii!
       end
 
       def Ucs2ToAscii!

--- a/lib/miq_unicode.rb
+++ b/lib/miq_unicode.rb
@@ -1,0 +1,43 @@
+module ManageIQ
+  refine String do
+    def UnicodeToUtf8
+      dup.force_encoding("UTF-16LE").encode("UTF-8")
+    end
+
+    def UnicodeToUtf8!
+      force_encoding("UTF-16LE").encode!("UTF-8")
+    end
+
+    def Utf8ToUnicode
+      dup.force_encoding("UTF-8").encode("UTF-16LE")
+    end
+
+    def Utf8ToUnicode!
+      force_encoding("UTF-8").encode!("UTF-16LE")
+    end
+
+    def AsciiToUtf8
+      dup.force_encoding("ISO-8859-1").encode("UTF-8")
+    end
+
+    def AsciiToUtf8!
+      force_encoding("ISO-8859-1").encode!("UTF-8")
+    end
+
+    def Utf8ToAscii
+      dup.force_encoding("UTF-8").encode("ISO-8859-1")
+    end
+
+    def Utf8ToAscii!
+      force_encoding("UTF-8").encode!("ISO-8859-1")
+    end
+
+    def Ucs2ToAscii
+      dup.force_encoding("UTF-16LE").encode("ISO-8859-1")
+    end
+
+    def Ucs2ToAscii!
+      force_encoding("UTF-16LE").encode!("ISO-8859-1")
+    end
+  end
+end

--- a/spec/miq_unicode_spec.rb
+++ b/spec/miq_unicode_spec.rb
@@ -1,0 +1,95 @@
+require 'miq_unicode'
+
+describe 'miq_unicode' do
+  using ManageIQ::UnicodeString
+
+  context "with Unicode and UTF-8 data" do
+    before(:each) do
+      @unicode_str = "S\000Y\000S\000T\000E\000M\000\000\000\000\000\000\000"
+      @utf8_str    = "SYSTEM\000\000\000"
+
+      @unicode_str.force_encoding("UTF-16LE")
+      @utf8_str.force_encoding("UTF-8")
+    end
+
+    it '.UnicodeToUtf8' do
+      converted_utf8 = @unicode_str.UnicodeToUtf8
+      expect(converted_utf8.object_id).not_to eq(@unicode_str.object_id)
+      expect(converted_utf8).to eq(@utf8_str)
+    end
+
+    it '.UnicodeToUtf8!' do
+      converted_utf8 = @unicode_str.UnicodeToUtf8!
+      expect(converted_utf8.object_id).to eq(@unicode_str.object_id)
+      expect(converted_utf8).to eq(@utf8_str)
+    end
+
+    it '.Utf8ToUnicode' do
+      converted_unicode = @utf8_str.Utf8ToUnicode
+      expect(converted_unicode.object_id).not_to eq(@utf8_str.object_id)
+      expect(converted_unicode).to eq(@unicode_str)
+    end
+
+    it '.Utf8ToUnicode!' do
+      converted_unicode = @utf8_str.Utf8ToUnicode!
+      expect(converted_unicode.object_id).to eq(@utf8_str.object_id)
+      expect(converted_unicode).to eq(@unicode_str)
+    end
+  end
+
+  context "with UTF-8 and ASCII data" do
+    before(:each) do
+      @utf8_str  = "123\303\245456"
+      @ascii_str = "123\345456"
+
+      @utf8_str.force_encoding("UTF-8")
+      @ascii_str.force_encoding("ISO-8859-1")
+    end
+
+    it '.AsciiToUtf8' do
+      converted_utf8 = @ascii_str.AsciiToUtf8
+      expect(converted_utf8.object_id).not_to eq(@ascii_str.object_id)
+      expect(converted_utf8).to eq(@utf8_str)
+    end
+
+    it '.AsciiToUtf8!' do
+      converted_utf8 = @ascii_str.AsciiToUtf8!
+      expect(converted_utf8.object_id).to eq(@ascii_str.object_id)
+      expect(converted_utf8).to eq(@utf8_str)
+    end
+
+    it '.Utf8ToAscii' do
+      converted_ascii = @utf8_str.Utf8ToAscii
+      expect(converted_ascii.object_id).not_to eq(@utf8_str.object_id)
+      expect(converted_ascii).to eq(@ascii_str)
+    end
+
+    it '.Utf8ToAscii!' do
+      converted_ascii = @utf8_str.Utf8ToAscii!
+      expect(converted_ascii.object_id).to eq(@utf8_str.object_id)
+      expect(converted_ascii).to eq(@ascii_str)
+    end
+  end
+
+  context "with ASCII and UCS-2 data" do
+    before(:each) do
+      @ucs2_str  = "1\000.\0008\000.\0007\000"
+      @ascii_str = "1.8.7"
+
+      @ucs2_str.force_encoding("UTF-16LE")
+      @ascii_str.force_encoding("ISO-8859-1")
+    end
+
+    it '.Ucs2ToAscii' do
+      converted_ascii = @ucs2_str.Ucs2ToAscii
+      expect(converted_ascii.object_id).not_to eq(@ucs2_str.object_id)
+      expect(converted_ascii).to eq(@ascii_str)
+    end
+
+    it '.Ucs2ToAscii!' do
+      converted_ascii = @ucs2_str.Ucs2ToAscii!
+      expect(converted_ascii.object_id).to eq(@ucs2_str.object_id)
+      expect(converted_ascii).to eq(@ascii_str)
+    end
+  end
+end


### PR DESCRIPTION
This moves the methods from miq-unicode.rb from gems-pending into the smartstate repo directly. Since we're reopening a base class (String), I thought this would be a good opportunity to use Ruby's refinements. This ensures that we don't cause any entanglements with any other libraries, now or in the future.

Part of the gems-pending effort: https://github.com/ManageIQ/manageiq-gems-pending/issues/231

Note that one other repo (virtfs-ntfs) uses a few of these methods so that will have to be addressed before we can remove miq-unicode.rb from gems-pending.

The virt_disk repo uses identical methods but defines them locally.