### PR TITLE
Add 8.0, drop EOL rails less than 7.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,13 @@ jobs:
     strategy:
       matrix:
         ruby-version:
+        - '3.2'
         - '3.3'
+        rails-version:
+        - '7.2'
+        - '8.0'
+    env:
+      TEST_RAILS_VERSION: "${{ matrix.rails-version }}"
     steps:
     - uses: actions/checkout@v6
     - name: Set up system

--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,13 @@ gem "manageiq-gems-pending", :git => "https://github.com/ManageIQ/manageiq-gems-
 
 # Modified gems for vmware_web_service.  Setting sources here since they are git references
 gem "handsoap", "=0.2.5.5", :require => false, :source => "https://rubygems.manageiq.org"
+
+minimum_version =
+  case ENV['TEST_RAILS_VERSION']
+  when "8.0"
+    "~>8.0.4"
+  else
+    "~>7.2.3"
+  end
+
+gem "activesupport", minimum_version

--- a/lib/fs/ext3/test/tc_Ext3BlockPointersPath.rb
+++ b/lib/fs/ext3/test/tc_Ext3BlockPointersPath.rb
@@ -1,4 +1,4 @@
-require 'minitest/unit'
+require 'minitest/autorun'
 require 'fs/ext3/block_pointers_path'
 include  Ext3
 

--- a/lib/metadata/linux/test/tc_LinuxUtils.rb
+++ b/lib/metadata/linux/test/tc_LinuxUtils.rb
@@ -1,4 +1,4 @@
-require 'minitest/unit'
+require 'minitest/autorun'
 
 require 'metadata/linux/LinuxUtils'
 

--- a/manageiq-smartstate.gemspec
+++ b/manageiq-smartstate.gemspec
@@ -20,7 +20,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activesupport",      ">= 7.0.8", "<8.0"
+  spec.required_ruby_version = '>= 3.2'
+
+  spec.add_dependency "activesupport",      ">= 7.2.3", "<8.1"
   spec.add_dependency "awesome_spawn",      "~> 1.5"
   spec.add_dependency "azure-armrest",      "~> 0.9"
   spec.add_dependency "binary_struct",      "~> 2.1"

--- a/test/DiskTestCommon/fat32/tc_fat32_boot.rb
+++ b/test/DiskTestCommon/fat32/tc_fat32_boot.rb
@@ -1,4 +1,4 @@
-require 'minitest/unit'
+require 'minitest/autorun'
 require 'ostruct'
 
 require_relative '../../VmsFromYaml'

--- a/test/DiskTestCommon/fat32/tc_fat32_file.rb
+++ b/test/DiskTestCommon/fat32/tc_fat32_file.rb
@@ -1,4 +1,4 @@
-require 'minitest/unit'
+require 'minitest/autorun'
 require 'ostruct'
 
 require_relative '../../VmsFromYaml'

--- a/test/DiskTestCommon/fat32/tc_fat32_rootdir.rb
+++ b/test/DiskTestCommon/fat32/tc_fat32_rootdir.rb
@@ -1,4 +1,4 @@
-require 'minitest/unit'
+require 'minitest/autorun'
 require 'ostruct'
 
 require_relative '../../VmsFromYaml'

--- a/test/DiskTestCommon/fat32/tc_fat32_write.rb
+++ b/test/DiskTestCommon/fat32/tc_fat32_write.rb
@@ -1,4 +1,4 @@
-require 'minitest/unit'
+require 'minitest/autorun'
 require 'ostruct'
 
 require_relative '../../VmsFromYaml'

--- a/test/DiskTestCommon/ntfs/tc_ntfs_boot.rb
+++ b/test/DiskTestCommon/ntfs/tc_ntfs_boot.rb
@@ -1,4 +1,4 @@
-require 'minitest/unit'
+require 'minitest/autorun'
 require 'ostruct'
 
 require_relative '../../VmsFromYaml'

--- a/test/DiskTestCommon/ntfs/tc_ntfs_file.rb
+++ b/test/DiskTestCommon/ntfs/tc_ntfs_file.rb
@@ -1,4 +1,4 @@
-require 'minitest/unit'
+require 'minitest/autorun'
 require 'ostruct'
 
 require_relative '../../VmsFromYaml'

--- a/test/DiskTestCommon/ntfs/tc_ntfs_index.rb
+++ b/test/DiskTestCommon/ntfs/tc_ntfs_index.rb
@@ -1,4 +1,4 @@
-require 'minitest/unit'
+require 'minitest/autorun'
 require 'ostruct'
 
 require_relative '../../VmsFromYaml'

