### PR TITLE
Add a version limit on activesupport gem

### DIFF
--- a/manageiq-smartstate.gemspec
+++ b/manageiq-smartstate.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activesupport"
+  spec.add_dependency "activesupport",      ">= 7.0.8", "<8.0"
   spec.add_dependency "awesome_spawn",      "~> 1.5"
   spec.add_dependency "azure-armrest",      "~> 0.9"
   spec.add_dependency "binary_struct",      "~> 2.1"


### PR DESCRIPTION
Without an upper limit on activesupport this was bringing in v8.0.0 which was conflicting with core's uri version.
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
