### PR TITLE
Remove Kernel.taint

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,8 @@ jobs:
         ruby-version:
         - '3.0'
         - '3.1'
+        - '3.2'
+        - '3.3'
     env:
       CC_TEST_REPORTER_ID: "${{ secrets.CC_TEST_REPORTER_ID }}"
     steps:

--- a/lib/metadata/util/find_class_methods.rb
+++ b/lib/metadata/util/find_class_methods.rb
@@ -56,12 +56,12 @@ module FindClassMethods
 
     while (file = paths.shift)
       depth = depths.shift
-      yield file.dup.taint
+      yield file.dup
       next if max_depth && depth + 1 > max_depth
 
       get_dir_entries(file).each do |f|
         f = File.join(file, f)
-        paths.unshift f.untaint
+        paths.unshift f
         depths.unshift depth + 1
       end
     end

--- a/spec/support/camcorder_helper.rb
+++ b/spec/support/camcorder_helper.rb
@@ -38,7 +38,7 @@ module Camcorder
 
   class Recorder
     def start
-      if File.exists?(filename)
+      if File.exist?(filename)
         contents = File.read(filename)
         @recordings = YAML.respond_to?(:safe_load) ? YAML.safe_load(contents, :permitted_classes => [Camcorder::Recording, Symbol]) : YAML.load(contents)
         @replaying = true

--- a/test/extract/tc_registry.rb
+++ b/test/extract/tc_registry.rb
@@ -71,7 +71,7 @@ module Extract
       refute_nil(xml.root.attributes['created_on'])
       refute_nil(xml.root.attributes['display_time'])
       assert_instance_of(String, xml.root.attributes['display_time'])
-      assert_instance_of(Fixnum, eval(xml.root.attributes['created_on']))
+      assert_instance_of(Integer, eval(xml.root.attributes['created_on']))
 
       # Use the as an exit point to generate the reference xml for testing
       # createReferenceXml(xml, category)


### PR DESCRIPTION
Taint tracking removed in ruby 2.7
Added deprecation warning message in ruby 3.2
Removed in ruby 3.3

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
