### PR TITLE
Drop the useless MiqVimBroker require

### DIFF
--- a/lib/metadata/MIQExtract/MIQExtract.rb
+++ b/lib/metadata/MIQExtract/MIQExtract.rb
@@ -16,7 +16,6 @@ require 'metadata/ScanProfile/VmScanProfiles'
 require 'VMwareWebService/MiqVim'
 require 'OpenStackExtract/MiqOpenStackVm/MiqOpenStackImage'
 require 'OpenStackExtract/MiqOpenStackVm/MiqOpenStackInstance'
-require 'VMwareWebService/MiqVimBroker'
 
 class MIQExtract
   attr_reader :systemFsMsg, :systemFs, :vm

--- a/lib/metadata/VmConfig/VmConfig.rb
+++ b/lib/metadata/VmConfig/VmConfig.rb
@@ -5,7 +5,6 @@ require 'util/miq-xml'
 require 'VMwareWebService/MiqVimInventory'
 require 'timeout'
 require 'util/miq-extensions'
-require 'VMwareWebService/MiqVimBroker'
 
 class VmConfig
   using ManageIQ::UnicodeString


### PR DESCRIPTION
Usage of DRb/MiqFaultTolerantVim was removed in
d109c09d9f923ffca03ef17ce907244ce0ab6fa4 so the MiqVimBroker require is
no longer needed

https://github.com/ManageIQ/vmware_web_service/pull/101