### PR TITLE
Fix MiqTempfile initialize kwargs error

### DIFF
--- a/lib/miq_tempfile.rb
+++ b/lib/miq_tempfile.rb
@@ -5,11 +5,11 @@ class MiqTempfile < DelegateClass(Tempfile)
   # TODO: share this definition with appliance console code.
   MIQ_TMP_DIR = '/var/www/miq_tmp'.freeze
 
-  def initialize(basename, *options)
+  def initialize(basename, **options)
     if File.directory?(MIQ_TMP_DIR)
-      super(Tempfile.new(basename, MIQ_TMP_DIR, *options))
+      super(Tempfile.new(basename, MIQ_TMP_DIR, **options))
     else
-      super(Tempfile.new(basename, *options))
+      super(Tempfile.new(basename, **options))
     end
   end
 end


### PR DESCRIPTION
`Tempfile` takes a `**options` parameter which we were passing in as splat-ed positional parameters causing this error:

```
>> MiqTempfile.new("test", :encoding => 'ascii-8bit')
/usr/lib/ruby/3.1.0/tempfile.rb:134:in `initialize': wrong number of arguments (given 3, expected 0..2) (ArgumentError)
	from /home/grare/adam/src/manageiq/manageiq-smartstate/lib/miq_tempfile.rb:10:in `new'
	from /home/grare/adam/src/manageiq/manageiq-smartstate/lib/miq_tempfile.rb:10:in `initialize'
```

With this change applied:
```
>> MiqTempfile.new("test", :encoding => 'ascii-8bit')
=> #<File:/var/www/miq_tmp/test20240919-14037-7833j7>
```

https://github.com/ManageIQ/manageiq-providers-openstack/issues/890
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