--- a/test/DiskTestCommon/ntfs/tc_ntfs_mft.rb
+++ b/test/DiskTestCommon/ntfs/tc_ntfs_mft.rb
@@ -1,6 +1,6 @@
 # encoding: US-ASCII
 
-require 'minitest/unit'
+require 'minitest/autorun'
 require 'ostruct'
 
 require_relative '../../VmsFromYaml'

--- a/test/DiskTestCommon/tc_MiqDisk.rb
+++ b/test/DiskTestCommon/tc_MiqDisk.rb
@@ -1,6 +1,6 @@
 require 'disk/MiqDisk'
 require 'ostruct'
-require 'minitest/unit'
+require 'minitest/autorun'
 
 module DiskTestCommon
   class TestMiqDisk < Minitest::Test

--- a/test/DiskTestCommon/tc_MiqLargeFile.rb
+++ b/test/DiskTestCommon/tc_MiqLargeFile.rb
@@ -1,6 +1,6 @@
 require 'disk/modules/MiqLargeFile'
 require 'metadata/util/md5deep'
-require 'minitest/unit'
+require 'minitest/autorun'
 require 'tmpdir'
 
 module DiskTestCommon

--- a/test/DiskTestCommon/tc_seek.rb
+++ b/test/DiskTestCommon/tc_seek.rb
@@ -1,4 +1,4 @@
-require 'minitest/unit'
+require 'minitest/autorun'
 require 'ostruct'
 
 require_relative '../VmsFromYaml'

--- a/test/DiskTestCommon/tc_vfyreg.rb
+++ b/test/DiskTestCommon/tc_vfyreg.rb
@@ -1,4 +1,4 @@
-require 'minitest/unit'
+require 'minitest/autorun'
 require 'ostruct'
 
 require_relative './FSTestUtil'

--- a/test/Iso9660/tc_iso9660BootSector.rb
+++ b/test/Iso9660/tc_iso9660BootSector.rb
@@ -1,5 +1,5 @@
 require 'ostruct'
-require 'minitest/unit'
+require 'minitest/autorun'
 require 'disk/MiqDisk'
 require 'fs/iso9660/boot_sector'
 include Iso9660

--- a/test/Iso9660/tc_iso9660Directory.rb
+++ b/test/Iso9660/tc_iso9660Directory.rb
@@ -1,5 +1,5 @@
 require 'ostruct'
-require 'minitest/unit'
+require 'minitest/autorun'
 require 'disk/MiqDisk'
 require 'fs/iso9660/boot_sector'
 require 'fs/iso9660/directory_entry'

--- a/test/Iso9660/tc_iso9660FileSystem.rb
+++ b/test/Iso9660/tc_iso9660FileSystem.rb
@@ -1,5 +1,5 @@
 require 'ostruct'
-require 'minitest/unit'
+require 'minitest/autorun'
 require 'disk/MiqDisk'
 require 'fs/MiqFS/MiqFS'
 

--- a/test/extract/tc_md5deep.rb
+++ b/test/extract/tc_md5deep.rb
@@ -1,5 +1,5 @@
 require 'metadata/util/md5deep'
-require 'minitest/unit'
+require 'minitest/autorun'
 
 module Extract
   class TestVersionInfo < Minitest::Test

--- a/test/extract/tc_registry.rb
+++ b/test/extract/tc_registry.rb
@@ -3,7 +3,7 @@ require 'metadata/MIQExtract/MIQExtract'
 require 'manageiq/gems/pending'
 require 'util/miq-xml'
 require 'digest/md5'
-require 'minitest/unit'
+require 'minitest/autorun'
 
 module Extract
   class TestRegistry < Minitest::Test

--- a/test/extract/tc_versioninfo.rb
+++ b/test/extract/tc_versioninfo.rb
@@ -1,5 +1,5 @@
 require 'metadata/util/win32/versioninfo'
-require 'minitest/unit'
+require 'minitest/autorun'
 
 module Extract
   class TestVersionInfo < Minitest::Test


### PR DESCRIPTION
Add ruby 3.2 as minimum required.

Note, to get to ruby 3.4, we'll need to upgrade httpclient 2.9.0 for: https://www.github.com/nahi/httpclient/pull/455

That resolves the following issue with webmock in this repo with ruby 3.4: https://www.github.com/bblimke/webmock/issues/1094

See also: https://github.com/ManageIQ/manageiq/issues/23688

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
