### PR TITLE
Remove gems-pending runcmd references in favor of AwesomeSpawn

### DIFF
--- a/lib/VmLocalDiskAccess/test/localCfg.rb
+++ b/lib/VmLocalDiskAccess/test/localCfg.rb
@@ -1,14 +1,12 @@
 require 'util/miq-xml'
-require 'util/runcmd'
 require 'metadata/VmConfig/VmConfig'
 require 'VolumeManager/MiqNativeVolumeManager'
 require 'fs/MiqMountManager'
+require 'awesome_spawn'
 
 module MiqNativeMountManager
-  LSHW = "lshw"
-
   def self.mountVolumes
-    lshwXml = MiqUtil.runcmd("#{LSHW} -xml")
+    lshwXml = AwesomeSpawn.run!("lshw", :params => ["-xml"], :combined_output => true).output
     nodeHash = Hash.new { |h, k| h[k] = [] }
     doc = MiqXml.load(lshwXml)
     doc.find_match("//node").each { |n| nodeHash[n.attributes["id"].split(':', 2)[0]] << n }

--- a/lib/metadata/VmConfig/GetNativeCfg.rb
+++ b/lib/metadata/VmConfig/GetNativeCfg.rb
@@ -1,12 +1,10 @@
 require 'util/miq-xml'
-require 'util/runcmd'
 require 'metadata/VmConfig/VmConfig'
+require 'awesome_spawn'
 
 class GetNativeCfg
-  LSHW = "lshw"
-
   def self.new
-    lshwXml = MiqUtil.runcmd("#{LSHW} -xml")
+    lshwXml = AwesomeSpawn.run!("lshw", :params => ["-xml"], :combined_output => true).output
     nodeHash = Hash.new { |h, k| h[k] = [] }
     doc = MiqXml.load(lshwXml)
     doc.find_match("//node").each { |n| nodeHash[n.attributes["id"].split(':', 2)[0]] << n }

--- a/lib/metadata/VmConfig/xmlConfig.rb
+++ b/lib/metadata/VmConfig/xmlConfig.rb
@@ -1,5 +1,5 @@
 require 'util/miq-xml'
-require 'util/runcmd'
+require 'awesome_spawn'
 
 module XmlConfig
   def convert(filename)
@@ -12,9 +12,9 @@ module XmlConfig
       if Sys::Platform::IMPL == :linux
         begin
           # First check to see if the command is available
-          MiqUtil.runcmd("virsh list")
+          AwesomeSpawn.run!("virsh", :params => ["list"])
           begin
-            xml_data = MiqUtil.runcmd("virsh dumpxml #{File.basename(filename, ".*")}")
+            xml_data = AwesomeSpawn.run!("virsh", :params => ["dumpxml", File.basename(filename, ".*")], :combined_output => true).output
           rescue => err
             $log.error "#{err}\n#{err.backtrace.join("\n")}"
           end

--- a/manageiq-smartstate.gemspec
+++ b/manageiq-smartstate.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "activesupport"
+  spec.add_dependency "awesome_spawn",      "~> 1.5"
   spec.add_dependency "azure-armrest",      "~> 0.9"
   spec.add_dependency "binary_struct",      "~> 2.1"
   spec.add_dependency "iniparse"


### PR DESCRIPTION
This removes another dependency on gems-pending.

@chessbyte Please review.

For reference, this is the source of runcmd for comparison... https://github.com/ManageIQ/manageiq-gems-pending/blob/f984beaecc995a311d2f6e4b59cb57feb7003d75/lib/gems/pending/util/runcmd.rb#L3-L19