### PR TITLE
Add explicit require statements for miq_unicode to modules that need them

### DIFF
--- a/lib/metadata/VmConfig/cfgConfig.rb
+++ b/lib/metadata/VmConfig/cfgConfig.rb
@@ -1,4 +1,8 @@
+require 'miq_unicode'
+
 module CfgConfig
+  using ManageIQ::UnicodeString
+
   def convert(filename)
     @convertText = ""
     $log.debug "Processing Windows Configuration file [#{filename}]"

--- a/lib/metadata/util/win32/Win32Accounts.rb
+++ b/lib/metadata/util/win32/Win32Accounts.rb
@@ -2,8 +2,11 @@
 
 require 'util/miq-xml'
 require 'enumerator'
+require 'miq_unicode'
 
 module MiqWin32
+  using ManageIQ::UnicodeString
+
   class Accounts
     attr_reader :users, :groups
 


### PR DESCRIPTION
Add explicit require's to modules that need them.

A couple other places where these methods are used are already picked up via MSCommon.rb.

Followup to https://github.com/ManageIQ/manageiq-smartstate/pull/149